### PR TITLE
feat(secrets): infra_output generator — populate secrets from IaC apply state

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -841,7 +841,21 @@ func runInfraApply(args []string) error {
 	}
 
 	fmt.Printf("Applying infrastructure from %s...\n", cfgFile)
-	return runPipelineRun([]string{"-c", pipelineCfg, "-p", "apply"})
+	if err := runPipelineRun([]string{"-c", pipelineCfg, "-p", "apply"}); err != nil {
+		return err
+	}
+
+	// Post-apply: sync infra_output secrets from the now-written state.
+	secretsCfg, err := parseSecretsConfig(cfgFile)
+	if err != nil || secretsCfg == nil {
+		return err
+	}
+	provider, err := resolveSecretsProvider(secretsCfg)
+	if err != nil {
+		return fmt.Errorf("resolve secrets provider for infra_output sync: %w", err)
+	}
+	states := loadCurrentState(cfgFile)
+	return syncInfraOutputSecrets(context.Background(), secretsCfg, provider, states)
 }
 
 func runInfraStatus(args []string) error {

--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -219,6 +219,11 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 	}
 
 	for _, gen := range cfg.Generate {
+		// infra_output secrets depend on apply-time state; skip during bootstrap.
+		if gen.Type == "infra_output" {
+			continue
+		}
+
 		// Build generator config from SecretGen fields.
 		genConfig := map[string]any{}
 		if gen.Length > 0 {

--- a/cmd/wfctl/infra_output_secrets.go
+++ b/cmd/wfctl/infra_output_secrets.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/secrets"
+)
+
+// buildStateOutputsMap converts a slice of ResourceState into a map keyed by
+// module name so generators can look up outputs by "module.field" source.
+// Modules with nil Outputs are excluded.
+func buildStateOutputsMap(states []interfaces.ResourceState) map[string]map[string]any {
+	m := make(map[string]map[string]any, len(states))
+	for i := range states {
+		s := &states[i]
+		if s.Outputs != nil {
+			m[s.Name] = s.Outputs
+		}
+	}
+	return m
+}
+
+// syncInfraOutputSecrets writes infra_output-typed secrets after a successful
+// apply. It skips secrets that already exist in the provider so idempotent
+// re-runs never overwrite live values.
+func syncInfraOutputSecrets(ctx context.Context, secretsCfg *SecretsConfig, provider secrets.Provider, states []interfaces.ResourceState) error {
+	if secretsCfg == nil {
+		return nil
+	}
+	var gens []SecretGen
+	for _, g := range secretsCfg.Generate {
+		if g.Type == "infra_output" {
+			gens = append(gens, g)
+		}
+	}
+	if len(gens) == 0 {
+		return nil
+	}
+
+	// Lazy List() cache — same pattern as bootstrapSecrets for write-only
+	// providers (GitHub Actions) that return ErrUnsupported on Get.
+	var listSet map[string]struct{}
+	var listErr error
+	var listDone bool
+	lookupViaList := func(key string) (bool, error) {
+		if !listDone {
+			names, err := provider.List(ctx)
+			listErr = err
+			if err == nil {
+				listSet = make(map[string]struct{}, len(names))
+				for _, n := range names {
+					listSet[n] = struct{}{}
+				}
+			}
+			listDone = true
+		}
+		if listErr != nil && !errors.Is(listErr, secrets.ErrUnsupported) {
+			return false, fmt.Errorf("list secrets to check %q: %w", key, listErr)
+		}
+		_, ok := listSet[key]
+		return ok, nil
+	}
+	secretExists := func(key string) (bool, error) {
+		_, err := provider.Get(ctx, key)
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.Is(err, secrets.ErrNotFound):
+			return false, nil
+		case errors.Is(err, secrets.ErrUnsupported):
+			return lookupViaList(key)
+		default:
+			return false, fmt.Errorf("check secret %q: %w", key, err)
+		}
+	}
+
+	stateOutputs := buildStateOutputsMap(states)
+
+	for _, gen := range gens {
+		exists, err := secretExists(gen.Key)
+		if err != nil {
+			return err
+		}
+		if exists {
+			fmt.Printf("  secret %q: already exists — skipped\n", gen.Key)
+			continue
+		}
+
+		genConfig := map[string]any{
+			"source":         gen.Source,
+			"_state_outputs": stateOutputs,
+		}
+		value, err := generateSecret(ctx, "infra_output", genConfig)
+		if err != nil {
+			return fmt.Errorf("generate infra_output secret %q: %w", gen.Key, err)
+		}
+		if err := provider.Set(ctx, gen.Key, value); err != nil {
+			return fmt.Errorf("store secret %q: %w", gen.Key, err)
+		}
+		fmt.Printf("  secret %q: created from infra output\n", gen.Key)
+	}
+	return nil
+}

--- a/cmd/wfctl/infra_output_secrets_test.go
+++ b/cmd/wfctl/infra_output_secrets_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/secrets"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// simpleProvider is a read/write/list fake for testing.
+type simpleProvider struct {
+	data map[string]string
+}
+
+func newSimpleProvider() *simpleProvider {
+	return &simpleProvider{data: map[string]string{}}
+}
+
+func (p *simpleProvider) Name() string { return "simple-fake" }
+
+func (p *simpleProvider) Get(_ context.Context, key string) (string, error) {
+	if v, ok := p.data[key]; ok {
+		return v, nil
+	}
+	return "", secrets.ErrNotFound
+}
+
+func (p *simpleProvider) Set(_ context.Context, key, val string) error {
+	p.data[key] = val
+	return nil
+}
+
+func (p *simpleProvider) Delete(_ context.Context, key string) error {
+	delete(p.data, key)
+	return nil
+}
+
+func (p *simpleProvider) List(_ context.Context) ([]string, error) {
+	keys := make([]string, 0, len(p.data))
+	for k := range p.data {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+// sampleStates returns a slice of ResourceState with known outputs.
+func sampleStates() []interfaces.ResourceState {
+	return []interfaces.ResourceState{
+		{
+			Name:   "bmw-database",
+			Type:   "infra.database",
+			Outputs: map[string]any{
+				"uri":  "postgres://user:pass@db.example.com:5432/app",
+				"host": "db.example.com",
+			},
+		},
+		{
+			Name:   "bmw-cache",
+			Type:   "infra.cache",
+			Outputs: map[string]any{
+				"url": "redis://cache.example.com:6379",
+			},
+		},
+	}
+}
+
+// ── buildStateOutputsMap ──────────────────────────────────────────────────────
+
+func TestBuildStateOutputsMap_Basic(t *testing.T) {
+	states := sampleStates()
+	m := buildStateOutputsMap(states)
+	if len(m) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(m))
+	}
+	if m["bmw-database"]["uri"] != "postgres://user:pass@db.example.com:5432/app" {
+		t.Errorf("bmw-database.uri: got %v", m["bmw-database"]["uri"])
+	}
+	if m["bmw-cache"]["url"] != "redis://cache.example.com:6379" {
+		t.Errorf("bmw-cache.url: got %v", m["bmw-cache"]["url"])
+	}
+}
+
+func TestBuildStateOutputsMap_NilOutputsSkipped(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{Name: "no-outputs", Type: "infra.vpc"},
+		{Name: "has-outputs", Type: "infra.database", Outputs: map[string]any{"uri": "pg://..."}},
+	}
+	m := buildStateOutputsMap(states)
+	if _, ok := m["no-outputs"]; ok {
+		t.Error("module with nil outputs should not appear in map")
+	}
+	if m["has-outputs"]["uri"] != "pg://..." {
+		t.Errorf("unexpected: %v", m["has-outputs"])
+	}
+}
+
+func TestBuildStateOutputsMap_Empty(t *testing.T) {
+	m := buildStateOutputsMap(nil)
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
+}
+
+// ── syncInfraOutputSecrets ────────────────────────────────────────────────────
+
+func TestSyncInfraOutputSecrets_NilConfig(t *testing.T) {
+	p := newSimpleProvider()
+	err := syncInfraOutputSecrets(context.Background(), nil, p, sampleStates())
+	if err != nil {
+		t.Fatalf("nil config should be no-op: %v", err)
+	}
+	if len(p.data) != 0 {
+		t.Errorf("no secrets should be written: %v", p.data)
+	}
+}
+
+func TestSyncInfraOutputSecrets_NoInfraOutputGens(t *testing.T) {
+	p := newSimpleProvider()
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "JWT_SECRET", Type: "random_hex", Length: 32},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err != nil {
+		t.Fatalf("no infra_output generators should be no-op: %v", err)
+	}
+	if len(p.data) != 0 {
+		t.Errorf("no secrets should be written: %v", p.data)
+	}
+}
+
+func TestSyncInfraOutputSecrets_WritesSecret(t *testing.T) {
+	p := newSimpleProvider()
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "STAGING_DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err != nil {
+		t.Fatalf("syncInfraOutputSecrets: %v", err)
+	}
+	if p.data["STAGING_DATABASE_URL"] != "postgres://user:pass@db.example.com:5432/app" {
+		t.Errorf("STAGING_DATABASE_URL: got %q", p.data["STAGING_DATABASE_URL"])
+	}
+}
+
+func TestSyncInfraOutputSecrets_WritesMultiple(t *testing.T) {
+	p := newSimpleProvider()
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
+			{Key: "REDIS_URL", Type: "infra_output", Source: "bmw-cache.url"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err != nil {
+		t.Fatalf("syncInfraOutputSecrets: %v", err)
+	}
+	if p.data["DATABASE_URL"] != "postgres://user:pass@db.example.com:5432/app" {
+		t.Errorf("DATABASE_URL: got %q", p.data["DATABASE_URL"])
+	}
+	if p.data["REDIS_URL"] != "redis://cache.example.com:6379" {
+		t.Errorf("REDIS_URL: got %q", p.data["REDIS_URL"])
+	}
+}
+
+func TestSyncInfraOutputSecrets_SkipsExisting(t *testing.T) {
+	p := newSimpleProvider()
+	p.data["DATABASE_URL"] = "already-set"
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err != nil {
+		t.Fatalf("syncInfraOutputSecrets: %v", err)
+	}
+	// Must not overwrite the existing value.
+	if p.data["DATABASE_URL"] != "already-set" {
+		t.Errorf("existing secret should not be overwritten: got %q", p.data["DATABASE_URL"])
+	}
+}
+
+func TestSyncInfraOutputSecrets_WriteOnlyProviderSkips(t *testing.T) {
+	p := &writeOnlyProvider{
+		existing: []string{"DATABASE_URL"},
+		listOK:   true,
+	}
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err != nil {
+		t.Fatalf("syncInfraOutputSecrets: %v", err)
+	}
+	if len(p.stored) != 0 {
+		t.Errorf("should not write to write-only provider when secret exists: %v", p.stored)
+	}
+}
+
+func TestSyncInfraOutputSecrets_WriteOnlyProviderWrites(t *testing.T) {
+	p := &writeOnlyProvider{
+		existing: []string{},
+		listOK:   true,
+	}
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err != nil {
+		t.Fatalf("syncInfraOutputSecrets: %v", err)
+	}
+	if p.stored["DATABASE_URL"] != "postgres://user:pass@db.example.com:5432/app" {
+		t.Errorf("DATABASE_URL: got %q", p.stored["DATABASE_URL"])
+	}
+}
+
+func TestSyncInfraOutputSecrets_MissingModule(t *testing.T) {
+	p := newSimpleProvider()
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "X", Type: "infra_output", Source: "nonexistent.uri"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, sampleStates())
+	if err == nil {
+		t.Fatal("expected error for missing module in state")
+	}
+}
+
+func TestSyncInfraOutputSecrets_EmptyStates(t *testing.T) {
+	p := newSimpleProvider()
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "X", Type: "infra_output", Source: "bmw-database.uri"},
+		},
+	}
+	err := syncInfraOutputSecrets(context.Background(), cfg, p, nil)
+	if err == nil {
+		t.Fatal("expected error when state has no matching module")
+	}
+}
+
+// ── bootstrapSecrets skips infra_output ───────────────────────────────────────
+
+func TestBootstrapSecrets_SkipsInfraOutputGens(t *testing.T) {
+	generatorCalled := false
+	withStubGenerator(t, func(_ context.Context, genType string, _ map[string]any) (string, error) {
+		if genType == "infra_output" {
+			generatorCalled = true
+			return "", fmt.Errorf("infra_output should not be called during bootstrap")
+		}
+		return "random-value", nil
+	})
+	p := &writeOnlyProvider{listOK: true}
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "JWT_SECRET", Type: "random_hex", Length: 32},
+			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
+		},
+	}
+	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+		t.Fatalf("bootstrapSecrets: %v", err)
+	}
+	if generatorCalled {
+		t.Error("infra_output generator must not be called during bootstrap")
+	}
+	// JWT_SECRET should be written; DATABASE_URL should not.
+	if _, ok := p.stored["JWT_SECRET"]; !ok {
+		t.Error("JWT_SECRET should have been generated")
+	}
+	if _, ok := p.stored["DATABASE_URL"]; ok {
+		t.Error("DATABASE_URL (infra_output) should not be set during bootstrap")
+	}
+}

--- a/secrets/generators.go
+++ b/secrets/generators.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"strings"
 )
 
 const alphanumChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -28,6 +29,8 @@ func GenerateSecret(ctx context.Context, genType string, config map[string]any) 
 		return generateRandomAlphanumeric(config)
 	case "provider_credential":
 		return generateProviderCredential(ctx, config)
+	case "infra_output":
+		return generateFromInfraOutput(config)
 	default:
 		return "", fmt.Errorf("secrets: unknown generator type %q", genType)
 	}
@@ -85,6 +88,53 @@ func generateProviderCredential(ctx context.Context, config map[string]any) (str
 	default:
 		return "", fmt.Errorf("secrets: provider_credential: unknown source %q", source)
 	}
+}
+
+// generateFromInfraOutput resolves a secret value from the outputs of a
+// previously-applied IaC resource. The caller is expected to pre-load the
+// resource outputs into config["_state_outputs"] (map[string]map[string]any)
+// before invoking GenerateSecret. This separation keeps the generator
+// stateless and fully testable without a real state backend.
+//
+// config["source"] must be "module_name.output_field" (e.g. "bmw-database.uri").
+func generateFromInfraOutput(config map[string]any) (string, error) {
+	source, _ := config["source"].(string)
+	if source == "" {
+		return "", fmt.Errorf("secrets: infra_output: 'source' is required (format: \"module.field\")")
+	}
+	dot := strings.Index(source, ".")
+	if dot < 1 || dot >= len(source)-1 {
+		return "", fmt.Errorf("secrets: infra_output: invalid source %q: expected \"module.field\" format", source)
+	}
+	moduleName := source[:dot]
+	field := source[dot+1:]
+
+	stateOutputs, _ := config["_state_outputs"].(map[string]map[string]any)
+	if stateOutputs == nil {
+		return "", fmt.Errorf("secrets: infra_output: state outputs not available for source %q — did infra apply succeed?", source)
+	}
+	outputs, ok := stateOutputs[moduleName]
+	if !ok {
+		return "", fmt.Errorf("secrets: infra_output: module %q not found in state (available: %s)", moduleName, joinKeys(stateOutputs))
+	}
+	val, ok := outputs[field]
+	if !ok {
+		return "", fmt.Errorf("secrets: infra_output: field %q not found in outputs of module %q", field, moduleName)
+	}
+	s, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("secrets: infra_output: output field %q of module %q is %T, expected string", field, moduleName, val)
+	}
+	return s, nil
+}
+
+// joinKeys returns a comma-separated list of map keys for error messages.
+func joinKeys(m map[string]map[string]any) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
 }
 
 func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, error) {

--- a/secrets/generators_test.go
+++ b/secrets/generators_test.go
@@ -145,3 +145,114 @@ func TestGenerateSecret_ProviderCredential_MissingToken(t *testing.T) {
 		t.Error("expected error when DIGITALOCEAN_TOKEN is unset")
 	}
 }
+
+// ── infra_output generator ────────────────────────────────────────────────────
+
+func sampleStateOutputs() map[string]map[string]any {
+	return map[string]map[string]any{
+		"bmw-database": {
+			"uri":      "postgres://user:pass@db.example.com:5432/app",
+			"host":     "db.example.com",
+			"port":     "5432",
+			"readonly": "true",
+		},
+	}
+}
+
+func TestGenerateSecret_InfraOutput_Success(t *testing.T) {
+	val, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+		"source":         "bmw-database.uri",
+		"_state_outputs": sampleStateOutputs(),
+	})
+	if err != nil {
+		t.Fatalf("infra_output: unexpected error: %v", err)
+	}
+	if val != "postgres://user:pass@db.example.com:5432/app" {
+		t.Errorf("got %q", val)
+	}
+}
+
+func TestGenerateSecret_InfraOutput_DifferentField(t *testing.T) {
+	val, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+		"source":         "bmw-database.host",
+		"_state_outputs": sampleStateOutputs(),
+	})
+	if err != nil {
+		t.Fatalf("infra_output: unexpected error: %v", err)
+	}
+	if val != "db.example.com" {
+		t.Errorf("got %q", val)
+	}
+}
+
+func TestGenerateSecret_InfraOutput_MissingSource(t *testing.T) {
+	_, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+		"_state_outputs": sampleStateOutputs(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+	if !containsStr(err.Error(), "source") {
+		t.Errorf("error should mention 'source': %v", err)
+	}
+}
+
+func TestGenerateSecret_InfraOutput_InvalidSourceFormat(t *testing.T) {
+	for _, bad := range []string{"nodot", ".nomodule", "nofield."} {
+		_, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+			"source":         bad,
+			"_state_outputs": sampleStateOutputs(),
+		})
+		if err == nil {
+			t.Errorf("source=%q: expected error for invalid format", bad)
+		}
+	}
+}
+
+func TestGenerateSecret_InfraOutput_NoStateOutputs(t *testing.T) {
+	_, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+		"source": "bmw-database.uri",
+		// _state_outputs intentionally absent
+	})
+	if err == nil {
+		t.Fatal("expected error when state outputs not provided")
+	}
+}
+
+func TestGenerateSecret_InfraOutput_MissingModule(t *testing.T) {
+	_, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+		"source":         "nonexistent-module.uri",
+		"_state_outputs": sampleStateOutputs(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing module")
+	}
+	if !containsStr(err.Error(), "nonexistent-module") {
+		t.Errorf("error should name the missing module: %v", err)
+	}
+}
+
+func TestGenerateSecret_InfraOutput_MissingField(t *testing.T) {
+	_, err := GenerateSecret(context.Background(), "infra_output", map[string]any{
+		"source":         "bmw-database.nonexistent_field",
+		"_state_outputs": sampleStateOutputs(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing field")
+	}
+	if !containsStr(err.Error(), "nonexistent_field") {
+		t.Errorf("error should name the missing field: %v", err)
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}


### PR DESCRIPTION
## Summary

- Adds `infra_output` as a new secret generator type in `secrets/generators.go` — resolves `"module.field"` from a pre-loaded `_state_outputs` map (stateless, easily testable)
- Adds `buildStateOutputsMap` / `syncInfraOutputSecrets` in `cmd/wfctl/infra_output_secrets.go` — wires state outputs into the generator config and handles skip-if-exists with write-only provider support (GitHub Actions)
- `bootstrapSecrets` now skips `infra_output` generators (state doesn't exist pre-apply)
- `runInfraApply` calls `syncInfraOutputSecrets` post-pipeline with `loadCurrentState` so DATABASE_URL, REDIS_URL etc. are auto-populated after every apply

## Test plan

- [ ] `GOWORK=off go test ./secrets/... ./cmd/wfctl/...` — all green
- [ ] `buildStateOutputsMap` — 3 tests (basic, nil outputs skipped, empty)
- [ ] `syncInfraOutputSecrets` — 8 tests including write-only provider skip/write paths, missing module error, empty states error
- [ ] `bootstrapSecrets` — 1 new test verifying infra_output type is skipped
- [ ] `generateFromInfraOutput` — 7 unit tests in `secrets` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)