### PR TITLE
Potential fix for code scanning alert no. 17: Database query built from user-controlled sources

### DIFF
--- a/plugin/storebrowser/handler.go
+++ b/plugin/storebrowser/handler.go
@@ -145,9 +145,10 @@ func (h *handler) tableRows(w http.ResponseWriter, r *http.Request) {
 
 	// Validate sort column if provided.
 	sortCol := r.URL.Query().Get("sort")
-	order := strings.ToUpper(r.URL.Query().Get("order"))
-	if order != "DESC" {
-		order = "ASC"
+	orderParam := strings.ToUpper(r.URL.Query().Get("order"))
+	order := "ASC"
+	if orderParam == "DESC" {
+		order = "DESC"
 	}
 
 	orderClause := ""


### PR DESCRIPTION
Potential fix for [https://github.com/GoCodeAlone/workflow/security/code-scanning/17](https://github.com/GoCodeAlone/workflow/security/code-scanning/17)

In general, to fix “query built from user-controlled sources” issues, we should (a) use parameter placeholders for values, and (b) ensure that any part of the query that cannot be parameterized (like table and column names, or `ASC`/`DESC`) is derived from a strict allowlist, not directly from tainted input. The current code already validates `tableName` and `sortCol` against the database schema and normalizes the `order` direction, but CodeQL still observes tainted flow from `r.URL` into the string. We should explicitly map the user-provided `order` to a fixed, untainted value and keep the rest of the logic unchanged.

The best minimal change, without altering functionality, is:

- Replace the direct normalization of `order`:
  ```go
  order := strings.ToUpper(r.URL.Query().Get("order"))
  if order != "DESC" {
      order = "ASC"
  }
  ```
  with a pattern that maps the tainted string to one of two hard-coded constants using a local variable, e.g.:
  ```go
  orderParam := strings.ToUpper(r.URL.Query().Get("order"))
  order := "ASC"
  if orderParam == "DESC" {
      order = "DESC"
  }
  ```
  This maintains exactly the same behavior but makes the safe values (`"ASC"` / `"DESC"`) explicit and independent of arbitrary user content. Static analysis tools typically recognize that `order` is drawn from a fixed finite set and is not directly tainted.

- Keep the `sortCol` validation and `tableName` validation as-is, because they already enforce allowlists based on the database schema.

All changes occur in `plugin/storebrowser/handler.go` around lines 147–151, within the provided snippet. No new methods or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
