### PR TITLE
refactor(admin): fix stale handler name references after Phase A consolidation

### DIFF
--- a/docs/PLATFORM_ROADMAP.md
+++ b/docs/PLATFORM_ROADMAP.md
@@ -267,7 +267,7 @@ Example from the admin API (a real production route):
 # From admin/config.yaml -- the engine serves its own API using pipelines
 - method: GET
   path: "/api/v1/admin/companies/{id}"
-  handler: admin-v1-queries
+  handler: admin-queries
   middlewares: [admin-cors, admin-auth-middleware]
   pipeline:
     steps:

--- a/module/api_v1_handler.go
+++ b/module/api_v1_handler.go
@@ -14,8 +14,8 @@ import (
 )
 
 // V1APIHandler handles the /api/v1/admin/ CRUD endpoints for companies, projects,
-// and workflows. It is wired as a fallback on the admin-v1-queries and
-// admin-v1-commands CQRS handler modules.
+// and workflows. It is wired as a fallback on the admin-queries and
+// admin-commands CQRS handler modules.
 type V1APIHandler struct {
 	store              *V1Store
 	jwtSecret          string


### PR DESCRIPTION
## Summary

- The `admin/config.yaml` Phase A consolidation (removing 16 domain-specific handler modules, renaming `admin-v1-queries`/`admin-v1-commands` to `admin-queries`/`admin-commands`) was completed in commit ab226f8
- Two stale references to the old handler names remained in non-config files

**Changes:**
- `module/api_v1_handler.go`: Update comment to reference `admin-queries` and `admin-commands` (was `admin-v1-queries` and `admin-v1-commands`)
- `docs/PLATFORM_ROADMAP.md`: Update inline YAML example to use `handler: admin-queries` (was `handler: admin-v1-queries`)

## Verification

- `go build -o /tmp/server ./cmd/server` — compiles cleanly
- `./server -config admin/config.yaml` — starts successfully, `admin-queries` and `admin-commands` modules register and initialize
- `go test ./...` — all tests pass
- `golangci-lint run` — 0 issues

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)