### PR TITLE
refactor(handlers): flatten 4-level nested conditional in integration retry logic

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,9 +1,9 @@
 package api
 
 import (
+	"fmt"
 	"math"
 	"net"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"

--- a/handlers/integration.go
+++ b/handlers/integration.go
@@ -339,6 +339,44 @@ func executeStepWithRetry(ctx context.Context, connector module.IntegrationConne
 	return result, err
 }
 
+// ensureConnectorConnected connects the connector if not already connected and verifies the connection.
+func ensureConnectorConnected(ctx context.Context, connector module.IntegrationConnector, stepName string) error {
+	if connector.IsConnected() {
+		return nil
+	}
+	if err := connector.Connect(ctx); err != nil {
+		return fmt.Errorf("error executing step '%s': connector not connected: %w", stepName, err)
+	}
+	if !connector.IsConnected() {
+		return fmt.Errorf("error executing step '%s': connector not connected after connection attempt", stepName)
+	}
+	return nil
+}
+
+// resolveParamValue resolves a single input value, substituting step result references where applicable.
+// References use the ${varName} syntax. If the variable is not found, the original value is returned.
+func resolveParamValue(v any, results map[string]any) any {
+	strVal, ok := v.(string)
+	if !ok || len(strVal) <= 3 || strVal[0:2] != "${" || strVal[len(strVal)-1] != '}' {
+		return v
+	}
+	// Extract the variable name, e.g., ${step1.value} -> step1.value
+	varName := strVal[2 : len(strVal)-1]
+	if result, found := results[varName]; found {
+		return result
+	}
+	return v
+}
+
+// resolveStepParams builds the params map for a step, substituting ${varName} references from results.
+func resolveStepParams(input map[string]any, results map[string]any) map[string]any {
+	params := make(map[string]any, len(input))
+	for k, v := range input {
+		params[k] = resolveParamValue(v, results)
+	}
+	return params
+}
+
 // ExecuteIntegrationWorkflow executes a sequence of integration steps
 func (h *IntegrationWorkflowHandler) ExecuteIntegrationWorkflow(
 	ctx context.Context,
@@ -347,10 +385,8 @@ func (h *IntegrationWorkflowHandler) ExecuteIntegrationWorkflow(
 	initialContext map[string]any,
 ) (map[string]any, error) {
 	results := make(map[string]any)
-	// Add initial context values to results
 	maps.Copy(results, initialContext)
 
-	// Execute steps sequentially
 	for i := range steps {
 		step := &steps[i]
 		stepStartTime := time.Now()
@@ -358,7 +394,6 @@ func (h *IntegrationWorkflowHandler) ExecuteIntegrationWorkflow(
 			h.eventEmitter.EmitStepStarted(ctx, "integration", step.Name, step.Connector, step.Action)
 		}
 
-		// Get the connector for this step
 		connector, err := registry.GetConnector(step.Connector)
 		if err != nil {
 			return results, fmt.Errorf("error getting connector '%s': %w", step.Connector, err)
@@ -367,68 +402,33 @@ func (h *IntegrationWorkflowHandler) ExecuteIntegrationWorkflow(
 			return results, fmt.Errorf("connector '%s' not found", step.Connector)
 		}
 
-		// Ensure the connector is connected
-		if !connector.IsConnected() {
-			if err = connector.Connect(ctx); err != nil {
-				return results, fmt.Errorf("error executing step '%s': connector not connected: %w", step.Name, err)
-			}
-
-			// Double check it's now connected
-			if !connector.IsConnected() {
-				return results, fmt.Errorf("error executing step '%s': connector not connected after connection attempt", step.Name)
-			}
+		if err := ensureConnectorConnected(ctx, connector, step.Name); err != nil {
+			return results, err
 		}
 
-		// Process input parameters - could handle variable substitution here
-		params := make(map[string]any)
-		for k, v := range step.Input {
-			// Simple variable substitution from previous steps
-			if strVal, ok := v.(string); ok && len(strVal) > 3 && strVal[0:2] == "${" && strVal[len(strVal)-1] == '}' {
-				// Extract the variable name, e.g., ${step1.value} -> step1.value
-				varName := strVal[2 : len(strVal)-1]
-
-				// Check if it's a reference to a previous step result
-				if result, ok := results[varName]; ok {
-					params[k] = result
-				} else {
-					// If not found, keep the original value
-					params[k] = v
-				}
-			} else {
-				// Use the value as is
-				params[k] = v
-			}
-		}
+		params := resolveStepParams(step.Input, results)
 
 		stepResult, err := executeStepWithRetry(ctx, connector, step, params)
 		if err != nil {
 			if step.OnError != "" {
-				// Could invoke error handler here
-				// For now, just continue and store the error in results
+				// Store the error in results and continue to the next step
 				results[step.Name+"_error"] = err.Error()
 				continue
 			}
-			// No error handler, return the error
 			if h.eventEmitter != nil {
 				h.eventEmitter.EmitStepFailed(ctx, "integration", step.Name, step.Connector, step.Action, time.Since(stepStartTime), err)
 			}
 			return results, fmt.Errorf("error executing step '%s': %w", step.Name, err)
 		}
 
-		// Store the result
 		results[step.Name] = stepResult
 
 		if h.eventEmitter != nil {
 			h.eventEmitter.EmitStepCompleted(ctx, "integration", step.Name, step.Connector, step.Action, time.Since(stepStartTime), stepResult)
 		}
 
-		// Handle success path if specified
-		if step.OnSuccess != "" {
-			// Could invoke success handler here
-			// For now, we just continue with the next step
-			// Note: Logging would require access to logger (stepIndex: %d, onSuccess: %s)
-			_ = step.OnSuccess // Mark as used to satisfy linter
-		}
+		// Handle success path if specified (reserved for future use)
+		_ = step.OnSuccess
 	}
 
 	return results, nil


### PR DESCRIPTION
## Summary

- Extracted `ensureConnectorConnected()` helper to replace 3-level nested connector connection check (`if !connected { if connect fails { ... } if still !connected { ... } }`)
- Extracted `resolveParamValue()` helper to replace 4-level nested variable substitution logic (`for input { if string { if template { if found { ... } } } }`)
- Extracted `resolveStepParams()` helper to iterate input and delegate to `resolveParamValue()`
- `ExecuteIntegrationWorkflow()` now has a maximum of 2 nesting levels in any code path
- Pure behavior-preserving refactor — no logic changes

Closes #74

## Test plan

- [x] `go test ./handlers/... -count=1` passes
- [x] `go test ./...` passes (full suite)
- [x] `golangci-lint run` reports 0 issues
- [x] Pre-push hooks pass (build + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)