### PR TITLE
feat(deploy): make wfctl ci run deploy plugin-aware via iac.provider modules

### DIFF
--- a/cmd/wfctl/ci_run.go
+++ b/cmd/wfctl/ci_run.go
@@ -358,7 +358,7 @@ func runDeployPhaseWithConfig(
 	}
 
 	// Step 3: resolve provider and deploy.
-	provider, err := newDeployProvider(env.Provider)
+	provider, err := newDeployProvider(env.Provider, wfCfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/interfaces"
 )
 
 // DeployConfig holds all parameters needed to execute a deployment.
@@ -41,7 +42,10 @@ type DeployProvider interface {
 }
 
 // newDeployProvider returns the DeployProvider for the given provider name.
-func newDeployProvider(provider string) (DeployProvider, error) {
+// For non-built-in providers, wfCfg is consulted to find a matching iac.provider
+// module and its infra.container_service resource. Pass nil wfCfg to restrict to
+// built-ins only.
+func newDeployProvider(provider string, wfCfg *config.WorkflowConfig) (DeployProvider, error) {
 	switch provider {
 	case "kubernetes", "k8s":
 		return &kubernetesProvider{}, nil
@@ -50,8 +54,116 @@ func newDeployProvider(provider string) (DeployProvider, error) {
 	case "aws-ecs":
 		return &awsECSProvider{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported deploy provider %q (supported: kubernetes, docker, aws-ecs)", provider)
+		return newPluginDeployProvider(provider, wfCfg)
 	}
+}
+
+// resolveIaCProvider is the factory used by newPluginDeployProvider to obtain a
+// live IaCProvider from module config. Tests override this to inject fakes.
+var resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
+	return nil, fmt.Errorf("no in-process provider loader available; use pre-deploy steps with 'wfctl infra apply' to deploy via a workflow plugin")
+}
+
+// newPluginDeployProvider looks up a matching iac.provider + infra.container_service
+// module pair in wfCfg and wraps them as a DeployProvider.
+func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) (DeployProvider, error) {
+	const hint = "\n  Example:\n    modules:\n    - name: my-provider\n      type: iac.provider\n      config:\n        provider: %s\n        credentials: env"
+	if wfCfg == nil || len(wfCfg.Modules) == 0 {
+		return nil, fmt.Errorf("unsupported deploy provider %q (built-ins: kubernetes, docker, aws-ecs; to use a plugin provider, declare an iac.provider module in your workflow config)%s", providerName, fmt.Sprintf(hint, providerName))
+	}
+
+	// Find the iac.provider module matching the requested provider name.
+	var providerModName string
+	var providerModCfg map[string]any
+	for _, m := range wfCfg.Modules {
+		if m.Type != "iac.provider" {
+			continue
+		}
+		cfgProvider, _ := m.Config["provider"].(string)
+		if cfgProvider == providerName || m.Name == providerName {
+			providerModName = m.Name
+			providerModCfg = m.Config
+			break
+		}
+	}
+	if providerModName == "" {
+		return nil, fmt.Errorf("unsupported deploy provider %q (built-ins: kubernetes, docker, aws-ecs; to use a plugin provider, declare an iac.provider module in your workflow config)%s", providerName, fmt.Sprintf(hint, providerName))
+	}
+
+	// Find the first infra.container_service module referencing this provider.
+	var resourceName string
+	var resourceCfg map[string]any
+	for _, m := range wfCfg.Modules {
+		if m.Type != "infra.container_service" {
+			continue
+		}
+		if p, _ := m.Config["provider"].(string); p == providerModName {
+			resourceName = m.Name
+			resourceCfg = m.Config
+			break
+		}
+	}
+	if resourceName == "" {
+		return nil, fmt.Errorf("no infra.container_service module found for provider %q in workflow config", providerModName)
+	}
+
+	iacProvider, err := resolveIaCProvider(context.Background(), providerName, providerModCfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve provider %q: %w", providerName, err)
+	}
+
+	return &pluginDeployProvider{
+		provider:     iacProvider,
+		resourceName: resourceName,
+		resourceType: "infra.container_service",
+		resourceCfg:  resourceCfg,
+	}, nil
+}
+
+// pluginDeployProvider wraps an IaCProvider and a single infra resource as a DeployProvider.
+type pluginDeployProvider struct {
+	provider     interfaces.IaCProvider
+	resourceName string
+	resourceType string
+	resourceCfg  map[string]any
+}
+
+func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) error {
+	driver, err := p.provider.ResourceDriver(p.resourceType)
+	if err != nil {
+		return fmt.Errorf("plugin deploy: no driver for %q: %w", p.resourceType, err)
+	}
+	merged := make(map[string]any, len(p.resourceCfg)+1)
+	for k, v := range p.resourceCfg {
+		merged[k] = v
+	}
+	merged["image"] = cfg.ImageTag
+	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
+	spec := interfaces.ResourceSpec{Name: p.resourceName, Type: p.resourceType, Config: merged}
+	if _, err := driver.Update(ctx, ref, spec); err != nil {
+		return fmt.Errorf("plugin deploy %q: update image: %w", p.resourceName, err)
+	}
+	fmt.Printf("  plugin deploy: updated %q to %s\n", p.resourceName, cfg.ImageTag)
+	return nil
+}
+
+func (p *pluginDeployProvider) HealthCheck(ctx context.Context, cfg DeployConfig) error {
+	if cfg.Env == nil || cfg.Env.HealthCheck == nil {
+		return nil
+	}
+	driver, err := p.provider.ResourceDriver(p.resourceType)
+	if err != nil {
+		return fmt.Errorf("plugin health check: no driver for %q: %w", p.resourceType, err)
+	}
+	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
+	result, err := driver.HealthCheck(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("plugin health check %q: %w", p.resourceName, err)
+	}
+	if !result.Healthy {
+		return fmt.Errorf("plugin health check %q: unhealthy: %s", p.resourceName, result.Message)
+	}
+	return nil
 }
 
 // ── kubernetes provider ───────────────────────────────────────────────────────

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// ── fakes ─────────────────────────────────────────────────────────────────────
+
+type fakeResourceDriver struct {
+	updateImage string
+	hcResult    *interfaces.HealthResult
+	hcErr       error
+}
+
+func (d *fakeResourceDriver) Create(_ context.Context, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (d *fakeResourceDriver) Read(_ context.Context, _ interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (d *fakeResourceDriver) Update(_ context.Context, _ interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	d.updateImage, _ = spec.Config["image"].(string)
+	return &interfaces.ResourceOutput{}, nil
+}
+func (d *fakeResourceDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
+func (d *fakeResourceDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, _ *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	return nil, nil
+}
+func (d *fakeResourceDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	if d.hcResult != nil {
+		return d.hcResult, d.hcErr
+	}
+	return &interfaces.HealthResult{Healthy: true}, nil
+}
+func (d *fakeResourceDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (d *fakeResourceDriver) SensitiveKeys() []string { return nil }
+
+type fakeIaCProvider struct {
+	name    string
+	drivers map[string]interfaces.ResourceDriver
+}
+
+func (f *fakeIaCProvider) Name() string                          { return f.name }
+func (f *fakeIaCProvider) Version() string                       { return "0.0.0" }
+func (f *fakeIaCProvider) Initialize(_ context.Context, _ map[string]any) error { return nil }
+func (f *fakeIaCProvider) Capabilities() []interfaces.IaCCapabilityDeclaration  { return nil }
+func (f *fakeIaCProvider) Plan(_ context.Context, _ []interfaces.ResourceSpec, _ []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) Apply(_ context.Context, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) Destroy(_ context.Context, _ []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) Status(_ context.Context, _ []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) DetectDrift(_ context.Context, _ []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) Import(_ context.Context, _ string, _ string) (*interfaces.ResourceState, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) ResolveSizing(_ string, _ interfaces.Size, _ *interfaces.ResourceHints) (*interfaces.ProviderSizing, error) {
+	return nil, nil
+}
+func (f *fakeIaCProvider) ResourceDriver(rt string) (interfaces.ResourceDriver, error) {
+	d, ok := f.drivers[rt]
+	if !ok {
+		return nil, fmt.Errorf("no driver for %q", rt)
+	}
+	return d, nil
+}
+func (f *fakeIaCProvider) Close() error { return nil }
+
+// makePluginTestConfig builds a WorkflowConfig with an iac.provider + infra.container_service.
+func makePluginTestConfig(providerName, moduleName string) *config.WorkflowConfig {
+	return &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name: moduleName,
+				Type: "iac.provider",
+				Config: map[string]any{
+					"provider":    providerName,
+					"credentials": "env",
+				},
+			},
+			{
+				Name: "my-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider":  moduleName,
+					"http_port": 8080,
+				},
+			},
+		},
+	}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestNewDeployProvider_BuiltIns(t *testing.T) {
+	cases := map[string]interface{}{
+		"kubernetes":     (*kubernetesProvider)(nil),
+		"k8s":            (*kubernetesProvider)(nil),
+		"docker":         (*dockerProvider)(nil),
+		"docker-compose": (*dockerProvider)(nil),
+		"aws-ecs":        (*awsECSProvider)(nil),
+	}
+	for name := range cases {
+		p, err := newDeployProvider(name, nil)
+		if err != nil {
+			t.Errorf("newDeployProvider(%q): unexpected error: %v", name, err)
+			continue
+		}
+		if p == nil {
+			t.Errorf("newDeployProvider(%q): got nil provider", name)
+		}
+	}
+}
+
+func TestNewDeployProvider_PluginProvider_Resolves(t *testing.T) {
+	driver := &fakeResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+
+	orig := resolveIaCProvider
+	defer func() { resolveIaCProvider = orig }()
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
+		return fake, nil
+	}
+
+	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
+	p, err := newDeployProvider("fake-cloud", cfg)
+	if err != nil {
+		t.Fatalf("newDeployProvider: unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+	if _, ok := p.(*pluginDeployProvider); !ok {
+		t.Fatalf("expected *pluginDeployProvider, got %T", p)
+	}
+}
+
+func TestNewDeployProvider_UnknownProvider_ErrorsClearly(t *testing.T) {
+	_, err := newDeployProvider("nonexistent-cloud", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "kubernetes") {
+		t.Errorf("error should mention built-in providers, got: %v", err)
+	}
+	if !strings.Contains(errStr, "iac.provider") {
+		t.Errorf("error should hint at iac.provider module declaration, got: %v", err)
+	}
+}
+
+func TestPluginDeployProvider_DeployCallsDriverUpdate(t *testing.T) {
+	driver := &fakeResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"http_port": 8080},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:abc123",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if driver.updateImage != "registry.example.com/myapp:abc123" {
+		t.Errorf("expected image %q passed to driver.Update, got %q", "registry.example.com/myapp:abc123", driver.updateImage)
+	}
+}
+
+func TestPluginDeployProvider_HealthCheck(t *testing.T) {
+	driver := &fakeResourceDriver{
+		hcResult: &interfaces.HealthResult{Healthy: true},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		Env: &config.CIDeployEnvironment{
+			HealthCheck: &config.CIHealthCheck{Path: "/healthz"},
+		},
+	}
+	if err := p.HealthCheck(context.Background(), cfg); err != nil {
+		t.Fatalf("HealthCheck: unexpected error: %v", err)
+	}
+}
+
+func TestPluginDeployProvider_HealthCheck_Unhealthy(t *testing.T) {
+	driver := &fakeResourceDriver{
+		hcResult: &interfaces.HealthResult{Healthy: false, Message: "not ready"},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		Env: &config.CIDeployEnvironment{
+			HealthCheck: &config.CIHealthCheck{Path: "/healthz"},
+		},
+	}
+	err := p.HealthCheck(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error for unhealthy resource")
+	}
+	if !strings.Contains(err.Error(), "not ready") {
+		t.Errorf("expected 'not ready' in error, got: %v", err)
+	}
+}

--- a/cmd/wfctl/deploy_providers_test.go
+++ b/cmd/wfctl/deploy_providers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewDeployProvider_Kubernetes(t *testing.T) {
 	for _, name := range []string{"kubernetes", "k8s"} {
-		p, err := newDeployProvider(name)
+		p, err := newDeployProvider(name, nil)
 		if err != nil {
 			t.Fatalf("newDeployProvider(%q): unexpected error: %v", name, err)
 		}
@@ -25,7 +25,7 @@ func TestNewDeployProvider_Kubernetes(t *testing.T) {
 
 func TestNewDeployProvider_Docker(t *testing.T) {
 	for _, name := range []string{"docker", "docker-compose"} {
-		p, err := newDeployProvider(name)
+		p, err := newDeployProvider(name, nil)
 		if err != nil {
 			t.Fatalf("newDeployProvider(%q): unexpected error: %v", name, err)
 		}
@@ -36,7 +36,7 @@ func TestNewDeployProvider_Docker(t *testing.T) {
 }
 
 func TestNewDeployProvider_AWSECS(t *testing.T) {
-	p, err := newDeployProvider("aws-ecs")
+	p, err := newDeployProvider("aws-ecs", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestNewDeployProvider_AWSECS(t *testing.T) {
 }
 
 func TestNewDeployProvider_Unknown(t *testing.T) {
-	_, err := newDeployProvider("unknown-provider")
+	_, err := newDeployProvider("unknown-provider", nil)
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}


### PR DESCRIPTION
## Summary

- `newDeployProvider` now accepts `*config.WorkflowConfig` and, for non-built-in provider names, walks the modules list to find a matching `iac.provider` module + its `infra.container_service` resource
- The pair is wrapped as `pluginDeployProvider` that delegates `Deploy` to `ResourceDriver.Update` (image merged into resource config) and `HealthCheck` to `ResourceDriver.HealthCheck`
- `resolveIaCProvider` is a hookable var (defaulting to a descriptive error) for test injection without cloud dependencies
- `ci_run.go` passes `wfCfg` to `newDeployProvider` so config is available at deploy resolution time
- Error messages for unknown providers name the built-ins and show an example `iac.provider` module declaration
- No DO-specific logic in wfctl core; `workflow-plugin-digitalocean` is unchanged

## Test plan

- [ ] `TestNewDeployProvider_BuiltIns` — kubernetes/docker/aws-ecs all resolve (regression guard)
- [ ] `TestNewDeployProvider_PluginProvider_Resolves` — fake IaCProvider injected via `resolveIaCProvider` override
- [ ] `TestNewDeployProvider_UnknownProvider_ErrorsClearly` — error names built-ins and hints at `iac.provider` declaration
- [ ] `TestPluginDeployProvider_DeployCallsDriverUpdate` — `Deploy` passes correct image to `ResourceDriver.Update`
- [ ] `TestPluginDeployProvider_HealthCheck` — healthy result passes through
- [ ] `TestPluginDeployProvider_HealthCheck_Unhealthy` — unhealthy result surfaces message in error
- [ ] `GOWORK=off go test ./cmd/wfctl/...` and `./module/...` clean
- [ ] `GOWORK=off go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)