### PR TITLE
fix(wfctl): imageRefForContainer resolves registry name to path

### DIFF
--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -84,7 +84,7 @@ func runBuildImageWithOutput(args []string, out io.Writer) error {
 				return fmt.Errorf("ko build %q: %w", ctr.Name, err)
 			}
 		default: // dockerfile
-			if err := buildWithDockerfile(ctr, tag, *dryRun, hardened, out); err != nil {
+			if err := buildWithDockerfile(ctr, tag, *dryRun, hardened, cfg.CI.Registries, out); err != nil {
 				return fmt.Errorf("dockerfile build %q: %w", ctr.Name, err)
 			}
 		}
@@ -92,13 +92,13 @@ func runBuildImageWithOutput(args []string, out io.Writer) error {
 	return nil
 }
 
-func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, hardened bool, out io.Writer) error {
+func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, hardened bool, registries []config.CIRegistry, out io.Writer) error {
 	dockerfile := ctr.Dockerfile
 	if dockerfile == "" {
 		dockerfile = "Dockerfile"
 	}
 
-	imageRef := imageRefForContainer(ctr, tag)
+	imageRef := imageRefForContainer(ctr, tag, registries)
 	args := []string{"build", "--file", dockerfile, "--tag", imageRef}
 
 	// Platforms (BuildKit multi-arch).
@@ -238,7 +238,15 @@ func buildExternalImageRef(ctr config.CIContainerTarget, tag string, registries 
 	return ctr.Name + ":" + tag
 }
 
-func imageRefForContainer(ctr config.CIContainerTarget, tag string) string {
+func imageRefForContainer(ctr config.CIContainerTarget, tag string, registries []config.CIRegistry) string {
+	for _, regName := range ctr.PushTo {
+		for _, reg := range registries {
+			if reg.Name == regName {
+				return reg.Path + "/" + ctr.Name + ":" + tag
+			}
+		}
+	}
+	// Fall back to raw push_to name when no registry path is configured.
 	if len(ctr.PushTo) > 0 {
 		return ctr.PushTo[0] + "/" + ctr.Name + ":" + tag
 	}

--- a/cmd/wfctl/build_image_test.go
+++ b/cmd/wfctl/build_image_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
 )
 
 func TestRunBuildImage_DockerfileDryRun(t *testing.T) {
@@ -151,6 +153,93 @@ func TestRunBuildImage_NotHardenedNoProvenanceArgs(t *testing.T) {
 	out := buf.String()
 	if strings.Contains(out, "--provenance") {
 		t.Errorf("expected no --provenance flag when hardened=false, got: %q", out)
+	}
+}
+
+// TestImageRefForContainer_RegistryNameResolvesToPath verifies that imageRefForContainer
+// resolves a registry name to its path via ci.registries.
+func TestImageRefForContainer_RegistryNameResolvesToPath(t *testing.T) {
+	ctr := config.CIContainerTarget{Name: "buymywishlist", PushTo: []string{"docr"}}
+	registries := []config.CIRegistry{
+		{Name: "docr", Path: "registry.digitalocean.com/bmw-registry"},
+	}
+	got := imageRefForContainer(ctr, "abc123", registries)
+	want := "registry.digitalocean.com/bmw-registry/buymywishlist:abc123"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestImageRefForContainer_NoMatchFallback verifies fallback when no registry matches.
+func TestImageRefForContainer_NoMatchFallback(t *testing.T) {
+	ctr := config.CIContainerTarget{Name: "app", PushTo: []string{"unknown-reg"}}
+	registries := []config.CIRegistry{
+		{Name: "docr", Path: "registry.digitalocean.com/bmw-registry"},
+	}
+	got := imageRefForContainer(ctr, "latest", registries)
+	want := "unknown-reg/app:latest"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestImageRefForContainer_EmptyPushTo verifies fallback when push_to is empty.
+func TestImageRefForContainer_EmptyPushTo(t *testing.T) {
+	ctr := config.CIContainerTarget{Name: "myapp"}
+	got := imageRefForContainer(ctr, "v1.0", nil)
+	want := "myapp:v1.0"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestImageRefForContainer_MultiplePushTo verifies first resolvable path is used.
+func TestImageRefForContainer_MultiplePushTo(t *testing.T) {
+	ctr := config.CIContainerTarget{Name: "app", PushTo: []string{"docr", "ghcr"}}
+	registries := []config.CIRegistry{
+		{Name: "docr", Path: "registry.digitalocean.com/bmw-registry"},
+		{Name: "ghcr", Path: "ghcr.io/gocodalone"},
+	}
+	got := imageRefForContainer(ctr, "sha256abc", registries)
+	want := "registry.digitalocean.com/bmw-registry/app:sha256abc"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestRunBuildImage_ImageRefUsesRegistryPath verifies the dry-run output shows registry path.
+func TestRunBuildImage_ImageRefUsesRegistryPath(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  registries:
+    - name: docr
+      type: do
+      path: registry.digitalocean.com/bmw-registry
+  build:
+    containers:
+      - name: buymywishlist
+        method: dockerfile
+        dockerfile: Dockerfile
+        push_to:
+          - docr
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath}, &buf); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "registry.digitalocean.com/bmw-registry/buymywishlist") {
+		t.Errorf("expected registry path in dry-run output, got: %q", out)
+	}
+	if strings.Contains(out, "docr/buymywishlist") {
+		t.Errorf("expected no registry name prefix in dry-run output, got: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

`imageRefForContainer` in `cmd/wfctl/build_image.go` was using `ctr.PushTo[0]` (the registry *name*, e.g. `docr`) as the image ref prefix. This produced tags like `docr/buymywishlist:sha`, while the actual push target resolved to `registry.digitalocean.com/bmw-registry/buymywishlist:sha`. Docker push failed because the local image didn't exist under the push target name.

The symptom in BMW: images were built, retag + manual push was needed on every deploy.

## Fix

- Changed `imageRefForContainer` signature to accept `registries []config.CIRegistry`
- Resolution now mirrors `buildExternalImageRef`: scan `ci.registries[]` for a `Name` match, use `Path`, fall back to raw name for backward compat
- Threaded `cfg.CI.Registries` through `buildWithDockerfile` to the new signature

## Test plan

- `TestImageRefForContainer_RegistryNameResolvesToPath` — name match → uses path
- `TestImageRefForContainer_NoMatchFallback` — no match → falls back to raw name
- `TestImageRefForContainer_EmptyPushTo` — no push_to → returns `name:tag`
- `TestImageRefForContainer_MultiplePushTo` — multiple push_to → first resolvable path used
- `TestRunBuildImage_ImageRefUsesRegistryPath` — integration: dry-run output shows registry path, not registry name
- All existing tests pass: `GOWORK=off go test ./cmd/wfctl/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)