### PR TITLE
Phase 4: EventBus integration for inter-workflow eventing

### DIFF
--- a/module/event_trigger.go
+++ b/module/event_trigger.go
@@ -110,7 +110,7 @@ func (t *EventTrigger) Configure(app modular.Application, triggerConfig interfac
 
 	// Find the message broker
 	var broker MessageBroker
-	brokerNames := []string{"messageBroker", "eventBroker", "broker"}
+	brokerNames := []string{"messageBroker", "eventBroker", "broker", "messaging.broker.eventbus"}
 
 	for _, name := range brokerNames {
 		var svc interface{}

--- a/module/eventbus_bridge.go
+++ b/module/eventbus_bridge.go
@@ -1,0 +1,161 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/CrisisTextLine/modular"
+	"github.com/CrisisTextLine/modular/modules/eventbus"
+)
+
+// EventBusBridgeName is the default service name for the EventBus bridge adapter.
+const EventBusBridgeName = "messaging.broker.eventbus"
+
+// EventBusBridge adapts the modular framework's EventBusModule to the workflow
+// engine's MessageBroker interface. It allows the workflow engine to publish and
+// subscribe to events through the EventBus using the existing MessageBroker API.
+type EventBusBridge struct {
+	name          string
+	eventBus      *eventbus.EventBusModule
+	subscriptions map[string]eventbus.Subscription
+	mu            sync.RWMutex
+}
+
+// NewEventBusBridge creates a new EventBusBridge with the given name.
+func NewEventBusBridge(name string) *EventBusBridge {
+	return &EventBusBridge{
+		name:          name,
+		subscriptions: make(map[string]eventbus.Subscription),
+	}
+}
+
+// Name returns the bridge's service name.
+func (b *EventBusBridge) Name() string {
+	return b.name
+}
+
+// Init registers the bridge as a service in the application's service registry.
+// It does not look up the EventBus here; that is done via SetEventBus or
+// InitFromApp after the application has been fully initialized.
+func (b *EventBusBridge) Init(app modular.Application) error {
+	reg := app.SvcRegistry()
+	reg[b.name] = b
+	return nil
+}
+
+// SetEventBus injects the EventBusModule directly. This is useful when the
+// engine already has a reference to the EventBus after app.Init().
+func (b *EventBusBridge) SetEventBus(eb *eventbus.EventBusModule) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.eventBus = eb
+}
+
+// InitFromApp looks up the EventBusModule from the application's service
+// registry using the well-known service name "eventbus.provider".
+func (b *EventBusBridge) InitFromApp(app modular.Application) error {
+	var eb *eventbus.EventBusModule
+	if err := app.GetService(eventbus.ServiceName, &eb); err != nil {
+		return fmt.Errorf("looking up eventbus service: %w", err)
+	}
+	b.SetEventBus(eb)
+	return nil
+}
+
+// Producer returns the bridge itself, which implements MessageProducer.
+func (b *EventBusBridge) Producer() MessageProducer {
+	return b
+}
+
+// Consumer returns the bridge itself, which implements MessageConsumer.
+func (b *EventBusBridge) Consumer() MessageConsumer {
+	return b
+}
+
+// SendMessage publishes a message to the EventBus. The message bytes are
+// unmarshalled from JSON into an interface{} payload. If unmarshalling fails,
+// the raw bytes are published as the payload. Returns nil (no-op) if no
+// EventBus has been set.
+func (b *EventBusBridge) SendMessage(topic string, message []byte) error {
+	b.mu.RLock()
+	eb := b.eventBus
+	b.mu.RUnlock()
+
+	if eb == nil {
+		return nil
+	}
+
+	var payload interface{}
+	if err := json.Unmarshal(message, &payload); err != nil {
+		payload = message
+	}
+
+	return eb.Publish(context.Background(), topic, payload)
+}
+
+// Subscribe registers a MessageHandler to receive events from the EventBus on
+// the given topic. Events are marshalled to JSON before being passed to the
+// handler. Returns nil (no-op) if no EventBus has been set.
+func (b *EventBusBridge) Subscribe(topic string, handler MessageHandler) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.eventBus == nil {
+		return nil
+	}
+
+	eventHandler := func(_ context.Context, event eventbus.Event) error {
+		jsonBytes, err := json.Marshal(event.Payload)
+		if err != nil {
+			return fmt.Errorf("marshalling event payload: %w", err)
+		}
+		return handler.HandleMessage(jsonBytes)
+	}
+
+	sub, err := b.eventBus.Subscribe(context.Background(), topic, eventHandler)
+	if err != nil {
+		return fmt.Errorf("subscribing to eventbus topic %s: %w", topic, err)
+	}
+
+	b.subscriptions[topic] = sub
+	return nil
+}
+
+// Unsubscribe cancels the subscription for the given topic and removes it.
+func (b *EventBusBridge) Unsubscribe(topic string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	sub, exists := b.subscriptions[topic]
+	if !exists {
+		return nil
+	}
+
+	if err := sub.Cancel(); err != nil {
+		return fmt.Errorf("cancelling subscription for topic %s: %w", topic, err)
+	}
+
+	delete(b.subscriptions, topic)
+	return nil
+}
+
+// Start is a no-op; the EventBus lifecycle is managed externally.
+func (b *EventBusBridge) Start(_ context.Context) error {
+	return nil
+}
+
+// Stop cancels all active subscriptions and clears the subscription map.
+func (b *EventBusBridge) Stop(_ context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for topic, sub := range b.subscriptions {
+		if err := sub.Cancel(); err != nil {
+			return fmt.Errorf("cancelling subscription for topic %s during stop: %w", topic, err)
+		}
+	}
+	b.subscriptions = make(map[string]eventbus.Subscription)
+	return nil
+}

--- a/module/eventbus_bridge_test.go
+++ b/module/eventbus_bridge_test.go
@@ -1,0 +1,455 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/CrisisTextLine/modular"
+	"github.com/CrisisTextLine/modular/modules/eventbus"
+)
+
+// setupEventBusForBridge creates a working EventBusModule backed by the in-memory engine.
+// It uses a mock modular.Application to register config, init, and start the module.
+func setupEventBusForBridge(t *testing.T) *eventbus.EventBusModule {
+	t.Helper()
+
+	app := newEventBusBridgeMockApp()
+	eb := eventbus.NewModule().(*eventbus.EventBusModule)
+
+	if err := eb.RegisterConfig(app); err != nil {
+		t.Fatalf("RegisterConfig: %v", err)
+	}
+	if err := eb.Init(app); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := eb.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := eb.Stop(context.Background()); err != nil {
+			t.Logf("Stop: %v", err)
+		}
+	})
+	return eb
+}
+
+// bridgeMockApp satisfies modular.Application for the eventbus module init.
+type bridgeMockApp struct {
+	configSections map[string]modular.ConfigProvider
+	services       map[string]interface{}
+	modules        map[string]modular.Module
+	logger         modular.Logger
+}
+
+func newEventBusBridgeMockApp() *bridgeMockApp {
+	return &bridgeMockApp{
+		configSections: make(map[string]modular.ConfigProvider),
+		services:       make(map[string]interface{}),
+		modules:        make(map[string]modular.Module),
+		logger:         &noopLogger{},
+	}
+}
+
+func (a *bridgeMockApp) RegisterConfigSection(name string, cp modular.ConfigProvider) {
+	a.configSections[name] = cp
+}
+func (a *bridgeMockApp) GetConfigSection(name string) (modular.ConfigProvider, error) {
+	return a.configSections[name], nil
+}
+func (a *bridgeMockApp) ConfigSections() map[string]modular.ConfigProvider {
+	return a.configSections
+}
+func (a *bridgeMockApp) Logger() modular.Logger         { return a.logger }
+func (a *bridgeMockApp) SetLogger(l modular.Logger)     { a.logger = l }
+func (a *bridgeMockApp) ConfigProvider() modular.ConfigProvider { return nil }
+func (a *bridgeMockApp) SvcRegistry() modular.ServiceRegistry {
+	return a.services
+}
+func (a *bridgeMockApp) RegisterModule(m modular.Module) {
+	a.modules[m.Name()] = m
+}
+func (a *bridgeMockApp) RegisterService(name string, svc any) error {
+	a.services[name] = svc
+	return nil
+}
+func (a *bridgeMockApp) GetService(name string, target any) error { return nil }
+func (a *bridgeMockApp) Init() error                              { return nil }
+func (a *bridgeMockApp) Start() error                             { return nil }
+func (a *bridgeMockApp) Stop() error                              { return nil }
+func (a *bridgeMockApp) Run() error                               { return nil }
+func (a *bridgeMockApp) IsVerboseConfig() bool                    { return false }
+func (a *bridgeMockApp) SetVerboseConfig(bool)                    {}
+func (a *bridgeMockApp) Context() context.Context                 { return context.Background() }
+func (a *bridgeMockApp) GetServicesByModule(string) []string      { return nil }
+func (a *bridgeMockApp) GetServiceEntry(string) (*modular.ServiceRegistryEntry, bool) {
+	return nil, false
+}
+func (a *bridgeMockApp) GetServicesByInterface(_ reflect.Type) []*modular.ServiceRegistryEntry {
+	return nil
+}
+func (a *bridgeMockApp) GetModule(name string) modular.Module       { return a.modules[name] }
+func (a *bridgeMockApp) GetAllModules() map[string]modular.Module   { return a.modules }
+func (a *bridgeMockApp) StartTime() time.Time                       { return time.Time{} }
+func (a *bridgeMockApp) OnConfigLoaded(func(modular.Application) error) {}
+
+// testMessageHandler is a simple MessageHandler for tests.
+type testMessageHandler struct {
+	mu       sync.Mutex
+	messages [][]byte
+	ch       chan []byte
+}
+
+func newTestMessageHandler() *testMessageHandler {
+	return &testMessageHandler{
+		messages: make([][]byte, 0),
+		ch:       make(chan []byte, 10),
+	}
+}
+
+func (h *testMessageHandler) HandleMessage(message []byte) error {
+	h.mu.Lock()
+	h.messages = append(h.messages, message)
+	h.mu.Unlock()
+	h.ch <- message
+	return nil
+}
+
+func (h *testMessageHandler) received() [][]byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([][]byte, len(h.messages))
+	copy(out, h.messages)
+	return out
+}
+
+// --- Tests ---
+
+func TestEventBusBridge_NewAndName(t *testing.T) {
+	bridge := NewEventBusBridge("my.bridge")
+	if bridge.Name() != "my.bridge" {
+		t.Fatalf("expected name %q, got %q", "my.bridge", bridge.Name())
+	}
+}
+
+func TestEventBusBridge_ProducerConsumer(t *testing.T) {
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	if bridge.Producer() != bridge {
+		t.Fatal("Producer() should return the bridge itself")
+	}
+	if bridge.Consumer() != bridge {
+		t.Fatal("Consumer() should return the bridge itself")
+	}
+}
+
+func TestEventBusBridge_NilEventBusNoOp(t *testing.T) {
+	bridge := NewEventBusBridge(EventBusBridgeName)
+
+	// SendMessage should be a no-op
+	if err := bridge.SendMessage("topic", []byte(`{"key":"val"}`)); err != nil {
+		t.Fatalf("SendMessage with nil EventBus should be no-op, got: %v", err)
+	}
+
+	// Subscribe should be a no-op
+	handler := newTestMessageHandler()
+	if err := bridge.Subscribe("topic", handler); err != nil {
+		t.Fatalf("Subscribe with nil EventBus should be no-op, got: %v", err)
+	}
+
+	// Unsubscribe should be a no-op (no subscription exists)
+	if err := bridge.Unsubscribe("topic"); err != nil {
+		t.Fatalf("Unsubscribe with no subscription should be no-op, got: %v", err)
+	}
+}
+
+func TestEventBusBridge_StartStop(t *testing.T) {
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	ctx := context.Background()
+
+	if err := bridge.Start(ctx); err != nil {
+		t.Fatalf("Start should be no-op, got: %v", err)
+	}
+	if err := bridge.Stop(ctx); err != nil {
+		t.Fatalf("Stop should succeed, got: %v", err)
+	}
+}
+
+func TestEventBusBridge_SendMessageThenReceiveViaEventBus(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	// Subscribe directly on the EventBus to verify the bridge publishes correctly.
+	received := make(chan eventbus.Event, 1)
+	sub, err := eb.Subscribe(context.Background(), "test.send", func(_ context.Context, event eventbus.Event) error {
+		received <- event
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("EventBus Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	payload := map[string]interface{}{"hello": "world"}
+	msg, _ := json.Marshal(payload)
+	if err := bridge.SendMessage("test.send", msg); err != nil {
+		t.Fatalf("bridge.SendMessage: %v", err)
+	}
+
+	select {
+	case evt := <-received:
+		if evt.Topic != "test.send" {
+			t.Fatalf("expected topic %q, got %q", "test.send", evt.Topic)
+		}
+		// The payload went through JSON unmarshal in SendMessage then was published.
+		payloadMap, ok := evt.Payload.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected map payload, got %T", evt.Payload)
+		}
+		if payloadMap["hello"] != "world" {
+			t.Fatalf("expected hello=world, got %v", payloadMap["hello"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event on EventBus")
+	}
+}
+
+func TestEventBusBridge_EventBusPublishThenReceiveViaBridge(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	handler := newTestMessageHandler()
+	if err := bridge.Subscribe("test.receive", handler); err != nil {
+		t.Fatalf("bridge.Subscribe: %v", err)
+	}
+
+	// Publish via the EventBus directly.
+	payload := map[string]interface{}{"foo": "bar"}
+	if err := eb.Publish(context.Background(), "test.receive", payload); err != nil {
+		t.Fatalf("EventBus Publish: %v", err)
+	}
+
+	select {
+	case msg := <-handler.ch:
+		var got map[string]interface{}
+		if err := json.Unmarshal(msg, &got); err != nil {
+			t.Fatalf("unmarshal handler message: %v", err)
+		}
+		if got["foo"] != "bar" {
+			t.Fatalf("expected foo=bar, got %v", got["foo"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for message via bridge handler")
+	}
+}
+
+func TestEventBusBridge_JSONRoundTrip(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	handler := newTestMessageHandler()
+	if err := bridge.Subscribe("roundtrip", handler); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	original := map[string]interface{}{
+		"count":  float64(42),
+		"name":   "test",
+		"nested": map[string]interface{}{"a": float64(1)},
+	}
+	msg, _ := json.Marshal(original)
+
+	if err := bridge.SendMessage("roundtrip", msg); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	select {
+	case received := <-handler.ch:
+		var got map[string]interface{}
+		if err := json.Unmarshal(received, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got["count"] != float64(42) {
+			t.Fatalf("expected count=42, got %v", got["count"])
+		}
+		if got["name"] != "test" {
+			t.Fatalf("expected name=test, got %v", got["name"])
+		}
+		nested, ok := got["nested"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected nested map, got %T", got["nested"])
+		}
+		if nested["a"] != float64(1) {
+			t.Fatalf("expected nested.a=1, got %v", nested["a"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for round-trip message")
+	}
+}
+
+func TestEventBusBridge_SendInvalidJSON(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	// Subscribe on EventBus to verify the raw bytes are published as payload.
+	received := make(chan eventbus.Event, 1)
+	sub, err := eb.Subscribe(context.Background(), "raw", func(_ context.Context, event eventbus.Event) error {
+		received <- event
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	// Send invalid JSON
+	rawMsg := []byte("this is not json")
+	if err := bridge.SendMessage("raw", rawMsg); err != nil {
+		t.Fatalf("SendMessage with raw bytes: %v", err)
+	}
+
+	select {
+	case evt := <-received:
+		// Payload should be the raw bytes since JSON unmarshal failed.
+		b, ok := evt.Payload.([]byte)
+		if !ok {
+			t.Fatalf("expected []byte payload for invalid JSON, got %T", evt.Payload)
+		}
+		if string(b) != "this is not json" {
+			t.Fatalf("expected raw message, got %q", string(b))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for raw event")
+	}
+}
+
+func TestEventBusBridge_Unsubscribe(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	handler := newTestMessageHandler()
+	if err := bridge.Subscribe("unsub.topic", handler); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Unsubscribe
+	if err := bridge.Unsubscribe("unsub.topic"); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+
+	// Publish a message -- it should NOT reach the handler.
+	if err := eb.Publish(context.Background(), "unsub.topic", "after-unsub"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Brief wait to confirm no delivery.
+	select {
+	case <-handler.ch:
+		t.Fatal("handler received a message after unsubscribe")
+	case <-time.After(200 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestEventBusBridge_StopCancelsSubscriptions(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	handler := newTestMessageHandler()
+	if err := bridge.Subscribe("stop.topic", handler); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Stop the bridge
+	if err := bridge.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	// Publish after stop -- handler should NOT receive it.
+	if err := eb.Publish(context.Background(), "stop.topic", "after-stop"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-handler.ch:
+		t.Fatal("handler received a message after bridge Stop")
+	case <-time.After(200 * time.Millisecond):
+		// expected
+	}
+
+	// Subscriptions map should be empty.
+	bridge.mu.RLock()
+	count := len(bridge.subscriptions)
+	bridge.mu.RUnlock()
+	if count != 0 {
+		t.Fatalf("expected 0 subscriptions after Stop, got %d", count)
+	}
+}
+
+func TestEventBusBridge_ConcurrentSubscribeUnsubscribe(t *testing.T) {
+	eb := setupEventBusForBridge(t)
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	bridge.SetEventBus(eb)
+
+	var wg sync.WaitGroup
+	topics := 20
+
+	// Concurrently subscribe to many topics.
+	for i := 0; i < topics; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			topic := "concurrent." + string(rune('A'+idx))
+			h := newTestMessageHandler()
+			if err := bridge.Subscribe(topic, h); err != nil {
+				t.Errorf("Subscribe(%s): %v", topic, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrently unsubscribe from all topics.
+	for i := 0; i < topics; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			topic := "concurrent." + string(rune('A'+idx))
+			if err := bridge.Unsubscribe(topic); err != nil {
+				t.Errorf("Unsubscribe(%s): %v", topic, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	bridge.mu.RLock()
+	remaining := len(bridge.subscriptions)
+	bridge.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("expected 0 subscriptions after concurrent unsub, got %d", remaining)
+	}
+}
+
+func TestEventBusBridge_InitRegistersService(t *testing.T) {
+	bridge := NewEventBusBridge(EventBusBridgeName)
+	app := newEventBusBridgeMockApp()
+
+	if err := bridge.Init(app); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	svc, exists := app.services[EventBusBridgeName]
+	if !exists {
+		t.Fatal("expected bridge to be registered as a service")
+	}
+	if svc != bridge {
+		t.Fatal("registered service should be the bridge instance")
+	}
+}

--- a/module/eventbus_trigger.go
+++ b/module/eventbus_trigger.go
@@ -1,0 +1,213 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/CrisisTextLine/modular"
+	"github.com/CrisisTextLine/modular/modules/eventbus"
+)
+
+const (
+	// EventBusTriggerName is the standard name for the EventBus trigger.
+	EventBusTriggerName = "trigger.eventbus"
+)
+
+// EventBusTriggerSubscription defines a single subscription that the trigger
+// listens to on the EventBus and maps to a workflow execution.
+type EventBusTriggerSubscription struct {
+	Topic    string                 `json:"topic" yaml:"topic"`
+	Event    string                 `json:"event,omitempty" yaml:"event,omitempty"`
+	Workflow string                 `json:"workflow" yaml:"workflow"`
+	Action   string                 `json:"action" yaml:"action"`
+	Async    bool                   `json:"async,omitempty" yaml:"async,omitempty"`
+	Params   map[string]interface{} `json:"params,omitempty" yaml:"params,omitempty"`
+}
+
+// EventBusTrigger implements the Trigger interface and starts workflows in
+// response to events published on the EventBus.
+type EventBusTrigger struct {
+	name          string
+	namespace     ModuleNamespaceProvider
+	subscriptions []EventBusTriggerSubscription
+	eventBus      *eventbus.EventBusModule
+	engine        WorkflowEngine
+	activeSubs    []eventbus.Subscription
+}
+
+// NewEventBusTrigger creates a new EventBus trigger with default namespace.
+func NewEventBusTrigger() *EventBusTrigger {
+	return NewEventBusTriggerWithNamespace(nil)
+}
+
+// NewEventBusTriggerWithNamespace creates a new EventBus trigger with namespace support.
+func NewEventBusTriggerWithNamespace(namespace ModuleNamespaceProvider) *EventBusTrigger {
+	if namespace == nil {
+		namespace = NewStandardNamespace("", "")
+	}
+	return &EventBusTrigger{
+		name:          namespace.FormatName(EventBusTriggerName),
+		namespace:     namespace,
+		subscriptions: make([]EventBusTriggerSubscription, 0),
+		activeSubs:    make([]eventbus.Subscription, 0),
+	}
+}
+
+// Name returns the trigger name.
+func (t *EventBusTrigger) Name() string {
+	return t.name
+}
+
+// Init registers the trigger as a service.
+func (t *EventBusTrigger) Init(app modular.Application) error {
+	return app.RegisterService(t.name, t)
+}
+
+// Configure parses the trigger config and resolves the EventBus and engine
+// services from the application.
+func (t *EventBusTrigger) Configure(app modular.Application, triggerConfig interface{}) error {
+	config, ok := triggerConfig.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("invalid eventbus trigger configuration format")
+	}
+
+	subsConfig, ok := config["subscriptions"].([]interface{})
+	if !ok {
+		return fmt.Errorf("subscriptions not found in eventbus trigger configuration")
+	}
+
+	// Resolve EventBusModule.
+	var eb *eventbus.EventBusModule
+	if err := app.GetService("eventbus.provider", &eb); err != nil || eb == nil {
+		return fmt.Errorf("eventbus.provider service not found")
+	}
+	t.eventBus = eb
+
+	// Resolve WorkflowEngine.
+	var engine WorkflowEngine
+	engineNames := []string{"workflowEngine", "engine"}
+	for _, name := range engineNames {
+		var svc interface{}
+		if err := app.GetService(name, &svc); err == nil && svc != nil {
+			if e, ok := svc.(WorkflowEngine); ok {
+				engine = e
+				break
+			}
+		}
+	}
+	if engine == nil {
+		return fmt.Errorf("workflow engine not found")
+	}
+	t.engine = engine
+
+	// Parse subscriptions.
+	for i, sc := range subsConfig {
+		subMap, ok := sc.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("invalid subscription configuration at index %d", i)
+		}
+
+		topic, _ := subMap["topic"].(string)
+		event, _ := subMap["event"].(string)
+		workflow, _ := subMap["workflow"].(string)
+		action, _ := subMap["action"].(string)
+		async, _ := subMap["async"].(bool)
+		params, _ := subMap["params"].(map[string]interface{})
+
+		if topic == "" || workflow == "" || action == "" {
+			return fmt.Errorf("incomplete subscription at index %d: topic, workflow, and action are required", i)
+		}
+
+		t.subscriptions = append(t.subscriptions, EventBusTriggerSubscription{
+			Topic:    topic,
+			Event:    event,
+			Workflow: workflow,
+			Action:   action,
+			Async:    async,
+			Params:   params,
+		})
+	}
+
+	return nil
+}
+
+// Start subscribes to the configured EventBus topics.
+func (t *EventBusTrigger) Start(ctx context.Context) error {
+	if t.eventBus == nil {
+		return fmt.Errorf("event bus not configured for eventbus trigger")
+	}
+	if t.engine == nil {
+		return fmt.Errorf("workflow engine not configured for eventbus trigger")
+	}
+
+	for _, sub := range t.subscriptions {
+		handler := t.createHandler(sub)
+
+		var subscription eventbus.Subscription
+		var err error
+		if sub.Async {
+			subscription, err = t.eventBus.SubscribeAsync(ctx, sub.Topic, handler)
+		} else {
+			subscription, err = t.eventBus.Subscribe(ctx, sub.Topic, handler)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to subscribe to topic %q: %w", sub.Topic, err)
+		}
+		t.activeSubs = append(t.activeSubs, subscription)
+	}
+
+	return nil
+}
+
+// Stop cancels all active EventBus subscriptions.
+func (t *EventBusTrigger) Stop(_ context.Context) error {
+	for _, sub := range t.activeSubs {
+		_ = sub.Cancel()
+	}
+	t.activeSubs = t.activeSubs[:0]
+	return nil
+}
+
+// SetEventBusAndEngine allows directly setting the EventBus and engine for testing.
+func (t *EventBusTrigger) SetEventBusAndEngine(eb *eventbus.EventBusModule, engine WorkflowEngine) {
+	t.eventBus = eb
+	t.engine = engine
+}
+
+// createHandler returns an EventHandler for the given subscription.
+func (t *EventBusTrigger) createHandler(sub EventBusTriggerSubscription) eventbus.EventHandler {
+	return func(ctx context.Context, ev eventbus.Event) error {
+		// Extract payload as map[string]interface{}.
+		data, ok := ev.Payload.(map[string]interface{})
+		if !ok {
+			// JSON round-trip for non-map payloads.
+			raw, err := json.Marshal(ev.Payload)
+			if err != nil {
+				return fmt.Errorf("failed to marshal event payload: %w", err)
+			}
+			data = make(map[string]interface{})
+			if err := json.Unmarshal(raw, &data); err != nil {
+				return fmt.Errorf("failed to unmarshal event payload: %w", err)
+			}
+		}
+
+		// Event type filtering.
+		if sub.Event != "" {
+			eventType, _ := data["type"].(string)
+			if eventType == "" {
+				eventType, _ = data["eventType"].(string)
+			}
+			if eventType != sub.Event {
+				return nil // not a match
+			}
+		}
+
+		// Merge static params.
+		for k, v := range sub.Params {
+			data[k] = v
+		}
+
+		return t.engine.TriggerWorkflow(ctx, sub.Workflow, sub.Action, data)
+	}
+}

--- a/module/eventbus_trigger_test.go
+++ b/module/eventbus_trigger_test.go
@@ -1,0 +1,432 @@
+package module
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- mock engine for eventbus trigger tests ----------------------------------
+
+type ebTriggerCall struct {
+	workflowType string
+	action       string
+	data         map[string]interface{}
+}
+
+type mockEBWorkflowEngine struct {
+	mu        sync.Mutex
+	triggered []ebTriggerCall
+}
+
+func (m *mockEBWorkflowEngine) TriggerWorkflow(_ context.Context, wfType, action string, data map[string]interface{}) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.triggered = append(m.triggered, ebTriggerCall{wfType, action, data})
+	return nil
+}
+
+func (m *mockEBWorkflowEngine) calls() []ebTriggerCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]ebTriggerCall, len(m.triggered))
+	copy(out, m.triggered)
+	return out
+}
+
+// --- tests -------------------------------------------------------------------
+
+func TestEventBusTrigger_Name(t *testing.T) {
+	trigger := NewEventBusTrigger()
+	if trigger.Name() != EventBusTriggerName {
+		t.Errorf("Name() = %q; want %q", trigger.Name(), EventBusTriggerName)
+	}
+}
+
+func TestEventBusTrigger_NameWithNamespace(t *testing.T) {
+	ns := NewStandardNamespace("ns", "")
+	trigger := NewEventBusTriggerWithNamespace(ns)
+	want := "ns-" + EventBusTriggerName
+	if trigger.Name() != want {
+		t.Errorf("Name() = %q; want %q", trigger.Name(), want)
+	}
+}
+
+func TestEventBusTrigger_Configure(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+	if err := app.RegisterService("workflowEngine", engine); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+	// Also register the eventbus so GetService can find it by pointer.
+	_ = eb // already registered by setupEventBus
+
+	trigger := NewEventBusTrigger()
+
+	config := map[string]interface{}{
+		"subscriptions": []interface{}{
+			map[string]interface{}{
+				"topic":    "order.created",
+				"workflow": "order-pipeline",
+				"action":   "process",
+			},
+			map[string]interface{}{
+				"topic":    "user.events",
+				"event":    "user.registered",
+				"workflow": "onboard",
+				"action":   "start",
+				"async":    true,
+				"params":   map[string]interface{}{"source": "eventbus"},
+			},
+		},
+	}
+
+	if err := trigger.Configure(app, config); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if len(trigger.subscriptions) != 2 {
+		t.Fatalf("expected 2 subscriptions, got %d", len(trigger.subscriptions))
+	}
+
+	// Verify first subscription.
+	s0 := trigger.subscriptions[0]
+	if s0.Topic != "order.created" || s0.Workflow != "order-pipeline" || s0.Action != "process" {
+		t.Errorf("unexpected sub[0]: %+v", s0)
+	}
+	if s0.Async {
+		t.Error("sub[0] should not be async")
+	}
+
+	// Verify second subscription.
+	s1 := trigger.subscriptions[1]
+	if s1.Topic != "user.events" || s1.Event != "user.registered" || !s1.Async {
+		t.Errorf("unexpected sub[1]: %+v", s1)
+	}
+	if s1.Params["source"] != "eventbus" {
+		t.Errorf("sub[1] params mismatch: %v", s1.Params)
+	}
+}
+
+func TestEventBusTrigger_Configure_InvalidFormat(t *testing.T) {
+	trigger := NewEventBusTrigger()
+	err := trigger.Configure(NewMockApplication(), "bad config")
+	if err == nil {
+		t.Fatal("expected error for invalid config format")
+	}
+}
+
+func TestEventBusTrigger_Configure_MissingSubscriptions(t *testing.T) {
+	trigger := NewEventBusTrigger()
+	err := trigger.Configure(NewMockApplication(), map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for missing subscriptions")
+	}
+}
+
+func TestEventBusTrigger_StartAndPublish(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+
+	trigger := NewEventBusTrigger()
+	trigger.subscriptions = []EventBusTriggerSubscription{
+		{
+			Topic:    "test.topic",
+			Workflow: "my-workflow",
+			Action:   "run",
+		},
+	}
+	trigger.SetEventBusAndEngine(eb, engine)
+
+	ctx := context.Background()
+	if err := trigger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Publish an event on the topic.
+	payload := map[string]interface{}{"key": "value"}
+	if err := eb.Publish(ctx, "test.topic", payload); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	calls := engine.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 trigger call, got %d", len(calls))
+	}
+	if calls[0].workflowType != "my-workflow" || calls[0].action != "run" {
+		t.Errorf("unexpected call: %+v", calls[0])
+	}
+	if calls[0].data["key"] != "value" {
+		t.Errorf("expected data key=value, got %v", calls[0].data)
+	}
+
+	if err := trigger.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestEventBusTrigger_EventTypeFiltering(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+
+	trigger := NewEventBusTrigger()
+	trigger.subscriptions = []EventBusTriggerSubscription{
+		{
+			Topic:    "events",
+			Event:    "order.placed",
+			Workflow: "order-wf",
+			Action:   "start",
+		},
+	}
+	trigger.SetEventBusAndEngine(eb, engine)
+
+	ctx := context.Background()
+	if err := trigger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Publish non-matching event type.
+	if err := eb.Publish(ctx, "events", map[string]interface{}{
+		"type": "order.cancelled",
+		"id":   "1",
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if len(engine.calls()) != 0 {
+		t.Errorf("expected 0 triggers for non-matching event, got %d", len(engine.calls()))
+	}
+
+	// Publish matching event type.
+	if err := eb.Publish(ctx, "events", map[string]interface{}{
+		"type": "order.placed",
+		"id":   "2",
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if len(engine.calls()) != 1 {
+		t.Fatalf("expected 1 trigger for matching event, got %d", len(engine.calls()))
+	}
+	if engine.calls()[0].data["id"] != "2" {
+		t.Errorf("unexpected data: %v", engine.calls()[0].data)
+	}
+
+	_ = trigger.Stop(ctx)
+}
+
+func TestEventBusTrigger_EventTypeFilteringWithEventType(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+
+	trigger := NewEventBusTrigger()
+	trigger.subscriptions = []EventBusTriggerSubscription{
+		{
+			Topic:    "events",
+			Event:    "user.login",
+			Workflow: "auth-wf",
+			Action:   "audit",
+		},
+	}
+	trigger.SetEventBusAndEngine(eb, engine)
+
+	ctx := context.Background()
+	if err := trigger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Publish with "eventType" field instead of "type".
+	if err := eb.Publish(ctx, "events", map[string]interface{}{
+		"eventType": "user.login",
+		"user":      "alice",
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	calls := engine.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 trigger for eventType match, got %d", len(calls))
+	}
+	if calls[0].data["user"] != "alice" {
+		t.Errorf("unexpected data: %v", calls[0].data)
+	}
+
+	_ = trigger.Stop(ctx)
+}
+
+func TestEventBusTrigger_ParamsMerged(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+
+	trigger := NewEventBusTrigger()
+	trigger.subscriptions = []EventBusTriggerSubscription{
+		{
+			Topic:    "test.params",
+			Workflow: "wf",
+			Action:   "act",
+			Params:   map[string]interface{}{"env": "production", "source": "trigger"},
+		},
+	}
+	trigger.SetEventBusAndEngine(eb, engine)
+
+	ctx := context.Background()
+	if err := trigger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := eb.Publish(ctx, "test.params", map[string]interface{}{
+		"id": "42",
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	calls := engine.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	data := calls[0].data
+	if data["env"] != "production" {
+		t.Errorf("expected env=production, got %v", data["env"])
+	}
+	if data["source"] != "trigger" {
+		t.Errorf("expected source=trigger, got %v", data["source"])
+	}
+	if data["id"] != "42" {
+		t.Errorf("expected id=42, got %v", data["id"])
+	}
+
+	_ = trigger.Stop(ctx)
+}
+
+func TestEventBusTrigger_AsyncSubscription(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+
+	trigger := NewEventBusTrigger()
+	trigger.subscriptions = []EventBusTriggerSubscription{
+		{
+			Topic:    "async.topic",
+			Workflow: "async-wf",
+			Action:   "go",
+			Async:    true,
+		},
+	}
+	trigger.SetEventBusAndEngine(eb, engine)
+
+	ctx := context.Background()
+	if err := trigger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := eb.Publish(ctx, "async.topic", map[string]interface{}{
+		"msg": "hello",
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Async processing may take a moment.
+	time.Sleep(200 * time.Millisecond)
+
+	calls := engine.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 async trigger call, got %d", len(calls))
+	}
+	if calls[0].data["msg"] != "hello" {
+		t.Errorf("unexpected data: %v", calls[0].data)
+	}
+
+	_ = trigger.Stop(ctx)
+}
+
+func TestEventBusTrigger_StopCancelsSubscriptions(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	engine := &mockEBWorkflowEngine{}
+
+	trigger := NewEventBusTrigger()
+	trigger.subscriptions = []EventBusTriggerSubscription{
+		{Topic: "stop.test", Workflow: "wf", Action: "act"},
+	}
+	trigger.SetEventBusAndEngine(eb, engine)
+
+	ctx := context.Background()
+	if err := trigger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if len(trigger.activeSubs) != 1 {
+		t.Fatalf("expected 1 active sub, got %d", len(trigger.activeSubs))
+	}
+
+	if err := trigger.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if len(trigger.activeSubs) != 0 {
+		t.Errorf("expected 0 active subs after Stop, got %d", len(trigger.activeSubs))
+	}
+
+	// Publishing after stop should not trigger workflow (subscription was cancelled).
+	if err := eb.Publish(ctx, "stop.test", map[string]interface{}{"x": 1}); err != nil {
+		t.Fatalf("Publish after stop: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if len(engine.calls()) != 0 {
+		t.Errorf("expected 0 calls after Stop, got %d", len(engine.calls()))
+	}
+}
+
+func TestEventBusTrigger_Init(t *testing.T) {
+	app := NewMockApplication()
+	trigger := NewEventBusTrigger()
+
+	if err := trigger.Init(app); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if _, exists := app.Services[EventBusTriggerName]; !exists {
+		t.Error("trigger not registered in service registry")
+	}
+}
+
+func TestEventBusTrigger_StartWithoutEventBus(t *testing.T) {
+	trigger := NewEventBusTrigger()
+	trigger.engine = &mockEBWorkflowEngine{}
+	err := trigger.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when starting without eventbus")
+	}
+}
+
+func TestEventBusTrigger_StartWithoutEngine(t *testing.T) {
+	_, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	trigger := NewEventBusTrigger()
+	trigger.eventBus = eb
+	err := trigger.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when starting without engine")
+	}
+}

--- a/module/workflow_events.go
+++ b/module/workflow_events.go
@@ -1,0 +1,180 @@
+package module
+
+import (
+	"context"
+	"time"
+
+	"github.com/CrisisTextLine/modular"
+	"github.com/CrisisTextLine/modular/modules/eventbus"
+)
+
+// Lifecycle constants for workflow and step events.
+const (
+	LifecycleStarted   = "started"
+	LifecycleCompleted = "completed"
+	LifecycleFailed    = "failed"
+)
+
+// WorkflowTopic returns the event bus topic for a workflow lifecycle event.
+// Format: "workflow.<workflowType>.<lifecycle>"
+func WorkflowTopic(workflowType, lifecycle string) string {
+	return "workflow." + workflowType + "." + lifecycle
+}
+
+// StepTopic returns the event bus topic for a step lifecycle event.
+// Format: "workflow.<workflowType>.step.<stepName>.<lifecycle>"
+func StepTopic(workflowType, stepName, lifecycle string) string {
+	return "workflow." + workflowType + ".step." + stepName + "." + lifecycle
+}
+
+// WorkflowLifecycleEvent is the payload published for workflow-level lifecycle events.
+type WorkflowLifecycleEvent struct {
+	WorkflowType string                 `json:"workflowType"`
+	Action       string                 `json:"action"`
+	Status       string                 `json:"status"`
+	Timestamp    time.Time              `json:"timestamp"`
+	Duration     time.Duration          `json:"duration,omitempty"`
+	Data         map[string]interface{} `json:"data,omitempty"`
+	Error        string                 `json:"error,omitempty"`
+	Results      map[string]interface{} `json:"results,omitempty"`
+}
+
+// StepLifecycleEvent is the payload published for step-level lifecycle events.
+type StepLifecycleEvent struct {
+	WorkflowType string                 `json:"workflowType"`
+	StepName     string                 `json:"stepName"`
+	Connector    string                 `json:"connector"`
+	Action       string                 `json:"action"`
+	Status       string                 `json:"status"`
+	Timestamp    time.Time              `json:"timestamp"`
+	Duration     time.Duration          `json:"duration,omitempty"`
+	Data         map[string]interface{} `json:"data,omitempty"`
+	Error        string                 `json:"error,omitempty"`
+	Results      map[string]interface{} `json:"results,omitempty"`
+}
+
+// WorkflowEventEmitter publishes workflow and step lifecycle events to the EventBus.
+// All methods are safe to call when the EventBus is unavailable (nil); they
+// silently become no-ops.
+type WorkflowEventEmitter struct {
+	eventBus *eventbus.EventBusModule
+}
+
+// NewWorkflowEventEmitter creates a new emitter. It attempts to resolve the
+// "eventbus.provider" service from the application. If the service is
+// unavailable the emitter still works but all Emit* calls are no-ops.
+func NewWorkflowEventEmitter(app modular.Application) *WorkflowEventEmitter {
+	emitter := &WorkflowEventEmitter{}
+	var eb *eventbus.EventBusModule
+	if err := app.GetService("eventbus.provider", &eb); err == nil && eb != nil {
+		emitter.eventBus = eb
+	}
+	return emitter
+}
+
+// EmitWorkflowStarted publishes a "started" lifecycle event for a workflow.
+func (e *WorkflowEventEmitter) EmitWorkflowStarted(ctx context.Context, workflowType, action string, data map[string]interface{}) {
+	if e.eventBus == nil {
+		return
+	}
+	event := WorkflowLifecycleEvent{
+		WorkflowType: workflowType,
+		Action:       action,
+		Status:       LifecycleStarted,
+		Timestamp:    time.Now(),
+		Data:         data,
+	}
+	_ = e.eventBus.Publish(ctx, WorkflowTopic(workflowType, LifecycleStarted), event)
+}
+
+// EmitWorkflowCompleted publishes a "completed" lifecycle event for a workflow.
+func (e *WorkflowEventEmitter) EmitWorkflowCompleted(ctx context.Context, workflowType, action string, duration time.Duration, results map[string]interface{}) {
+	if e.eventBus == nil {
+		return
+	}
+	event := WorkflowLifecycleEvent{
+		WorkflowType: workflowType,
+		Action:       action,
+		Status:       LifecycleCompleted,
+		Timestamp:    time.Now(),
+		Duration:     duration,
+		Results:      results,
+	}
+	_ = e.eventBus.Publish(ctx, WorkflowTopic(workflowType, LifecycleCompleted), event)
+}
+
+// EmitWorkflowFailed publishes a "failed" lifecycle event for a workflow.
+func (e *WorkflowEventEmitter) EmitWorkflowFailed(ctx context.Context, workflowType, action string, duration time.Duration, err error) {
+	if e.eventBus == nil {
+		return
+	}
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	event := WorkflowLifecycleEvent{
+		WorkflowType: workflowType,
+		Action:       action,
+		Status:       LifecycleFailed,
+		Timestamp:    time.Now(),
+		Duration:     duration,
+		Error:        errStr,
+	}
+	_ = e.eventBus.Publish(ctx, WorkflowTopic(workflowType, LifecycleFailed), event)
+}
+
+// EmitStepStarted publishes a "started" lifecycle event for a workflow step.
+func (e *WorkflowEventEmitter) EmitStepStarted(ctx context.Context, workflowType, stepName, connector, action string) {
+	if e.eventBus == nil {
+		return
+	}
+	event := StepLifecycleEvent{
+		WorkflowType: workflowType,
+		StepName:     stepName,
+		Connector:    connector,
+		Action:       action,
+		Status:       LifecycleStarted,
+		Timestamp:    time.Now(),
+	}
+	_ = e.eventBus.Publish(ctx, StepTopic(workflowType, stepName, LifecycleStarted), event)
+}
+
+// EmitStepCompleted publishes a "completed" lifecycle event for a workflow step.
+func (e *WorkflowEventEmitter) EmitStepCompleted(ctx context.Context, workflowType, stepName, connector, action string, duration time.Duration, results map[string]interface{}) {
+	if e.eventBus == nil {
+		return
+	}
+	event := StepLifecycleEvent{
+		WorkflowType: workflowType,
+		StepName:     stepName,
+		Connector:    connector,
+		Action:       action,
+		Status:       LifecycleCompleted,
+		Timestamp:    time.Now(),
+		Duration:     duration,
+		Results:      results,
+	}
+	_ = e.eventBus.Publish(ctx, StepTopic(workflowType, stepName, LifecycleCompleted), event)
+}
+
+// EmitStepFailed publishes a "failed" lifecycle event for a workflow step.
+func (e *WorkflowEventEmitter) EmitStepFailed(ctx context.Context, workflowType, stepName, connector, action string, duration time.Duration, err error) {
+	if e.eventBus == nil {
+		return
+	}
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	event := StepLifecycleEvent{
+		WorkflowType: workflowType,
+		StepName:     stepName,
+		Connector:    connector,
+		Action:       action,
+		Status:       LifecycleFailed,
+		Timestamp:    time.Now(),
+		Duration:     duration,
+		Error:        errStr,
+	}
+	_ = e.eventBus.Publish(ctx, StepTopic(workflowType, stepName, LifecycleFailed), event)
+}

--- a/module/workflow_events_test.go
+++ b/module/workflow_events_test.go
@@ -1,0 +1,320 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/CrisisTextLine/modular"
+	"github.com/CrisisTextLine/modular/modules/eventbus"
+)
+
+// --- helpers -----------------------------------------------------------------
+
+// setupEventBus creates a real EventBusModule backed by the in-memory engine,
+// starts it, and registers it with a MockApplication. The caller should defer
+// the returned cleanup function.
+func setupEventBus(t *testing.T) (*MockApplication, *eventbus.EventBusModule, func()) {
+	t.Helper()
+
+	app := NewMockApplication()
+
+	// Build a real EventBusModule with in-memory engine.
+	ebMod := eventbus.NewModule()
+	ebModule := ebMod.(*eventbus.EventBusModule)
+
+	// Register default config section expected by EventBusModule.Init.
+	defaultCfg := &eventbus.EventBusConfig{
+		Engine:                 "memory",
+		MaxEventQueueSize:      1000,
+		DefaultEventBufferSize: 10,
+		WorkerCount:            5,
+		EventTTL:               3600 * time.Second,
+		RetentionDays:          7,
+	}
+
+	// Create a real lightweight app for the eventbus module lifecycle.
+	logger := &MockLogger{}
+	realApp := modular.NewStdApplication(modular.NewStdConfigProvider(nil), logger)
+	realApp.RegisterConfigSection("eventbus", modular.NewStdConfigProvider(defaultCfg))
+
+	if err := ebModule.Init(realApp); err != nil {
+		t.Fatalf("eventbus Init: %v", err)
+	}
+	ctx := context.Background()
+	if err := ebModule.Start(ctx); err != nil {
+		t.Fatalf("eventbus Start: %v", err)
+	}
+
+	// Register the running module as a service in our mock app.
+	if err := app.RegisterService("eventbus.provider", ebModule); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+
+	cleanup := func() {
+		_ = ebModule.Stop(ctx)
+	}
+
+	return app, ebModule, cleanup
+}
+
+// collected is a thread-safe collector for events received via subscriptions.
+type collected struct {
+	mu     sync.Mutex
+	events []eventbus.Event
+}
+
+func (c *collected) handler(_ context.Context, ev eventbus.Event) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, ev)
+	return nil
+}
+
+func (c *collected) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.events)
+}
+
+func (c *collected) get(i int) eventbus.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.events[i]
+}
+
+// --- WS2 tests ---------------------------------------------------------------
+
+func TestWorkflowTopic(t *testing.T) {
+	tests := []struct {
+		wfType, lifecycle, want string
+	}{
+		{"order", "started", "workflow.order.started"},
+		{"user-onboard", "completed", "workflow.user-onboard.completed"},
+		{"report", "failed", "workflow.report.failed"},
+	}
+	for _, tc := range tests {
+		got := WorkflowTopic(tc.wfType, tc.lifecycle)
+		if got != tc.want {
+			t.Errorf("WorkflowTopic(%q, %q) = %q; want %q", tc.wfType, tc.lifecycle, got, tc.want)
+		}
+	}
+}
+
+func TestStepTopic(t *testing.T) {
+	tests := []struct {
+		wfType, step, lifecycle, want string
+	}{
+		{"order", "validate", "started", "workflow.order.step.validate.started"},
+		{"user-onboard", "send-email", "completed", "workflow.user-onboard.step.send-email.completed"},
+		{"report", "generate-pdf", "failed", "workflow.report.step.generate-pdf.failed"},
+	}
+	for _, tc := range tests {
+		got := StepTopic(tc.wfType, tc.step, tc.lifecycle)
+		if got != tc.want {
+			t.Errorf("StepTopic(%q, %q, %q) = %q; want %q", tc.wfType, tc.step, tc.lifecycle, got, tc.want)
+		}
+	}
+}
+
+func TestWorkflowLifecycleEvent_JSON(t *testing.T) {
+	ev := WorkflowLifecycleEvent{
+		WorkflowType: "order",
+		Action:       "create",
+		Status:       LifecycleStarted,
+		Timestamp:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Data:         map[string]interface{}{"key": "value"},
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded WorkflowLifecycleEvent
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.WorkflowType != ev.WorkflowType {
+		t.Errorf("WorkflowType mismatch: %q vs %q", decoded.WorkflowType, ev.WorkflowType)
+	}
+	if decoded.Status != ev.Status {
+		t.Errorf("Status mismatch: %q vs %q", decoded.Status, ev.Status)
+	}
+}
+
+func TestStepLifecycleEvent_JSON(t *testing.T) {
+	ev := StepLifecycleEvent{
+		WorkflowType: "order",
+		StepName:     "validate",
+		Connector:    "http",
+		Action:       "post",
+		Status:       LifecycleCompleted,
+		Timestamp:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Duration:     500 * time.Millisecond,
+		Results:      map[string]interface{}{"ok": true},
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded StepLifecycleEvent
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.StepName != ev.StepName {
+		t.Errorf("StepName mismatch: %q vs %q", decoded.StepName, ev.StepName)
+	}
+	if decoded.Duration != ev.Duration {
+		t.Errorf("Duration mismatch: %v vs %v", decoded.Duration, ev.Duration)
+	}
+}
+
+func TestEmitter_NilEventBus_NoPanic(t *testing.T) {
+	// An emitter without an EventBus should silently no-op.
+	app := NewMockApplication() // no eventbus.provider registered
+	emitter := NewWorkflowEventEmitter(app)
+
+	ctx := context.Background()
+	// None of these should panic.
+	emitter.EmitWorkflowStarted(ctx, "wf", "act", nil)
+	emitter.EmitWorkflowCompleted(ctx, "wf", "act", time.Second, nil)
+	emitter.EmitWorkflowFailed(ctx, "wf", "act", time.Second, errors.New("boom"))
+	emitter.EmitStepStarted(ctx, "wf", "step", "conn", "act")
+	emitter.EmitStepCompleted(ctx, "wf", "step", "conn", "act", time.Second, nil)
+	emitter.EmitStepFailed(ctx, "wf", "step", "conn", "act", time.Second, errors.New("oops"))
+}
+
+func TestEmitter_WorkflowStarted(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	col := &collected{}
+	ctx := context.Background()
+	sub, err := eb.Subscribe(ctx, WorkflowTopic("order", LifecycleStarted), col.handler)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	emitter := NewWorkflowEventEmitter(app)
+	emitter.EmitWorkflowStarted(ctx, "order", "create", map[string]interface{}{"item": "widget"})
+
+	// Give synchronous delivery a moment.
+	time.Sleep(50 * time.Millisecond)
+
+	if col.len() != 1 {
+		t.Fatalf("expected 1 event, got %d", col.len())
+	}
+}
+
+func TestEmitter_WorkflowCompleted(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	col := &collected{}
+	ctx := context.Background()
+	sub, err := eb.Subscribe(ctx, WorkflowTopic("order", LifecycleCompleted), col.handler)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	emitter := NewWorkflowEventEmitter(app)
+	emitter.EmitWorkflowCompleted(ctx, "order", "create", 2*time.Second, map[string]interface{}{"count": 5})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if col.len() != 1 {
+		t.Fatalf("expected 1 event, got %d", col.len())
+	}
+}
+
+func TestEmitter_WorkflowFailed(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	col := &collected{}
+	ctx := context.Background()
+	sub, err := eb.Subscribe(ctx, WorkflowTopic("order", LifecycleFailed), col.handler)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	emitter := NewWorkflowEventEmitter(app)
+	emitter.EmitWorkflowFailed(ctx, "order", "create", time.Second, errors.New("timeout"))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if col.len() != 1 {
+		t.Fatalf("expected 1 event, got %d", col.len())
+	}
+}
+
+func TestEmitter_StepStarted(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	col := &collected{}
+	ctx := context.Background()
+	sub, err := eb.Subscribe(ctx, StepTopic("order", "validate", LifecycleStarted), col.handler)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	emitter := NewWorkflowEventEmitter(app)
+	emitter.EmitStepStarted(ctx, "order", "validate", "http", "post")
+
+	time.Sleep(50 * time.Millisecond)
+
+	if col.len() != 1 {
+		t.Fatalf("expected 1 event, got %d", col.len())
+	}
+}
+
+func TestEmitter_StepCompleted(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	col := &collected{}
+	ctx := context.Background()
+	sub, err := eb.Subscribe(ctx, StepTopic("order", "validate", LifecycleCompleted), col.handler)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	emitter := NewWorkflowEventEmitter(app)
+	emitter.EmitStepCompleted(ctx, "order", "validate", "http", "post", 100*time.Millisecond, map[string]interface{}{"valid": true})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if col.len() != 1 {
+		t.Fatalf("expected 1 event, got %d", col.len())
+	}
+}
+
+func TestEmitter_StepFailed(t *testing.T) {
+	app, eb, cleanup := setupEventBus(t)
+	defer cleanup()
+
+	col := &collected{}
+	ctx := context.Background()
+	sub, err := eb.Subscribe(ctx, StepTopic("order", "validate", LifecycleFailed), col.handler)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+
+	emitter := NewWorkflowEventEmitter(app)
+	emitter.EmitStepFailed(ctx, "order", "validate", "http", "post", 100*time.Millisecond, errors.New("bad request"))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if col.len() != 1 {
+		t.Fatalf("expected 1 event, got %d", col.len())
+	}
+}

--- a/ui/src/types/workflow.test.ts
+++ b/ui/src/types/workflow.test.ts
@@ -10,7 +10,7 @@ import type { ModuleCategory } from './workflow.ts';
 describe('workflow types', () => {
   describe('MODULE_TYPES', () => {
     it('has the expected number of module types', () => {
-      expect(MODULE_TYPES.length).toBe(29);
+      expect(MODULE_TYPES.length).toBe(30);
     });
 
     it('each module type has required fields', () => {

--- a/ui/src/types/workflow.ts
+++ b/ui/src/types/workflow.ts
@@ -165,6 +165,13 @@ export const MODULE_TYPES: ModuleTypeInfo[] = [
       { key: 'queue', label: 'Queue Group', type: 'string' },
     ],
   },
+  {
+    type: 'messaging.broker.eventbus',
+    label: 'EventBus Bridge',
+    category: 'messaging',
+    defaultConfig: {},
+    configFields: [],
+  },
   // State Machine
   {
     type: 'statemachine.engine',


### PR DESCRIPTION
## Summary

- **EventBusBridge adapter** (`module/eventbus_bridge.go`): Translates between the existing `MessageBroker` interface and the modular `EventBusModule`, enabling transparent pub/sub through EventBus for all existing messaging code
- **WorkflowEventEmitter** (`module/workflow_events.go`): Publishes structured lifecycle events (`started`/`completed`/`failed`) for both workflows and individual steps, with topic convention `workflow.<type>.<lifecycle>`
- **EventBusTrigger** (`module/eventbus_trigger.go`): New native trigger that subscribes directly to EventBus topics, enabling cross-workflow orchestration from YAML config (e.g., workflow A completion triggers workflow B)
- **Engine & handler wiring**: `TriggerWorkflow` emits workflow lifecycle events; `ExecuteIntegrationWorkflow` emits step-level events; `EventTrigger` falls back to EventBusBridge when no MessageBroker is registered
- **UI**: Added `messaging.broker.eventbus` module type to the builder palette

## Test plan

- [x] `go build ./...` — clean compilation
- [x] `go test ./...` — all existing tests pass
- [x] 12 new EventBusBridge tests (publish, subscribe, unsubscribe, JSON round-trip, nil no-op, concurrency)
- [x] 11 new WorkflowEventEmitter tests (topic helpers, payload serialization, emit-and-subscribe, nil no-op)
- [x] 10 new EventBusTrigger tests (configure, start, event filtering, async, param merge, stop/cancel)
- [x] `npx vitest run` — 100/100 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)