### PR TITLE
fix(wfctl): add missing cmd-build pipeline to wfctl.yaml

### DIFF
--- a/cmd/wfctl/wfctl.yaml
+++ b/cmd/wfctl/wfctl.yaml
@@ -481,3 +481,14 @@ pipelines:
         type: step.cli_invoke
         config:
           command: wizard
+
+  cmd-build:
+    trigger:
+      type: cli
+      config:
+        command: build
+    steps:
+      - name: run
+        type: step.cli_invoke
+        config:
+          command: build


### PR DESCRIPTION
## Summary

- `wfctl build` (and all subcommands: `wfctl build image`, `wfctl build go`, etc.) fail with `error: cli trigger: no pipeline registered for command "build"` because the `cmd-build` pipeline was missing from `wfctl.yaml`
- The `build` command was correctly registered in `main.go`'s `commands` map and listed in the wfctl.yaml command descriptions, but the corresponding `cmd-build:` workflow pipeline was absent
- Added `cmd-build:` following the identical pattern used by all other `cmd-*` pipelines

## Root Cause

Every wfctl command requires two registrations:
1. Entry in `commands` map in `main.go` → present for `build`
2. `cmd-<name>:` pipeline in `wfctl.yaml` → **missing** for `build`

The `ci` and `dev` commands had their pipelines; `build` did not.

## Test Plan

- [ ] `wfctl build --help` no longer errors with "no pipeline registered"
- [ ] `WFCTL_BUILD_DRY_RUN=1 wfctl build image --config app.yaml` prints the planned `docker build` command
- [ ] `wfctl build --dry-run --config app.yaml` runs the full build orchestration in dry-run mode

Discovered while migrating GoCodeAlone/buymywishlist to v0.14.1 `wfctl build` + `wfctl ci init` primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)