### PR TITLE
fix(deploy): re-wrap plugin not-found errors with ErrResourceNotFound sentinel

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -403,6 +403,23 @@ type remoteResourceDriver struct {
 	resourceType string
 }
 
+// wrapNotFound re-wraps err as ErrResourceNotFound when the error message
+// contains a known not-found pattern. Errors crossing the plugin boundary
+// arrive as plain strings, so errors.Is can't match the sentinel directly —
+// this function bridges that gap for Update, Read, and Delete.
+func wrapNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	for _, pat := range []string{"not found", "404", "405", "does not exist", "no such"} {
+		if strings.Contains(msg, pat) {
+			return fmt.Errorf("%w: %v", interfaces.ErrResourceNotFound, err)
+		}
+	}
+	return err
+}
+
 // decodeResourceOutput converts an InvokeService response map into a *interfaces.ResourceOutput,
 // including the Outputs map and Sensitive flags that the previous Update implementation discarded.
 func decodeResourceOutput(m map[string]any) *interfaces.ResourceOutput {
@@ -455,7 +472,7 @@ func (d *remoteResourceDriver) Read(_ context.Context, ref interfaces.ResourceRe
 		"ref_provider_id": ref.ProviderID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, wrapNotFound(err)
 	}
 	return decodeResourceOutput(res), nil
 }
@@ -471,7 +488,7 @@ func (d *remoteResourceDriver) Update(_ context.Context, ref interfaces.Resource
 		"spec_config":     spec.Config,
 	})
 	if err != nil {
-		return nil, err
+		return nil, wrapNotFound(err)
 	}
 	return decodeResourceOutput(res), nil
 }
@@ -483,7 +500,7 @@ func (d *remoteResourceDriver) Delete(_ context.Context, ref interfaces.Resource
 		"ref_type":        ref.Type,
 		"ref_provider_id": ref.ProviderID,
 	})
-	return err
+	return wrapNotFound(err)
 }
 
 func (d *remoteResourceDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {

--- a/cmd/wfctl/deploy_providers_remote_driver_test.go
+++ b/cmd/wfctl/deploy_providers_remote_driver_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -325,5 +326,142 @@ func TestRemoteDriver_SensitiveKeys_Error(t *testing.T) {
 	keys := d.SensitiveKeys()
 	if len(keys) != 0 {
 		t.Errorf("expected empty keys on error, got %v", keys)
+	}
+}
+
+// ── wrapNotFound ──────────────────────────────────────────────────────────────
+
+func TestWrapNotFound_Patterns(t *testing.T) {
+	patterns := []string{
+		"not found",
+		"NOT FOUND",
+		"Not Found",
+		"404",
+		"405",
+		"does not exist",
+		"Does Not Exist",
+		"no such",
+		"No Such Resource",
+		"resource 404: gone",
+		"error: the item does not exist in the store",
+	}
+	for _, msg := range patterns {
+		err := wrapNotFound(fmt.Errorf("%s", msg))
+		if !errors.Is(err, interfaces.ErrResourceNotFound) {
+			t.Errorf("pattern %q: expected ErrResourceNotFound, got %v", msg, err)
+		}
+	}
+}
+
+func TestWrapNotFound_PassThrough(t *testing.T) {
+	msgs := []string{
+		"permission denied",
+		"internal server error",
+		"timeout",
+		"rate limit exceeded",
+		"conflict",
+	}
+	for _, msg := range msgs {
+		orig := fmt.Errorf("%s", msg)
+		err := wrapNotFound(orig)
+		if errors.Is(err, interfaces.ErrResourceNotFound) {
+			t.Errorf("message %q: should NOT be wrapped as ErrResourceNotFound", msg)
+		}
+		if err.Error() != orig.Error() {
+			t.Errorf("message %q: error string changed: got %q", msg, err.Error())
+		}
+	}
+}
+
+func TestWrapNotFound_Nil(t *testing.T) {
+	if wrapNotFound(nil) != nil {
+		t.Error("wrapNotFound(nil) should return nil")
+	}
+}
+
+// ── Update/Read/Delete not-found wrapping ─────────────────────────────────────
+
+func TestRemoteDriver_Update_WrapsNotFound(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("resource 404: not found")}
+	d := newDriver(si)
+	_, err := d.Update(context.Background(), sampleRef(), sampleSpec())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Errorf("Update: expected ErrResourceNotFound, got %v", err)
+	}
+}
+
+func TestRemoteDriver_Read_WrapsNotFound(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("no such resource: pid-123")}
+	d := newDriver(si)
+	_, err := d.Read(context.Background(), sampleRef())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Errorf("Read: expected ErrResourceNotFound, got %v", err)
+	}
+}
+
+func TestRemoteDriver_Delete_WrapsNotFound(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("does not exist")}
+	d := newDriver(si)
+	err := d.Delete(context.Background(), sampleRef())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Errorf("Delete: expected ErrResourceNotFound, got %v", err)
+	}
+}
+
+func TestRemoteDriver_Update_PreservesOtherErrors(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("permission denied")}
+	d := newDriver(si)
+	_, err := d.Update(context.Background(), sampleRef(), sampleSpec())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Error("Update: 'permission denied' should NOT be wrapped as ErrResourceNotFound")
+	}
+}
+
+func TestRemoteDriver_Read_PreservesOtherErrors(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("rate limit exceeded")}
+	d := newDriver(si)
+	_, err := d.Read(context.Background(), sampleRef())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Error("Read: 'rate limit exceeded' should NOT be wrapped as ErrResourceNotFound")
+	}
+}
+
+func TestRemoteDriver_Delete_PreservesOtherErrors(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("internal server error")}
+	d := newDriver(si)
+	err := d.Delete(context.Background(), sampleRef())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Error("Delete: 'internal server error' should NOT be wrapped as ErrResourceNotFound")
+	}
+}
+
+// Create must NOT wrap not-found — it's the fallback target of upsert.
+func TestRemoteDriver_Create_DoesNotWrapNotFound(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("404 not found")}
+	d := newDriver(si)
+	_, err := d.Create(context.Background(), sampleSpec())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Error("Create: must NOT wrap errors as ErrResourceNotFound")
 	}
 }


### PR DESCRIPTION
## Summary

- Errors returned by `InvokeService` cross the plugin boundary as plain strings — `errors.Is(err, ErrResourceNotFound)` was always false, so the upsert in `pluginDeployProvider.Deploy` never fell back to Create
- Adds `wrapNotFound(err error) error` helper that detects patterns (`"not found"`, `"404"`, `"405"`, `"does not exist"`, `"no such"`) in the lowercased error message and re-wraps with `fmt.Errorf("%w: %v", interfaces.ErrResourceNotFound, err)`
- Wires `wrapNotFound` into `remoteResourceDriver.Read`, `.Update`, `.Delete` — `Create` is intentionally excluded (it is the upsert fallback target)

## Test plan

- [ ] `GOWORK=off go test ./cmd/wfctl/...` — all green
- [ ] `TestWrapNotFound_Patterns` — table-driven, all 11 not-found patterns produce `ErrResourceNotFound`
- [ ] `TestWrapNotFound_PassThrough` — 5 unrelated messages pass through unchanged
- [ ] `TestWrapNotFound_Nil` — nil input returns nil
- [ ] `TestRemoteDriver_Update/Read/Delete_WrapsNotFound` — stub returns "404"/"no such"/"does not exist"; asserts `errors.Is(err, ErrResourceNotFound)`
- [ ] `TestRemoteDriver_Update_PreservesOtherErrors` / `Read` / `Delete` — "permission denied"/"rate limit exceeded"/"internal server error" are not wrapped
- [ ] `TestRemoteDriver_Create_DoesNotWrapNotFound` — Create never wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)