### PR TITLE
Fix 3 UI bugs found during exploratory testing

### DIFF
--- a/ui/src/store/workflowStore.ts
+++ b/ui/src/store/workflowStore.ts
@@ -182,6 +182,7 @@ const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   updateNodeConfig: (id, config) => {
+    get().pushHistory();
     set({
       nodes: get().nodes.map((n) =>
         n.id === id ? { ...n, data: { ...n.data, config: { ...n.data.config, ...config } } } : n
@@ -190,6 +191,7 @@ const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   updateNodeName: (id, name) => {
+    get().pushHistory();
     set({
       nodes: get().nodes.map((n) =>
         n.id === id ? { ...n, data: { ...n.data, label: name } } : n
@@ -216,14 +218,15 @@ const useWorkflowStore = create<WorkflowStore>((set, get) => ({
 
 function nodeComponentType(moduleType: string): string {
   if (moduleType.startsWith('http.middleware.')) return 'middlewareNode';
-  if (moduleType.startsWith('http.')) return 'httpNode';
-  if (moduleType === 'api.handler') return 'httpNode';
+  if (moduleType === 'http.server') return 'httpNode';
+  if (moduleType.startsWith('http.')) return 'httpRouterNode';
+  if (moduleType === 'api.handler') return 'httpRouterNode';
   if (moduleType.startsWith('messaging.')) return 'messagingNode';
   if (moduleType.startsWith('statemachine.') || moduleType.startsWith('state.')) return 'stateMachineNode';
   if (moduleType === 'scheduler.modular') return 'schedulerNode';
   if (moduleType === 'eventlogger.modular' || moduleType === 'eventbus.modular') return 'eventNode';
   if (moduleType === 'httpclient.modular') return 'integrationNode';
-  if (moduleType === 'chimux.router') return 'httpNode';
+  if (moduleType === 'chimux.router') return 'httpRouterNode';
   return 'infrastructureNode';
 }
 

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -108,7 +108,7 @@ export async function listDynamicComponents(): Promise<DynamicComponent[]> {
 export async function createDynamicComponent(name: string, source: string, language: string): Promise<void> {
   await apiFetch<void>('/dynamic/components', {
     method: 'POST',
-    body: JSON.stringify({ name, source, language }),
+    body: JSON.stringify({ id: name, source, language }),
   });
 }
 

--- a/ui/src/utils/serialization.ts
+++ b/ui/src/utils/serialization.ts
@@ -94,14 +94,15 @@ export function configToNodes(config: WorkflowConfig): {
 
 function nodeComponentType(moduleType: string): string {
   if (moduleType.startsWith('http.middleware.')) return 'middlewareNode';
-  if (moduleType.startsWith('http.')) return 'httpNode';
-  if (moduleType === 'api.handler') return 'httpNode';
+  if (moduleType === 'http.server') return 'httpNode';
+  if (moduleType.startsWith('http.')) return 'httpRouterNode';
+  if (moduleType === 'api.handler') return 'httpRouterNode';
   if (moduleType.startsWith('messaging.')) return 'messagingNode';
   if (moduleType.startsWith('statemachine.') || moduleType.startsWith('state.')) return 'stateMachineNode';
   if (moduleType === 'scheduler.modular') return 'schedulerNode';
   if (moduleType === 'eventlogger.modular' || moduleType === 'eventbus.modular') return 'eventNode';
   if (moduleType === 'httpclient.modular') return 'integrationNode';
-  if (moduleType === 'chimux.router') return 'httpNode';
+  if (moduleType === 'chimux.router') return 'httpRouterNode';
   return 'infrastructureNode';
 }
 


### PR DESCRIPTION
## Summary
- **Fix node handle mapping**: `http.router`, `http.handler`, `http.proxy`, `api.handler`, and `chimux.router` were all mapped to `HTTPServerNode` (which has `hasInput={false}`), making them unable to receive incoming connections. Now only `http.server` maps to `httpNode`; all other HTTP types map to `httpRouterNode` with both input and output handles.
- **Fix dynamic component API field mismatch**: `createDynamicComponent` in `api.ts` sent `{ name, source, language }` but the Go server at `dynamic/api.go` expects `{ id, source }`. Changed to `{ id: name, source, language }`.
- **Fix missing undo history for property edits**: `updateNodeConfig()` and `updateNodeName()` now call `pushHistory()` before mutating state, so property changes via the PropertyPanel can be undone with Ctrl+Z.

## Test plan
- [x] All 100 unit tests pass (6 test files)
- [x] Browser-verified: HTTP Router node has both target and source handles
- [x] Browser-verified: Edge connection from HTTP Server → HTTP Router succeeds
- [x] Browser-verified: Rename node → Ctrl+Z → name reverts
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)