### PR TITLE
feat: admin as plugin — serve admin UI and config as engine plugin (#89)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/GoCodeAlone/workflow/plugin/docmanager"
 	pluginexternal "github.com/GoCodeAlone/workflow/plugin/external"
 	_ "github.com/GoCodeAlone/workflow/plugin/storebrowser"
+	pluginadmin "github.com/GoCodeAlone/workflow/plugins/admin"
 	pluginai "github.com/GoCodeAlone/workflow/plugins/ai"
 	pluginapi "github.com/GoCodeAlone/workflow/plugins/api"
 	pluginauth "github.com/GoCodeAlone/workflow/plugins/auth"
@@ -49,7 +50,6 @@ import (
 	pluginmodcompat "github.com/GoCodeAlone/workflow/plugins/modularcompat"
 	pluginobs "github.com/GoCodeAlone/workflow/plugins/observability"
 	pluginpipeline "github.com/GoCodeAlone/workflow/plugins/pipelinesteps"
-	pluginadmin "github.com/GoCodeAlone/workflow/plugins/admin"
 	pluginplatform "github.com/GoCodeAlone/workflow/plugins/platform"
 	pluginscheduler "github.com/GoCodeAlone/workflow/plugins/scheduler"
 	pluginsecrets "github.com/GoCodeAlone/workflow/plugins/secrets"
@@ -307,13 +307,7 @@ func setup(logger *slog.Logger, cfg *config.WorkflowConfig) (*serverApp, error) 
 		logger: logger,
 	}
 
-	// Merge admin config into primary config — admin UI is always enabled.
-	// The admin config provides all management endpoints (auth, API, schema,
-	// AI, dynamic components) via the engine's own modules and routes.
-	if err := mergeAdminConfig(logger, cfg); err != nil {
-		return nil, fmt.Errorf("failed to set up admin: %w", err)
-	}
-
+	// Admin config is merged by the admin plugin's wiring hook during buildEngine.
 	engine, loader, registry, err := buildEngine(cfg, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build engine: %w", err)
@@ -345,59 +339,6 @@ func setup(logger *slog.Logger, cfg *config.WorkflowConfig) (*serverApp, error) 
 	app.mgmt.auditLogger.LogConfigChange(context.Background(), "system", "server", "server started")
 
 	return app, nil
-}
-
-// mergeAdminConfig loads the embedded admin config and merges admin
-// modules/routes into the primary config. If --admin-ui-dir (or ADMIN_UI_DIR
-// env var) is set the static.fileserver root is updated to that path,
-// allowing the admin UI to be deployed and updated independently of the binary.
-// If the config already contains admin modules (e.g., the user passed the
-// admin config directly), the merge is skipped to avoid duplicates — but
-// the UI root is still injected so the static fileserver works.
-func mergeAdminConfig(logger *slog.Logger, cfg *config.WorkflowConfig) error {
-	// Resolve the UI root: flag > ADMIN_UI_DIR env > leave as configured in config.yaml
-	uiDir := *adminUIDir
-
-	// Check if the config already contains admin modules
-	for _, m := range cfg.Modules {
-		if m.Name == "admin-server" {
-			logger.Info("Config already contains admin modules, skipping merge")
-			if uiDir != "" {
-				injectUIRoot(cfg, uiDir)
-				logger.Info("Admin UI root overridden", "uiDir", uiDir)
-			}
-			return nil
-		}
-	}
-
-	adminCfg, err := admin.LoadConfig()
-	if err != nil {
-		return err
-	}
-
-	if uiDir != "" {
-		injectUIRoot(adminCfg, uiDir)
-		logger.Info("Admin UI root overridden", "uiDir", uiDir)
-	}
-
-	// Merge admin modules and routes into primary config
-	admin.MergeInto(cfg, adminCfg)
-
-	logger.Info("Admin UI enabled")
-	return nil
-}
-
-// injectUIRoot updates every static.fileserver module config in cfg to serve
-// from the given root directory.
-func injectUIRoot(cfg *config.WorkflowConfig, uiRoot string) {
-	for i := range cfg.Modules {
-		if cfg.Modules[i].Type == "static.fileserver" {
-			if cfg.Modules[i].Config == nil {
-				cfg.Modules[i].Config = make(map[string]any)
-			}
-			cfg.Modules[i].Config["root"] = uiRoot
-		}
-	}
 }
 
 // initManagementHandlers creates all management service handlers and stores


### PR DESCRIPTION
Creates `plugins/admin/` that serves the admin dashboard UI and loads admin config routes as an engine plugin. Part of #89.

## Changes

### New: `plugins/admin/plugin.go`
- `AdminPlugin` implementing `EnginePlugin` interface
- **`admin.dashboard`** module type: wraps `StaticFileServer` for admin UI static files
- **`admin.config_loader`** module type: dependency anchor for admin config loading
- **Wiring hook** (`admin-config-merge`): merges embedded `admin/config.yaml` into the engine config at priority 100
- `WithUIDir()` / `WithLogger()` builder methods for configuration
- Capability contracts: `admin-ui`, `admin-config`
- Module schemas for UI palette integration

### Modified: `cmd/server/main.go`
- Added `pluginadmin` import and registered admin plugin in the standard plugin set

### Tests: `plugins/admin/plugin_test.go`
- 15 tests covering: interface compliance, manifest validation, capabilities, module factories, schemas, wiring hooks, config merge/skip/inject logic, builder chaining