### PR TITLE
feat(deploy): resolve per-env module config in newPluginDeployProvider

### DIFF
--- a/cmd/wfctl/ci_run.go
+++ b/cmd/wfctl/ci_run.go
@@ -363,7 +363,7 @@ func runDeployPhaseWithConfig(
 	}
 
 	// Step 3: resolve provider and deploy.
-	provider, err := newDeployProvider(env.Provider, wfCfg)
+	provider, err := newDeployProvider(env.Provider, wfCfg, envName)
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/deploy_plugin_loader_test.go
+++ b/cmd/wfctl/deploy_plugin_loader_test.go
@@ -106,7 +106,7 @@ func TestPluginDeployProvider_LazyResolution(t *testing.T) {
 	}
 
 	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
-	p, err := newDeployProvider("fake-cloud", cfg)
+	p, err := newDeployProvider("fake-cloud", cfg, "")
 	if err != nil {
 		t.Fatalf("newDeployProvider: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestPluginDeployProvider_ResourceTypeFromModule(t *testing.T) {
 	}
 
 	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
-	p, err := newDeployProvider("fake-cloud", cfg)
+	p, err := newDeployProvider("fake-cloud", cfg, "")
 	if err != nil {
 		t.Fatalf("newDeployProvider: %v", err)
 	}

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -51,8 +51,9 @@ type DeployProvider interface {
 // newDeployProvider returns the DeployProvider for the given provider name.
 // For non-built-in providers, wfCfg is consulted to find a matching iac.provider
 // module and its infra.container_service resource. Pass nil wfCfg to restrict to
-// built-ins only.
-func newDeployProvider(provider string, wfCfg *config.WorkflowConfig) (DeployProvider, error) {
+// built-ins only. envName selects the per-environment config overlay; pass ""
+// to use top-level config only.
+func newDeployProvider(provider string, wfCfg *config.WorkflowConfig, envName string) (DeployProvider, error) {
 	switch provider {
 	case "kubernetes", "k8s":
 		return &kubernetesProvider{}, nil
@@ -61,7 +62,7 @@ func newDeployProvider(provider string, wfCfg *config.WorkflowConfig) (DeployPro
 	case "aws-ecs":
 		return &awsECSProvider{}, nil
 	default:
-		return newPluginDeployProvider(provider, wfCfg)
+		return newPluginDeployProvider(provider, wfCfg, envName)
 	}
 }
 
@@ -605,24 +606,45 @@ type closerFunc func() error
 func (f closerFunc) Close() error { return f() }
 
 // newPluginDeployProvider looks up a matching iac.provider + infra.container_service
-// module pair in wfCfg and wraps them as a DeployProvider.
-func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) (DeployProvider, error) {
+// module pair in wfCfg and wraps them as a DeployProvider. envName selects the
+// per-environment config overlay via ModuleConfig.ResolveForEnv; pass "" to use
+// top-level config only (modules marked deleted for the env are skipped).
+func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig, envName string) (DeployProvider, error) {
 	const hint = "\n  Example:\n    modules:\n    - name: my-provider\n      type: iac.provider\n      config:\n        provider: %s\n        credentials: env"
 	if wfCfg == nil || len(wfCfg.Modules) == 0 {
 		return nil, fmt.Errorf("unsupported deploy provider %q (built-ins: kubernetes, docker, aws-ecs; to use a plugin provider, declare an iac.provider module in your workflow config)%s", providerName, fmt.Sprintf(hint, providerName))
 	}
 
+	// resolveModCfg returns the effective config map for m after applying the
+	// per-env overlay (when envName is set). ok=false means the module is
+	// explicitly deleted for this env and should be skipped.
+	resolveModCfg := func(m *config.ModuleConfig) (map[string]any, bool) {
+		if envName == "" {
+			return m.Config, true
+		}
+		resolved, ok := m.ResolveForEnv(envName)
+		if !ok {
+			return nil, false
+		}
+		return resolved.Config, true
+	}
+
 	// Find the iac.provider module matching the requested provider name.
 	var providerModName string
 	var providerModCfg map[string]any
-	for _, m := range wfCfg.Modules {
+	for i := range wfCfg.Modules {
+		m := &wfCfg.Modules[i]
 		if m.Type != "iac.provider" {
 			continue
 		}
-		cfgProvider, _ := m.Config["provider"].(string)
+		cfg, ok := resolveModCfg(m)
+		if !ok {
+			continue
+		}
+		cfgProvider, _ := cfg["provider"].(string)
 		if cfgProvider == providerName || m.Name == providerName {
 			providerModName = m.Name
-			providerModCfg = m.Config
+			providerModCfg = cfg
 			break
 		}
 	}
@@ -646,14 +668,19 @@ func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) 
 	var resourceName, resourceType string
 	var resourceCfg map[string]any
 	findByType := func(target string) bool {
-		for _, m := range wfCfg.Modules {
+		for i := range wfCfg.Modules {
+			m := &wfCfg.Modules[i]
 			if m.Type != target {
 				continue
 			}
-			if p, _ := m.Config["provider"].(string); p == providerModName {
+			cfg, ok := resolveModCfg(m)
+			if !ok {
+				continue
+			}
+			if p, _ := cfg["provider"].(string); p == providerModName {
 				resourceName = m.Name
 				resourceType = m.Type
-				resourceCfg = m.Config
+				resourceCfg = cfg
 				return true
 			}
 		}
@@ -666,16 +693,21 @@ func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) 
 	}
 	if resourceName == "" {
 		// Fallback: first infra.* module with matching provider.
-		for _, m := range wfCfg.Modules {
+		for i := range wfCfg.Modules {
+			m := &wfCfg.Modules[i]
 			if m.Type == "iac.provider" || m.Type == "" {
 				continue
 			}
-			if p, _ := m.Config["provider"].(string); p == providerModName {
+			cfg, ok := resolveModCfg(m)
+			if !ok {
+				continue
+			}
+			if p, _ := cfg["provider"].(string); p == providerModName {
 				fmt.Fprintf(os.Stderr, "warning: no deploy-target module (%v) found for provider %q; falling back to first infra module %q (type %q)\n",
 					deployTargetTypes, providerModName, m.Name, m.Type)
 				resourceName = m.Name
 				resourceType = m.Type
-				resourceCfg = m.Config
+				resourceCfg = cfg
 				break
 			}
 		}
@@ -684,11 +716,13 @@ func newPluginDeployProvider(providerName string, wfCfg *config.WorkflowConfig) 
 		return nil, fmt.Errorf("no infra resource module found for provider %q in workflow config", providerModName)
 	}
 
-	// Expand env-var references in both configs before storing. This resolves
-	// ${TOKEN} / $TOKEN placeholders that were written into the YAML using
-	// environment variables (e.g. token: ${DIGITALOCEAN_TOKEN}). Expansion
-	// happens here — at construction time — so the resolved values are always
-	// used downstream, regardless of which method accesses them.
+	// Expand env-var references in both configs after the env-config merge.
+	// This resolves ${TOKEN} / $TOKEN placeholders written into the YAML.
+	// Expansion happens here — at construction time — so the resolved values
+	// are always used downstream, regardless of which method accesses them.
+	//
+	// Order matters: ResolveForEnv (above) merges per-env config into the map
+	// first, so ${VAR} refs introduced by per-env overlays are expanded here.
 	//
 	// Secrets flow: if the caller has already injected secrets via os.Setenv
 	// (e.g. env-provider secrets), ExpandEnvInMap picks them up here. Secrets

--- a/cmd/wfctl/deploy_providers_env_expand_test.go
+++ b/cmd/wfctl/deploy_providers_env_expand_test.go
@@ -62,7 +62,7 @@ func TestPluginDeployProvider_ProviderConfigExpanded(t *testing.T) {
 		},
 	}
 
-	p, err := newPluginDeployProvider("digitalocean", wfCfg)
+	p, err := newPluginDeployProvider("digitalocean", wfCfg, "")
 	if err != nil {
 		t.Fatalf("newPluginDeployProvider: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestPluginDeployProvider_ResourceConfigExpanded(t *testing.T) {
 		},
 	}
 
-	p, err := newPluginDeployProvider("digitalocean", wfCfg)
+	p, err := newPluginDeployProvider("digitalocean", wfCfg, "")
 	if err != nil {
 		t.Fatalf("newPluginDeployProvider: %v", err)
 	}

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -135,7 +135,7 @@ func TestNewDeployProvider_BuiltIns(t *testing.T) {
 		"aws-ecs":        (*awsECSProvider)(nil),
 	}
 	for name := range cases {
-		p, err := newDeployProvider(name, nil)
+		p, err := newDeployProvider(name, nil, "")
 		if err != nil {
 			t.Errorf("newDeployProvider(%q): unexpected error: %v", name, err)
 			continue
@@ -160,7 +160,7 @@ func TestNewDeployProvider_PluginProvider_Resolves(t *testing.T) {
 	}
 
 	cfg := makePluginTestConfig("fake-cloud", "fake-provider")
-	p, err := newDeployProvider("fake-cloud", cfg)
+	p, err := newDeployProvider("fake-cloud", cfg, "")
 	if err != nil {
 		t.Fatalf("newDeployProvider: unexpected error: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestNewDeployProvider_PluginProvider_Resolves(t *testing.T) {
 }
 
 func TestNewDeployProvider_UnknownProvider_ErrorsClearly(t *testing.T) {
-	_, err := newDeployProvider("nonexistent-cloud", nil)
+	_, err := newDeployProvider("nonexistent-cloud", nil, "")
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}

--- a/cmd/wfctl/deploy_providers_test.go
+++ b/cmd/wfctl/deploy_providers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewDeployProvider_Kubernetes(t *testing.T) {
 	for _, name := range []string{"kubernetes", "k8s"} {
-		p, err := newDeployProvider(name, nil)
+		p, err := newDeployProvider(name, nil, "")
 		if err != nil {
 			t.Fatalf("newDeployProvider(%q): unexpected error: %v", name, err)
 		}
@@ -25,7 +25,7 @@ func TestNewDeployProvider_Kubernetes(t *testing.T) {
 
 func TestNewDeployProvider_Docker(t *testing.T) {
 	for _, name := range []string{"docker", "docker-compose"} {
-		p, err := newDeployProvider(name, nil)
+		p, err := newDeployProvider(name, nil, "")
 		if err != nil {
 			t.Fatalf("newDeployProvider(%q): unexpected error: %v", name, err)
 		}
@@ -36,7 +36,7 @@ func TestNewDeployProvider_Docker(t *testing.T) {
 }
 
 func TestNewDeployProvider_AWSECS(t *testing.T) {
-	p, err := newDeployProvider("aws-ecs", nil)
+	p, err := newDeployProvider("aws-ecs", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,9 +46,175 @@ func TestNewDeployProvider_AWSECS(t *testing.T) {
 }
 
 func TestNewDeployProvider_Unknown(t *testing.T) {
-	_, err := newDeployProvider("unknown-provider", nil)
+	_, err := newDeployProvider("unknown-provider", nil, "")
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
+	}
+}
+
+// ── newPluginDeployProvider env-resolution ─────────────────────────────────────
+
+// TestNewPluginDeployProvider_MergesEnvironmentConfig verifies that when envName
+// is set, the per-env config overlay is merged into the top-level config before
+// the provider is constructed, so environment-specific fields (like image) are
+// visible in resourceCfg.
+func TestNewPluginDeployProvider_MergesEnvironmentConfig(t *testing.T) {
+	wfCfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name:   "do-provider",
+				Type:   "iac.provider",
+				Config: map[string]any{"provider": "do-provider"},
+			},
+			{
+				Name: "bmw-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider": "do-provider",
+					"http_port": 8080,
+				},
+				Environments: map[string]*config.InfraEnvironmentResolution{
+					"staging": {
+						Config: map[string]any{
+							"image": "foo:bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p, err := newDeployProvider("do-provider", wfCfg, "staging")
+	if err != nil {
+		t.Fatalf("newDeployProvider: %v", err)
+	}
+	pdp, ok := p.(*pluginDeployProvider)
+	if !ok {
+		t.Fatalf("expected *pluginDeployProvider, got %T", p)
+	}
+	got, _ := pdp.resourceCfg["image"].(string)
+	if got != "foo:bar" {
+		t.Errorf("resourceCfg[image]: want %q, got %q", "foo:bar", got)
+	}
+}
+
+// TestNewPluginDeployProvider_EnvOverridesTopLevel verifies that a per-env
+// config value overrides the corresponding top-level value.
+func TestNewPluginDeployProvider_EnvOverridesTopLevel(t *testing.T) {
+	wfCfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name:   "do-provider",
+				Type:   "iac.provider",
+				Config: map[string]any{"provider": "do-provider"},
+			},
+			{
+				Name: "bmw-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider": "do-provider",
+					"image":    "old:v1",
+				},
+				Environments: map[string]*config.InfraEnvironmentResolution{
+					"staging": {
+						Config: map[string]any{
+							"image": "new:v2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p, err := newDeployProvider("do-provider", wfCfg, "staging")
+	if err != nil {
+		t.Fatalf("newDeployProvider: %v", err)
+	}
+	pdp := p.(*pluginDeployProvider)
+	got, _ := pdp.resourceCfg["image"].(string)
+	if got != "new:v2" {
+		t.Errorf("resourceCfg[image]: want %q, got %q", "new:v2", got)
+	}
+}
+
+// TestNewPluginDeployProvider_NoEnv verifies that when envName is empty the
+// top-level module config is used unchanged.
+func TestNewPluginDeployProvider_NoEnv(t *testing.T) {
+	wfCfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name:   "do-provider",
+				Type:   "iac.provider",
+				Config: map[string]any{"provider": "do-provider"},
+			},
+			{
+				Name: "bmw-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider": "do-provider",
+					"image":    "top-level:tag",
+				},
+				Environments: map[string]*config.InfraEnvironmentResolution{
+					"staging": {
+						Config: map[string]any{
+							"image": "staging:tag",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p, err := newDeployProvider("do-provider", wfCfg, "")
+	if err != nil {
+		t.Fatalf("newDeployProvider: %v", err)
+	}
+	pdp := p.(*pluginDeployProvider)
+	got, _ := pdp.resourceCfg["image"].(string)
+	if got != "top-level:tag" {
+		t.Errorf("resourceCfg[image]: want %q, got %q", "top-level:tag", got)
+	}
+}
+
+// TestNewPluginDeployProvider_EnvSubstitutionAfterMerge verifies that
+// ExpandEnvInMap runs after the env-config merge, so ${VAR} placeholders in
+// per-env config fields are expanded using the OS environment.
+func TestNewPluginDeployProvider_EnvSubstitutionAfterMerge(t *testing.T) {
+	t.Setenv("DEPLOY_RESOLVE_TEST_IMAGE_TAG", "registry/org/app:abc123")
+
+	wfCfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{
+			{
+				Name:   "do-provider",
+				Type:   "iac.provider",
+				Config: map[string]any{"provider": "do-provider"},
+			},
+			{
+				Name: "bmw-app",
+				Type: "infra.container_service",
+				Config: map[string]any{
+					"provider": "do-provider",
+				},
+				Environments: map[string]*config.InfraEnvironmentResolution{
+					"staging": {
+						Config: map[string]any{
+							"image": "${DEPLOY_RESOLVE_TEST_IMAGE_TAG}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p, err := newDeployProvider("do-provider", wfCfg, "staging")
+	if err != nil {
+		t.Fatalf("newDeployProvider: %v", err)
+	}
+	pdp := p.(*pluginDeployProvider)
+	got, _ := pdp.resourceCfg["image"].(string)
+	want := "registry/org/app:abc123"
+	if got != want {
+		t.Errorf("resourceCfg[image]: want %q, got %q", want, got)
 	}
 }
 

--- a/cmd/wfctl/infra_e2e_integration_test.go
+++ b/cmd/wfctl/infra_e2e_integration_test.go
@@ -151,7 +151,7 @@ secrets:
 		t.Fatalf("phase 3 load config: %v", err)
 	}
 
-	dp, err := newDeployProvider("fake-cloud", wfCfg)
+	dp, err := newDeployProvider("fake-cloud", wfCfg, "")
 	if err != nil {
 		t.Fatalf("phase 3 newDeployProvider: %v", err)
 	}
@@ -391,7 +391,7 @@ secrets:
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	dp, err := newDeployProvider("fake-cloud", wfCfg)
+	dp, err := newDeployProvider("fake-cloud", wfCfg, "")
 	if err != nil {
 		t.Fatalf("newDeployProvider: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `newDeployProvider` and `newPluginDeployProvider` now accept `envName string` so `environments[env].config` overlays are merged before config is extracted from YAML
- Added `resolveModCfg` helper inside `newPluginDeployProvider` that calls `m.ResolveForEnv(envName)` for every module iterated (both provider and resource); modules marked `nil` for the env are skipped; `envName=""` preserves existing top-level-only behaviour
- `ExpandEnvInMap` runs **after** the env-config merge so `${VAR}` refs introduced by per-env overlays are still expanded
- `ci_run.go` passes `envName` through to `newDeployProvider`
- All existing callers updated to pass `""` (no regression)

## Problem fixed

`wfctl ci run --phase deploy --env staging` was grabbing `m.Config` (top-level, no `image`) and ignoring `environments.staging.config.image`, causing:

```
image is empty — set IMAGE_TAG or configure image in YAML
```

## Tests added (TDD)

- `TestNewPluginDeployProvider_MergesEnvironmentConfig` — env overlay image is present in `resourceCfg`
- `TestNewPluginDeployProvider_EnvOverridesTopLevel` — env value wins over top-level value
- `TestNewPluginDeployProvider_NoEnv` — `envName=""` leaves top-level config unchanged
- `TestNewPluginDeployProvider_EnvSubstitutionAfterMerge` — `${VAR}` in per-env config is expanded post-merge

## Verification

```
GOWORK=off go test ./cmd/wfctl/... -race   # ok
GOWORK=off go vet ./cmd/wfctl/...          # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)