### PR TITLE
fix(wfctl): use docker buildx build in hardened mode

### DIFF
--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -99,7 +99,13 @@ func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, 
 	}
 
 	imageRef := imageRefForContainer(ctr, tag, registries)
-	args := []string{"build", "--file", dockerfile, "--tag", imageRef}
+	// hardened mode uses buildx for provenance/SBOM attestation support.
+	var args []string
+	if hardened {
+		args = []string{"buildx", "build", "--file", dockerfile, "--tag", imageRef}
+	} else {
+		args = []string{"build", "--file", dockerfile, "--tag", imageRef}
+	}
 
 	// Platforms (BuildKit multi-arch).
 	if len(ctr.Platforms) > 0 {
@@ -155,6 +161,15 @@ func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, 
 	if dryRun {
 		fmt.Fprintf(out, "[dry-run] docker %s\n", strings.Join(args, " "))
 		return nil
+	}
+
+	if hardened {
+		// buildx with the docker-container driver is required for attestation flags.
+		// Verify a non-default builder is active; the default "docker" driver rejects --provenance.
+		if err := exec.Command("docker", "buildx", "inspect", "--bootstrap").Run(); err != nil {
+			return fmt.Errorf("hardened build requires docker buildx: run 'docker buildx create --use' " +
+				"or add 'docker/setup-buildx-action@v3' to your CI workflow (%w)", err)
+		}
 	}
 
 	//nolint:gosec // G204: docker command constructed from validated config fields

--- a/cmd/wfctl/build_image_test.go
+++ b/cmd/wfctl/build_image_test.go
@@ -156,6 +156,68 @@ func TestRunBuildImage_NotHardenedNoProvenanceArgs(t *testing.T) {
 	}
 }
 
+// TestRunBuildImage_HardenedUsesBuildx verifies hardened=true produces "docker buildx build".
+func TestRunBuildImage_HardenedUsesBuildx(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    security:
+      hardened: true
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	t.Setenv("DOCKER_BUILDKIT", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath}, &buf); err != nil {
+		t.Fatalf("hardened buildx dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "docker buildx build") {
+		t.Errorf("expected 'docker buildx build' in hardened dry-run output, got: %q", out)
+	}
+}
+
+// TestRunBuildImage_NonHardenedUsesPlainDocker verifies hardened=false produces "docker build" (no buildx).
+func TestRunBuildImage_NonHardenedUsesPlainDocker(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    security:
+      hardened: false
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath}, &buf); err != nil {
+		t.Fatalf("non-hardened dry-run: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "buildx") {
+		t.Errorf("expected no 'buildx' in non-hardened dry-run output, got: %q", out)
+	}
+	if !strings.Contains(out, "docker build") {
+		t.Errorf("expected 'docker build' in non-hardened dry-run output, got: %q", out)
+	}
+}
+
 // TestImageRefForContainer_RegistryNameResolvesToPath verifies that imageRefForContainer
 // resolves a registry name to its path via ci.registries.
 func TestImageRefForContainer_RegistryNameResolvesToPath(t *testing.T) {


### PR DESCRIPTION
## Problem

`buildWithDockerfile` appended `--provenance=mode=max --sbom=true` when `ci.build.security.hardened=true` but still called `docker build`. The classic docker driver rejects attestation flags with:

> Attestation is not supported for the docker driver. Switch to a different driver, or turn on the containerd image store.

This was the root cause of the BMW CI failure that required a manual retag + push workaround.

## Fix

- When `hardened=true`: invoke `docker buildx build` (prepend `buildx` to args). The docker-container driver supports `--provenance` and `--sbom`.
- When `hardened=false`: keep existing `docker build` behavior unchanged (backward compat).
- Added a driver readiness check (`docker buildx inspect --bootstrap`) before the live hardened build. If it fails, returns a clear error: `run 'docker buildx create --use' or add 'docker/setup-buildx-action@v3' to your CI workflow`.
- Dry-run output now correctly shows `docker buildx build ...` vs `docker build ...`.

## Test plan

- `TestRunBuildImage_HardenedUsesBuildx` — hardened=true dry-run output contains `docker buildx build`
- `TestRunBuildImage_NonHardenedUsesPlainDocker` — hardened=false dry-run output has `docker build`, no `buildx`
- Existing `TestRunBuildImage_HardenedProvenanceArgs` — still passes (provenance/sbom flags present)
- Existing `TestRunBuildImage_NotHardenedNoProvenanceArgs` — still passes (no provenance flags)
- All tests: `GOWORK=off go test ./cmd/wfctl/...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)