### PR TITLE
fix(helm): upgrade-safe deployments — PVC for data, zero-downtime RollingUpdate

### DIFF
--- a/deploy/helm/workflow/templates/deployment.yaml
+++ b/deploy/helm/workflow/templates/deployment.yaml
@@ -8,6 +8,11 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "workflow.selectorLabels" . | nindent 6 }}
@@ -90,7 +95,12 @@ spec:
             {{- end }}
       volumes:
         - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "workflow.fullname" . }}-data
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         {{- if .Values.config.inline }}
         - name: config
           configMap:

--- a/deploy/helm/workflow/templates/pvc.yaml
+++ b/deploy/helm/workflow/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "workflow.fullname" . }}-data
+  labels:
+    {{- include "workflow.labels" . | nindent 4 }}
+  annotations:
+    # Keep PVC on helm uninstall to prevent data loss
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/workflow/values.yaml
+++ b/deploy/helm/workflow/values.yaml
@@ -93,6 +93,15 @@ env:
 # Sensitive values from Kubernetes secrets
 envFromSecret: ""
 
+# Plugin and runtime data persistence
+# With emptyDir (disabled), data is lost on pod restart — plugins must be re-fetched.
+# Enable to retain downloaded plugins and runtime state across restarts.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
 # Prometheus monitoring
 monitoring:
   enabled: false


### PR DESCRIPTION
## Summary
- **Add `pvc.yaml`** for `/app/data` with `helm.sh/resource-policy: keep` — PVC survives `helm uninstall`, preventing loss of downloaded plugins and runtime state. Opt-in via `persistence.enabled=true` (default: `false` / emptyDir for stateless installs).
- **Explicit `RollingUpdate` strategy** with `maxSurge: 1, maxUnavailable: 0` — ensures old pods keep serving traffic until the new pod is fully healthy (passes readiness probe at `/healthz`).

## Test plan
- [ ] `helm upgrade --install workflow ./deploy/helm/workflow` — verify no data loss
- [ ] With `persistence.enabled=true`: confirm PVC is created and survives `helm uninstall`
- [ ] Rolling update: confirm zero downtime (old pod stays up until new pod is ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)