### PR TITLE
fix(deploy): expand env vars in pluginDeployProvider config (fixes BMW 401)

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -684,6 +684,20 @@ func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) 
 		return nil, fmt.Errorf("no infra resource module found for provider %q in workflow config", providerModName)
 	}
 
+	// Expand env-var references in both configs before storing. This resolves
+	// ${TOKEN} / $TOKEN placeholders that were written into the YAML using
+	// environment variables (e.g. token: ${DIGITALOCEAN_TOKEN}). Expansion
+	// happens here — at construction time — so the resolved values are always
+	// used downstream, regardless of which method accesses them.
+	//
+	// Secrets flow: if the caller has already injected secrets via os.Setenv
+	// (e.g. env-provider secrets), ExpandEnvInMap picks them up here. Secrets
+	// that come from vault / other stores and are carried in DeployConfig.Secrets
+	// are NOT yet available at this point; those are applied in Deploy() just
+	// before the final config is sent to the resource driver.
+	providerModCfg = config.ExpandEnvInMap(providerModCfg)
+	resourceCfg = config.ExpandEnvInMap(resourceCfg)
+
 	// Provider is resolved lazily on first Deploy/HealthCheck to thread the real ctx.
 	return &pluginDeployProvider{
 		providerName: providerName,
@@ -750,6 +764,25 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 		merged[k] = v
 	}
 	merged["image"] = cfg.ImageTag
+
+	// Secrets carried in DeployConfig (fetched from vault / external stores by
+	// injectSecrets) are not in the OS environment. Export them temporarily so
+	// that ExpandEnvInMap can resolve any ${SECRET_NAME} references that were
+	// not already substituted at construction time. Each secret is restored to
+	// its previous value (or unset) after expansion to avoid leaking values into
+	// other goroutines or child processes.
+	for k, v := range cfg.Secrets {
+		prev, had := os.LookupEnv(k)
+		os.Setenv(k, v) //nolint:errcheck
+		defer func(key, previous string, wasDefined bool) {
+			if wasDefined {
+				os.Setenv(key, previous) //nolint:errcheck
+			} else {
+				os.Unsetenv(key) //nolint:errcheck
+			}
+		}(k, prev, had)
+	}
+	merged = config.ExpandEnvInMap(merged)
 	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
 	spec := interfaces.ResourceSpec{Name: p.resourceName, Type: p.resourceType, Config: merged}
 	_, updateErr := driver.Update(ctx, ref, spec)

--- a/cmd/wfctl/deploy_providers_env_expand_test.go
+++ b/cmd/wfctl/deploy_providers_env_expand_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// captureResourceDriver extends fakeResourceDriver to record the full spec.Config
+// passed to both Update and Create, so tests can assert on any field (not just image).
+type captureResourceDriver struct {
+	fakeResourceDriver
+	updateCfg map[string]any
+	createCfg map[string]any
+}
+
+func (d *captureResourceDriver) Update(_ context.Context, _ interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	d.updateCfg = spec.Config
+	d.updateImage, _ = spec.Config["image"].(string)
+	if d.updateErr != nil {
+		return nil, d.updateErr
+	}
+	return &interfaces.ResourceOutput{}, nil
+}
+
+func (d *captureResourceDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	d.createCalled = true
+	d.createCfg = spec.Config
+	d.createSpec = spec
+	if d.createErr != nil {
+		return nil, d.createErr
+	}
+	return &interfaces.ResourceOutput{}, nil
+}
+
+// ── TestPluginDeployProvider_ProviderConfigExpanded ─────────────────────────────
+
+func TestPluginDeployProvider_ProviderConfigExpanded(t *testing.T) {
+	t.Setenv("TEST_DO_TOKEN", "tok_LIVE123")
+
+	wfCfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name: "do-provider",
+				Type: "iac.provider",
+				Config: map[string]any{
+					"provider": "digitalocean",
+					"token":    "${TEST_DO_TOKEN}",
+				},
+			},
+			{
+				Name: "my-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider": "do-provider",
+					"region":   "nyc3",
+				},
+			},
+		},
+	}
+
+	p, err := newPluginDeployProvider("digitalocean", wfCfg)
+	if err != nil {
+		t.Fatalf("newPluginDeployProvider: %v", err)
+	}
+	pdp, ok := p.(*pluginDeployProvider)
+	if !ok {
+		t.Fatalf("expected *pluginDeployProvider, got %T", p)
+	}
+
+	// The provider config stored on the struct should have the token expanded.
+	got, _ := pdp.providerCfg["token"].(string)
+	if got != "tok_LIVE123" {
+		t.Errorf("providerCfg[token]: want %q, got %q", "tok_LIVE123", got)
+	}
+
+	// Original module config in wfCfg must NOT be mutated.
+	orig, _ := wfCfg.Modules[0].Config["token"].(string)
+	if orig != "${TEST_DO_TOKEN}" {
+		t.Errorf("original wfCfg module config was mutated: got %q", orig)
+	}
+}
+
+// ── TestPluginDeployProvider_ResourceConfigExpanded ─────────────────────────────
+
+func TestPluginDeployProvider_ResourceConfigExpanded(t *testing.T) {
+	t.Setenv("TEST_REGION", "sfo3")
+
+	wfCfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name: "do-provider",
+				Type: "iac.provider",
+				Config: map[string]any{
+					"provider": "digitalocean",
+					"token":    "static-token",
+				},
+			},
+			{
+				Name: "my-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider": "do-provider",
+					"region":   "${TEST_REGION}",
+				},
+			},
+		},
+	}
+
+	p, err := newPluginDeployProvider("digitalocean", wfCfg)
+	if err != nil {
+		t.Fatalf("newPluginDeployProvider: %v", err)
+	}
+	pdp := p.(*pluginDeployProvider)
+
+	// Resource config stored on the struct should have region expanded.
+	got, _ := pdp.resourceCfg["region"].(string)
+	if got != "sfo3" {
+		t.Errorf("resourceCfg[region]: want %q, got %q", "sfo3", got)
+	}
+}
+
+// ── TestPluginDeployProvider_DeployPassesExpandedConfigToDriver ──────────────
+
+func TestPluginDeployProvider_DeployPassesExpandedConfigToDriver(t *testing.T) {
+	t.Setenv("TEST_HTTP_PORT_STR", "9090")
+
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	// Simulate a resourceCfg that already had its env vars expanded at construction.
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"label": "${TEST_HTTP_PORT_STR}"},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	// The merged config passed to driver.Update should have the label expanded.
+	got, _ := driver.updateCfg["label"].(string)
+	if got != "9090" {
+		t.Errorf("updateCfg[label]: want %q, got %q", "9090", got)
+	}
+}
+
+// ── TestPluginDeployProvider_Deploy_SecretsExpandedViaEnv ────────────────────
+
+// TestPluginDeployProvider_Deploy_SecretsExpandedViaEnv verifies that secrets
+// carried in DeployConfig.Secrets are available for ${VAR} expansion in the
+// resource config during Deploy. The deploy path temporarily exports each
+// secret as an env var before calling ExpandEnvInMap, then restores the previous
+// value so sibling tests are not affected.
+func TestPluginDeployProvider_Deploy_SecretsExpandedViaEnv(t *testing.T) {
+	// Do NOT pre-set the env var — it should come from cfg.Secrets.
+	// t.Setenv cleans up after the test; use a unique name to avoid collisions.
+	t.Setenv("DEPLOY_SECRET_TOKEN_UNIQUE", "") // ensure clean state; t.Setenv restores
+
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		// token references a secret injected via cfg.Secrets
+		resourceCfg: map[string]any{"token": "${DEPLOY_SECRET_TOKEN_UNIQUE}"},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+		Secrets:  map[string]string{"DEPLOY_SECRET_TOKEN_UNIQUE": "vault_secret_abc"},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	got, _ := driver.updateCfg["token"].(string)
+	if got != "vault_secret_abc" {
+		t.Errorf("updateCfg[token]: want %q, got %q", "vault_secret_abc", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes BMW's 401 bug: `${DIGITALOCEAN_TOKEN}` literal was being passed as bearer token to the DO API
- Calls `config.ExpandEnvInMap` on `providerModCfg` and `resourceCfg` in `newPluginDeployProvider` — resolves `${VAR}` placeholders at construction time
- In `Deploy()`, temporarily exports `cfg.Secrets` as env vars before a final `ExpandEnvInMap` pass, so vault-sourced secrets can also be referenced via `${SECRET_NAME}` in configs
- Deep-copies inputs so original `WorkflowConfig` is never mutated

**Depends on**: #438 (merged)

## Test plan
- [x] `TestPluginDeployProvider_ProviderConfigExpanded` — set `TEST_DO_TOKEN` env var, build config with `${TEST_DO_TOKEN}`, assert `providerCfg` has expanded value
- [x] `TestPluginDeployProvider_ResourceConfigExpanded` — same for resource module config
- [x] `TestPluginDeployProvider_DeployPassesExpandedConfigToDriver` — assert driver receives expanded config
- [x] `TestPluginDeployProvider_Deploy_SecretsExpandedViaEnv` — assert `cfg.Secrets` values expand `${VAR}` in resource config
- [x] Full `cmd/wfctl` suite: `GOWORK=off go test ./cmd/wfctl/... -race -count=1` passes
- [x] Build + vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)