### PR TITLE
feat: workflow v0.14.1 — security-audit + provenance + GitLab auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-04-19
+
+### Added
+
+#### `wfctl build audit` — supply-chain security checks (T34)
+
+- **`wfctl build audit`** — scans the build config for supply-chain security issues. Six checks:
+  1. `ci.build.security.hardened=false` → WARN
+  2. Dockerfile containers without `sbom` or `provenance` configured → WARN
+  3. Registries without a `retention:` policy → WARN
+  4. `requires.plugins` or `plugins.external` declared without a `.wfctl.yaml` lockfile → WARN
+  5. Registry `auth.env` pointing to an env var not set at audit time → WARN
+  6. `environments.local.build.security.hardened=false` → NOTE (expected for local dev)
+- **`--strict`** flag — exits 1 if any WARN-level findings are present (default: exit 0 always).
+
+#### BuildKit provenance attestation (T33)
+
+- When `ci.build.security.hardened=true`, `wfctl build image` appends `--provenance=mode=max` and `--sbom=true` to every `docker build` invocation.
+- Emits a warning when `DOCKER_BUILDKIT` is not set to `1`, since BuildKit is required for provenance attestation to work.
+
+#### GitLab Container Registry provider (T31)
+
+- **`plugins/registry-gitlab`** — full implementation replacing the stub:
+  - `Login`: uses `gitlab-ci-token` + `$CI_JOB_TOKEN` in CI context; falls back to `oauth2` + `auth.env` token.
+  - `Push`: `docker push <ref>` (GitLab accepts anything under the logged-in registry path).
+  - `Prune`: calls GitLab API (`GET /api/v4/projects/:id/registry/repositories` + `DELETE .../tags/:name`) to delete tags beyond `retention.keep_latest`.
+
 ## [0.14.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### `wfctl build audit` — supply-chain security checks (T34)
 
-- **`wfctl build audit`** — scans the build config for supply-chain security issues. Six checks:
+- **`wfctl build audit`** — two-layer security audit combining CI config checks and per-target Dockerfile linting.
+
+  **Config-level checks (six):**
   1. `ci.build.security.hardened=false` → WARN
   2. Dockerfile containers without `sbom` or `provenance` configured → WARN
   3. Registries without a `retention:` policy → WARN
   4. `requires.plugins` or `plugins.external` declared without a `.wfctl.yaml` lockfile → WARN
   5. Registry `auth.env` pointing to an env var not set at audit time → WARN
   6. `environments.local.build.security.hardened=false` → NOTE (expected for local dev)
-- **`--strict`** flag — exits 1 if any WARN-level findings are present (default: exit 0 always).
+
+  **Target-level checks:**
+  - Calls `builder.SecurityLint(cfg)` for each typed build target (go, nodejs, custom) and aggregates findings.
+  - For each `method: dockerfile` container, lints the Dockerfile for:
+    - `USER root` → CRITICAL
+    - Missing `USER` directive → CRITICAL
+    - `FROM <image>:latest` without version pinning → WARN
+    - `ADD https?://` URL (untrusted remote fetch) → WARN
+    - Embedded secret patterns (`password=`, `token=`, `api_key=`, etc.) → CRITICAL
+    - Base image not in `ci.build.security.base_image_policy.allow_prefixes` → WARN (when policy is set)
+
+  **Exit codes:** CRITICAL findings always exit 1. `--strict` also exits 1 on any WARN. Plain runs exit 0 unless CRITICAL.
 
 #### BuildKit provenance attestation (T33)
 

--- a/cmd/wfctl/build.go
+++ b/cmd/wfctl/build.go
@@ -30,8 +30,10 @@ func runBuild(args []string) error {
 			return runBuildPush(rest)
 		case "custom":
 			return runBuildCustom(rest)
+		case "audit", "--security-audit":
+			return runBuildSecurityAudit(rest)
 		default:
-			return fmt.Errorf("unknown build subcommand %q — valid: go, ui, image, push, custom", sub)
+			return fmt.Errorf("unknown build subcommand %q — valid: go, ui, image, push, custom, audit", sub)
 		}
 	}
 

--- a/cmd/wfctl/build.go
+++ b/cmd/wfctl/build.go
@@ -30,7 +30,7 @@ func runBuild(args []string) error {
 			return runBuildPush(rest)
 		case "custom":
 			return runBuildCustom(rest)
-		case "audit", "--security-audit":
+		case "audit":
 			return runBuildSecurityAudit(rest)
 		default:
 			return fmt.Errorf("unknown build subcommand %q — valid: go, ui, image, push, custom, audit", sub)

--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -77,13 +77,14 @@ func runBuildImageWithOutput(args []string, out io.Writer) error {
 			method = "dockerfile"
 		}
 
+		hardened := cfg.CI.Build.Security != nil && cfg.CI.Build.Security.Hardened
 		switch method {
 		case "ko":
 			if err := buildWithKo(ctr, tag, *dryRun, out); err != nil {
 				return fmt.Errorf("ko build %q: %w", ctr.Name, err)
 			}
 		default: // dockerfile
-			if err := buildWithDockerfile(ctr, tag, *dryRun, out); err != nil {
+			if err := buildWithDockerfile(ctr, tag, *dryRun, hardened, out); err != nil {
 				return fmt.Errorf("dockerfile build %q: %w", ctr.Name, err)
 			}
 		}
@@ -91,7 +92,7 @@ func runBuildImageWithOutput(args []string, out io.Writer) error {
 	return nil
 }
 
-func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, out io.Writer) error {
+func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, hardened bool, out io.Writer) error {
 	dockerfile := ctr.Dockerfile
 	if dockerfile == "" {
 		dockerfile = "Dockerfile"
@@ -138,6 +139,14 @@ func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, 
 	// Build target (multi-stage).
 	if ctr.Target != "" {
 		args = append(args, "--target", ctr.Target)
+	}
+
+	// T33: BuildKit provenance attestation when hardened=true.
+	if hardened {
+		if os.Getenv("DOCKER_BUILDKIT") != "1" {
+			fmt.Fprintf(out, "warning: DOCKER_BUILDKIT is not set to 1; provenance attestation requires BuildKit\n")
+		}
+		args = append(args, "--provenance=mode=max", "--sbom=true")
 	}
 
 	args = append(args, ".")

--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -143,7 +143,8 @@ func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, 
 
 	// T33: BuildKit provenance attestation when hardened=true.
 	if hardened {
-		if os.Getenv("DOCKER_BUILDKIT") != "1" {
+		// Warn only in dry-run: in live mode DOCKER_BUILDKIT=1 is already forced on cmd.Env.
+		if dryRun && os.Getenv("DOCKER_BUILDKIT") != "1" {
 			fmt.Fprintf(out, "warning: DOCKER_BUILDKIT is not set to 1; provenance attestation requires BuildKit\n")
 		}
 		args = append(args, "--provenance=mode=max", "--sbom=true")

--- a/cmd/wfctl/build_image_test.go
+++ b/cmd/wfctl/build_image_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -50,6 +52,72 @@ func TestRunBuildImage_KoDryRun(t *testing.T) {
 	err := runBuildImage([]string{"--config", cfgPath})
 	if err != nil {
 		t.Fatalf("ko dry-run: %v", err)
+	}
+}
+
+// TestRunBuildImage_HardenedProvenanceArgs verifies that --provenance and --sbom flags
+// are appended to the docker build command when ci.build.security.hardened=true (T33).
+func TestRunBuildImage_HardenedProvenanceArgs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	t.Setenv("DOCKER_BUILDKIT", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath}, &buf); err != nil {
+		t.Fatalf("hardened dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "--provenance=mode=max") {
+		t.Errorf("expected --provenance=mode=max in dry-run output, got: %q", out)
+	}
+	if !strings.Contains(out, "--sbom=true") {
+		t.Errorf("expected --sbom=true in dry-run output, got: %q", out)
+	}
+}
+
+// TestRunBuildImage_NotHardenedNoProvenanceArgs verifies that provenance flags are
+// NOT added when hardened=false (T33).
+func TestRunBuildImage_NotHardenedNoProvenanceArgs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    security:
+      hardened: false
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath}, &buf); err != nil {
+		t.Fatalf("non-hardened dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "--provenance") {
+		t.Errorf("expected no --provenance flag when hardened=false, got: %q", out)
 	}
 }
 

--- a/cmd/wfctl/build_image_test.go
+++ b/cmd/wfctl/build_image_test.go
@@ -91,6 +91,39 @@ func TestRunBuildImage_HardenedProvenanceArgs(t *testing.T) {
 	}
 }
 
+// TestRunBuildImage_HardenedBuildKitWarning verifies the DOCKER_BUILDKIT warning is only
+// emitted in dry-run mode (in live mode the env is forced via cmd.Env).
+func TestRunBuildImage_HardenedBuildKitWarning(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Ensure DOCKER_BUILDKIT is unset to trigger the warning path.
+	t.Setenv("DOCKER_BUILDKIT", "")
+
+	// Dry-run: warning should appear.
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	var dryBuf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath}, &dryBuf); err != nil {
+		t.Fatalf("hardened dry-run: %v", err)
+	}
+	if !strings.Contains(dryBuf.String(), "DOCKER_BUILDKIT") {
+		t.Errorf("expected DOCKER_BUILDKIT warning in dry-run output, got: %q", dryBuf.String())
+	}
+}
+
 // TestRunBuildImage_NotHardenedNoProvenanceArgs verifies that provenance flags are
 // NOT added when hardened=false (T33).
 func TestRunBuildImage_NotHardenedNoProvenanceArgs(t *testing.T) {

--- a/cmd/wfctl/build_security_audit.go
+++ b/cmd/wfctl/build_security_audit.go
@@ -75,17 +75,26 @@ func runBuildSecurityAudit(args []string) error {
 	}
 
 	// Critical always exits 1.
+	criticalCount := 0
 	for _, f := range findings {
 		if f.Severity == "CRITICAL" {
-			return fmt.Errorf("%d build security issue(s) found", len(findings))
+			criticalCount++
 		}
 	}
-	// --strict exits 1 on any warn.
+	if criticalCount > 0 {
+		return fmt.Errorf("%d critical build security issue(s) found", criticalCount)
+	}
+
+	// --strict exits 1 on any WARN (NOTE does not count).
 	if *strict {
+		warnCount := 0
 		for _, f := range findings {
 			if f.Severity == "WARN" {
-				return fmt.Errorf("%d build security issue(s) found", len(findings))
+				warnCount++
 			}
+		}
+		if warnCount > 0 {
+			return fmt.Errorf("%d build security warning(s) found", warnCount)
 		}
 	}
 	return nil

--- a/cmd/wfctl/build_security_audit.go
+++ b/cmd/wfctl/build_security_audit.go
@@ -1,23 +1,32 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/plugin/builder"
 )
 
 // buildAuditFinding is a single finding from the build security audit.
 type buildAuditFinding struct {
-	Severity string // WARN | NOTE
+	Severity string // CRITICAL | WARN | NOTE
 	Check    string
 	Message  string
+	File     string // non-empty for Dockerfile findings
+	Line     int    // 1-based line number for Dockerfile findings
 }
 
 func (f buildAuditFinding) String() string {
+	if f.File != "" {
+		return fmt.Sprintf("[%s] %s: %s (%s:%d)", f.Severity, f.Check, f.Message, f.File, f.Line)
+	}
 	return fmt.Sprintf("[%s] %s: %s", f.Severity, f.Check, f.Message)
 }
 
@@ -26,7 +35,7 @@ func runBuildSecurityAudit(args []string) error {
 	fs := flag.NewFlagSet("build audit", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	cfgPath := fs.String("config", "", "Path to workflow config file")
-	strict := fs.Bool("strict", false, "Exit 1 if any warnings are found")
+	strict := fs.Bool("strict", false, "Exit 1 if any warnings are found (critical always exits 1)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -55,12 +64,23 @@ func runBuildSecurityAudit(args []string) error {
 	fmt.Fprintln(tw, "SEVERITY\tCHECK\tFINDING")
 	fmt.Fprintln(tw, "--------\t-----\t-------")
 	for _, f := range findings {
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", f.Severity, f.Check, f.Message)
+		loc := ""
+		if f.File != "" {
+			loc = fmt.Sprintf(" (%s:%d)", f.File, f.Line)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s%s\n", f.Severity, f.Check, f.Message, loc)
 	}
 	if err := tw.Flush(); err != nil {
 		return err
 	}
 
+	// Critical always exits 1.
+	for _, f := range findings {
+		if f.Severity == "CRITICAL" {
+			return fmt.Errorf("%d build security issue(s) found", len(findings))
+		}
+	}
+	// --strict exits 1 on any warn.
 	if *strict {
 		for _, f := range findings {
 			if f.Severity == "WARN" {
@@ -72,7 +92,7 @@ func runBuildSecurityAudit(args []string) error {
 }
 
 // runBuildAuditChecks runs all audit checks and returns the findings.
-// workDir is the directory used to locate the plugins lockfile.
+// workDir is the directory used to locate the plugins lockfile and Dockerfiles.
 func runBuildAuditChecks(cfgPath, workDir string) []buildAuditFinding {
 	cfg, err := config.LoadFromFile(cfgPath)
 	if err != nil {
@@ -81,7 +101,7 @@ func runBuildAuditChecks(cfgPath, workDir string) []buildAuditFinding {
 	return auditBuildSecurity(cfg, workDir)
 }
 
-// auditBuildSecurity performs all six T34 audit checks against cfg.
+// auditBuildSecurity performs all audit checks against cfg.
 func auditBuildSecurity(cfg *config.WorkflowConfig, workDir string) []buildAuditFinding {
 	var findings []buildAuditFinding
 
@@ -160,5 +180,154 @@ func auditBuildSecurity(cfg *config.WorkflowConfig, workDir string) []buildAudit
 		}
 	}
 
+	if build == nil {
+		return findings
+	}
+
+	// Target-level audits: builder.SecurityLint() for each typed target.
+	for _, target := range build.Targets {
+		b, ok := builder.Get(target.Type)
+		if !ok {
+			continue
+		}
+		var sec *builder.SecurityConfig
+		if build.Security != nil {
+			sec = &builder.SecurityConfig{
+				Hardened:   build.Security.Hardened,
+				SBOM:       build.Security.SBOM,
+				Provenance: build.Security.Provenance,
+				NonRoot:    build.Security.NonRoot,
+			}
+		}
+		lintFindings := b.SecurityLint(builder.Config{
+			TargetName: target.Name,
+			Path:       target.Path,
+			Fields:     target.Config,
+			Security:   sec,
+		})
+		for _, lf := range lintFindings {
+			severity := strings.ToUpper(lf.Severity)
+			findings = append(findings, buildAuditFinding{
+				Severity: severity,
+				Check:    fmt.Sprintf("target:%s", target.Name),
+				Message:  lf.Message,
+				File:     lf.File,
+				Line:     lf.Line,
+			})
+		}
+	}
+
+	// Dockerfile linting for each container target with method=dockerfile.
+	var allowPrefixes []string
+	if build.Security != nil && build.Security.BaseImagePolicy != nil {
+		allowPrefixes = build.Security.BaseImagePolicy.AllowPrefixes
+	}
+	for i := range build.Containers {
+		ctr := &build.Containers[i]
+		method := ctr.Method
+		if method == "" {
+			method = "dockerfile"
+		}
+		if method != "dockerfile" {
+			continue
+		}
+		dfPath := ctr.Dockerfile
+		if dfPath == "" {
+			dfPath = "Dockerfile"
+		}
+		if !filepath.IsAbs(dfPath) {
+			dfPath = filepath.Join(workDir, dfPath)
+		}
+		dfFindings := lintDockerfile(dfPath, ctr.Name, allowPrefixes)
+		findings = append(findings, dfFindings...)
+	}
+
 	return findings
+}
+
+var (
+	reUserRoot       = regexp.MustCompile(`(?i)^USER\s+root\s*$`)
+	reUserAny        = regexp.MustCompile(`(?i)^USER\s+\S`)
+	reFromLatest     = regexp.MustCompile(`(?i)^FROM\s+[^:\s]+:latest(\s|$)`)
+	reFromImage      = regexp.MustCompile(`(?i)^FROM\s+(\S+)`)
+	reAddURL         = regexp.MustCompile(`(?i)^ADD\s+https?://`)
+	reEmbeddedSecret = regexp.MustCompile(`(?i)(password|secret|token|api[_-]?key)\s*=\s*["']?[A-Za-z0-9]`)
+)
+
+// lintDockerfile scans a Dockerfile and returns security findings.
+func lintDockerfile(dfPath, containerName string, allowPrefixes []string) []buildAuditFinding {
+	var findings []buildAuditFinding
+
+	data, err := os.ReadFile(dfPath)
+	if err != nil {
+		// Dockerfile not present — skip silently (may not exist in audit-only context).
+		return findings
+	}
+
+	checkName := "dockerfile:" + containerName
+	addDF := func(severity, msg string, lineNum int) {
+		findings = append(findings, buildAuditFinding{
+			Severity: severity,
+			Check:    checkName,
+			Message:  msg,
+			File:     dfPath,
+			Line:     lineNum,
+		})
+	}
+
+	hasUser := false
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		if reUserRoot.MatchString(line) {
+			addDF("CRITICAL", "USER root detected — container will run as root", lineNum)
+		}
+		if reUserAny.MatchString(line) {
+			hasUser = true
+		}
+		if reFromLatest.MatchString(line) {
+			addDF("WARN", "FROM uses :latest tag — pin to a digest or explicit version for reproducibility", lineNum)
+		}
+		if reAddURL.MatchString(line) {
+			addDF("WARN", "ADD with URL is untrusted — use RUN curl/wget with checksum verification instead", lineNum)
+		}
+		if reEmbeddedSecret.MatchString(line) {
+			addDF("CRITICAL", fmt.Sprintf("possible embedded secret in line %d — use BuildKit secrets (--secret) instead", lineNum), lineNum)
+		}
+
+		// Base image policy.
+		if len(allowPrefixes) > 0 && reFromImage.MatchString(line) {
+			m := reFromImage.FindStringSubmatch(line)
+			if len(m) > 1 && m[1] != "scratch" {
+				img := m[1]
+				if !matchesAnyPrefix(img, allowPrefixes) {
+					addDF("WARN", fmt.Sprintf("base image %q does not match allow_prefixes policy %v", img, allowPrefixes), lineNum)
+				}
+			}
+		}
+	}
+
+	if !hasUser {
+		findings = append(findings, buildAuditFinding{
+			Severity: "CRITICAL",
+			Check:    checkName,
+			Message:  "no USER directive found — container will run as root by default",
+			File:     dfPath,
+			Line:     0,
+		})
+	}
+
+	return findings
+}
+
+func matchesAnyPrefix(image string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(image, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/wfctl/build_security_audit.go
+++ b/cmd/wfctl/build_security_audit.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// buildAuditFinding is a single finding from the build security audit.
+type buildAuditFinding struct {
+	Severity string // WARN | NOTE
+	Check    string
+	Message  string
+}
+
+func (f buildAuditFinding) String() string {
+	return fmt.Sprintf("[%s] %s: %s", f.Severity, f.Check, f.Message)
+}
+
+// runBuildSecurityAudit implements `wfctl build audit` and `wfctl build --security-audit`.
+func runBuildSecurityAudit(args []string) error {
+	fs := flag.NewFlagSet("build audit", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cfgPath := fs.String("config", "", "Path to workflow config file")
+	strict := fs.Bool("strict", false, "Exit 1 if any warnings are found")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *cfgPath == "" {
+		for _, c := range []string{"workflow.yaml", "app.yaml", "ci.yaml"} {
+			if _, err := os.Stat(c); err == nil {
+				*cfgPath = c
+				break
+			}
+		}
+	}
+	if *cfgPath == "" {
+		return fmt.Errorf("wfctl build audit: no config file found")
+	}
+
+	workDir := filepath.Dir(*cfgPath)
+	findings := runBuildAuditChecks(*cfgPath, workDir)
+
+	if len(findings) == 0 {
+		fmt.Println("No build security issues found.")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "SEVERITY\tCHECK\tFINDING")
+	fmt.Fprintln(tw, "--------\t-----\t-------")
+	for _, f := range findings {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", f.Severity, f.Check, f.Message)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if *strict {
+		for _, f := range findings {
+			if f.Severity == "WARN" {
+				return fmt.Errorf("%d build security issue(s) found", len(findings))
+			}
+		}
+	}
+	return nil
+}
+
+// runBuildAuditChecks runs all audit checks and returns the findings.
+// workDir is the directory used to locate the plugins lockfile.
+func runBuildAuditChecks(cfgPath, workDir string) []buildAuditFinding {
+	cfg, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		return []buildAuditFinding{{Severity: "WARN", Check: "config", Message: fmt.Sprintf("failed to load config: %v", err)}}
+	}
+	return auditBuildSecurity(cfg, workDir)
+}
+
+// auditBuildSecurity performs all six T34 audit checks against cfg.
+func auditBuildSecurity(cfg *config.WorkflowConfig, workDir string) []buildAuditFinding {
+	var findings []buildAuditFinding
+
+	add := func(severity, check, message string) {
+		findings = append(findings, buildAuditFinding{Severity: severity, Check: check, Message: message})
+	}
+
+	var build *config.CIBuildConfig
+	var registries []config.CIRegistry
+	if cfg.CI != nil {
+		build = cfg.CI.Build
+		registries = cfg.CI.Registries
+	}
+
+	// Check 1: ci.build.security.hardened=false.
+	if build != nil && build.Security != nil && !build.Security.Hardened {
+		add("WARN", "hardened", "ci.build.security.hardened=false — supply-chain hardening is disabled")
+	}
+
+	// Check 2: dockerfile containers without sbom or provenance.
+	if build != nil {
+		for i := range build.Containers {
+			ctr := &build.Containers[i]
+			method := ctr.Method
+			if method == "" {
+				method = "dockerfile"
+			}
+			if method != "dockerfile" {
+				continue
+			}
+			sec := build.Security
+			if sec == nil || !sec.SBOM {
+				add("WARN", "sbom", fmt.Sprintf("container %q uses dockerfile but ci.build.security.sbom is not enabled", ctr.Name))
+			}
+			if sec == nil || sec.Provenance == "" {
+				add("WARN", "provenance", fmt.Sprintf("container %q uses dockerfile but ci.build.security.provenance is not set", ctr.Name))
+			}
+		}
+	}
+
+	// Check 3: registries without retention.
+	for _, reg := range registries {
+		if reg.Retention == nil {
+			add("WARN", "retention", fmt.Sprintf("ci.registries[%q] has no retention policy defined", reg.Name))
+		}
+	}
+
+	// Check 4: plugins declared without a plugins lockfile.
+	hasPlugins := (cfg.Requires != nil && len(cfg.Requires.Plugins) > 0) ||
+		(cfg.Plugins != nil && len(cfg.Plugins.External) > 0)
+	if hasPlugins {
+		lockPath := filepath.Join(workDir, wfctlYAMLPath)
+		lf, err := loadPluginLockfile(lockPath)
+		if err != nil || len(lf.Plugins) == 0 {
+			add("WARN", "lockfile", fmt.Sprintf("plugins are declared in config but no plugins lockfile found at %s", lockPath))
+		}
+	}
+
+	// Check 5: registries with auth.env where the env var is not set.
+	for _, reg := range registries {
+		if reg.Auth == nil || reg.Auth.Env == "" {
+			continue
+		}
+		if os.Getenv(reg.Auth.Env) == "" {
+			add("WARN", "auth-env", fmt.Sprintf("ci.registries[%q] auth.env=%q is not set in the current environment", reg.Name, reg.Auth.Env))
+		}
+	}
+
+	// Check 6: environments.local.build overrides that disable hardening — NOTE only.
+	if cfg.Environments != nil {
+		if localEnv, ok := cfg.Environments["local"]; ok && localEnv != nil && localEnv.Build != nil {
+			sec := localEnv.Build.Security
+			if sec != nil && !sec.Hardened {
+				add("NOTE", "local-hardening", "environments.local.build.security.hardened=false — expected for local dev, not a security issue")
+			}
+		}
+	}
+
+	return findings
+}

--- a/cmd/wfctl/build_security_audit_test.go
+++ b/cmd/wfctl/build_security_audit_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBuildAuditConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestBuildSecurityAudit_HardenedFalse checks check 1: hardened=false → WARN.
+func TestBuildSecurityAudit_HardenedFalse(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: false
+    containers:
+      - name: app
+        method: dockerfile
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "hardened") {
+		t.Errorf("expected WARN about hardened=false, got: %v", findings)
+	}
+}
+
+// TestBuildSecurityAudit_HardenedTrue checks no WARN when hardened=true.
+func TestBuildSecurityAudit_HardenedTrue(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	for _, f := range findings {
+		if f.Severity == "WARN" && strings.Contains(strings.ToLower(f.Message), "hardened") {
+			t.Errorf("unexpected WARN about hardened: %v", f)
+		}
+	}
+}
+
+// TestBuildSecurityAudit_DockerfileNoSBOM checks check 2: dockerfile without sbom/provenance → WARN.
+func TestBuildSecurityAudit_DockerfileNoSBOM(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: true
+      sbom: false
+      provenance: ""
+    containers:
+      - name: app
+        method: dockerfile
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "sbom") && !hasMatch(findings, "WARN", "provenance") {
+		t.Errorf("expected WARN about sbom/provenance for dockerfile, got: %v", findings)
+	}
+}
+
+// TestBuildSecurityAudit_RegistryNoRetention checks check 3: registry without retention → WARN.
+func TestBuildSecurityAudit_RegistryNoRetention(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  registries:
+    - name: ghcr
+      type: ghcr
+      path: ghcr.io/myorg
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "retention") {
+		t.Errorf("expected WARN about missing retention, got: %v", findings)
+	}
+}
+
+// TestBuildSecurityAudit_RegistryWithRetention checks no WARN when retention is defined.
+func TestBuildSecurityAudit_RegistryWithRetention(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  registries:
+    - name: ghcr
+      type: ghcr
+      path: ghcr.io/myorg
+      retention:
+        keep_latest: 5
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	for _, f := range findings {
+		if f.Severity == "WARN" && strings.Contains(strings.ToLower(f.Message), "retention") {
+			t.Errorf("unexpected WARN about retention: %v", f)
+		}
+	}
+}
+
+// TestBuildSecurityAudit_PluginsNoLockfile checks check 4: plugins in config without lockfile → WARN.
+func TestBuildSecurityAudit_PluginsNoLockfile(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+requires:
+  plugins:
+    - name: my-plugin
+      version: 1.0.0
+`)
+	// No .wfctl.yaml exists in the temp dir.
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "lock") {
+		t.Errorf("expected WARN about missing plugins lockfile, got: %v", findings)
+	}
+}
+
+// TestBuildSecurityAudit_PluginsWithLockfile checks no WARN when lockfile exists.
+func TestBuildSecurityAudit_PluginsWithLockfile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+requires:
+  plugins:
+    - name: my-plugin
+      version: 1.0.0
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Write .wfctl.yaml lockfile.
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(`plugins:
+  my-plugin:
+    version: 1.0.0
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	findings := runBuildAuditChecks(cfgPath, dir)
+	for _, f := range findings {
+		if f.Severity == "WARN" && strings.Contains(strings.ToLower(f.Message), "lock") {
+			t.Errorf("unexpected WARN about lockfile: %v", f)
+		}
+	}
+}
+
+// TestBuildSecurityAudit_EnvAuthMissing checks check 5: auth.env var not set → WARN.
+func TestBuildSecurityAudit_EnvAuthMissing(t *testing.T) {
+	envVar := "WFCTL_TEST_AUDIT_TOKEN_MISSING_XYZ"
+	os.Unsetenv(envVar)
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  registries:
+    - name: ghcr
+      type: ghcr
+      path: ghcr.io/myorg
+      auth:
+        env: `+envVar+`
+      retention:
+        keep_latest: 5
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", envVar) {
+		t.Errorf("expected WARN about missing env var %s, got: %v", envVar, findings)
+	}
+}
+
+// TestBuildSecurityAudit_EnvAuthSet checks no WARN when env var is set.
+func TestBuildSecurityAudit_EnvAuthSet(t *testing.T) {
+	envVar := "WFCTL_TEST_AUDIT_TOKEN_SET_XYZ"
+	t.Setenv(envVar, "sometoken")
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  registries:
+    - name: ghcr
+      type: ghcr
+      path: ghcr.io/myorg
+      auth:
+        env: `+envVar+`
+      retention:
+        keep_latest: 5
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	for _, f := range findings {
+		if f.Severity == "WARN" && strings.Contains(f.Message, envVar) {
+			t.Errorf("unexpected WARN about env var: %v", f)
+		}
+	}
+}
+
+// TestBuildSecurityAudit_LocalHardeningDisabled checks check 6: local env disabling hardening → NOTE.
+func TestBuildSecurityAudit_LocalHardeningDisabled(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: true
+environments:
+  local:
+    build:
+      security:
+        hardened: false
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "NOTE", "local") {
+		t.Errorf("expected NOTE about local env disabling hardening, got: %v", findings)
+	}
+	// Must NOT be a WARN (it's expected for local).
+	for _, f := range findings {
+		if f.Severity == "WARN" && strings.Contains(strings.ToLower(f.Message), "local") && strings.Contains(strings.ToLower(f.Message), "harden") {
+			t.Errorf("local hardening override should be NOTE not WARN: %v", f)
+		}
+	}
+}
+
+// TestBuildSecurityAudit_StrictExitCode checks --strict causes exit 1 when warnings exist.
+func TestBuildSecurityAudit_StrictExitCode(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: false
+`)
+	err := runBuildSecurityAudit([]string{"--strict", "--config", cfgPath})
+	if err == nil {
+		t.Error("expected non-nil error in strict mode with warnings")
+	}
+}
+
+// TestBuildSecurityAudit_NoStrictClean checks exit 0 when no warnings.
+func TestBuildSecurityAudit_NoStrictClean(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+  registries:
+    - name: ghcr
+      type: ghcr
+      path: ghcr.io/myorg
+      retention:
+        keep_latest: 5
+`)
+	err := runBuildSecurityAudit([]string{"--config", cfgPath})
+	if err != nil {
+		t.Errorf("expected nil error with clean config, got: %v", err)
+	}
+}
+
+// hasMatch returns true if any finding matches the given severity and message substring.
+func hasMatch(findings []buildAuditFinding, severity, msgSubstr string) bool {
+	for _, f := range findings {
+		if f.Severity == severity && strings.Contains(strings.ToLower(f.Message), strings.ToLower(msgSubstr)) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/wfctl/build_security_audit_test.go
+++ b/cmd/wfctl/build_security_audit_test.go
@@ -261,3 +261,187 @@ func hasMatch(findings []buildAuditFinding, severity, msgSubstr string) bool {
 	}
 	return false
 }
+
+// --- T34 Dockerfile linting tests ---
+
+func writeDockerfileAuditFixture(t *testing.T, cfgYAML, dockerfileContent string) (cfgPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath = filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if dockerfileContent != "" {
+		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfileContent), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return cfgPath
+}
+
+// TestDockerfileAudit_UserRoot checks that USER root → critical.
+func TestDockerfileAudit_UserRoot(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22
+USER root
+RUN go build .
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "CRITICAL", "root") {
+		t.Errorf("expected CRITICAL for USER root, got: %v", findings)
+	}
+}
+
+// TestDockerfileAudit_NoUser checks that missing USER → critical.
+func TestDockerfileAudit_NoUser(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22
+RUN go build .
+COPY . .
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "CRITICAL", "user") {
+		t.Errorf("expected CRITICAL for missing USER directive, got: %v", findings)
+	}
+}
+
+// TestDockerfileAudit_LatestTag checks FROM :latest → warn.
+func TestDockerfileAudit_LatestTag(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:latest
+USER app
+RUN go build .
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "latest") {
+		t.Errorf("expected WARN for FROM :latest, got: %v", findings)
+	}
+}
+
+// TestDockerfileAudit_AddURL checks ADD https:// → warn.
+func TestDockerfileAudit_AddURL(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22
+USER app
+ADD https://example.com/file.tar.gz /tmp/
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "add") {
+		t.Errorf("expected WARN for ADD URL, got: %v", findings)
+	}
+}
+
+// TestDockerfileAudit_EmbeddedSecret checks secret pattern → critical.
+func TestDockerfileAudit_EmbeddedSecret(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22
+USER app
+ENV API_KEY=abc123secret
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "CRITICAL", "secret") && !hasMatch(findings, "CRITICAL", "api") {
+		t.Errorf("expected CRITICAL for embedded secret, got: %v", findings)
+	}
+}
+
+// TestDockerfileAudit_Clean checks a clean Dockerfile produces no Dockerfile findings.
+func TestDockerfileAudit_Clean(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22-alpine
+RUN addgroup -S app && adduser -S app -G app
+USER app
+COPY . .
+RUN go build .
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	for _, f := range findings {
+		if f.File != "" && (f.Severity == "CRITICAL" || f.Severity == "WARN") {
+			t.Errorf("unexpected Dockerfile finding in clean file: %v", f)
+		}
+	}
+}
+
+// TestDockerfileAudit_BaseImagePolicy checks allow_prefixes enforcement.
+func TestDockerfileAudit_BaseImagePolicy(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+      base_image_policy:
+        allow_prefixes:
+          - gcr.io/distroless/
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22-alpine
+USER app
+`)
+	findings := runBuildAuditChecks(cfgPath, filepath.Dir(cfgPath))
+	if !hasMatch(findings, "WARN", "policy") && !hasMatch(findings, "WARN", "allow") {
+		t.Errorf("expected WARN for base image policy violation, got: %v", findings)
+	}
+}
+
+// TestBuildAudit_CriticalExitsOne checks that CRITICAL findings cause exit 1 even without --strict.
+func TestBuildAudit_CriticalExitsOne(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+`, `FROM golang:1.22
+USER root
+`)
+	err := runBuildSecurityAudit([]string{"--config", cfgPath})
+	if err == nil {
+		t.Error("expected non-nil error when critical findings exist")
+	}
+}
+
+// TestBuildAudit_WarnNoStrictExitsZero checks that WARN alone exits 0 without --strict.
+func TestBuildAudit_WarnNoStrictExitsZero(t *testing.T) {
+	cfgPath := writeDockerfileAuditFixture(t, `
+ci:
+  build:
+    security:
+      hardened: false
+`, "")
+	err := runBuildSecurityAudit([]string{"--config", cfgPath})
+	if err != nil {
+		t.Errorf("expected exit 0 for WARN without --strict, got: %v", err)
+	}
+}

--- a/cmd/wfctl/build_security_audit_test.go
+++ b/cmd/wfctl/build_security_audit_test.go
@@ -445,3 +445,25 @@ ci:
 		t.Errorf("expected exit 0 for WARN without --strict, got: %v", err)
 	}
 }
+
+// TestBuildAudit_NoteOnlyStrictExitsZero checks that NOTE-only findings do NOT trigger
+// exit 1 even with --strict (NOTE is informational, not a warning).
+func TestBuildAudit_NoteOnlyStrictExitsZero(t *testing.T) {
+	cfgPath := writeBuildAuditConfig(t, `
+ci:
+  build:
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+environments:
+  local:
+    build:
+      security:
+        hardened: false
+`)
+	err := runBuildSecurityAudit([]string{"--strict", "--config", cfgPath})
+	if err != nil {
+		t.Errorf("expected exit 0 for NOTE-only findings with --strict, got: %v", err)
+	}
+}

--- a/config/ci_registry.go
+++ b/config/ci_registry.go
@@ -7,6 +7,10 @@ type CIRegistry struct {
 	Path      string               `json:"path" yaml:"path"`
 	Auth      *CIRegistryAuth      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Retention *CIRegistryRetention `json:"retention,omitempty" yaml:"retention,omitempty"`
+	// APIBaseURL is the base URL for the registry provider's API.
+	// Used by the GitLab provider to support self-managed instances.
+	// Defaults to https://gitlab.com when unset.
+	APIBaseURL string `json:"api_base_url,omitempty" yaml:"api_base_url,omitempty"`
 }
 
 // CIRegistryAuth holds credentials for pushing/pulling from a registry.

--- a/plugins/registry-gitlab/plugin.go
+++ b/plugins/registry-gitlab/plugin.go
@@ -1,8 +1,17 @@
-// Package registrygitlab is a stub registry provider for GitLab Container Registry.
-// Full implementation tracked in the issue tracker.
+// Package registrygitlab provides the GitLab Container Registry provider.
 package registrygitlab
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
 	"github.com/GoCodeAlone/workflow/plugin/registry"
 )
 
@@ -10,24 +19,216 @@ func init() {
 	registry.Register(New())
 }
 
+// GitLabProvider implements registry.RegistryProvider for GitLab Container Registry.
 type GitLabProvider struct{}
 
+// New returns a new GitLabProvider.
 func New() registry.RegistryProvider { return &GitLabProvider{} }
 
 func (g *GitLabProvider) Name() string { return "gitlab" }
 
-func (g *GitLabProvider) Login(_ registry.Context, _ registry.ProviderConfig) error {
-	return registry.ErrNotImplemented
+// Login authenticates with registry.gitlab.com.
+// In CI context ($CI_JOB_TOKEN set), uses gitlab-ci-token as username.
+// Otherwise uses oauth2 with the token from auth.env.
+func (g *GitLabProvider) Login(ctx registry.Context, cfg registry.ProviderConfig) error {
+	host := registryHost(cfg.Registry.Path)
+	username, token, err := resolveCredentials(cfg)
+	if err != nil {
+		return err
+	}
+
+	args := []string{"login", host, "--username", username, "--password-stdin"}
+	if ctx.DryRun() {
+		fmt.Fprintf(ctx.Out(), "[dry-run] echo $TOKEN | docker %s\n", joinArgs(args))
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec
+	cmd.Stdin = strings.NewReader(token)
+	cmd.Stdout = ctx.Out()
+	cmd.Stderr = ctx.Out()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker login %s: %w", host, err)
+	}
+	return nil
 }
 
-func (g *GitLabProvider) Logout(_ registry.Context, _ registry.ProviderConfig) error {
-	return registry.ErrNotImplemented
+func (g *GitLabProvider) Logout(ctx registry.Context, cfg registry.ProviderConfig) error {
+	host := registryHost(cfg.Registry.Path)
+	args := []string{"logout", host}
+	if ctx.DryRun() {
+		fmt.Fprintf(ctx.Out(), "[dry-run] docker %s\n", joinArgs(args))
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec
+	cmd.Stdout = ctx.Out()
+	cmd.Stderr = ctx.Out()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker logout %s: %w", host, err)
+	}
+	return nil
 }
 
-func (g *GitLabProvider) Push(_ registry.Context, _ registry.ProviderConfig, _ string) error {
-	return registry.ErrNotImplemented
+func (g *GitLabProvider) Push(ctx registry.Context, cfg registry.ProviderConfig, imageRef string) error {
+	if ctx.DryRun() {
+		fmt.Fprintf(ctx.Out(), "[dry-run] docker push %s\n", imageRef)
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "docker", "push", imageRef) //nolint:gosec
+	cmd.Stdout = ctx.Out()
+	cmd.Stderr = ctx.Out()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker push %s: %w", imageRef, err)
+	}
+	return nil
 }
 
-func (g *GitLabProvider) Prune(_ registry.Context, _ registry.ProviderConfig) error {
-	return registry.ErrNotImplemented
+// Prune deletes tags beyond retention.keep_latest via the GitLab Container Registry API.
+// Uses GET /api/v4/projects/:id/registry/repositories to find repo IDs, then
+// DELETE /api/v4/projects/:id/registry/repositories/:repo_id/tags/:tag_name.
+func (g *GitLabProvider) Prune(ctx registry.Context, cfg registry.ProviderConfig) error {
+	ret := cfg.Registry.Retention
+	if ret == nil || ret.KeepLatest <= 0 {
+		return nil
+	}
+
+	_, token, err := resolveCredentials(cfg)
+	if err != nil {
+		return err
+	}
+
+	projectPath := gitlabProjectPath(cfg.Registry.Path)
+
+	if ctx.DryRun() {
+		fmt.Fprintf(ctx.Out(), "[dry-run] GitLab API: prune registry tags for %s, keep latest %d\n",
+			projectPath, ret.KeepLatest)
+		return nil
+	}
+
+	return pruneGitLabTags(ctx, token, projectPath, ret.KeepLatest)
+}
+
+// resolveCredentials returns (username, token, error) for GitLab auth.
+// In CI (CI_JOB_TOKEN set), uses gitlab-ci-token + CI_JOB_TOKEN.
+// Otherwise uses oauth2 + auth.env token.
+func resolveCredentials(cfg registry.ProviderConfig) (username, token string, err error) {
+	if ciToken := os.Getenv("CI_JOB_TOKEN"); ciToken != "" {
+		return "gitlab-ci-token", ciToken, nil
+	}
+	if cfg.Registry.Auth == nil || cfg.Registry.Auth.Env == "" {
+		return "", "", fmt.Errorf("gitlab registry %q: auth.env is required (or set CI_JOB_TOKEN)", cfg.Registry.Name)
+	}
+	envVar := cfg.Registry.Auth.Env
+	tok := os.Getenv(envVar)
+	if tok == "" {
+		return "", "", fmt.Errorf("gitlab registry %q: env var %s is not set or empty", cfg.Registry.Name, envVar)
+	}
+	return "oauth2", tok, nil
+}
+
+// registryHost extracts the hostname from a registry path.
+// "registry.gitlab.com/myorg/myproject" → "registry.gitlab.com".
+func registryHost(path string) string {
+	if i := strings.Index(path, "/"); i >= 0 {
+		return path[:i]
+	}
+	return path
+}
+
+// gitlabProjectPath extracts the project path from a registry path.
+// "registry.gitlab.com/myorg/myproject" → "myorg/myproject".
+func gitlabProjectPath(path string) string {
+	if i := strings.Index(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+type glRepoTag struct {
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+type glRepository struct {
+	ID int `json:"id"`
+}
+
+func pruneGitLabTags(ctx registry.Context, token, projectPath string, keepLatest int) error {
+	encodedProject := url.PathEscape(projectPath)
+	baseURL := "https://gitlab.com"
+
+	// List registry repositories for the project.
+	repoURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories", baseURL, encodedProject)
+	repos, err := glGetJSON[[]glRepository](ctx, token, repoURL)
+	if err != nil {
+		return fmt.Errorf("list gitlab registry repositories: %w", err)
+	}
+
+	for _, repo := range repos {
+		tagsURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories/%d/tags", baseURL, encodedProject, repo.ID)
+		tags, err := glGetJSON[[]glRepoTag](ctx, token, tagsURL)
+		if err != nil {
+			return fmt.Errorf("list tags for repo %d: %w", repo.ID, err)
+		}
+
+		// Sort newest first (ISO 8601 lexicographic works).
+		sort.Slice(tags, func(i, j int) bool {
+			return tags[i].CreatedAt > tags[j].CreatedAt
+		})
+
+		for i, tag := range tags {
+			if i < keepLatest {
+				continue
+			}
+			delURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories/%d/tags/%s",
+				baseURL, encodedProject, repo.ID, url.PathEscape(tag.Name))
+			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, delURL, nil)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("PRIVATE-TOKEN", token)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				fmt.Fprintf(ctx.Out(), "warn: delete tag %s: %v\n", tag.Name, err)
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+				fmt.Fprintf(ctx.Out(), "deleted tag %s\n", tag.Name)
+			} else {
+				fmt.Fprintf(ctx.Out(), "warn: delete tag %s: HTTP %d\n", tag.Name, resp.StatusCode)
+			}
+		}
+	}
+	return nil
+}
+
+func glGetJSON[T any](ctx registry.Context, token, rawURL string) (T, error) {
+	var zero T
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return zero, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return zero, fmt.Errorf("GitLab API %s: %s", resp.Status, body)
+	}
+
+	var result T
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return zero, err
+	}
+	return result, nil
+}
+
+func joinArgs(args []string) string {
+	return strings.Join(args, " ")
 }

--- a/plugins/registry-gitlab/plugin.go
+++ b/plugins/registry-gitlab/plugin.go
@@ -27,12 +27,12 @@ func New() registry.RegistryProvider { return &GitLabProvider{} }
 
 func (g *GitLabProvider) Name() string { return "gitlab" }
 
-// Login authenticates with registry.gitlab.com.
+// Login authenticates with the GitLab registry host.
 // In CI context ($CI_JOB_TOKEN set), uses gitlab-ci-token as username.
 // Otherwise uses oauth2 with the token from auth.env.
 func (g *GitLabProvider) Login(ctx registry.Context, cfg registry.ProviderConfig) error {
 	host := registryHost(cfg.Registry.Path)
-	username, token, err := resolveCredentials(cfg)
+	username, token, _, err := resolveCredentials(cfg)
 	if err != nil {
 		return err
 	}
@@ -84,20 +84,20 @@ func (g *GitLabProvider) Push(ctx registry.Context, cfg registry.ProviderConfig,
 }
 
 // Prune deletes tags beyond retention.keep_latest via the GitLab Container Registry API.
-// Uses GET /api/v4/projects/:id/registry/repositories to find repo IDs, then
-// DELETE /api/v4/projects/:id/registry/repositories/:repo_id/tags/:tag_name.
+// Supports self-managed instances via ci.registries[].api_base_url.
 func (g *GitLabProvider) Prune(ctx registry.Context, cfg registry.ProviderConfig) error {
 	ret := cfg.Registry.Retention
 	if ret == nil || ret.KeepLatest <= 0 {
 		return nil
 	}
 
-	_, token, err := resolveCredentials(cfg)
+	_, token, tokenType, err := resolveCredentials(cfg)
 	if err != nil {
 		return err
 	}
 
 	projectPath := gitlabProjectPath(cfg.Registry.Path)
+	apiBase := glAPIBase(cfg)
 
 	if ctx.DryRun() {
 		fmt.Fprintf(ctx.Out(), "[dry-run] GitLab API: prune registry tags for %s, keep latest %d\n",
@@ -105,41 +105,58 @@ func (g *GitLabProvider) Prune(ctx registry.Context, cfg registry.ProviderConfig
 		return nil
 	}
 
-	return pruneGitLabTags(ctx, token, projectPath, ret.KeepLatest)
+	return pruneGitLabTags(ctx, token, tokenType, apiBase, projectPath, ret.KeepLatest)
 }
 
-// resolveCredentials returns (username, token, error) for GitLab auth.
-// In CI (CI_JOB_TOKEN set), uses gitlab-ci-token + CI_JOB_TOKEN.
-// Otherwise uses oauth2 + auth.env token.
-func resolveCredentials(cfg registry.ProviderConfig) (username, token string, err error) {
+// resolveCredentials returns (username, token, tokenType, error).
+// tokenType is "job" when CI_JOB_TOKEN is used, "private" otherwise.
+// The JOB-TOKEN header is required for CI_JOB_TOKEN; PRIVATE-TOKEN for PATs.
+func resolveCredentials(cfg registry.ProviderConfig) (username, token, tokenType string, err error) {
 	if ciToken := os.Getenv("CI_JOB_TOKEN"); ciToken != "" {
-		return "gitlab-ci-token", ciToken, nil
+		return "gitlab-ci-token", ciToken, "job", nil
 	}
 	if cfg.Registry.Auth == nil || cfg.Registry.Auth.Env == "" {
-		return "", "", fmt.Errorf("gitlab registry %q: auth.env is required (or set CI_JOB_TOKEN)", cfg.Registry.Name)
+		return "", "", "", fmt.Errorf("gitlab registry %q: auth.env is required (or set CI_JOB_TOKEN)", cfg.Registry.Name)
 	}
 	envVar := cfg.Registry.Auth.Env
 	tok := os.Getenv(envVar)
 	if tok == "" {
-		return "", "", fmt.Errorf("gitlab registry %q: env var %s is not set or empty", cfg.Registry.Name, envVar)
+		return "", "", "", fmt.Errorf("gitlab registry %q: env var %s is not set or empty", cfg.Registry.Name, envVar)
 	}
-	return "oauth2", tok, nil
+	return "oauth2", tok, "private", nil
+}
+
+// AuthHeaderFor returns the correct GitLab API auth header name for tokenType.
+// Exported for testing. tokenType is "job" (CI_JOB_TOKEN) or "private" (PAT/oauth2).
+func AuthHeaderFor(tokenType string) string {
+	if tokenType == "job" {
+		return "JOB-TOKEN"
+	}
+	return "PRIVATE-TOKEN"
+}
+
+// glAPIBase returns the GitLab API base URL for the registry config.
+// Uses cfg.Registry.APIBaseURL if set; defaults to https://gitlab.com.
+func glAPIBase(cfg registry.ProviderConfig) string {
+	if cfg.Registry.APIBaseURL != "" {
+		return strings.TrimRight(cfg.Registry.APIBaseURL, "/")
+	}
+	return "https://gitlab.com"
 }
 
 // registryHost extracts the hostname from a registry path.
 // "registry.gitlab.com/myorg/myproject" → "registry.gitlab.com".
 func registryHost(path string) string {
-	if i := strings.Index(path, "/"); i >= 0 {
-		return path[:i]
-	}
-	return path
+	host, _, _ := strings.Cut(path, "/")
+	return host
 }
 
 // gitlabProjectPath extracts the project path from a registry path.
 // "registry.gitlab.com/myorg/myproject" → "myorg/myproject".
 func gitlabProjectPath(path string) string {
-	if i := strings.Index(path, "/"); i >= 0 {
-		return path[i+1:]
+	_, rest, found := strings.Cut(path, "/")
+	if found {
+		return rest
 	}
 	return path
 }
@@ -153,20 +170,18 @@ type glRepository struct {
 	ID int `json:"id"`
 }
 
-func pruneGitLabTags(ctx registry.Context, token, projectPath string, keepLatest int) error {
+func pruneGitLabTags(ctx registry.Context, token, tokenType, apiBase, projectPath string, keepLatest int) error {
 	encodedProject := url.PathEscape(projectPath)
-	baseURL := "https://gitlab.com"
 
-	// List registry repositories for the project.
-	repoURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories", baseURL, encodedProject)
-	repos, err := glGetJSON[[]glRepository](ctx, token, repoURL)
+	repoURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories?per_page=100", apiBase, encodedProject)
+	repos, err := glPaginatedGet[glRepository](ctx, token, tokenType, repoURL)
 	if err != nil {
 		return fmt.Errorf("list gitlab registry repositories: %w", err)
 	}
 
 	for _, repo := range repos {
-		tagsURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories/%d/tags", baseURL, encodedProject, repo.ID)
-		tags, err := glGetJSON[[]glRepoTag](ctx, token, tagsURL)
+		tagsURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories/%d/tags?per_page=100", apiBase, encodedProject, repo.ID)
+		tags, err := glPaginatedGet[glRepoTag](ctx, token, tokenType, tagsURL)
 		if err != nil {
 			return fmt.Errorf("list tags for repo %d: %w", repo.ID, err)
 		}
@@ -181,12 +196,12 @@ func pruneGitLabTags(ctx registry.Context, token, projectPath string, keepLatest
 				continue
 			}
 			delURL := fmt.Sprintf("%s/api/v4/projects/%s/registry/repositories/%d/tags/%s",
-				baseURL, encodedProject, repo.ID, url.PathEscape(tag.Name))
+				apiBase, encodedProject, repo.ID, url.PathEscape(tag.Name))
 			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, delURL, nil)
 			if err != nil {
 				return err
 			}
-			req.Header.Set("PRIVATE-TOKEN", token)
+			req.Header.Set(AuthHeaderFor(tokenType), token)
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				fmt.Fprintf(ctx.Out(), "warn: delete tag %s: %v\n", tag.Name, err)
@@ -203,30 +218,72 @@ func pruneGitLabTags(ctx registry.Context, token, projectPath string, keepLatest
 	return nil
 }
 
-func glGetJSON[T any](ctx registry.Context, token, rawURL string) (T, error) {
-	var zero T
+// glPaginatedGet fetches all pages of a GitLab API list endpoint,
+// following X-Next-Page headers until exhausted.
+func glPaginatedGet[T any](ctx registry.Context, token, tokenType, firstURL string) ([]T, error) {
+	var all []T
+	nextURL := firstURL
+	for nextURL != "" {
+		page, nextPage, err := glGetPage[T](ctx, token, tokenType, nextURL)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		nextURL = nextPage
+	}
+	return all, nil
+}
+
+// glGetPage fetches one page and returns items + the URL for the next page (empty if done).
+func glGetPage[T any](ctx registry.Context, token, tokenType, rawURL string) ([]T, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return zero, err
+		return nil, "", err
 	}
-	req.Header.Set("PRIVATE-TOKEN", token)
+	req.Header.Set(AuthHeaderFor(tokenType), token)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return zero, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return zero, fmt.Errorf("GitLab API %s: %s", resp.Status, body)
+		return nil, "", fmt.Errorf("GitLab API %s: %s", resp.Status, body)
 	}
 
-	var result T
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return zero, err
+	var items []T
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, "", err
 	}
-	return result, nil
+
+	// Follow X-Next-Page header for pagination.
+	nextPage := resp.Header.Get("X-Next-Page")
+	if nextPage == "" {
+		return items, "", nil
+	}
+
+	// Build next page URL by appending/replacing the page parameter.
+	nextURL := appendPageParam(rawURL, nextPage)
+	return items, nextURL, nil
+}
+
+// appendPageParam adds or replaces the page= query parameter in a URL.
+func appendPageParam(rawURL, page string) string {
+	base, query, hasQuery := strings.Cut(rawURL, "?")
+	if hasQuery {
+		parts := strings.Split(query, "&")
+		filtered := parts[:0]
+		for _, p := range parts {
+			if !strings.HasPrefix(p, "page=") {
+				filtered = append(filtered, p)
+			}
+		}
+		filtered = append(filtered, "page="+page)
+		return base + "?" + strings.Join(filtered, "&")
+	}
+	return rawURL + "?page=" + page
 }
 
 func joinArgs(args []string) string {

--- a/plugins/registry-gitlab/plugin_test.go
+++ b/plugins/registry-gitlab/plugin_test.go
@@ -1,8 +1,11 @@
 package registrygitlab_test
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/plugin/registry"
 	registrygitlab "github.com/GoCodeAlone/workflow/plugins/registry-gitlab"
 )
@@ -14,23 +17,136 @@ func TestGitLabProvider_Name(t *testing.T) {
 	}
 }
 
-func TestGitLabProvider_ReturnsNotImplemented(t *testing.T) {
+func TestGitLabProvider_Login_DryRun_WithToken(t *testing.T) {
 	p := registrygitlab.New()
-	var buf noopWriter
-	ctx := registry.NewContext(t.Context(), &buf, false)
-	cfg := registry.ProviderConfig{}
+	reg := config.CIRegistry{
+		Name: "gitlab-registry",
+		Type: "gitlab",
+		Path: "registry.gitlab.com/myorg/myproject",
+		Auth: &config.CIRegistryAuth{Env: "GITLAB_TOKEN"},
+	}
+	t.Setenv("GITLAB_TOKEN", "glpat-test-token")
 
-	if err := p.Login(ctx, cfg); err == nil {
-		t.Fatal("want ErrNotImplemented from Login")
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	if err := p.Login(ctx, registry.ProviderConfig{Registry: reg}); err != nil {
+		t.Fatalf("Login dry-run: %v", err)
 	}
-	if err := p.Push(ctx, cfg, "img"); err == nil {
-		t.Fatal("want ErrNotImplemented from Push")
+
+	out := buf.String()
+	if !strings.Contains(out, "docker") {
+		t.Errorf("dry-run should mention docker, got: %q", out)
 	}
-	if err := p.Prune(ctx, cfg); err == nil {
-		t.Fatal("want ErrNotImplemented from Prune")
+	if !strings.Contains(out, "login") {
+		t.Errorf("dry-run should mention login, got: %q", out)
+	}
+	if !strings.Contains(out, "registry.gitlab.com") {
+		t.Errorf("dry-run should mention gitlab registry host, got: %q", out)
 	}
 }
 
-type noopWriter struct{}
+func TestGitLabProvider_Login_DryRun_CIJobToken(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name: "gitlab-registry",
+		Type: "gitlab",
+		Path: "registry.gitlab.com/myorg/myproject",
+	}
+	t.Setenv("CI_JOB_TOKEN", "ci-job-token-value")
 
-func (n *noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	if err := p.Login(ctx, registry.ProviderConfig{Registry: reg}); err != nil {
+		t.Fatalf("Login dry-run with CI_JOB_TOKEN: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "gitlab-ci-token") {
+		t.Errorf("expected gitlab-ci-token username in CI context, got: %q", out)
+	}
+}
+
+func TestGitLabProvider_Login_MissingToken(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name: "gitlab-registry",
+		Type: "gitlab",
+		Path: "registry.gitlab.com/myorg/myproject",
+		Auth: &config.CIRegistryAuth{Env: "MISSING_GITLAB_TOKEN_XYZ"},
+	}
+
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, false)
+	err := p.Login(ctx, registry.ProviderConfig{Registry: reg})
+	if err == nil {
+		t.Fatal("want error for missing token env var")
+	}
+	if !strings.Contains(err.Error(), "MISSING_GITLAB_TOKEN_XYZ") {
+		t.Errorf("error should mention env var name, got: %v", err)
+	}
+}
+
+func TestGitLabProvider_Push_DryRun(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name: "gitlab-registry",
+		Type: "gitlab",
+		Path: "registry.gitlab.com/myorg/myproject",
+	}
+
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	imageRef := "registry.gitlab.com/myorg/myproject/app:v1.0.0"
+	if err := p.Push(ctx, registry.ProviderConfig{Registry: reg}, imageRef); err != nil {
+		t.Fatalf("Push dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, imageRef) {
+		t.Errorf("dry-run should mention image ref, got: %q", out)
+	}
+	if !strings.Contains(out, "docker push") {
+		t.Errorf("dry-run should mention docker push, got: %q", out)
+	}
+}
+
+func TestGitLabProvider_Prune_DryRun_NoRetention(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name: "gitlab-registry",
+		Type: "gitlab",
+		Path: "registry.gitlab.com/myorg/myproject",
+	}
+
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	// No retention set — should be a no-op.
+	if err := p.Prune(ctx, registry.ProviderConfig{Registry: reg}); err != nil {
+		t.Fatalf("Prune dry-run (no retention): %v", err)
+	}
+}
+
+func TestGitLabProvider_Prune_DryRun_WithRetention(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name: "gitlab-registry",
+		Type: "gitlab",
+		Path: "registry.gitlab.com/myorg/myproject",
+		Auth: &config.CIRegistryAuth{Env: "GITLAB_TOKEN"},
+		Retention: &config.CIRegistryRetention{
+			KeepLatest: 5,
+		},
+	}
+	t.Setenv("GITLAB_TOKEN", "glpat-test-token")
+
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	if err := p.Prune(ctx, registry.ProviderConfig{Registry: reg}); err != nil {
+		t.Fatalf("Prune dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "prune") && !strings.Contains(out, "keep") {
+		t.Errorf("expected prune/keep info in dry-run output, got: %q", out)
+	}
+}

--- a/plugins/registry-gitlab/plugin_test.go
+++ b/plugins/registry-gitlab/plugin_test.go
@@ -150,3 +150,69 @@ func TestGitLabProvider_Prune_DryRun_WithRetention(t *testing.T) {
 		t.Errorf("expected prune/keep info in dry-run output, got: %q", out)
 	}
 }
+
+// TestGitLabProvider_Prune_SelfManaged checks dry-run mentions the custom API base URL.
+func TestGitLabProvider_Prune_SelfManaged(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name:       "self-managed",
+		Type:       "gitlab",
+		Path:       "registry.example.com/myorg/myproject",
+		APIBaseURL: "https://gitlab.example.com",
+		Auth:       &config.CIRegistryAuth{Env: "GITLAB_TOKEN"},
+		Retention:  &config.CIRegistryRetention{KeepLatest: 3},
+	}
+	t.Setenv("GITLAB_TOKEN", "glpat-selfmanaged-token")
+
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	if err := p.Prune(ctx, registry.ProviderConfig{Registry: reg}); err != nil {
+		t.Fatalf("Prune dry-run self-managed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "myorg/myproject") {
+		t.Errorf("expected project path in dry-run output, got: %q", out)
+	}
+}
+
+// TestGitLabProvider_Login_SelfManaged checks login works with a non-default registry host.
+func TestGitLabProvider_Login_SelfManaged(t *testing.T) {
+	p := registrygitlab.New()
+	reg := config.CIRegistry{
+		Name: "self-managed",
+		Type: "gitlab",
+		Path: "registry.example.com/myorg/myproject",
+		Auth: &config.CIRegistryAuth{Env: "GITLAB_TOKEN"},
+	}
+	t.Setenv("GITLAB_TOKEN", "glpat-selfmanaged")
+
+	var buf bytes.Buffer
+	ctx := registry.NewContext(t.Context(), &buf, true)
+	if err := p.Login(ctx, registry.ProviderConfig{Registry: reg}); err != nil {
+		t.Fatalf("Login dry-run self-managed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "registry.example.com") {
+		t.Errorf("expected self-managed host in login output, got: %q", out)
+	}
+}
+
+// TestAuthHeaderFor checks that JOB-TOKEN is used for CI tokens and PRIVATE-TOKEN for PATs.
+func TestAuthHeaderFor(t *testing.T) {
+	tests := []struct {
+		tokenType string
+		want      string
+	}{
+		{"job", "JOB-TOKEN"},
+		{"private", "PRIVATE-TOKEN"},
+		{"", "PRIVATE-TOKEN"},
+	}
+	for _, tt := range tests {
+		got := registrygitlab.AuthHeaderFor(tt.tokenType)
+		if got != tt.want {
+			t.Errorf("AuthHeaderFor(%q) = %q, want %q", tt.tokenType, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up release addressing three features deferred from v0.14.0:

- **T34 — `wfctl build audit`** (a944096): 6 supply-chain security checks + `--strict` flag. Checks hardening flag, dockerfile without SBOM/provenance, registries without retention, plugins without lockfile, unset env-var auth tokens, local environments that disable hardening.
- **T33 — BuildKit provenance** (b9037a2): when `ci.build.security.hardened=true`, `wfctl build image` now appends `--provenance=mode=max --sbom=true` to the docker build invocation. Warns if `DOCKER_BUILDKIT=1` is not set.
- **T31 — GitLab Container Registry** (73f19cf): `plugins/registry-gitlab` now implements Login/Push/Prune. Supports `CI_JOB_TOKEN` auth for GitLab CI contexts and PAT-based auth elsewhere.

CHANGELOG updated with `## v0.14.1` section.

## Diff

- `cmd/wfctl/build_security_audit.go` + test — new audit command
- `cmd/wfctl/build.go` — wired `wfctl build audit` subcommand
- `cmd/wfctl/build_image.go` + test — provenance/sbom args when hardened
- `plugins/registry-gitlab/plugin.go` + test — GitLab CR provider

## Test plan

- [x] `go test ./cmd/wfctl/... ./plugins/registry-gitlab/... -count=1` — all green locally (21 new tests)
- [x] `golangci-lint run --timeout=10m` — zero issues locally
- [ ] CI green
- [ ] Copilot review addressed

## Related

- v0.14.0: #413
- Design: `docs/plans/2026-04-18-wfctl-build-deploy-design.md`
- Plan: `docs/plans/2026-04-18-wfctl-build-deploy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)