### PR TITLE
feat(deploy): wire real plugin loader into resolveIaCProvider

### DIFF
--- a/cmd/wfctl/ci_run.go
+++ b/cmd/wfctl/ci_run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -365,6 +366,9 @@ func runDeployPhaseWithConfig(
 	provider, err := newDeployProvider(env.Provider, wfCfg)
 	if err != nil {
 		return err
+	}
+	if c, ok := provider.(io.Closer); ok {
+		defer c.Close() //nolint:errcheck
 	}
 
 	deployCfg := DeployConfig{

--- a/cmd/wfctl/ci_run.go
+++ b/cmd/wfctl/ci_run.go
@@ -20,6 +20,7 @@ func runCIRun(args []string) error {
 	phases := fs.String("phase", "build,test", "Comma-separated phases: build, test, deploy")
 	env := fs.String("env", "", "Target environment (required for deploy phase)")
 	verbose := fs.Bool("verbose", false, "Show detailed output")
+	pluginDir := fs.String("plugin-dir", "", "Directory containing installed plugins (default: $WFCTL_PLUGIN_DIR or ./data/plugins)")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl ci run [options]\n\nRun CI phases from workflow config.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -59,6 +60,9 @@ func runCIRun(args []string) error {
 		case "deploy":
 			if *env == "" {
 				return fmt.Errorf("--env is required for deploy phase")
+			}
+			if *pluginDir != "" {
+				os.Setenv("WFCTL_PLUGIN_DIR", *pluginDir) //nolint:errcheck
 			}
 			if len(cfg.Services) > 0 {
 				if err := runMultiServiceDeploy(cfg.CI.Deploy, *env, &cfg, cfg.Services, *verbose); err != nil {

--- a/cmd/wfctl/deploy_plugin_loader_test.go
+++ b/cmd/wfctl/deploy_plugin_loader_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// TestDefaultResolveIaCProvider_IsNotPlaceholder verifies the default
+// resolveIaCProvider no longer returns the old "no in-process provider loader"
+// stub message.
+func TestDefaultResolveIaCProvider_IsNotPlaceholder(t *testing.T) {
+	t.Setenv("WFCTL_PLUGIN_DIR", t.TempDir()) // empty dir — no plugins
+	_, err := resolveIaCProvider(context.Background(), "any-provider", nil)
+	if err == nil {
+		t.Skip("resolveIaCProvider succeeded unexpectedly")
+	}
+	if strings.Contains(err.Error(), "no in-process provider loader") {
+		t.Errorf("default resolveIaCProvider still returns old placeholder message: %v", err)
+	}
+}
+
+// TestDefaultResolveIaCProvider_NoPluginDir verifies the error hints at
+// 'wfctl plugin install' when the plugin directory does not exist.
+func TestDefaultResolveIaCProvider_NoPluginDir(t *testing.T) {
+	t.Setenv("WFCTL_PLUGIN_DIR", filepath.Join(t.TempDir(), "nonexistent"))
+	_, err := resolveIaCProvider(context.Background(), "fake-provider", nil)
+	if err == nil {
+		t.Fatal("expected error when plugin dir does not exist")
+	}
+	if !strings.Contains(err.Error(), "wfctl plugin install") {
+		t.Errorf("expected hint to run 'wfctl plugin install', got: %v", err)
+	}
+}
+
+// TestDefaultResolveIaCProvider_NoMatchingPlugin verifies the error hints at
+// 'wfctl plugin install' when no plugin declares the requested iacProvider name.
+func TestDefaultResolveIaCProvider_NoMatchingPlugin(t *testing.T) {
+	dir := t.TempDir()
+	pluginSubDir := filepath.Join(dir, "some-plugin")
+	if err := os.MkdirAll(pluginSubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name":"some-plugin","version":"0.1.0","capabilities":{"iacProvider":{"name":"other-provider"}}}`
+	if err := os.WriteFile(filepath.Join(pluginSubDir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("WFCTL_PLUGIN_DIR", dir)
+	_, err := resolveIaCProvider(context.Background(), "digitalocean", nil)
+	if err == nil {
+		t.Fatal("expected error when no matching plugin found")
+	}
+	if !strings.Contains(err.Error(), "wfctl plugin install") {
+		t.Errorf("expected hint to run 'wfctl plugin install', got: %v", err)
+	}
+}
+
+// TestDefaultResolveIaCProvider_MatchingPlugin_NotLoaded verifies that when a
+// matching plugin is found (correct iacProvider.name) but the plugin binary is
+// absent, the error is specific about the plugin name rather than silently
+// falling through to a generic message.
+func TestDefaultResolveIaCProvider_MatchingPlugin_NotLoaded(t *testing.T) {
+	dir := t.TempDir()
+	pluginSubDir := filepath.Join(dir, "workflow-plugin-digitalocean")
+	if err := os.MkdirAll(pluginSubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name":"workflow-plugin-digitalocean","version":"0.1.0","capabilities":{"iacProvider":{"name":"digitalocean"}}}`
+	if err := os.WriteFile(filepath.Join(pluginSubDir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No binary present → load will fail.
+
+	t.Setenv("WFCTL_PLUGIN_DIR", dir)
+	_, err := resolveIaCProvider(context.Background(), "digitalocean", nil)
+	if err == nil {
+		t.Fatal("expected error when plugin binary is absent")
+	}
+	if !strings.Contains(err.Error(), "workflow-plugin-digitalocean") {
+		t.Errorf("expected plugin name in error message, got: %v", err)
+	}
+}
+
+// TestPluginDeployProvider_LazyResolution verifies that resolveIaCProvider is
+// NOT called at construction time and IS called on the first Deploy.
+func TestPluginDeployProvider_LazyResolution(t *testing.T) {
+	callCount := 0
+	orig := resolveIaCProvider
+	defer func() { resolveIaCProvider = orig }()
+
+	driver := &fakeResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
+		callCount++
+		return fake, nil
+	}
+
+	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
+	p, err := newDeployProvider("fake-cloud", cfg)
+	if err != nil {
+		t.Fatalf("newDeployProvider: %v", err)
+	}
+
+	if callCount != 0 {
+		t.Errorf("resolveIaCProvider called at construction (%d times); want 0", callCount)
+	}
+
+	deployCfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), deployCfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("resolveIaCProvider call count after first Deploy: got %d, want 1", callCount)
+	}
+
+	// Second Deploy must reuse cached provider.
+	if err := p.Deploy(context.Background(), deployCfg); err != nil {
+		t.Fatalf("Deploy (second): %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("resolveIaCProvider called again on second Deploy: got %d total calls, want 1", callCount)
+	}
+}
+
+// TestPluginDeployProvider_ResourceTypeFromModule verifies the resource type
+// is taken from the infra module's Type field, not hardcoded.
+func TestPluginDeployProvider_ResourceTypeFromModule(t *testing.T) {
+	driver := &fakeResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+
+	orig := resolveIaCProvider
+	defer func() { resolveIaCProvider = orig }()
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
+		return fake, nil
+	}
+
+	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
+	p, err := newDeployProvider("fake-cloud", cfg)
+	if err != nil {
+		t.Fatalf("newDeployProvider: %v", err)
+	}
+
+	pp, ok := p.(*pluginDeployProvider)
+	if !ok {
+		t.Fatalf("expected *pluginDeployProvider, got %T", p)
+	}
+	if pp.resourceType != "infra.container_service" {
+		t.Errorf("resourceType = %q; want %q", pp.resourceType, "infra.container_service")
+	}
+}

--- a/cmd/wfctl/deploy_plugin_loader_test.go
+++ b/cmd/wfctl/deploy_plugin_loader_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,7 @@ import (
 // stub message.
 func TestDefaultResolveIaCProvider_IsNotPlaceholder(t *testing.T) {
 	t.Setenv("WFCTL_PLUGIN_DIR", t.TempDir()) // empty dir — no plugins
-	_, err := resolveIaCProvider(context.Background(), "any-provider", nil)
+	_, _, err := resolveIaCProvider(context.Background(), "any-provider", nil)
 	if err == nil {
 		t.Skip("resolveIaCProvider succeeded unexpectedly")
 	}
@@ -29,7 +30,7 @@ func TestDefaultResolveIaCProvider_IsNotPlaceholder(t *testing.T) {
 // 'wfctl plugin install' when the plugin directory does not exist.
 func TestDefaultResolveIaCProvider_NoPluginDir(t *testing.T) {
 	t.Setenv("WFCTL_PLUGIN_DIR", filepath.Join(t.TempDir(), "nonexistent"))
-	_, err := resolveIaCProvider(context.Background(), "fake-provider", nil)
+	_, _, err := resolveIaCProvider(context.Background(), "fake-provider", nil)
 	if err == nil {
 		t.Fatal("expected error when plugin dir does not exist")
 	}
@@ -52,7 +53,7 @@ func TestDefaultResolveIaCProvider_NoMatchingPlugin(t *testing.T) {
 	}
 
 	t.Setenv("WFCTL_PLUGIN_DIR", dir)
-	_, err := resolveIaCProvider(context.Background(), "digitalocean", nil)
+	_, _, err := resolveIaCProvider(context.Background(), "digitalocean", nil)
 	if err == nil {
 		t.Fatal("expected error when no matching plugin found")
 	}
@@ -78,7 +79,7 @@ func TestDefaultResolveIaCProvider_MatchingPlugin_NotLoaded(t *testing.T) {
 	// No binary present → load will fail.
 
 	t.Setenv("WFCTL_PLUGIN_DIR", dir)
-	_, err := resolveIaCProvider(context.Background(), "digitalocean", nil)
+	_, _, err := resolveIaCProvider(context.Background(), "digitalocean", nil)
 	if err == nil {
 		t.Fatal("expected error when plugin binary is absent")
 	}
@@ -99,9 +100,9 @@ func TestPluginDeployProvider_LazyResolution(t *testing.T) {
 		name:    "fake-cloud",
 		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
 	}
-	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
 		callCount++
-		return fake, nil
+		return fake, nil, nil
 	}
 
 	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
@@ -146,8 +147,8 @@ func TestPluginDeployProvider_ResourceTypeFromModule(t *testing.T) {
 
 	orig := resolveIaCProvider
 	defer func() { resolveIaCProvider = orig }()
-	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
-		return fake, nil
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+		return fake, nil, nil
 	}
 
 	cfg := makePluginTestConfig("fake-cloud", "fake-provider")

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -3,16 +3,19 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/plugin/external"
 )
 
 // DeployConfig holds all parameters needed to execute a deployment.
@@ -58,10 +61,104 @@ func newDeployProvider(provider string, wfCfg *config.WorkflowConfig) (DeployPro
 	}
 }
 
-// resolveIaCProvider is the factory used by newPluginDeployProvider to obtain a
-// live IaCProvider from module config. Tests override this to inject fakes.
-var resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
-	return nil, fmt.Errorf("no in-process provider loader available; use pre-deploy steps with 'wfctl infra apply' to deploy via a workflow plugin")
+// resolveIaCProvider is the factory used by pluginDeployProvider.ensureProvider
+// to load a live IaCProvider from an installed external plugin. Tests override
+// this var to inject fakes without touching the filesystem.
+var resolveIaCProvider = func(ctx context.Context, providerName string, cfg map[string]any) (interfaces.IaCProvider, error) {
+	return discoverAndLoadIaCProvider(ctx, providerName, cfg)
+}
+
+// iacPluginManifest is the minimal shape needed to read capabilities.iacProvider.name
+// from a plugin.json without relying on the full PluginCapabilities struct.
+type iacPluginManifest struct {
+	Capabilities struct {
+		IaCProvider struct {
+			Name string `json:"name"`
+		} `json:"iacProvider"`
+	} `json:"capabilities"`
+}
+
+// findIaCPluginDir scans pluginDir subdirectories for a plugin.json that
+// declares capabilities.iacProvider.name == providerName.
+// Returns ("", false, nil) when not found; ("name", true/false, nil) when the
+// manifest matches (hasBinary indicates whether the executable is present).
+func findIaCPluginDir(pluginDir, providerName string) (name string, hasBinary bool, err error) {
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("scan plugin directory %q: %w", pluginDir, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pluginName := entry.Name()
+		data, readErr := os.ReadFile(filepath.Join(pluginDir, pluginName, "plugin.json"))
+		if readErr != nil {
+			continue
+		}
+		var m iacPluginManifest
+		if jsonErr := json.Unmarshal(data, &m); jsonErr != nil {
+			continue
+		}
+		if m.Capabilities.IaCProvider.Name != providerName {
+			continue
+		}
+		binaryPath := filepath.Join(pluginDir, pluginName, pluginName)
+		_, statErr := os.Stat(binaryPath)
+		return pluginName, statErr == nil, nil
+	}
+	return "", false, nil
+}
+
+// discoverAndLoadIaCProvider implements the default resolveIaCProvider: it scans
+// the plugin directory for a plugin that declares iacProvider.name == providerName,
+// loads it via ExternalPluginManager, and returns the IaCProvider.
+func discoverAndLoadIaCProvider(ctx context.Context, providerName string, cfg map[string]any) (interfaces.IaCProvider, error) {
+	pluginDir := os.Getenv("WFCTL_PLUGIN_DIR")
+	if pluginDir == "" {
+		pluginDir = "./data/plugins"
+	}
+
+	pluginName, hasBinary, err := findIaCPluginDir(pluginDir, providerName)
+	if err != nil {
+		return nil, fmt.Errorf("resolve IaC provider %q: %w", providerName, err)
+	}
+	if pluginName == "" {
+		return nil, fmt.Errorf("no plugin found for IaC provider %q in %s — run: wfctl plugin install <plugin-name>", providerName, pluginDir)
+	}
+	if !hasBinary {
+		return nil, fmt.Errorf("plugin %q declares provider %q but binary is missing — run: wfctl plugin install %s", pluginName, providerName, pluginName)
+	}
+
+	mgr := external.NewExternalPluginManager(pluginDir, nil)
+	adapter, loadErr := mgr.LoadPlugin(pluginName)
+	if loadErr != nil {
+		return nil, fmt.Errorf("load plugin %q for provider %q: %w", pluginName, providerName, loadErr)
+	}
+
+	factories := adapter.ModuleFactories()
+	factory, ok := factories["iac.provider"]
+	if !ok {
+		return nil, fmt.Errorf("plugin %q does not expose an iac.provider module type — upgrade with: wfctl plugin update %s", pluginName, pluginName)
+	}
+
+	mod := factory("iac-provider", cfg)
+	if mod == nil {
+		return nil, fmt.Errorf("plugin %q iac.provider factory returned nil", pluginName)
+	}
+
+	iacProvider, ok := mod.(interfaces.IaCProvider)
+	if !ok {
+		return nil, fmt.Errorf("plugin %q iac.provider module (%T) does not implement interfaces.IaCProvider — upgrade with: wfctl plugin update %s", pluginName, mod, pluginName)
+	}
+
+	if initErr := iacProvider.Initialize(ctx, cfg); initErr != nil {
+		return nil, fmt.Errorf("initialize provider %q: %w", providerName, initErr)
+	}
+	return iacProvider, nil
 }
 
 // newPluginDeployProvider looks up a matching iac.provider + infra.container_service
@@ -90,45 +187,64 @@ func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) 
 		return nil, fmt.Errorf("unsupported deploy provider %q (built-ins: kubernetes, docker, aws-ecs; to use a plugin provider, declare an iac.provider module in your workflow config)%s", providerName, fmt.Sprintf(hint, providerName))
 	}
 
-	// Find the first infra.container_service module referencing this provider.
-	var resourceName string
+	// Find the first infra resource module referencing this provider.
+	var resourceName, resourceType string
 	var resourceCfg map[string]any
 	for _, m := range wfCfg.Modules {
-		if m.Type != "infra.container_service" {
+		if m.Type == "iac.provider" || m.Type == "" {
 			continue
 		}
 		if p, _ := m.Config["provider"].(string); p == providerModName {
 			resourceName = m.Name
+			resourceType = m.Type
 			resourceCfg = m.Config
 			break
 		}
 	}
 	if resourceName == "" {
-		return nil, fmt.Errorf("no infra.container_service module found for provider %q in workflow config", providerModName)
+		return nil, fmt.Errorf("no infra resource module found for provider %q in workflow config", providerModName)
 	}
 
-	iacProvider, err := resolveIaCProvider(context.Background(), providerName, providerModCfg)
-	if err != nil {
-		return nil, fmt.Errorf("resolve provider %q: %w", providerName, err)
-	}
-
+	// Provider is resolved lazily on first Deploy/HealthCheck to thread the real ctx.
 	return &pluginDeployProvider{
-		provider:     iacProvider,
+		providerName: providerName,
+		providerCfg:  providerModCfg,
 		resourceName: resourceName,
-		resourceType: "infra.container_service",
+		resourceType: resourceType,
 		resourceCfg:  resourceCfg,
 	}, nil
 }
 
 // pluginDeployProvider wraps an IaCProvider and a single infra resource as a DeployProvider.
+// The IaCProvider is resolved lazily on first use so the real request context is threaded
+// through to Initialize rather than a synthetic context.Background().
 type pluginDeployProvider struct {
+	// lazy-resolution fields (set at construction)
+	providerName string
+	providerCfg  map[string]any
+	// resolved on first ensureProvider call
 	provider     interfaces.IaCProvider
 	resourceName string
 	resourceType string
 	resourceCfg  map[string]any
 }
 
+func (p *pluginDeployProvider) ensureProvider(ctx context.Context) error {
+	if p.provider != nil {
+		return nil
+	}
+	prov, err := resolveIaCProvider(ctx, p.providerName, p.providerCfg)
+	if err != nil {
+		return fmt.Errorf("resolve provider %q: %w", p.providerName, err)
+	}
+	p.provider = prov
+	return nil
+}
+
 func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) error {
+	if err := p.ensureProvider(ctx); err != nil {
+		return err
+	}
 	driver, err := p.provider.ResourceDriver(p.resourceType)
 	if err != nil {
 		return fmt.Errorf("plugin deploy: no driver for %q: %w", p.resourceType, err)
@@ -150,6 +266,9 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 func (p *pluginDeployProvider) HealthCheck(ctx context.Context, cfg DeployConfig) error {
 	if cfg.Env == nil || cfg.Env.HealthCheck == nil {
 		return nil
+	}
+	if err := p.ensureProvider(ctx); err != nil {
+		return err
 	}
 	driver, err := p.provider.ResourceDriver(p.resourceType)
 	if err != nil {

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -62,9 +64,11 @@ func newDeployProvider(provider string, wfCfg *config.WorkflowConfig) (DeployPro
 }
 
 // resolveIaCProvider is the factory used by pluginDeployProvider.ensureProvider
-// to load a live IaCProvider from an installed external plugin. Tests override
-// this var to inject fakes without touching the filesystem.
-var resolveIaCProvider = func(ctx context.Context, providerName string, cfg map[string]any) (interfaces.IaCProvider, error) {
+// to load a live IaCProvider from an installed external plugin. It returns both
+// the provider and an io.Closer that shuts down any background subprocess.
+// Tests override this var to inject fakes without touching the filesystem;
+// they may return nil for the closer.
+var resolveIaCProvider = func(ctx context.Context, providerName string, cfg map[string]any) (interfaces.IaCProvider, io.Closer, error) {
 	return discoverAndLoadIaCProvider(ctx, providerName, cfg)
 }
 
@@ -115,8 +119,9 @@ func findIaCPluginDir(pluginDir, providerName string) (name string, hasBinary bo
 
 // discoverAndLoadIaCProvider implements the default resolveIaCProvider: it scans
 // the plugin directory for a plugin that declares iacProvider.name == providerName,
-// loads it via ExternalPluginManager, and returns the IaCProvider.
-func discoverAndLoadIaCProvider(ctx context.Context, providerName string, cfg map[string]any) (interfaces.IaCProvider, error) {
+// loads it via ExternalPluginManager, and returns the IaCProvider plus a Closer
+// that shuts down the plugin subprocess. The caller must call Close() when done.
+func discoverAndLoadIaCProvider(ctx context.Context, providerName string, cfg map[string]any) (interfaces.IaCProvider, io.Closer, error) {
 	pluginDir := os.Getenv("WFCTL_PLUGIN_DIR")
 	if pluginDir == "" {
 		pluginDir = "./data/plugins"
@@ -124,42 +129,54 @@ func discoverAndLoadIaCProvider(ctx context.Context, providerName string, cfg ma
 
 	pluginName, hasBinary, err := findIaCPluginDir(pluginDir, providerName)
 	if err != nil {
-		return nil, fmt.Errorf("resolve IaC provider %q: %w", providerName, err)
+		return nil, nil, fmt.Errorf("resolve IaC provider %q: %w", providerName, err)
 	}
 	if pluginName == "" {
-		return nil, fmt.Errorf("no plugin found for IaC provider %q in %s — run: wfctl plugin install <plugin-name>", providerName, pluginDir)
+		return nil, nil, fmt.Errorf("no plugin found for IaC provider %q in %s — run: wfctl plugin install <plugin-name>", providerName, pluginDir)
 	}
 	if !hasBinary {
-		return nil, fmt.Errorf("plugin %q declares provider %q but binary is missing — run: wfctl plugin install %s", pluginName, providerName, pluginName)
+		return nil, nil, fmt.Errorf("plugin %q declares provider %q but binary is missing — run: wfctl plugin install %s", pluginName, providerName, pluginName)
 	}
 
 	mgr := external.NewExternalPluginManager(pluginDir, nil)
+	closer := closerFunc(func() error { mgr.Shutdown(); return nil })
+
 	adapter, loadErr := mgr.LoadPlugin(pluginName)
 	if loadErr != nil {
-		return nil, fmt.Errorf("load plugin %q for provider %q: %w", pluginName, providerName, loadErr)
+		mgr.Shutdown()
+		return nil, nil, fmt.Errorf("load plugin %q for provider %q: %w", pluginName, providerName, loadErr)
 	}
 
 	factories := adapter.ModuleFactories()
 	factory, ok := factories["iac.provider"]
 	if !ok {
-		return nil, fmt.Errorf("plugin %q does not expose an iac.provider module type — upgrade with: wfctl plugin update %s", pluginName, pluginName)
+		mgr.Shutdown()
+		return nil, nil, fmt.Errorf("plugin %q does not expose an iac.provider module type — upgrade with: wfctl plugin update %s", pluginName, pluginName)
 	}
 
 	mod := factory("iac-provider", cfg)
 	if mod == nil {
-		return nil, fmt.Errorf("plugin %q iac.provider factory returned nil", pluginName)
+		mgr.Shutdown()
+		return nil, nil, fmt.Errorf("plugin %q iac.provider factory returned nil", pluginName)
 	}
 
 	iacProvider, ok := mod.(interfaces.IaCProvider)
 	if !ok {
-		return nil, fmt.Errorf("plugin %q iac.provider module (%T) does not implement interfaces.IaCProvider — upgrade with: wfctl plugin update %s", pluginName, mod, pluginName)
+		mgr.Shutdown()
+		return nil, nil, fmt.Errorf("plugin %q iac.provider module (%T) does not implement interfaces.IaCProvider — upgrade with: wfctl plugin update %s", pluginName, mod, pluginName)
 	}
 
 	if initErr := iacProvider.Initialize(ctx, cfg); initErr != nil {
-		return nil, fmt.Errorf("initialize provider %q: %w", providerName, initErr)
+		mgr.Shutdown()
+		return nil, nil, fmt.Errorf("initialize provider %q: %w", providerName, initErr)
 	}
-	return iacProvider, nil
+	return iacProvider, closer, nil
 }
+
+// closerFunc adapts a func() error to io.Closer.
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
 
 // newPluginDeployProvider looks up a matching iac.provider + infra.container_service
 // module pair in wfCfg and wraps them as a DeployProvider.
@@ -222,22 +239,39 @@ type pluginDeployProvider struct {
 	// lazy-resolution fields (set at construction)
 	providerName string
 	providerCfg  map[string]any
-	// resolved on first ensureProvider call
-	provider     interfaces.IaCProvider
+	// resource target (set at construction)
 	resourceName string
 	resourceType string
 	resourceCfg  map[string]any
+	// resolved once on first ensureProvider call
+	once     sync.Once
+	provider interfaces.IaCProvider
+	provErr  error
+	closer   io.Closer
 }
 
 func (p *pluginDeployProvider) ensureProvider(ctx context.Context) error {
-	if p.provider != nil {
-		return nil
+	p.once.Do(func() {
+		if p.provider != nil {
+			return // already injected (e.g. by tests constructing the struct directly)
+		}
+		prov, closer, err := resolveIaCProvider(ctx, p.providerName, p.providerCfg)
+		p.provider = prov
+		p.closer = closer
+		p.provErr = err
+	})
+	if p.provErr != nil {
+		return fmt.Errorf("resolve provider %q: %w", p.providerName, p.provErr)
 	}
-	prov, err := resolveIaCProvider(ctx, p.providerName, p.providerCfg)
-	if err != nil {
-		return fmt.Errorf("resolve provider %q: %w", p.providerName, err)
+	return nil
+}
+
+// Close shuts down the plugin subprocess, if any. The DeployProvider interface
+// does not include Close; callers should type-assert to io.Closer after use.
+func (p *pluginDeployProvider) Close() error {
+	if p.closer != nil {
+		return p.closer.Close()
 	}
-	p.provider = prov
 	return nil
 }
 

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -137,8 +138,8 @@ func TestNewDeployProvider_PluginProvider_Resolves(t *testing.T) {
 
 	orig := resolveIaCProvider
 	defer func() { resolveIaCProvider = orig }()
-	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, error) {
-		return fake, nil
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+		return fake, nil, nil
 	}
 
 	cfg := makePluginTestConfig("fake-cloud", "fake-provider")


### PR DESCRIPTION
## Summary

- Replace the \`resolveIaCProvider\` no-op stub with \`discoverAndLoadIaCProvider\`, which:
  - Scans \`WFCTL_PLUGIN_DIR\` subdirectories for \`plugin.json\` files declaring \`capabilities.iacProvider.name\`
  - On match: loads the plugin via \`ExternalPluginManager\`, asserts the \`iac.provider\` module factory result to \`interfaces.IaCProvider\`
  - Each failure mode returns an actionable error (no plugin dir → \`wfctl plugin install\`; binary missing → same; no module type → \`wfctl plugin update\`)
- Refactor \`pluginDeployProvider\` to resolve lazily via \`ensureProvider(ctx)\` — the real request context is now threaded through to \`Initialize\` instead of \`context.Background()\`
- Derive \`resourceType\` from the matched infra module's \`Type\` field instead of hardcoding \`"infra.container_service"\`
- Add \`--plugin-dir\` flag to \`wfctl ci run\` (also honoured via \`WFCTL_PLUGIN_DIR\` env var)

## Option A vs Option B

Option A (engine build + module walk) was skipped because \`iac.provider\` has no registered factory in the engine — \`workflow.NewEngineBuilder().BuildFromConfig(cfg)\` would skip the module rather than instantiate it, so there is nothing to extract. Option B (direct \`ExternalPluginManager\` + raw JSON manifest scan) is the only path that can discover and load the plugin without requiring engine-side changes.

## Known gap: workflow-plugin-digitalocean

\`workflow-plugin-digitalocean\` v0.1.0 declares \`capabilities.iacProvider.name = "digitalocean"\` in \`plugin.json\` but does **not** expose an \`iac.provider\` module type or any \`ServiceInvoker\` handlers. Deploying through it currently returns:

\`\`\`
plugin "workflow-plugin-digitalocean" does not expose an iac.provider module type — upgrade with: wfctl plugin update workflow-plugin-digitalocean
\`\`\`

The follow-up work in \`workflow-plugin-digitalocean\` is to:
1. Register \`iac.provider\` in \`moduleTypes\` in \`plugin.json\`
2. Implement \`sdk.ModuleProvider.CreateModule("iac.provider", ...)\` returning a module that implements \`interfaces.IaCProvider\`
3. Wire \`ResourceDriver.Update\` and \`ResourceDriver.HealthCheck\` through \`sdk.ServiceInvoker.InvokeMethod\`

## Integration check (manual)

Steps run against \`/Users/jon/workspace/buymywishlist\`:

**Step 1** — check plugin registry manifest exists:
\`\`\`
wfctl plugin search workflow-plugin-digitalocean
\`\`\`
Result: manifest exists in workflow-registry (added in PR #12).

**Step 2** — install plugin binary:
\`\`\`
wfctl plugin install workflow-plugin-digitalocean --plugin-dir ./data/plugins
\`\`\`
Result: binary installed to \`data/plugins/workflow-plugin-digitalocean/workflow-plugin-digitalocean\`.

**Step 3** — attempt deploy:
\`\`\`
DIGITALOCEAN_TOKEN=... SPACES_access_key=... SPACES_secret_key=... \
  wfctl ci run --phase deploy --env staging --config infra.yaml \
  --plugin-dir ./data/plugins
\`\`\`
Actual outcome (expected given known gap above):
\`\`\`
plugin "workflow-plugin-digitalocean" does not expose an iac.provider module type — upgrade with: wfctl plugin update workflow-plugin-digitalocean
\`\`\`
Plugin discovery and loading succeeds (ExternalPluginManager log lines appear on stderr); the error is returned at the \`ModuleFactories()["iac.provider"]\` assertion step — confirming the wiring is correct and the remaining work is entirely in the DO plugin.

## Test plan

- [x] \`TestDefaultResolveIaCProvider_IsNotPlaceholder\` — default no longer returns old stub message
- [x] \`TestDefaultResolveIaCProvider_NoPluginDir\` — missing dir → hint to \`wfctl plugin install\`
- [x] \`TestDefaultResolveIaCProvider_NoMatchingPlugin\` — unmatched provider → hint to \`wfctl plugin install\`
- [x] \`TestDefaultResolveIaCProvider_MatchingPlugin_NotLoaded\` — manifest found, binary absent → error names the plugin
- [x] \`TestPluginDeployProvider_LazyResolution\` — \`resolveIaCProvider\` not called at construction; called once on first \`Deploy\`; not called again on subsequent \`Deploy\`
- [x] \`TestPluginDeployProvider_ResourceTypeFromModule\` — \`resourceType\` matches the infra module's declared type
- [x] All pre-existing \`cmd/wfctl/...\` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)