### PR TITLE
refactor(plugins/api): make module constructors injectable

### DIFF
--- a/plugins/api/plugin_test.go
+++ b/plugins/api/plugin_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"testing"
 
+	"github.com/CrisisTextLine/modular"
+	"github.com/GoCodeAlone/workflow/module"
 	"github.com/GoCodeAlone/workflow/plugin"
 )
 
@@ -228,5 +230,182 @@ func TestHelperFunctions(t *testing.T) {
 	}
 	if v := getIntConfig(cfg, "missing", 99); v != 99 {
 		t.Errorf("expected %d, got %d", 99, v)
+	}
+}
+
+// --- injectable constructor tests ---
+
+// stubModule is a minimal modular.Module used to verify that the injected
+// constructor is called instead of the default concrete constructor.
+type stubModule struct {
+	name string
+}
+
+func (s *stubModule) Name() string                                  { return s.name }
+func (s *stubModule) Dependencies() []string                        { return nil }
+func (s *stubModule) ProvidesServices() []modular.ServiceProvider   { return nil }
+func (s *stubModule) RequiresServices() []modular.ServiceDependency { return nil }
+func (s *stubModule) RegisterConfig(_ modular.Application) error    { return nil }
+func (s *stubModule) Init(_ modular.Application) error              { return nil }
+func (s *stubModule) Start(_ modular.Application) error             { return nil }
+func (s *stubModule) Stop(_ modular.Application) error              { return nil }
+
+func TestInjectableQueryHandlerCtor(t *testing.T) {
+	called := false
+	p := New().WithQueryHandlerCtor(func(name string) modular.Module {
+		called = true
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["api.query"]("test-q", map[string]any{})
+	if !called {
+		t.Fatal("injected QueryHandlerCtor was not called")
+	}
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+}
+
+func TestInjectableCommandHandlerCtor(t *testing.T) {
+	called := false
+	p := New().WithCommandHandlerCtor(func(name string) modular.Module {
+		called = true
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["api.command"]("test-cmd", map[string]any{})
+	if !called {
+		t.Fatal("injected CommandHandlerCtor was not called")
+	}
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+}
+
+func TestInjectableRESTAPIHandlerCtor(t *testing.T) {
+	var gotName, gotResource string
+	p := New().WithRESTAPIHandlerCtor(func(name, resourceName string) modular.Module {
+		gotName = name
+		gotResource = resourceName
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["api.handler"]("test-h", map[string]any{"resourceName": "orders"})
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+	if gotName != "test-h" {
+		t.Errorf("expected name %q, got %q", "test-h", gotName)
+	}
+	if gotResource != "orders" {
+		t.Errorf("expected resourceName %q, got %q", "orders", gotResource)
+	}
+}
+
+func TestInjectableAPIGatewayCtor(t *testing.T) {
+	called := false
+	p := New().WithAPIGatewayCtor(func(name string) modular.Module {
+		called = true
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["api.gateway"]("test-gw", map[string]any{})
+	if !called {
+		t.Fatal("injected APIGatewayCtor was not called")
+	}
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+}
+
+func TestInjectableWorkflowRegistryCtor(t *testing.T) {
+	var gotBackend string
+	p := New().WithWorkflowRegistryCtor(func(name, storageBackend string) modular.Module {
+		gotBackend = storageBackend
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["workflow.registry"]("test-reg", map[string]any{"storageBackend": "my-db"})
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+	if gotBackend != "my-db" {
+		t.Errorf("expected storageBackend %q, got %q", "my-db", gotBackend)
+	}
+}
+
+func TestInjectableDataTransformerCtor(t *testing.T) {
+	called := false
+	p := New().WithDataTransformerCtor(func(name string) modular.Module {
+		called = true
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["data.transformer"]("test-dt", map[string]any{})
+	if !called {
+		t.Fatal("injected DataTransformerCtor was not called")
+	}
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+}
+
+func TestInjectableProcessingStepCtor(t *testing.T) {
+	var gotConfig module.ProcessingStepConfig
+	p := New().WithProcessingStepCtor(func(name string, cfg module.ProcessingStepConfig) modular.Module {
+		gotConfig = cfg
+		return &stubModule{name: name}
+	})
+	factories := p.ModuleFactories()
+	mod := factories["processing.step"]("test-ps", map[string]any{
+		"componentId":          "my-comp",
+		"successTransition":    "done",
+		"compensateTransition": "failed",
+		"maxRetries":           5,
+		"retryBackoffMs":       500,
+		"timeoutSeconds":       10,
+	})
+	if mod == nil {
+		t.Fatal("factory returned nil")
+	}
+	if gotConfig.ComponentID != "my-comp" {
+		t.Errorf("expected ComponentID %q, got %q", "my-comp", gotConfig.ComponentID)
+	}
+	if gotConfig.MaxRetries != 5 {
+		t.Errorf("expected MaxRetries 5, got %d", gotConfig.MaxRetries)
+	}
+}
+
+// TestDefaultCtorsUnchanged verifies that New() without any injected constructors
+// produces the same module types as before this refactor.
+func TestDefaultCtorsUnchanged(t *testing.T) {
+	p := New()
+	factories := p.ModuleFactories()
+	for _, typ := range []string{
+		"api.query", "api.command", "api.handler",
+		"api.gateway", "workflow.registry", "data.transformer",
+		"processing.step",
+	} {
+		mod := factories[typ]("default-"+typ, map[string]any{})
+		if mod == nil {
+			t.Errorf("default factory for %q returned nil", typ)
+		}
+	}
+}
+
+// TestWithCtorChainingReturnsSelf verifies that the With* setter methods
+// return the Plugin pointer, enabling method chaining.
+func TestWithCtorChainingReturnsSelf(t *testing.T) {
+	p := New()
+	p2 := p.
+		WithQueryHandlerCtor(func(name string) modular.Module { return &stubModule{name: name} }).
+		WithCommandHandlerCtor(func(name string) modular.Module { return &stubModule{name: name} }).
+		WithRESTAPIHandlerCtor(func(name, _ string) modular.Module { return &stubModule{name: name} }).
+		WithAPIGatewayCtor(func(name string) modular.Module { return &stubModule{name: name} }).
+		WithWorkflowRegistryCtor(func(name, _ string) modular.Module { return &stubModule{name: name} }).
+		WithDataTransformerCtor(func(name string) modular.Module { return &stubModule{name: name} }).
+		WithProcessingStepCtor(func(name string, _ module.ProcessingStepConfig) modular.Module { return &stubModule{name: name} })
+	if p2 != p {
+		t.Error("expected chained With* calls to return the same *Plugin")
 	}
 }


### PR DESCRIPTION
## Summary

- Add seven typed constructor function types (`QueryHandlerCtor`, `CommandHandlerCtor`, `RESTAPIHandlerCtor`, `APIGatewayCtor`, `WorkflowRegistryCtor`, `DataTransformerCtor`, `ProcessingStepCtor`) to `plugins/api/plugin.go`
- Add a private constructor field per type on `Plugin`, with a corresponding `With*` setter that returns `*Plugin` for method chaining
- `New()` initialises each field to a thin wrapper around the existing concrete constructor, so all callers remain fully backward-compatible without any changes
- `ModuleFactories()` now delegates construction to the injectable fields; post-construction config wiring uses local interface assertions so custom implementations only need to satisfy the methods they actually support

## Test plan

- [x] All 12 pre-existing tests in `plugins/api/plugin_test.go` continue to pass
- [x] 9 new tests added: one per injectable constructor (`TestInjectable*Ctor`), `TestDefaultCtorsUnchanged`, and `TestWithCtorChainingReturnsSelf`
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./plugins/api/...` reports 0 issues
- [x] Pre-push hooks (build + lint) pass

closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)