### PR TITLE
feat(module): add error_on_status option to step.http_call

### DIFF
--- a/module/pipeline_step_http_call.go
+++ b/module/pipeline_step_http_call.go
@@ -141,19 +141,20 @@ type oauthConfig struct {
 
 // HTTPCallStep makes an HTTP request as a pipeline step.
 type HTTPCallStep struct {
-	name       string
-	url        string
-	method     string
-	headers    map[string]string
-	body       map[string]any
-	bodyFrom   string // dot-path into pc.Current or a prior step result via "steps.<name>..."; if set, the resolved value is used as the request body (strings/[]byte sent as-is, other types JSON-marshaled)
-	timeout    time.Duration
-	tmpl       *TemplateEngine
-	auth       *oauthConfig
-	oauthEntry *oauthCacheEntry // shared entry from globalOAuthCache; nil when no auth configured
-	httpClient *http.Client     // timeout is enforced via the context passed to each request
-	clientRef  string           // service name for an HTTPClient registered in the service registry
-	app        modular.Application
+	name          string
+	url           string
+	method        string
+	headers       map[string]string
+	body          map[string]any
+	bodyFrom      string // dot-path into pc.Current or a prior step result via "steps.<name>..."; if set, the resolved value is used as the request body (strings/[]byte sent as-is, other types JSON-marshaled)
+	timeout       time.Duration
+	tmpl          *TemplateEngine
+	auth          *oauthConfig
+	oauthEntry    *oauthCacheEntry // shared entry from globalOAuthCache; nil when no auth configured
+	httpClient    *http.Client     // timeout is enforced via the context passed to each request
+	clientRef     string           // service name for an HTTPClient registered in the service registry
+	errorOnStatus bool             // when true (default), non-2xx responses return an error; when false, the response is returned as normal step output so downstream steps can inspect status
+	app           modular.Application
 }
 
 // NewHTTPCallStepFactory returns a StepFactory that creates HTTPCallStep instances.
@@ -183,14 +184,19 @@ func NewHTTPCallStepFactory() StepFactory {
 		}
 
 		step := &HTTPCallStep{
-			name:       name,
-			url:        rawURL,
-			method:     method,
-			timeout:    30 * time.Second,
-			tmpl:       NewTemplateEngine(),
-			httpClient: http.DefaultClient,
-			clientRef:  clientRef,
-			app:        app,
+			name:          name,
+			url:           rawURL,
+			method:        method,
+			timeout:       30 * time.Second,
+			tmpl:          NewTemplateEngine(),
+			httpClient:    http.DefaultClient,
+			clientRef:     clientRef,
+			errorOnStatus: true,
+			app:           app,
+		}
+
+		if v, ok := config["error_on_status"].(bool); ok {
+			step.errorOnStatus = v
 		}
 
 		if headers, ok := config["headers"].(map[string]any); ok {
@@ -649,7 +655,7 @@ func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepR
 		if instanceURL := s.oauthEntry.getInstanceURL(); instanceURL != "" {
 			output["instance_url"] = instanceURL
 		}
-		if retryResp.StatusCode >= 400 {
+		if s.errorOnStatus && retryResp.StatusCode >= 400 {
 			return nil, fmt.Errorf("http_call step %q: HTTP %d: %s", s.name, retryResp.StatusCode, string(respBody))
 		}
 		return &StepResult{Output: output}, nil
@@ -663,7 +669,7 @@ func (s *HTTPCallStep) Execute(ctx context.Context, pc *PipelineContext) (*StepR
 		}
 	}
 
-	if resp.StatusCode >= 400 {
+	if s.errorOnStatus && resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("http_call step %q: HTTP %d: %s", s.name, resp.StatusCode, string(respBody))
 	}
 

--- a/module/pipeline_step_http_call_test.go
+++ b/module/pipeline_step_http_call_test.go
@@ -86,6 +86,72 @@ func TestHTTPCallStep_ErrorResponse(t *testing.T) {
 	}
 }
 
+// TestHTTPCallStep_ErrorOnStatus_FalsePreservesResponse verifies that when
+// error_on_status is false, a non-2xx response is returned as normal step
+// output (with status_code, headers, body) instead of failing the pipeline.
+// Downstream steps (step.jq, step.branch) can then inspect the status and
+// shape the final output accordingly.
+func TestHTTPCallStep_ErrorOnStatus_FalsePreservesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"code":429,"message":"rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	factory := NewHTTPCallStepFactory()
+	step, err := factory("rl-test", map[string]any{
+		"url":              srv.URL,
+		"error_on_status":  false,
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	step.(*HTTPCallStep).httpClient = srv.Client()
+
+	pc := NewPipelineContext(nil, nil)
+	result, err := step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("unexpected error with error_on_status=false: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Output["status_code"] != http.StatusTooManyRequests {
+		t.Errorf("expected status_code=429, got %v", result.Output["status_code"])
+	}
+	headers, _ := result.Output["headers"].(map[string]any)
+	if headers == nil || headers["Retry-After"] != "30" {
+		t.Errorf("expected Retry-After=30 header, got headers=%v", headers)
+	}
+	body, _ := result.Output["body"].(map[string]any)
+	if body == nil || body["code"] != float64(429) {
+		t.Errorf("expected parsed JSON body with code=429, got body=%v", result.Output["body"])
+	}
+}
+
+// TestHTTPCallStep_ErrorOnStatus_DefaultErrorsOnNon2xx verifies that omitting
+// error_on_status preserves the default behavior: non-2xx returns an error.
+func TestHTTPCallStep_ErrorOnStatus_DefaultErrorsOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	factory := NewHTTPCallStepFactory()
+	step, err := factory("default-test", map[string]any{"url": srv.URL}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	step.(*HTTPCallStep).httpClient = srv.Client()
+
+	pc := NewPipelineContext(nil, nil)
+	_, err = step.Execute(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected error for 404 response with default settings")
+	}
+}
+
 // TestHTTPCallStep_OAuth2_FetchesToken verifies that a bearer token is obtained and sent.
 func TestHTTPCallStep_OAuth2_FetchesToken(t *testing.T) {
 	var tokenRequests int32

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -80,6 +80,7 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 			{Key: "body_from", Type: FieldTypeString, Description: "Template expression to build body from step outputs"},
 			{Key: "timeout", Type: FieldTypeDuration, Description: "Request timeout duration (e.g. 30s)", DefaultValue: "30s"},
 			{Key: "auth", Type: FieldTypeMap, Description: "Authentication config (type, token, client_id, client_secret, token_url for OAuth2)"},
+			{Key: "error_on_status", Type: FieldTypeBool, Description: "When true (default), non-2xx responses fail the pipeline. When false, the response is returned as normal step output so downstream steps can inspect status_code and shape error responses.", DefaultValue: "true"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "status_code", Type: "number", Description: "HTTP response status code (e.g. 200)"},


### PR DESCRIPTION
## Summary
- Adds `error_on_status` config option to `step.http_call` (default: `true`, backward compatible)
- When set to `false`, non-2xx responses are returned as normal step output instead of failing the pipeline
- Enables gateway-style pipelines to shape upstream API errors into structured client responses via downstream `step.jq` / `step.branch`

## Motivation
Without this, any pipeline wrapping an external API has two bad choices: let the pipeline fail opaquely on every 4xx, or lose the response entirely via `on_error: skip`. Neither lets a pipeline translate status codes (429 with `Retry-After`, 401, 404) into structured error shapes that clients can handle programmatically.

## Test plan
- [x] New test `TestHTTPCallStep_ErrorOnStatus_FalsePreservesResponse` — verifies a 429 response with `Retry-After: 30` is returned as step output with parsed JSON body
- [x] New test `TestHTTPCallStep_ErrorOnStatus_DefaultErrorsOnNon2xx` — verifies default behavior still errors on non-2xx
- [x] Existing `TestHTTPCallStep_ErrorResponse` still passes (default path)
- [x] Full `go test ./module/` passes (17s, no regressions)
- [x] `schema/step_schema_builtins.go` updated with new field; `go test ./schema/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)