### PR TITLE
fix(wfctl): register cmd-build pipeline in wfctl.yaml

### DIFF
--- a/cmd/wfctl/wfctl.yaml
+++ b/cmd/wfctl/wfctl.yaml
@@ -207,6 +207,17 @@ pipelines:
         config:
           command: build-ui
 
+  cmd-build:
+    trigger:
+      type: cli
+      config:
+        command: build
+    steps:
+      - name: run
+        type: step.cli_invoke
+        config:
+          command: build
+
   cmd-ui:
     trigger:
       type: cli


### PR DESCRIPTION
## Summary

- Fixes `wfctl build` and all its subcommands (`image`, `push`, `go`, `ui`, `custom`, `audit`) which all failed with `error: cli trigger: no pipeline registered for command "build"`
- Root cause: the `build` command was registered in the Go `commands` map (main.go:95) but no `cmd-build:` pipeline was declared in the embedded `wfctl.yaml`
- Fix: adds the 11-line `cmd-build` pipeline entry, consistent with all other command pipelines

## Reproduction

```sh
wfctl build image --config any.yaml
# error: cli trigger: no pipeline registered for command "build"
```

## Test plan

- [ ] `wfctl build --help` no longer errors
- [ ] `WFCTL_BUILD_DRY_RUN=1 wfctl build image --config testdata/ci-build.yaml` prints dry-run output
- [ ] Existing `build_image_test.go` and `build_orchestrate_test.go` tests pass

Discovered during workflow-dnd v0.14.1 migration smoke test (dry-run step failed, surfaced this missing registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)