### PR TITLE
fix(deploy): preserve YAML image when IMAGE_TAG is empty

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -763,7 +763,10 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	for k, v := range p.resourceCfg {
 		merged[k] = v
 	}
-	merged["image"] = cfg.ImageTag
+	if cfg.ImageTag != "" {
+		merged["image"] = cfg.ImageTag
+	}
+	// else: preserve spec.Config["image"] from the (already-substituted) module config
 
 	// Secrets carried in DeployConfig (fetched from vault / external stores by
 	// injectSecrets) are not in the OS environment. Export them temporarily so

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -795,6 +795,9 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 		}
 	}()
 	merged = config.ExpandEnvInMap(merged)
+	if img, _ := merged["image"].(string); img == "" {
+		return fmt.Errorf("plugin deploy %q: image is empty — set IMAGE_TAG or configure image in YAML", p.resourceName)
+	}
 	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
 	spec := interfaces.ResourceSpec{Name: p.resourceName, Type: p.resourceType, Config: merged}
 	_, updateErr := driver.Update(ctx, ref, spec)

--- a/cmd/wfctl/deploy_providers_env_expand_test.go
+++ b/cmd/wfctl/deploy_providers_env_expand_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -253,5 +254,145 @@ func TestPluginDeployProvider_Deploy_NonEmptyImageTagOverrides(t *testing.T) {
 	got, _ := driver.updateCfg["image"].(string)
 	if got != "new:tag" {
 		t.Errorf("updateCfg[image]: want %q, got %q", "new:tag", got)
+	}
+}
+
+// ── TestPluginDeployProvider_Deploy_BMWScenario ───────────────────────────────
+
+// TestPluginDeployProvider_Deploy_BMWScenario mirrors BMW's deploy.yml setup:
+// the image field in YAML contains ${IMAGE_SHA}, IMAGE_SHA is set in the
+// environment, and IMAGE_TAG (cfg.ImageTag) is absent. The driver must receive
+// the fully-substituted image reference.
+func TestPluginDeployProvider_Deploy_BMWScenario(t *testing.T) {
+	t.Setenv("IMAGE_SHA_DEPLOY_BMW_TEST", "sha256deadbeef")
+
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "buymywishlist",
+		resourceType: "infra.container_service",
+		resourceCfg: map[string]any{
+			"image": "registry.digitalocean.com/bmw-registry/buymywishlist:${IMAGE_SHA_DEPLOY_BMW_TEST}",
+		},
+	}
+	cfg := DeployConfig{
+		AppName:  "buymywishlist",
+		ImageTag: "", // IMAGE_TAG not set
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	want := "registry.digitalocean.com/bmw-registry/buymywishlist:sha256deadbeef"
+	got, _ := driver.updateCfg["image"].(string)
+	if got != want {
+		t.Errorf("updateCfg[image]: want %q, got %q", want, got)
+	}
+}
+
+// ── TestPluginDeployProvider_Deploy_ImageTagWinsOverYAMLSHA ──────────────────
+
+// TestPluginDeployProvider_Deploy_ImageTagWinsOverYAMLSHA verifies that a
+// non-empty cfg.ImageTag (IMAGE_TAG env) wins over the ${IMAGE_SHA}-encoded
+// image in the YAML, even when IMAGE_SHA is also set.
+func TestPluginDeployProvider_Deploy_ImageTagWinsOverYAMLSHA(t *testing.T) {
+	t.Setenv("IMAGE_SHA_DEPLOY_BMW_OVERRIDE_TEST", "sha256deadbeef")
+
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "buymywishlist",
+		resourceType: "infra.container_service",
+		resourceCfg: map[string]any{
+			"image": "registry.digitalocean.com/bmw-registry/buymywishlist:${IMAGE_SHA_DEPLOY_BMW_OVERRIDE_TEST}",
+		},
+	}
+	cfg := DeployConfig{
+		AppName:  "buymywishlist",
+		ImageTag: "explicit-override:latest",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	got, _ := driver.updateCfg["image"].(string)
+	if got != "explicit-override:latest" {
+		t.Errorf("updateCfg[image]: want %q, got %q", "explicit-override:latest", got)
+	}
+}
+
+// ── TestPluginDeployProvider_Deploy_EmptyImageBothLayers ─────────────────────
+
+// TestPluginDeployProvider_Deploy_EmptyImageBothLayers verifies that Deploy
+// returns a clear, actionable error when both IMAGE_TAG (cfg.ImageTag) and the
+// YAML module config have no image — rather than sending an empty image to the
+// remote API and getting an opaque provider error back.
+func TestPluginDeployProvider_Deploy_EmptyImageBothLayers(t *testing.T) {
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"region": "nyc3"}, // no "image" key
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "", // IMAGE_TAG also absent
+		Env:      &config.CIDeployEnvironment{},
+	}
+	err := p.Deploy(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("Deploy: expected error for empty image, got nil")
+	}
+	if !strings.Contains(err.Error(), "image") {
+		t.Errorf("Deploy error should mention 'image', got: %v", err)
+	}
+}
+
+// ── TestPluginDeployProvider_Deploy_SecretImageSubstitution ──────────────────
+
+// TestPluginDeployProvider_Deploy_SecretImageSubstitution verifies that when
+// the YAML image field contains a ${SECRET_VAR} reference, and that secret is
+// carried in cfg.Secrets (not the OS env), Deploy fully substitutes the image
+// before calling the driver.
+func TestPluginDeployProvider_Deploy_SecretImageSubstitution(t *testing.T) {
+	// Ensure the secret key is not already in the environment.
+	t.Setenv("SECRET_IMAGE_DEPLOY_TEST_UNIQUE", "")
+
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"image": "${SECRET_IMAGE_DEPLOY_TEST_UNIQUE}"},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "",
+		Env:      &config.CIDeployEnvironment{},
+		Secrets:  map[string]string{"SECRET_IMAGE_DEPLOY_TEST_UNIQUE": "foo:bar"},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	got, _ := driver.updateCfg["image"].(string)
+	if got != "foo:bar" {
+		t.Errorf("updateCfg[image]: want %q, got %q", "foo:bar", got)
 	}
 }

--- a/cmd/wfctl/deploy_providers_env_expand_test.go
+++ b/cmd/wfctl/deploy_providers_env_expand_test.go
@@ -192,3 +192,66 @@ func TestPluginDeployProvider_Deploy_SecretsExpandedViaEnv(t *testing.T) {
 		t.Errorf("updateCfg[token]: want %q, got %q", "vault_secret_abc", got)
 	}
 }
+
+// ── TestPluginDeployProvider_Deploy_EmptyImageTagPreservesConfig ──────────────
+
+// TestPluginDeployProvider_Deploy_EmptyImageTagPreservesConfig verifies that when
+// cfg.ImageTag is empty the spec.Config["image"] set in the YAML (post-substitution)
+// is passed through to the driver unchanged. This is the BMW scenario where the
+// image ref is encoded in the YAML and IMAGE_TAG is not set.
+func TestPluginDeployProvider_Deploy_EmptyImageTagPreservesConfig(t *testing.T) {
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"image": "registry/org/app:sha256abc"},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "", // not set — e.g. IMAGE_TAG env var absent
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	got, _ := driver.updateCfg["image"].(string)
+	if got != "registry/org/app:sha256abc" {
+		t.Errorf("updateCfg[image]: want %q, got %q", "registry/org/app:sha256abc", got)
+	}
+}
+
+// ── TestPluginDeployProvider_Deploy_NonEmptyImageTagOverrides ────────────────
+
+// TestPluginDeployProvider_Deploy_NonEmptyImageTagOverrides verifies that when
+// cfg.ImageTag is non-empty it overrides whatever the YAML config provided,
+// preserving the existing IMAGE_TAG env-override CI path.
+func TestPluginDeployProvider_Deploy_NonEmptyImageTagOverrides(t *testing.T) {
+	driver := &captureResourceDriver{}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"image": "old:tag"},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "new:tag",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	got, _ := driver.updateCfg["image"].(string)
+	if got != "new:tag" {
+		t.Errorf("updateCfg[image]: want %q, got %q", "new:tag", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `pluginDeployProvider.Deploy` was unconditionally writing `cfg.ImageTag` (sourced from `$IMAGE_TAG`) into `spec.Config["image"]`, even when `ImageTag` is empty string
- BMW's `deploy.yml` encodes the full image ref inline in the YAML via `${IMAGE_SHA}` — post-substitution the `image` field is already correct, but the empty `ImageTag` clobbered it, producing the `image config is empty` error
- Fix: guard the assignment with `if cfg.ImageTag != ""` so non-empty `ImageTag` still wins (preserves existing CI path), and empty `ImageTag` leaves the YAML-provided image intact

## Test plan

- [x] `TestPluginDeployProvider_Deploy_EmptyImageTagPreservesConfig` — empty `ImageTag`, YAML image passes through to driver unchanged
- [x] `TestPluginDeployProvider_Deploy_NonEmptyImageTagOverrides` — non-empty `ImageTag` overrides YAML image (regression guard for existing path)
- [x] `GOWORK=off go test ./cmd/wfctl/... -race -count=1` — all pass
- [x] `go vet ./cmd/wfctl/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)