### PR TITLE
fix(deploy): upsert in pluginDeployProvider — Create fallback on ErrResourceNotFound

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"io"
 	"net/http"
 	"os"
@@ -587,10 +589,20 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	merged["image"] = cfg.ImageTag
 	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
 	spec := interfaces.ResourceSpec{Name: p.resourceName, Type: p.resourceType, Config: merged}
-	if _, err := driver.Update(ctx, ref, spec); err != nil {
-		return fmt.Errorf("plugin deploy %q: update image: %w", p.resourceName, err)
+	_, updateErr := driver.Update(ctx, ref, spec)
+	if updateErr == nil {
+		fmt.Printf("  plugin deploy: updated %q to %s\n", p.resourceName, cfg.ImageTag)
+		return nil
 	}
-	fmt.Printf("  plugin deploy: updated %q to %s\n", p.resourceName, cfg.ImageTag)
+	if !errors.Is(updateErr, interfaces.ErrResourceNotFound) {
+		return fmt.Errorf("plugin deploy %q: update image: %w", p.resourceName, updateErr)
+	}
+	// Resource does not exist yet — fall back to Create.
+	log.Printf("plugin deploy %q: resource not found, creating new", p.resourceName)
+	if _, createErr := driver.Create(ctx, spec); createErr != nil {
+		return fmt.Errorf("plugin deploy %q: create failed: %w", p.resourceName, createErr)
+	}
+	fmt.Printf("  plugin deploy: created %q at %s\n", p.resourceName, cfg.ImageTag)
 	return nil
 }
 

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -600,7 +600,7 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	// Resource does not exist yet — fall back to Create.
 	log.Printf("plugin deploy %q: resource not found, creating new", p.resourceName)
 	if _, createErr := driver.Create(ctx, spec); createErr != nil {
-		return fmt.Errorf("plugin deploy %q: create failed: %w", p.resourceName, createErr)
+		return fmt.Errorf("plugin deploy %q: create failed: %w", p.resourceName, errors.Join(createErr, updateErr))
 	}
 	fmt.Printf("  plugin deploy: created %q at %s\n", p.resourceName, cfg.ImageTag)
 	return nil

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -14,19 +14,35 @@ import (
 // ── fakes ─────────────────────────────────────────────────────────────────────
 
 type fakeResourceDriver struct {
-	updateImage string
-	hcResult    *interfaces.HealthResult
-	hcErr       error
+	updateImage  string
+	updateErr    error
+	hcResult     *interfaces.HealthResult
+	hcErr        error
+	createCalled bool
+	createSpec   interfaces.ResourceSpec
+	createOut    *interfaces.ResourceOutput
+	createErr    error
 }
 
-func (d *fakeResourceDriver) Create(_ context.Context, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
-	return nil, nil
+func (d *fakeResourceDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	d.createCalled = true
+	d.createSpec = spec
+	if d.createErr != nil {
+		return nil, d.createErr
+	}
+	if d.createOut != nil {
+		return d.createOut, nil
+	}
+	return &interfaces.ResourceOutput{}, nil
 }
 func (d *fakeResourceDriver) Read(_ context.Context, _ interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
 	return nil, nil
 }
 func (d *fakeResourceDriver) Update(_ context.Context, _ interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	d.updateImage, _ = spec.Config["image"].(string)
+	if d.updateErr != nil {
+		return nil, d.updateErr
+	}
 	return &interfaces.ResourceOutput{}, nil
 }
 func (d *fakeResourceDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
@@ -243,5 +259,122 @@ func TestPluginDeployProvider_HealthCheck_Unhealthy(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not ready") {
 		t.Errorf("expected 'not ready' in error, got: %v", err)
+	}
+}
+
+func TestPluginDeployProvider_Deploy_FallsBackToCreateOnNotFound(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateErr: interfaces.ErrResourceNotFound,
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"http_port": 8080},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:new123",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: unexpected error: %v", err)
+	}
+	if !driver.createCalled {
+		t.Error("expected Create to be called after Update returned ErrResourceNotFound")
+	}
+	if driver.createSpec.Config["image"] != "registry.example.com/myapp:new123" {
+		t.Errorf("expected image %q in Create spec, got %v", "registry.example.com/myapp:new123", driver.createSpec.Config["image"])
+	}
+}
+
+func TestPluginDeployProvider_Deploy_WrappedNotFoundFallsBack(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateErr: fmt.Errorf("service layer: %w", interfaces.ErrResourceNotFound),
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:wrapped",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: unexpected error: %v", err)
+	}
+	if !driver.createCalled {
+		t.Error("expected Create to be called for wrapped ErrResourceNotFound")
+	}
+}
+
+func TestPluginDeployProvider_Deploy_OtherUpdateErrorNotRetried(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateErr: fmt.Errorf("quota exceeded"),
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	err := p.Deploy(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error for non-not-found update failure")
+	}
+	if driver.createCalled {
+		t.Error("expected Create NOT to be called for non-not-found update error")
+	}
+	if !strings.Contains(err.Error(), "quota exceeded") {
+		t.Errorf("expected original error in message, got: %v", err)
+	}
+}
+
+func TestPluginDeployProvider_Deploy_CreateFailureReturnsError(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateErr: interfaces.ErrResourceNotFound,
+		createErr: fmt.Errorf("capacity unavailable"),
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	err := p.Deploy(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error when Create fails")
+	}
+	if !strings.Contains(err.Error(), "capacity unavailable") {
+		t.Errorf("expected create error in message, got: %v", err)
 	}
 }

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -376,5 +377,8 @@ func TestPluginDeployProvider_Deploy_CreateFailureReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "capacity unavailable") {
 		t.Errorf("expected create error in message, got: %v", err)
+	}
+	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Errorf("expected update error (ErrResourceNotFound) also joined into returned error, got: %v", err)
 	}
 }

--- a/interfaces/iac_resource_driver.go
+++ b/interfaces/iac_resource_driver.go
@@ -1,6 +1,13 @@
 package interfaces
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrResourceNotFound is returned by ResourceDriver methods when the target
+// resource does not exist. Callers should use errors.Is to detect it.
+var ErrResourceNotFound = errors.New("iac: resource not found")
 
 // ResourceDriver handles CRUD for a single resource type within a provider.
 type ResourceDriver interface {


### PR DESCRIPTION
## Summary

- Adds `interfaces.ErrResourceNotFound` sentinel so drivers can signal a resource-does-not-exist condition in a way that callers can test with `errors.Is` (including wrapped errors)
- `pluginDeployProvider.Deploy` now performs an upsert: calls `Update` first; if the driver returns `ErrResourceNotFound` (directly or wrapped), falls back to `Create` — one code path handles both first-provision and subsequent redeploys
- Non-not-found update errors are still returned immediately (no fallback)

## Test plan

- [x] `TestPluginDeployProvider_Deploy_FallsBackToCreateOnNotFound` — direct sentinel triggers Create
- [x] `TestPluginDeployProvider_Deploy_WrappedNotFoundFallsBack` — wrapped `%w` sentinel also triggers Create
- [x] `TestPluginDeployProvider_Deploy_OtherUpdateErrorNotRetried` — quota/other errors bubble up without Create
- [x] `TestPluginDeployProvider_Deploy_CreateFailureReturnsError` — Create errors propagate correctly
- [x] `GOWORK=off go test ./cmd/wfctl/... -race` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)