### PR TITLE
fix: wire OTelMiddleware as global HTTP middleware so traces appear in Jaeger

### DIFF
--- a/plugins/observability/plugin.go
+++ b/plugins/observability/plugin.go
@@ -39,6 +39,7 @@ func New() *ObservabilityPlugin {
 				"http.middleware.otel",
 			},
 			WiringHooks: []string{
+				"observability.otel-middleware",
 				"observability.health-endpoints",
 				"observability.metrics-endpoint",
 				"observability.log-endpoint",

--- a/plugins/observability/plugin_test.go
+++ b/plugins/observability/plugin_test.go
@@ -36,8 +36,8 @@ func TestManifestValidation(t *testing.T) {
 	if m.Name != "observability" {
 		t.Errorf("manifest Name = %q, want %q", m.Name, "observability")
 	}
-	if len(m.ModuleTypes) != 5 {
-		t.Errorf("manifest ModuleTypes count = %d, want 5", len(m.ModuleTypes))
+	if len(m.ModuleTypes) != 6 {
+		t.Errorf("manifest ModuleTypes count = %d, want 6", len(m.ModuleTypes))
 	}
 }
 
@@ -79,6 +79,7 @@ func TestModuleFactories(t *testing.T) {
 		"log.collector",
 		"observability.otel",
 		"openapi.generator",
+		"http.middleware.otel",
 	}
 
 	if len(factories) != len(expectedTypes) {
@@ -166,6 +167,7 @@ func TestModuleSchemas(t *testing.T) {
 		"log.collector":      false,
 		"observability.otel": false,
 		"openapi.generator":  false,
+		"http.middleware.otel": false,
 	}
 
 	if len(schemas) != len(expectedTypes) {
@@ -235,11 +237,12 @@ func TestWiringHooks(t *testing.T) {
 	p := New()
 	hooks := p.WiringHooks()
 
-	if len(hooks) != 4 {
-		t.Fatalf("WiringHooks() count = %d, want 4", len(hooks))
+	if len(hooks) != 5 {
+		t.Fatalf("WiringHooks() count = %d, want 5", len(hooks))
 	}
 
 	expectedNames := map[string]bool{
+		"observability.otel-middleware":   false,
 		"observability.health-endpoints":  false,
 		"observability.metrics-endpoint":  false,
 		"observability.log-endpoint":      false,


### PR DESCRIPTION
## Summary

- `OTelMiddleware.Process()` was never called — the module was instantiated but had no path into the HTTP handler chain, so no traces were emitted.
- Added `StandardHTTPRouter.AddGlobalMiddleware()` which wraps the entire mux before dispatching, ensuring every request (health probes, metrics, pipeline triggers, static files) gets a trace span.
- Added `observability.otel-middleware` wiring hook (priority 100) that runs at startup and registers any `OTelMiddleware` found in the service registry as a global middleware on every `StandardHTTPRouter`.

## Root cause

`StandardHTTPRouter.ServeHTTP` delegated directly to the inner `serveMux` with no outer middleware chain. Per-route middlewares (via `AddRouteWithMiddleware`) were available, but the OTEL middleware module had no wiring hook to attach itself — it just registered as a service and sat unused.

## Changes

| File | Change |
|------|--------|
| `module/http_router.go` | Add `globalMiddlewares []HTTPMiddleware` field; `AddGlobalMiddleware()` method; `ServeHTTP` applies global chain before mux |
| `plugins/observability/wiring.go` | New `wireOTelMiddleware` hook at priority 100 |
| `plugins/observability/plugin.go` | Register `observability.otel-middleware` in manifest `WiringHooks` |
| `plugins/observability/plugin_test.go` | Update counts: 6 module types, 5 wiring hooks |

## Test plan

- [x] `go test ./...` — all packages pass
- [ ] Tag v0.2.4, update workflow-cloud to use it, cross-compile and deploy to minikube
- [ ] Hit endpoints via `curl http://localhost:8080/...`
- [ ] Confirm `workflow-cloud` appears in `curl -s http://localhost:16686/api/services`

🤖 Generated with [Claude Code](https://claude.com/claude-code)