### PR TITLE
fix: scan step stubs return ErrNotImplemented

### DIFF
--- a/module/errors.go
+++ b/module/errors.go
@@ -1,0 +1,9 @@
+package module
+
+import "errors"
+
+// ErrNotImplemented is returned by pipeline steps that are defined but not yet
+// backed by a real execution engine (e.g. steps that require sandbox.DockerSandbox).
+// Callers should treat this as a hard failure; relying on a stub step would give
+// false confidence in CI/CD pipelines.
+var ErrNotImplemented = errors.New("step not implemented: requires sandbox.DockerSandbox (not yet available)")

--- a/module/pipeline_step_scan_deps.go
+++ b/module/pipeline_step_scan_deps.go
@@ -3,13 +3,16 @@ package module
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/CrisisTextLine/modular"
 )
 
 // ScanDepsStep runs a dependency vulnerability scanner (e.g., Grype)
 // against a source path and evaluates findings against a severity gate.
+//
+// NOTE: This step is not yet implemented. Docker-based execution requires
+// sandbox.DockerSandbox, which is not yet available. Calls to Execute will
+// always return ErrNotImplemented.
 type ScanDepsStep struct {
 	name           string
 	scanner        string
@@ -66,46 +69,10 @@ func NewScanDepsStepFactory() StepFactory {
 func (s *ScanDepsStep) Name() string { return s.name }
 
 // Execute runs the dependency scanner and returns findings as a ScanResult.
+//
+// NOTE: This step is not yet implemented. Execution via sandbox.DockerSandbox
+// is required but the sandbox package is not yet available. This method always
+// returns ErrNotImplemented to prevent silent no-ops in CI/CD pipelines.
 func (s *ScanDepsStep) Execute(_ context.Context, _ *PipelineContext) (*StepResult, error) {
-	cmd := s.buildCommand()
-
-	// TODO: Execute via sandbox.DockerSandbox once the sandbox package is available.
-	_ = cmd
-
-	scanResult := NewScanResult(s.scanner)
-	scanResult.ComputeSummary()
-	scanResult.EvaluateGate(s.failOnSeverity)
-
-	return &StepResult{
-		Output: map[string]any{
-			"scan_result": scanResult,
-			"command":     strings.Join(cmd, " "),
-			"image":       s.image,
-		},
-	}, nil
-}
-
-// buildCommand constructs the Grype command arguments for dependency scanning.
-func (s *ScanDepsStep) buildCommand() []string {
-	switch s.scanner {
-	case "grype":
-		args := []string{"grype"}
-
-		// Set fail-on severity
-		args = append(args, "--fail-on", strings.ToLower(s.failOnSeverity))
-
-		switch s.outputFormat {
-		case "sarif":
-			args = append(args, "-o", "sarif")
-		case "json":
-			args = append(args, "-o", "json")
-		default:
-			args = append(args, "-o", "json")
-		}
-
-		args = append(args, "dir:"+s.sourcePath)
-		return args
-	default:
-		return []string{s.scanner, s.sourcePath}
-	}
+	return nil, fmt.Errorf("scan_deps step %q: %w", s.name, ErrNotImplemented)
 }

--- a/module/pipeline_step_scan_sast.go
+++ b/module/pipeline_step_scan_sast.go
@@ -3,13 +3,16 @@ package module
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/CrisisTextLine/modular"
 )
 
 // ScanSASTStep runs a SAST (Static Application Security Testing) scanner
 // inside a Docker container and evaluates findings against a severity gate.
+//
+// NOTE: This step is not yet implemented. Docker-based execution requires
+// sandbox.DockerSandbox, which is not yet available. Calls to Execute will
+// always return ErrNotImplemented.
 type ScanSASTStep struct {
 	name           string
 	scanner        string
@@ -73,42 +76,10 @@ func NewScanSASTStepFactory() StepFactory {
 func (s *ScanSASTStep) Name() string { return s.name }
 
 // Execute runs the SAST scanner and returns findings as a ScanResult.
+//
+// NOTE: This step is not yet implemented. Execution via sandbox.DockerSandbox
+// is required but the sandbox package is not yet available. This method always
+// returns ErrNotImplemented to prevent silent no-ops in CI/CD pipelines.
 func (s *ScanSASTStep) Execute(_ context.Context, _ *PipelineContext) (*StepResult, error) {
-	// Build the scanner command based on the configured scanner type
-	cmd := s.buildCommand()
-
-	// TODO: Execute via sandbox.DockerSandbox once the sandbox package is available.
-	// For now, construct the command and produce a placeholder result.
-	_ = cmd
-
-	scanResult := NewScanResult(s.scanner)
-	scanResult.ComputeSummary()
-	scanResult.EvaluateGate(s.failOnSeverity)
-
-	return &StepResult{
-		Output: map[string]any{
-			"scan_result": scanResult,
-			"command":     strings.Join(cmd, " "),
-			"image":       s.image,
-		},
-	}, nil
-}
-
-// buildCommand constructs the Docker command arguments for the configured scanner.
-func (s *ScanSASTStep) buildCommand() []string {
-	switch s.scanner {
-	case "semgrep":
-		args := []string{"semgrep", "scan"}
-		for _, rule := range s.rules {
-			args = append(args, "--config", rule)
-		}
-		if s.outputFormat == "sarif" {
-			args = append(args, "--sarif")
-		}
-		args = append(args, s.sourcePath)
-		return args
-	default:
-		// Generic fallback: run the scanner name as a command against the source path
-		return []string{s.scanner, s.sourcePath}
-	}
+	return nil, fmt.Errorf("scan_sast step %q: %w", s.name, ErrNotImplemented)
 }

--- a/module/pipeline_step_scan_test.go
+++ b/module/pipeline_step_scan_test.go
@@ -1,0 +1,55 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestScanSASTStep_ExecuteReturnsErrNotImplemented(t *testing.T) {
+	factory := NewScanSASTStepFactory()
+	step, err := factory("sast-step", map[string]any{"scanner": "semgrep"}, nil)
+	if err != nil {
+		t.Fatalf("factory returned error: %v", err)
+	}
+
+	_, execErr := step.Execute(context.Background(), &PipelineContext{})
+	if execErr == nil {
+		t.Fatal("expected Execute to return an error, got nil")
+	}
+	if !errors.Is(execErr, ErrNotImplemented) {
+		t.Errorf("expected errors.Is(err, ErrNotImplemented), got: %v", execErr)
+	}
+}
+
+func TestScanContainerStep_ExecuteReturnsErrNotImplemented(t *testing.T) {
+	factory := NewScanContainerStepFactory()
+	step, err := factory("container-step", map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("factory returned error: %v", err)
+	}
+
+	_, execErr := step.Execute(context.Background(), &PipelineContext{})
+	if execErr == nil {
+		t.Fatal("expected Execute to return an error, got nil")
+	}
+	if !errors.Is(execErr, ErrNotImplemented) {
+		t.Errorf("expected errors.Is(err, ErrNotImplemented), got: %v", execErr)
+	}
+}
+
+func TestScanDepsStep_ExecuteReturnsErrNotImplemented(t *testing.T) {
+	factory := NewScanDepsStepFactory()
+	step, err := factory("deps-step", map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("factory returned error: %v", err)
+	}
+
+	_, execErr := step.Execute(context.Background(), &PipelineContext{})
+	if execErr == nil {
+		t.Fatal("expected Execute to return an error, got nil")
+	}
+	if !errors.Is(execErr, ErrNotImplemented) {
+		t.Errorf("expected errors.Is(err, ErrNotImplemented), got: %v", execErr)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #67

The three security scan pipeline steps (`scan_sast`, `scan_container`, `scan_deps`) previously executed silently without performing any actual scanning work, returning a successful result with an empty `ScanResult`. This gave false confidence in CI/CD pipelines — a pipeline using these steps would appear to pass security scans when no scanning occurred.

- Add `module/errors.go` with `ErrNotImplemented` sentinel error
- Update `Execute()` on all three scan steps to return `fmt.Errorf("<step_type> step %q: %w", name, ErrNotImplemented)` so callers can use `errors.Is()` to check the specific error
- Remove dead `buildCommand()` helpers and associated unused imports that were only called from `Execute()`
- Add documentation comments on each type and `Execute()` method explaining the limitation
- Add `module/pipeline_step_scan_test.go` with three tests verifying each step's `Execute` returns a wrapped `ErrNotImplemented`

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] `go test ./module/...` passes — new tests `TestScanSASTStep_ExecuteReturnsErrNotImplemented`, `TestScanContainerStep_ExecuteReturnsErrNotImplemented`, `TestScanDepsStep_ExecuteReturnsErrNotImplemented` all pass
- [x] Existing `plugins/cicd` tests continue to pass (step factories still register correctly)
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)