### PR TITLE
feat: pgx driver + WorkflowDatabase Start/Stop lifecycle

### DIFF
--- a/module/database.go
+++ b/module/database.go
@@ -143,6 +143,22 @@ func (w *WorkflowDatabase) Open() (*sql.DB, error) {
 	return db, nil
 }
 
+// Start opens the database connection during application startup so that
+// pipeline steps (db_query, db_exec) can use DB() without requiring a
+// separate persistence.store module.
+func (w *WorkflowDatabase) Start(ctx context.Context) error {
+	if w.config.DSN == "" {
+		return nil // no DSN configured, skip auto-open
+	}
+	_, err := w.Open()
+	return err
+}
+
+// Stop closes the database connection during application shutdown.
+func (w *WorkflowDatabase) Stop(ctx context.Context) error {
+	return w.Close()
+}
+
 // Close closes the database connection
 func (w *WorkflowDatabase) Close() error {
 	w.mu.Lock()

--- a/module/database_drivers.go
+++ b/module/database_drivers.go
@@ -1,3 +1,6 @@
 package module
 
-import _ "modernc.org/sqlite"
+import (
+	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "modernc.org/sqlite"
+)


### PR DESCRIPTION
## Summary
- Register `pgx/v5` stdlib driver alongside SQLite in `module/database_drivers.go` so `database.workflow` can connect to PostgreSQL without a separate driver import
- Add `Start(ctx)`/`Stop(ctx)` methods to `WorkflowDatabase` so the modular framework auto-opens the DB at startup and closes at shutdown
- Removes the need for a separate `persistence.store` module when using `database.workflow` for SQL pipeline steps (`db_query`, `db_exec`)

## Context
BuyMyWishlist and other PostgreSQL-first deployments use `database.workflow` with `driver: pgx` directly. Without `Start()`/`Stop()`, the DB connection wasn't opened until the first step tried to use it, and there was no clean shutdown. Without the pgx driver import, users had to add it manually.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./module/...` passes
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)