### PR TITLE
feat(pipeline): add b64 template function

### DIFF
--- a/module/pipeline_template_test.go
+++ b/module/pipeline_template_test.go
@@ -361,6 +361,46 @@ func TestTemplateEngine_ResolveMap_ErrorPropagation(t *testing.T) {
 	}
 }
 
+func TestTemplateEngine_FuncB64(t *testing.T) {
+	te := NewTemplateEngine()
+	pc := NewPipelineContext(map[string]any{"secret": "hello"}, nil)
+
+	result, err := te.Resolve(`{{ b64 .secret }}`, pc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "aGVsbG8=" {
+		t.Errorf("expected b64 of 'hello' = 'aGVsbG8=', got %q", result)
+	}
+}
+
+func TestTemplateEngine_FuncB64_BasicAuthHeader(t *testing.T) {
+	te := NewTemplateEngine()
+	pc := NewPipelineContext(map[string]any{"id": "client", "sec": "secret"}, nil)
+
+	result, err := te.Resolve(`Basic {{ b64 (printf "%s:%s" .id .sec) }}`, pc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "client:secret" base64-encoded is "Y2xpZW50OnNlY3JldA=="
+	if result != "Basic Y2xpZW50OnNlY3JldA==" {
+		t.Errorf("expected 'Basic Y2xpZW50OnNlY3JldA==', got %q", result)
+	}
+}
+
+func TestTemplateEngine_FuncB64_EmptyString(t *testing.T) {
+	te := NewTemplateEngine()
+	pc := NewPipelineContext(nil, nil)
+
+	result, err := te.Resolve(`{{ b64 "" }}`, pc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
 func TestTemplateEngine_FuncUUID(t *testing.T) {
 	te := NewTemplateEngine()
 	pc := NewPipelineContext(nil, nil)

--- a/module/template_func_registry.go
+++ b/module/template_func_registry.go
@@ -130,6 +130,12 @@ func buildTemplateFuncDefs() []TemplateFuncDef {
 			Example:     `{{ .query | urlEncode }}`,
 		},
 		{
+			Name:        "b64",
+			Signature:   "b64(s string) string",
+			Description: "Encodes a string as standard base64 (RFC 4648). Typical use: HTTP Basic auth header from an id:secret pair.",
+			Example:     `Basic {{ b64 (printf "%s:%s" .client_id .client_secret) }}`,
+		},
+		{
 			Name:        "add",
 			Signature:   "add(a any, b any) any",
 			Description: "Returns a + b. Returns int64 if both are integer types, float64 otherwise.",

--- a/pipeline/template.go
+++ b/pipeline/template.go
@@ -5,6 +5,7 @@ package pipeline
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -687,6 +688,11 @@ func TemplateFuncMap() template.FuncMap {
 		"trimSpace": strings.TrimSpace,
 		// urlEncode percent-encodes a string for use in URLs.
 		"urlEncode": url.QueryEscape,
+		// b64 encodes a string as standard base64 (RFC 4648). Typical use:
+		// constructing an HTTP Basic auth header from an id:secret pair.
+		"b64": func(s string) string {
+			return base64.StdEncoding.EncodeToString([]byte(s))
+		},
 
 		// --- Math functions ---
 


### PR DESCRIPTION
## Summary
- Adds a `b64` template function that encodes a string as standard base64 (RFC 4648)
- Registered alongside other template string functions and documented in `TemplateFuncDescriptions`
- Tests cover round-trip encoding, use in a Basic auth header (the motivating use case), and empty string

## Motivation
Downstream consumers need to construct HTTP Basic auth headers from a dynamic id/secret pair fetched from a secrets provider. Without a base64 helper, there is no pure-YAML path to write the OAuth2 `authorization_code` token exchange (e.g. Zoom OAuth), since the `Authorization: Basic <b64>` header must be emitted inline in a `step.http_call`.

Example usage:
```yaml
- name: token-exchange
  type: step.http_call
  config:
    url: https://provider.example.com/oauth/token
    method: POST
    headers:
      Content-Type: application/x-www-form-urlencoded
      Authorization: 'Basic {{ b64 (printf "%s:%s" (step "fetch-creds" "client_id") (step "fetch-creds" "client_secret")) }}'
    body_form:
      grant_type: authorization_code
      code: '{{ trigger "code" }}'
```

## Test plan
- [x] `go test ./module/ -run TestTemplateEngine_FuncB64 -count=1` (new tests pass)
- [x] `go test ./module/ -run TestTemplateFuncDescriptionsCoversFuncMap` (registry coverage invariant still holds)
- [x] `go test ./module/ ./pipeline/ -count=1` (full module + pipeline suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)