### PR TITLE
fix: plugin install compatibility with ExternalPluginManager

### DIFF
--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -31,6 +31,8 @@ func runPlugin(args []string) error {
 		return runPluginRemove(args[1:])
 	case "validate":
 		return runPluginValidate(args[1:])
+	case "info":
+		return runPluginInfo(args[1:])
 	default:
 		return pluginUsage()
 	}
@@ -49,6 +51,7 @@ Subcommands:
   update   Update an installed plugin to its latest version
   remove   Uninstall a plugin
   validate Validate a plugin manifest from the registry or a local file
+  info     Show details about an installed plugin
 `)
 	return fmt.Errorf("plugin subcommand is required")
 }

--- a/cmd/wfctl/registry.go
+++ b/cmd/wfctl/registry.go
@@ -27,9 +27,20 @@ type RegistryManifest struct {
 	License          string          `json:"license"`
 	MinEngineVersion string          `json:"minEngineVersion,omitempty"`
 	Repository       string          `json:"repository,omitempty"`
-	Keywords         []string        `json:"keywords,omitempty"`
-	Downloads        []PluginDownload `json:"downloads,omitempty"`
-	Assets           *PluginAssets   `json:"assets,omitempty"`
+	Keywords         []string             `json:"keywords,omitempty"`
+	Homepage         string               `json:"homepage,omitempty"`
+	Capabilities     *RegistryCapabilities `json:"capabilities,omitempty"`
+	Downloads        []PluginDownload     `json:"downloads,omitempty"`
+	Assets           *PluginAssets        `json:"assets,omitempty"`
+}
+
+// RegistryCapabilities describes what module/step/trigger types a plugin provides.
+type RegistryCapabilities struct {
+	ConfigProvider   bool     `json:"configProvider,omitempty"`
+	ModuleTypes      []string `json:"moduleTypes,omitempty"`
+	StepTypes        []string `json:"stepTypes,omitempty"`
+	TriggerTypes     []string `json:"triggerTypes,omitempty"`
+	WorkflowHandlers []string `json:"workflowHandlers,omitempty"`
 }
 
 // PluginDownload describes a platform-specific binary download for a plugin.


### PR DESCRIPTION
## Summary
- **Expanded plugin.json** written by `wfctl plugin install` to include all fields required by `ExternalPluginManager.LoadPlugin()` — previously only wrote `name`+`version`, now includes `author`, `description`, `license`, `tier`, `repository`, `tags`, `type`, `moduleTypes`, `stepTypes`, `triggerTypes`
- **Parse registry manifest capabilities** — added `RegistryCapabilities` struct so `moduleTypes`, `stepTypes`, `triggerTypes` from registry manifests flow through to the installed plugin.json
- **Post-install verification** — after writing plugin.json, validates it using the engine's `plugin.LoadManifest()` and `Validate()`, and verifies the binary exists and is executable
- **New `wfctl plugin info` command** — shows detailed info about an installed plugin (all manifest fields + binary status)
- **Improved `plugin list`** — now shows TYPE and DESCRIPTION columns alongside NAME and VERSION

## Root Cause
`ExternalPluginManager.LoadPlugin()` calls `manifest.Validate()` which requires `author` and `description` fields. The installer was writing a minimal JSON with only `name` and `version`, causing validation failure when the engine tried to load installed plugins.

## Test plan
- [x] `TestPluginInstallE2E` — expanded to verify all manifest fields (author, description, type, capabilities)
- [x] `TestInstalledManifestEngineValidation` — writes manifest from RegistryManifest, validates with engine's loader
- [x] `TestPluginInstallFlatTarball` — tests flat tarball (like authz v0.1.0 produces), binary rename, and ExternalPluginManager discovery
- [x] All existing tests pass
- [x] golangci-lint: 0 issues
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)