### PR TITLE
fix(plugin/external): resolve plugin binary path to absolute before exec

### DIFF
--- a/plugin/external/manager.go
+++ b/plugin/external/manager.go
@@ -83,7 +83,16 @@ func (m *ExternalPluginManager) LoadPlugin(name string) (*ExternalPluginAdapter,
 
 	pluginDir := filepath.Join(m.pluginsDir, name)
 	manifestPath := filepath.Join(pluginDir, "plugin.json")
-	binaryPath := filepath.Join(pluginDir, name)
+	// Resolve the binary path to absolute. os/exec.Cmd.Start evaluates a
+	// relative Path *inside* cmd.Dir, so a relative binary path + relative
+	// cmd.Dir would double-nest to "<pluginDir>/<pluginDir>/<name>", which
+	// fails with ENOENT ("no such file or directory") even though the binary
+	// exists at the intended location. Absolutising here makes Path + Dir
+	// independent.
+	binaryPath, err := filepath.Abs(filepath.Join(pluginDir, name))
+	if err != nil {
+		return nil, fmt.Errorf("resolve binary path for plugin %q: %w", name, err)
+	}
 
 	// Validate manifest
 	manifest, err := pluginpkg.LoadManifest(manifestPath)


### PR DESCRIPTION
BMW deploy-staging consistently fails with `plugin failed to exit gracefully` + `error: no such file or directory` when wfctl ci run tries to load workflow-plugin-digitalocean. Reproduced locally with the darwin binary — same failure.

Root cause: `ExternalPluginManager.LoadPlugin` sets both `cmd.Path` and `cmd.Dir` to relative paths pointing at the plugin's subdir. Go's `os/exec` resolves a relative Path *inside* cmd.Dir, so the lookup becomes `<pluginDir>/<pluginDir>/<name>` — a doubled path. Reproducible with:

```go
cmd := exec.Command("data/plugins/X/X")
cmd.Dir = "data/plugins/X"
cmd.Start() // → fork/exec data/plugins/X/X: no such file or directory
```

Fix: `filepath.Abs` the binary path before exec. Verified the fix resolves the error; existing plugin/external tests pass.

cmd/wfctl/main.go's error-unwrap to the root cause made this much harder to diagnose than it needed to be — separate cleanup that could land is to stop unwrapping or at least preserve one layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)