### PR TITLE
fix(deploy): remember ProviderID from Deploy for HealthCheck

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -758,6 +758,10 @@ type pluginDeployProvider struct {
 	provider interfaces.IaCProvider
 	provErr  error
 	closer   io.Closer
+	// lastProviderID holds the ProviderID returned by the most recent successful
+	// Deploy call (from either Update or Create). It is passed to HealthCheck so
+	// the driver can locate the exact cloud resource rather than a blank ID.
+	lastProviderID string
 }
 
 func (p *pluginDeployProvider) ensureProvider(ctx context.Context) error {
@@ -832,11 +836,13 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	if img, _ := merged["image"].(string); img == "" {
 		return fmt.Errorf("plugin deploy %q: image is empty — set IMAGE_TAG or configure image in YAML", p.resourceName)
 	}
+	imageStr, _ := merged["image"].(string)
 	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
 	spec := interfaces.ResourceSpec{Name: p.resourceName, Type: p.resourceType, Config: merged}
-	_, updateErr := driver.Update(ctx, ref, spec)
+	out, updateErr := driver.Update(ctx, ref, spec)
 	if updateErr == nil {
-		fmt.Printf("  plugin deploy: updated %q to %s\n", p.resourceName, cfg.ImageTag)
+		p.lastProviderID = out.ProviderID
+		fmt.Printf("  plugin deploy: updated %q at %s (id=%s)\n", p.resourceName, imageStr, out.ProviderID)
 		return nil
 	}
 	if !errors.Is(updateErr, interfaces.ErrResourceNotFound) {
@@ -844,10 +850,12 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	}
 	// Resource does not exist yet — fall back to Create.
 	log.Printf("plugin deploy %q: resource not found, creating new", p.resourceName)
-	if _, createErr := driver.Create(ctx, spec); createErr != nil {
+	out, createErr := driver.Create(ctx, spec)
+	if createErr != nil {
 		return fmt.Errorf("plugin deploy %q: create failed: %w", p.resourceName, errors.Join(createErr, updateErr))
 	}
-	fmt.Printf("  plugin deploy: created %q at %s\n", p.resourceName, cfg.ImageTag)
+	p.lastProviderID = out.ProviderID
+	fmt.Printf("  plugin deploy: created %q at %s (id=%s)\n", p.resourceName, imageStr, out.ProviderID)
 	return nil
 }
 
@@ -862,7 +870,10 @@ func (p *pluginDeployProvider) HealthCheck(ctx context.Context, cfg DeployConfig
 	if err != nil {
 		return fmt.Errorf("plugin health check: no driver for %q: %w", p.resourceType, err)
 	}
-	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
+	if p.lastProviderID == "" {
+		return fmt.Errorf("health check: no ProviderID available — Deploy must run first")
+	}
+	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType, ProviderID: p.lastProviderID}
 	result, err := driver.HealthCheck(ctx, ref)
 	if err != nil {
 		return fmt.Errorf("plugin health check %q: %w", p.resourceName, err)

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -17,8 +18,10 @@ import (
 type fakeResourceDriver struct {
 	updateImage  string
 	updateErr    error
+	updateOut    *interfaces.ResourceOutput
 	hcResult     *interfaces.HealthResult
 	hcErr        error
+	lastHCRef    interfaces.ResourceRef
 	createCalled bool
 	createSpec   interfaces.ResourceSpec
 	createOut    *interfaces.ResourceOutput
@@ -44,13 +47,17 @@ func (d *fakeResourceDriver) Update(_ context.Context, _ interfaces.ResourceRef,
 	if d.updateErr != nil {
 		return nil, d.updateErr
 	}
+	if d.updateOut != nil {
+		return d.updateOut, nil
+	}
 	return &interfaces.ResourceOutput{}, nil
 }
 func (d *fakeResourceDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
 func (d *fakeResourceDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, _ *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
 	return nil, nil
 }
-func (d *fakeResourceDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+func (d *fakeResourceDriver) HealthCheck(_ context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	d.lastHCRef = ref
 	if d.hcResult != nil {
 		return d.hcResult, d.hcErr
 	}
@@ -220,10 +227,11 @@ func TestPluginDeployProvider_HealthCheck(t *testing.T) {
 		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
 	}
 	p := &pluginDeployProvider{
-		provider:     fake,
-		resourceName: "my-app",
-		resourceType: "infra.container_service",
-		resourceCfg:  map[string]any{},
+		provider:       fake,
+		resourceName:   "my-app",
+		resourceType:   "infra.container_service",
+		resourceCfg:    map[string]any{},
+		lastProviderID: "pre-existing-id",
 	}
 	cfg := DeployConfig{
 		Env: &config.CIDeployEnvironment{
@@ -244,10 +252,11 @@ func TestPluginDeployProvider_HealthCheck_Unhealthy(t *testing.T) {
 		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
 	}
 	p := &pluginDeployProvider{
-		provider:     fake,
-		resourceName: "my-app",
-		resourceType: "infra.container_service",
-		resourceCfg:  map[string]any{},
+		provider:       fake,
+		resourceName:   "my-app",
+		resourceType:   "infra.container_service",
+		resourceCfg:    map[string]any{},
+		lastProviderID: "pre-existing-id",
 	}
 	cfg := DeployConfig{
 		Env: &config.CIDeployEnvironment{
@@ -380,5 +389,160 @@ func TestPluginDeployProvider_Deploy_CreateFailureReturnsError(t *testing.T) {
 	}
 	if !errors.Is(err, interfaces.ErrResourceNotFound) {
 		t.Errorf("expected update error (ErrResourceNotFound) also joined into returned error, got: %v", err)
+	}
+}
+
+// ── ProviderID propagation ────────────────────────────────────────────────────
+
+func TestPluginDeployProvider_HealthCheck_UsesCreatedProviderID(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateErr: interfaces.ErrResourceNotFound, // force Create path
+		createOut: &interfaces.ResourceOutput{ProviderID: "abc-123"},
+		hcResult:  &interfaces.HealthResult{Healthy: true},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{"image": "app:v1"},
+	}
+
+	if err := p.Deploy(context.Background(), DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "app:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	cfg := DeployConfig{
+		Env: &config.CIDeployEnvironment{
+			HealthCheck: &config.CIHealthCheck{Path: "/healthz"},
+		},
+	}
+	if err := p.HealthCheck(context.Background(), cfg); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if driver.lastHCRef.ProviderID != "abc-123" {
+		t.Errorf("HealthCheck ref.ProviderID: want %q, got %q", "abc-123", driver.lastHCRef.ProviderID)
+	}
+}
+
+func TestPluginDeployProvider_HealthCheck_UsesUpdatedProviderID(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateOut: &interfaces.ResourceOutput{ProviderID: "upd-456"},
+		hcResult:  &interfaces.HealthResult{Healthy: true},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+
+	if err := p.Deploy(context.Background(), DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "app:v2",
+		Env:      &config.CIDeployEnvironment{},
+	}); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	cfg := DeployConfig{
+		Env: &config.CIDeployEnvironment{
+			HealthCheck: &config.CIHealthCheck{Path: "/healthz"},
+		},
+	}
+	if err := p.HealthCheck(context.Background(), cfg); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if driver.lastHCRef.ProviderID != "upd-456" {
+		t.Errorf("HealthCheck ref.ProviderID: want %q, got %q", "upd-456", driver.lastHCRef.ProviderID)
+	}
+}
+
+func TestPluginDeployProvider_HealthCheck_WithoutDeploy(t *testing.T) {
+	driver := &fakeResourceDriver{
+		hcResult: &interfaces.HealthResult{Healthy: true},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		Env: &config.CIDeployEnvironment{
+			HealthCheck: &config.CIHealthCheck{Path: "/healthz"},
+		},
+	}
+	err := p.HealthCheck(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error when HealthCheck called without prior Deploy")
+	}
+	if !strings.Contains(err.Error(), "no ProviderID") {
+		t.Errorf("expected 'no ProviderID' in error, got: %v", err)
+	}
+}
+
+func TestPluginDeployProvider_Deploy_LogsImageAndID(t *testing.T) {
+	driver := &fakeResourceDriver{
+		updateOut: &interfaces.ResourceOutput{ProviderID: "log-999"},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+
+	// Redirect stdout to capture log output.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	deployErr := p.Deploy(context.Background(), DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry/myapp:abc",
+		Env:      &config.CIDeployEnvironment{},
+	})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if deployErr != nil {
+		t.Fatalf("Deploy: %v", deployErr)
+	}
+
+	var buf strings.Builder
+	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
+		t.Fatalf("reading captured stdout: %v", copyErr)
+	}
+	output := buf.String()
+
+	if !strings.Contains(output, "registry/myapp:abc") {
+		t.Errorf("expected image in log output, got: %q", output)
+	}
+	if !strings.Contains(output, "log-999") {
+		t.Errorf("expected ProviderID in log output, got: %q", output)
 	}
 }


### PR DESCRIPTION
## Summary

- `pluginDeployProvider` now stores the `ProviderID` returned by `driver.Update`/`driver.Create` in a `lastProviderID` field after each successful `Deploy`
- `HealthCheck` uses that ID when constructing the `ResourceRef` passed to `driver.HealthCheck`, preventing the blank-ID 404 (`GET /v2/apps/: not found`) seen after BMW deployed with v0.16.3/v0.5.1
- `HealthCheck` returns a clear error (`"health check: no ProviderID available — Deploy must run first"`) if called without a prior `Deploy`
- Log lines now include the resolved image string and ProviderID (e.g. `plugin deploy: updated "my-app" at registry/img:sha (id=abc-123)`)

## Test plan

- [ ] `TestPluginDeployProvider_HealthCheck_UsesCreatedProviderID` — Create path stores and passes ProviderID
- [ ] `TestPluginDeployProvider_HealthCheck_UsesUpdatedProviderID` — Update path stores and passes ProviderID
- [ ] `TestPluginDeployProvider_HealthCheck_WithoutDeploy` — errors clearly when Deploy not called first
- [ ] `TestPluginDeployProvider_Deploy_LogsImageAndID` — stdout log contains both image and ID
- [ ] `GOWORK=off go test ./cmd/wfctl/... -race` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)