### PR TITLE
fix(wfctl): thread --tag from wfctl build to the push step

### DIFF
--- a/cmd/wfctl/build.go
+++ b/cmd/wfctl/build.go
@@ -168,6 +168,9 @@ func runBuildOrchestrate(cfg *config.WorkflowConfig, opts buildOpts) error {
 		if opts.cfgPath != "" {
 			pushArgs = append(pushArgs, "--config", opts.cfgPath)
 		}
+		if opts.tag != "" {
+			pushArgs = append(pushArgs, "--tag", opts.tag)
+		}
 		if err := runBuildPush(pushArgs); err != nil {
 			return fmt.Errorf("push: %w", err)
 		}

--- a/cmd/wfctl/build_push.go
+++ b/cmd/wfctl/build_push.go
@@ -13,6 +13,7 @@ import (
 func runBuildPush(args []string) error {
 	fs := flag.NewFlagSet("build push", flag.ContinueOnError)
 	cfgPath := fs.String("config", "workflow.yaml", "Path to workflow config file")
+	tagOverride := fs.String("tag", "", "Override image tag for all containers")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -47,7 +48,11 @@ func runBuildPush(args []string) error {
 			if !ok {
 				return fmt.Errorf("container %q references unknown registry %q", ct.Name, regName)
 			}
-			imageRef := fmt.Sprintf("%s/%s:%s", reg.Path, ct.Name, imageTag(ct.Tag))
+			tag := *tagOverride
+			if tag == "" {
+				tag = ct.Tag
+			}
+			imageRef := fmt.Sprintf("%s/%s:%s", reg.Path, ct.Name, imageTag(tag))
 			if dryRun {
 				fmt.Printf("push %s → %s\n", ct.Name, imageRef)
 				continue

--- a/cmd/wfctl/build_push_test.go
+++ b/cmd/wfctl/build_push_test.go
@@ -51,6 +51,53 @@ func TestRunBuildPush_DryRun_PrintsPlannedPushes(t *testing.T) {
 	}
 }
 
+// TestRunBuildPush_TagOverride verifies that --tag is threaded into the
+// image ref, overriding the container's static tag field. Without this,
+// `wfctl build --tag X` would still push :latest (the container default),
+// which breaks tagged-commit deploys where the build step tagged with X
+// but the subsequent push step didn't know about X.
+func TestRunBuildPush_TagOverride(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+ci:
+  registries:
+    - name: docr
+      type: do
+      path: registry.digitalocean.com/myorg
+  build:
+    containers:
+      - name: api
+        method: dockerfile
+        dockerfile: Dockerfile
+        push_to: [docr]
+`
+	cfgPath := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := runBuildPush([]string{"--config", cfgPath, "--tag", "abc1234"})
+	w.Close()
+	os.Stdout = oldStdout
+	if err != nil {
+		t.Fatalf("runBuildPush: %v", err)
+	}
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	out := string(buf[:n])
+	want := "registry.digitalocean.com/myorg/api:abc1234"
+	if !strings.Contains(out, want) {
+		t.Errorf("output should reference %q, got: %q", want, out)
+	}
+	if strings.Contains(out, ":latest") {
+		t.Errorf("output should not reference :latest, got: %q", out)
+	}
+}
+
 func TestRunBuildPush_UnknownRegistry(t *testing.T) {
 	dir := t.TempDir()
 	content := `


### PR DESCRIPTION
`wfctl build --tag abc1234` in v0.15.1 builds the image correctly at `registry/app:abc1234` but the subsequent push step ignores `--tag` and defaults to `:latest`, which doesn't exist locally. Result: `tag does not exist: ...:latest` push failure. Thread `opts.tag` through `runBuildOrchestrate` → `runBuildPush` and add a `--tag` flag to `runBuildPush` itself. New regression test: TestRunBuildPush_TagOverride.

🤖 Generated with [Claude Code](https://claude.com/claude-code)