### PR TITLE
feat(module): add client: ref on step.http_call

### DIFF
--- a/module/pipeline_step_http_call.go
+++ b/module/pipeline_step_http_call.go
@@ -487,7 +487,7 @@ func parseHTTPResponse(resp *http.Response, respBody []byte) map[string]any {
 }
 
 // resolveClientRef looks up the HTTPClient service from the service registry when clientRef is set.
-// Returns the effective *http.Client to use and an error if the service cannot be resolved.
+// Returns the effective HTTPClient to use and an error if the service cannot be resolved.
 // If clientRef is empty, returns nil (caller uses s.httpClient unchanged).
 func (s *HTTPCallStep) resolveClientRef() (HTTPClient, error) {
 	if s.clientRef == "" {
@@ -507,7 +507,7 @@ func (s *HTTPCallStep) resolveClientRef() (HTTPClient, error) {
 	return hc, nil
 }
 
-// resolveURL applies base-URL resolution when the step URL is relative (no scheme) and a
+// resolveStepURL applies base-URL resolution when the step URL is relative (no scheme) and a
 // clientRef's base URL is available. Absolute URLs pass through unchanged.
 func resolveStepURL(rawURL, baseURL string) (string, error) {
 	if baseURL == "" {
@@ -542,6 +542,9 @@ func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepR
 			return nil, err
 		}
 		activeClient = hc.Client()
+		if activeClient == nil {
+			return nil, fmt.Errorf("http_call step %q: referenced client %q returned nil *http.Client (module may not be started)", s.name, s.clientRef)
+		}
 		clientBaseURL = hc.BaseURL()
 	}
 

--- a/module/pipeline_step_http_call.go
+++ b/module/pipeline_step_http_call.go
@@ -152,11 +152,13 @@ type HTTPCallStep struct {
 	auth       *oauthConfig
 	oauthEntry *oauthCacheEntry // shared entry from globalOAuthCache; nil when no auth configured
 	httpClient *http.Client     // timeout is enforced via the context passed to each request
+	clientRef  string           // service name for an HTTPClient registered in the service registry
+	app        modular.Application
 }
 
 // NewHTTPCallStepFactory returns a StepFactory that creates HTTPCallStep instances.
 func NewHTTPCallStepFactory() StepFactory {
-	return func(name string, config map[string]any, _ modular.Application) (PipelineStep, error) {
+	return func(name string, config map[string]any, app modular.Application) (PipelineStep, error) {
 		rawURL, _ := config["url"].(string)
 		if rawURL == "" {
 			return nil, fmt.Errorf("http_call step %q: 'url' is required", name)
@@ -167,6 +169,19 @@ func NewHTTPCallStepFactory() StepFactory {
 			method = "GET"
 		}
 
+		clientRef, _ := config["client"].(string)
+
+		// Parse-time mutual exclusion: client: ref owns authentication; combining it with
+		// inline auth or oauth2 blocks is a configuration mistake.
+		if clientRef != "" {
+			if _, hasAuth := config["auth"]; hasAuth {
+				return nil, fmt.Errorf("http_call step %q: 'client' and 'auth' are mutually exclusive; the referenced http.client module owns authentication", name)
+			}
+			if _, hasOAuth2 := config["oauth2"]; hasOAuth2 {
+				return nil, fmt.Errorf("http_call step %q: 'client' and 'oauth2' are mutually exclusive; the referenced http.client module owns authentication", name)
+			}
+		}
+
 		step := &HTTPCallStep{
 			name:       name,
 			url:        rawURL,
@@ -174,6 +189,8 @@ func NewHTTPCallStepFactory() StepFactory {
 			timeout:    30 * time.Second,
 			tmpl:       NewTemplateEngine(),
 			httpClient: http.DefaultClient,
+			clientRef:  clientRef,
+			app:        app,
 		}
 
 		if headers, ok := config["headers"].(map[string]any); ok {
@@ -469,10 +486,64 @@ func parseHTTPResponse(resp *http.Response, respBody []byte) map[string]any {
 	return output
 }
 
+// resolveClientRef looks up the HTTPClient service from the service registry when clientRef is set.
+// Returns the effective *http.Client to use and an error if the service cannot be resolved.
+// If clientRef is empty, returns nil (caller uses s.httpClient unchanged).
+func (s *HTTPCallStep) resolveClientRef() (HTTPClient, error) {
+	if s.clientRef == "" {
+		return nil, nil
+	}
+	if s.app == nil {
+		return nil, fmt.Errorf("http_call step %q: client %q requested but no application context available", s.name, s.clientRef)
+	}
+	svc, ok := s.app.SvcRegistry()[s.clientRef]
+	if !ok {
+		return nil, fmt.Errorf("http_call step %q: client service %q not found in service registry", s.name, s.clientRef)
+	}
+	hc, ok := svc.(HTTPClient)
+	if !ok {
+		return nil, fmt.Errorf("http_call step %q: service %q does not implement HTTPClient", s.name, s.clientRef)
+	}
+	return hc, nil
+}
+
+// resolveURL applies base-URL resolution when the step URL is relative (no scheme) and a
+// clientRef's base URL is available. Absolute URLs pass through unchanged.
+func resolveStepURL(rawURL, baseURL string) (string, error) {
+	if baseURL == "" {
+		return rawURL, nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	// If the URL already has a scheme it is absolute — do not prefix with BaseURL.
+	if parsed.IsAbs() {
+		return rawURL, nil
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(parsed).String(), nil
+}
+
 // Execute performs the HTTP request and returns the response.
 func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
+
+	// Resolve client: ref if configured. This replaces s.httpClient for this execution.
+	activeClient := s.httpClient
+	var clientBaseURL string
+	if s.clientRef != "" {
+		hc, err := s.resolveClientRef()
+		if err != nil {
+			return nil, err
+		}
+		activeClient = hc.Client()
+		clientBaseURL = hc.BaseURL()
+	}
 
 	// Obtain OAuth2 bearer token first so that instance_url is available for URL template resolution.
 	var bearerToken string
@@ -496,6 +567,14 @@ func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepR
 		return nil, fmt.Errorf("http_call step %q: failed to resolve url: %w", s.name, err)
 	}
 
+	// Apply base-URL resolution for relative URLs when a client: ref is in use.
+	if clientBaseURL != "" {
+		resolvedURL, err = resolveStepURL(resolvedURL, clientBaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("http_call step %q: failed to resolve url against base: %w", s.name, err)
+		}
+	}
+
 	bodyReader, rawBody, err := s.buildBodyReader(pc)
 	if err != nil {
 		return nil, err
@@ -507,7 +586,7 @@ func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepR
 	}
 
 	start := time.Now()
-	resp, err := s.httpClient.Do(req) //nolint:gosec // G107: URL is user-configured
+	resp, err := activeClient.Do(req) //nolint:gosec // G107: URL is user-configured
 	if err != nil {
 		return nil, fmt.Errorf("http_call step %q: request failed: %w", s.name, err)
 	}
@@ -550,7 +629,7 @@ func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepR
 		}
 
 		retryStart := time.Now()
-		retryResp, doErr := s.httpClient.Do(retryReq) //nolint:gosec // G107: URL is user-configured
+		retryResp, doErr := activeClient.Do(retryReq) //nolint:gosec // G107: URL is user-configured
 		if doErr != nil {
 			return nil, fmt.Errorf("http_call step %q: retry request failed: %w", s.name, doErr)
 		}

--- a/module/pipeline_step_http_call_test.go
+++ b/module/pipeline_step_http_call_test.go
@@ -1153,3 +1153,243 @@ func TestOAuthTokenCache_ExpiredEntryEviction(t *testing.T) {
 
 	close(cache.stopCh)
 }
+
+// ---------------------------------------------------------------------------
+// client: ref field tests (Task 1.15)
+// ---------------------------------------------------------------------------
+
+// fakeHTTPClient is a minimal HTTPClient implementation for testing the client: ref path.
+type fakeHTTPClient struct {
+	client  *http.Client
+	baseURL string
+}
+
+func (f *fakeHTTPClient) Client() *http.Client { return f.client }
+func (f *fakeHTTPClient) BaseURL() string       { return f.baseURL }
+
+// fakeRoundTripper injects a fixed Authorization header into every request.
+type fakeRoundTripper struct {
+	base  http.RoundTripper
+	token string
+}
+
+func (rt *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+rt.token)
+	base := rt.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(clone)
+}
+
+// mockAppWithHTTPClient returns a MockApplication with an HTTPClient service registered under name.
+func mockAppWithHTTPClient(name string, hc HTTPClient) *MockApplication {
+	app := NewMockApplication()
+	app.Services[name] = hc
+	return app
+}
+
+// TestHTTPCallStep_ClientRef_UsesReferencedTransport verifies that when client: is set the step
+// uses the transport from the referenced HTTPClient service (which injects Authorization).
+func TestHTTPCallStep_ClientRef_UsesReferencedTransport(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	transport := &fakeRoundTripper{base: srv.Client().Transport, token: "fake-token"}
+	hc := &fakeHTTPClient{
+		client:  &http.Client{Transport: transport},
+		baseURL: srv.URL,
+	}
+	app := mockAppWithHTTPClient("zoom-client", hc)
+
+	factory := NewHTTPCallStepFactory()
+	step, err := factory("ref-transport-test", map[string]any{
+		"url":    srv.URL + "/ping",
+		"client": "zoom-client",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	pc := NewPipelineContext(nil, nil)
+	result, err := step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	if result.Output["status_code"] != http.StatusOK {
+		t.Errorf("expected 200, got %v", result.Output["status_code"])
+	}
+	if gotAuth != "Bearer fake-token" {
+		t.Errorf("expected Authorization: Bearer fake-token, got %q", gotAuth)
+	}
+}
+
+// TestHTTPCallStep_ClientRef_ResolvesRelativeURLAgainstBaseURL verifies that a relative URL
+// ("/items") is resolved against the HTTPClient's BaseURL.
+func TestHTTPCallStep_ClientRef_ResolvesRelativeURLAgainstBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	hc := &fakeHTTPClient{
+		client:  srv.Client(),
+		baseURL: srv.URL,
+	}
+	app := mockAppWithHTTPClient("zoom-client", hc)
+
+	factory := NewHTTPCallStepFactory()
+	step, err := factory("ref-relurl-test", map[string]any{
+		"url":    "/items",
+		"client": "zoom-client",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	pc := NewPipelineContext(nil, nil)
+	if _, err := step.Execute(context.Background(), pc); err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+
+	if gotPath != "/items" {
+		t.Errorf("expected path /items, got %q", gotPath)
+	}
+}
+
+// TestHTTPCallStep_ClientRef_RejectsInlineOAuth2 verifies that combining client: with oauth2 or
+// auth blocks is rejected at factory time with a clear error naming both fields.
+func TestHTTPCallStep_ClientRef_RejectsInlineOAuth2(t *testing.T) {
+	factory := NewHTTPCallStepFactory()
+
+	// client + oauth2 block
+	_, err := factory("bad-oauth2", map[string]any{
+		"url":    "http://example.com/api",
+		"client": "x",
+		"oauth2": map[string]any{
+			"token_url":     "http://example.com/token",
+			"client_id":     "cid",
+			"client_secret": "csec",
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for client + oauth2 combination")
+	}
+	if !strings.Contains(err.Error(), "client") || !strings.Contains(err.Error(), "oauth2") {
+		t.Errorf("expected error to mention both 'client' and 'oauth2', got: %v", err)
+	}
+
+	// client + auth block
+	_, err = factory("bad-auth", map[string]any{
+		"url":    "http://example.com/api",
+		"client": "x",
+		"auth": map[string]any{
+			"type":          "oauth2_client_credentials",
+			"token_url":     "http://example.com/token",
+			"client_id":     "cid",
+			"client_secret": "csec",
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for client + auth combination")
+	}
+	if !strings.Contains(err.Error(), "client") || !strings.Contains(err.Error(), "auth") {
+		t.Errorf("expected error to mention both 'client' and 'auth', got: %v", err)
+	}
+}
+
+// TestHTTPCallStep_ClientRef_MissingService verifies that Execute returns an error identifying the
+// missing service name when client: names a service not in the registry.
+func TestHTTPCallStep_ClientRef_MissingService(t *testing.T) {
+	app := NewMockApplication() // empty registry; "nonexistent" is not registered
+
+	factory := NewHTTPCallStepFactory()
+	step, err := factory("missing-svc-test", map[string]any{
+		"url":    "http://example.com/api",
+		"client": "nonexistent",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory should succeed (deferred lookup): %v", err)
+	}
+
+	pc := NewPipelineContext(nil, nil)
+	_, err = step.Execute(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected error for missing service")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected error to name the missing service, got: %v", err)
+	}
+}
+
+// TestHTTPCallStep_ClientRef_WrongServiceType verifies that Execute returns an error when the
+// registered service does not implement HTTPClient.
+func TestHTTPCallStep_ClientRef_WrongServiceType(t *testing.T) {
+	app := NewMockApplication()
+	app.Services["bad-svc"] = struct{ Name string }{Name: "not-an-http-client"} // wrong type
+
+	factory := NewHTTPCallStepFactory()
+	step, err := factory("wrong-type-test", map[string]any{
+		"url":    "http://example.com/api",
+		"client": "bad-svc",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory should succeed: %v", err)
+	}
+
+	pc := NewPipelineContext(nil, nil)
+	_, err = step.Execute(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected error for wrong service type")
+	}
+	if !strings.Contains(err.Error(), "bad-svc") {
+		t.Errorf("expected error to name the service, got: %v", err)
+	}
+}
+
+// TestHTTPCallStep_ClientRef_AbsoluteURLBypassesBaseURL verifies that an absolute URL is not
+// prefixed with the HTTPClient's BaseURL.
+func TestHTTPCallStep_ClientRef_AbsoluteURLBypassesBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	// BaseURL points to a different (hypothetical) base; the step uses an absolute URL
+	hc := &fakeHTTPClient{
+		client:  srv.Client(),
+		baseURL: "https://should-not-be-used.example.com",
+	}
+	app := mockAppWithHTTPClient("zoom-client", hc)
+
+	factory := NewHTTPCallStepFactory()
+	// Use srv.URL (absolute) as the step URL — base URL must NOT be prepended
+	step, err := factory("abs-url-test", map[string]any{
+		"url":    srv.URL + "/absolute/path",
+		"client": "zoom-client",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	pc := NewPipelineContext(nil, nil)
+	if _, err := step.Execute(context.Background(), pc); err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+
+	if gotPath != "/absolute/path" {
+		t.Errorf("expected path /absolute/path, got %q", gotPath)
+	}
+}

--- a/module/pipeline_step_http_call_test.go
+++ b/module/pipeline_step_http_call_test.go
@@ -1165,7 +1165,7 @@ type fakeHTTPClient struct {
 }
 
 func (f *fakeHTTPClient) Client() *http.Client { return f.client }
-func (f *fakeHTTPClient) BaseURL() string       { return f.baseURL }
+func (f *fakeHTTPClient) BaseURL() string      { return f.baseURL }
 
 // fakeRoundTripper injects a fixed Authorization header into every request.
 type fakeRoundTripper struct {
@@ -1193,9 +1193,9 @@ func mockAppWithHTTPClient(name string, hc HTTPClient) *MockApplication {
 // TestHTTPCallStep_ClientRef_UsesReferencedTransport verifies that when client: is set the step
 // uses the transport from the referenced HTTPClient service (which injects Authorization).
 func TestHTTPCallStep_ClientRef_UsesReferencedTransport(t *testing.T) {
-	var gotAuth string
+	gotAuthCh := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
+		gotAuthCh <- r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
@@ -1225,6 +1225,7 @@ func TestHTTPCallStep_ClientRef_UsesReferencedTransport(t *testing.T) {
 	if result.Output["status_code"] != http.StatusOK {
 		t.Errorf("expected 200, got %v", result.Output["status_code"])
 	}
+	gotAuth := <-gotAuthCh
 	if gotAuth != "Bearer fake-token" {
 		t.Errorf("expected Authorization: Bearer fake-token, got %q", gotAuth)
 	}
@@ -1233,9 +1234,9 @@ func TestHTTPCallStep_ClientRef_UsesReferencedTransport(t *testing.T) {
 // TestHTTPCallStep_ClientRef_ResolvesRelativeURLAgainstBaseURL verifies that a relative URL
 // ("/items") is resolved against the HTTPClient's BaseURL.
 func TestHTTPCallStep_ClientRef_ResolvesRelativeURLAgainstBaseURL(t *testing.T) {
-	var gotPath string
+	gotPathCh := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPathCh <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{}`))
 	}))
@@ -1261,6 +1262,7 @@ func TestHTTPCallStep_ClientRef_ResolvesRelativeURLAgainstBaseURL(t *testing.T) 
 		t.Fatalf("execute error: %v", err)
 	}
 
+	gotPath := <-gotPathCh
 	if gotPath != "/items" {
 		t.Errorf("expected path /items, got %q", gotPath)
 	}
@@ -1359,9 +1361,9 @@ func TestHTTPCallStep_ClientRef_WrongServiceType(t *testing.T) {
 // TestHTTPCallStep_ClientRef_AbsoluteURLBypassesBaseURL verifies that an absolute URL is not
 // prefixed with the HTTPClient's BaseURL.
 func TestHTTPCallStep_ClientRef_AbsoluteURLBypassesBaseURL(t *testing.T) {
-	var gotPath string
+	gotPathCh := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPathCh <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{}`))
 	}))
@@ -1389,6 +1391,7 @@ func TestHTTPCallStep_ClientRef_AbsoluteURLBypassesBaseURL(t *testing.T) {
 		t.Fatalf("execute error: %v", err)
 	}
 
+	gotPath := <-gotPathCh
 	if gotPath != "/absolute/path" {
 		t.Errorf("expected path /absolute/path, got %q", gotPath)
 	}


### PR DESCRIPTION
## Summary

Adds a `client:` field to `step.http_call` so a pipeline step can reuse an `http.client` module's authenticated transport and base URL instead of duplicating credential config.

- **`client: <service-name>`** — accepts the service-registry name of any registered `HTTPClient` (i.e. an `http.client` module instance). At Execute time the step resolves the service via `s.app.SvcRegistry()` and uses `client.Client()` as the active `*http.Client`.
- **Base-URL resolution** — relative URLs (no scheme) are resolved against `client.BaseURL()` via `url.Parse` + `ResolveReference`; absolute URLs pass through unchanged.
- **Mutual exclusion** — `client:` combined with either `auth:` or `oauth2:` blocks is rejected at factory time with a clear error naming both fields. The referenced module owns authentication.
- **Back-compat** — all existing paths (no client ref, inline oauth2, auth block) are untouched.
- **Deferred lookup** — service registry resolution happens in `Execute`, not the factory (same pattern as `step.secret_set`), so the step can be created before the full service graph is wired.

## New tests (6)

| Test | What it checks |
|------|----------------|
| `TestHTTPCallStep_ClientRef_UsesReferencedTransport` | Custom `RoundTripper` from the referenced client injects `Authorization: Bearer fake-token` |
| `TestHTTPCallStep_ClientRef_ResolvesRelativeURLAgainstBaseURL` | Relative `/items` URL resolved to `<server>/items` via `BaseURL()` |
| `TestHTTPCallStep_ClientRef_RejectsInlineOAuth2` | Factory errors when `client:` is combined with `oauth2:` or `auth:` block |
| `TestHTTPCallStep_ClientRef_MissingService` | Execute errors with the missing service name |
| `TestHTTPCallStep_ClientRef_WrongServiceType` | Execute errors when the service doesn't implement `HTTPClient` |
| `TestHTTPCallStep_ClientRef_AbsoluteURLBypassesBaseURL` | Absolute URL is not double-prefixed with `BaseURL()` |

## Test plan

- [x] All 6 new `TestHTTPCallStep_ClientRef_*` tests pass
- [x] Full `TestHTTPCallStep_*` suite (25 pre-existing + 6 new = 31 total) passes with no regressions
- [x] `go fmt ./...` clean
- [x] `golangci-lint run ./module/...` — 0 issues
- [x] `go test -race -run TestHTTPCallStep ./module/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)