### PR TITLE
ci: fix CodeQL Go analysis by replacing default setup with custom workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   security-events: write
 
 env:


### PR DESCRIPTION
## Summary
- Replaced GitHub's default CodeQL setup with a custom `.github/workflows/codeql.yml`
- Sets `GOPRIVATE` and `GONOSUMCHECK` for `github.com/GoCodeAlone/*` modules, matching `ci.yml`
- Disabled the default CodeQL setup via API (it doesn't support custom env vars)

## Problem
The default CodeQL setup runs `go mod tidy` during autobuild without `GOPRIVATE`/`GONOSUMCHECK`, causing a checksum mismatch when fetching `GoCodeAlone/yaegi` from the module proxy. This made the "Analyze (go)" check fail on every PR.

## Fix
Custom workflow provides the same env vars that `ci.yml` already uses. Covers all three languages: Go, JavaScript/TypeScript, and Actions.

## Test plan
- [x] Default CodeQL setup disabled via `gh api -X PATCH`
- [x] Custom workflow covers same languages (go, javascript-typescript, actions)
- [x] Verify "Analyze (go)" passes on this PR's CI run