### PR TITLE
fix(deploy): Read-by-name before Update/Create to resolve 409 on repeat deploys

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -839,6 +839,29 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	imageStr, _ := merged["image"].(string)
 	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType}
 	spec := interfaces.ResourceSpec{Name: p.resourceName, Type: p.resourceType, Config: merged}
+
+	// Read-by-name first: discover the existing ProviderID (if any) so Update
+	// can target the exact cloud resource rather than a blank ID.
+	readOut, readErr := driver.Read(ctx, ref)
+	switch {
+	case readErr == nil && readOut != nil && readOut.ProviderID != "":
+		ref.ProviderID = readOut.ProviderID
+		log.Printf("plugin deploy %q: found existing resource (id=%s)", p.resourceName, ref.ProviderID)
+	case readErr != nil && errors.Is(readErr, interfaces.ErrResourceNotFound):
+		// Resource confirmed absent — skip Update, go straight to Create.
+		log.Printf("plugin deploy %q: resource not found via Read, creating new", p.resourceName)
+		out, createErr := driver.Create(ctx, spec)
+		if createErr != nil {
+			return fmt.Errorf("plugin deploy %q: create failed: %w", p.resourceName, createErr)
+		}
+		p.lastProviderID = out.ProviderID
+		fmt.Printf("  plugin deploy: created %q at %s (id=%s)\n", p.resourceName, imageStr, out.ProviderID)
+		return nil
+	case readErr != nil:
+		return fmt.Errorf("plugin deploy %q: read existing resource: %w", p.resourceName, readErr)
+	}
+
+	// Belt-and-suspenders: Update first; fall back to Create on not-found.
 	out, updateErr := driver.Update(ctx, ref, spec)
 	if updateErr == nil {
 		p.lastProviderID = out.ProviderID

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -19,6 +19,8 @@ type fakeResourceDriver struct {
 	updateImage  string
 	updateErr    error
 	updateOut    *interfaces.ResourceOutput
+	updateRef    interfaces.ResourceRef
+	updateCalled bool
 	hcResult     *interfaces.HealthResult
 	hcErr        error
 	lastHCRef    interfaces.ResourceRef
@@ -26,6 +28,9 @@ type fakeResourceDriver struct {
 	createSpec   interfaces.ResourceSpec
 	createOut    *interfaces.ResourceOutput
 	createErr    error
+	readOut      *interfaces.ResourceOutput
+	readErr      error
+	readCalled   bool
 }
 
 func (d *fakeResourceDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -39,10 +44,19 @@ func (d *fakeResourceDriver) Create(_ context.Context, spec interfaces.ResourceS
 	}
 	return &interfaces.ResourceOutput{}, nil
 }
-func (d *fakeResourceDriver) Read(_ context.Context, _ interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+func (d *fakeResourceDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	d.readCalled = true
+	if d.readErr != nil {
+		return nil, d.readErr
+	}
+	if d.readOut != nil {
+		return d.readOut, nil
+	}
 	return nil, nil
 }
-func (d *fakeResourceDriver) Update(_ context.Context, _ interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+func (d *fakeResourceDriver) Update(_ context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	d.updateCalled = true
+	d.updateRef = ref
 	d.updateImage, _ = spec.Config["image"].(string)
 	if d.updateErr != nil {
 		return nil, d.updateErr
@@ -544,5 +558,115 @@ func TestPluginDeployProvider_Deploy_LogsImageAndID(t *testing.T) {
 	}
 	if !strings.Contains(output, "log-999") {
 		t.Errorf("expected ProviderID in log output, got: %q", output)
+	}
+}
+
+// ── Read-then-upsert ──────────────────────────────────────────────────────────
+
+// TestPluginDeployProvider_Deploy_ReadsExistingBeforeUpdate verifies that when
+// Read returns a resource with a non-empty ProviderID, Deploy passes that
+// ProviderID to Update and does not call Create.
+func TestPluginDeployProvider_Deploy_ReadsExistingBeforeUpdate(t *testing.T) {
+	driver := &fakeResourceDriver{
+		readOut: &interfaces.ResourceOutput{ProviderID: "abc"},
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: unexpected error: %v", err)
+	}
+	if !driver.readCalled {
+		t.Error("expected Read to be called before Update")
+	}
+	if !driver.updateCalled {
+		t.Error("expected Update to be called")
+	}
+	if driver.updateRef.ProviderID != "abc" {
+		t.Errorf("expected Update called with ref.ProviderID=%q, got %q", "abc", driver.updateRef.ProviderID)
+	}
+	if driver.createCalled {
+		t.Error("expected Create NOT to be called when Read finds an existing resource")
+	}
+}
+
+// TestPluginDeployProvider_Deploy_ReadNotFoundCreates verifies that when Read
+// returns ErrResourceNotFound, Deploy skips Update and goes straight to Create.
+func TestPluginDeployProvider_Deploy_ReadNotFoundCreates(t *testing.T) {
+	driver := &fakeResourceDriver{
+		readErr: fmt.Errorf("app not found: %w", interfaces.ErrResourceNotFound),
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:new",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	if err := p.Deploy(context.Background(), cfg); err != nil {
+		t.Fatalf("Deploy: unexpected error: %v", err)
+	}
+	if !driver.createCalled {
+		t.Error("expected Create to be called when Read returns ErrResourceNotFound")
+	}
+	if driver.updateCalled {
+		t.Error("expected Update NOT to be called when Read returns ErrResourceNotFound")
+	}
+}
+
+// TestPluginDeployProvider_Deploy_ReadErrorPropagates verifies that when Read
+// returns a non-not-found error (e.g. permission denied), Deploy surfaces it
+// immediately without calling Update or Create.
+func TestPluginDeployProvider_Deploy_ReadErrorPropagates(t *testing.T) {
+	driver := &fakeResourceDriver{
+		readErr: fmt.Errorf("permission denied"),
+	}
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	p := &pluginDeployProvider{
+		provider:     fake,
+		resourceName: "my-app",
+		resourceType: "infra.container_service",
+		resourceCfg:  map[string]any{},
+	}
+	cfg := DeployConfig{
+		AppName:  "my-app",
+		ImageTag: "registry.example.com/myapp:v1",
+		Env:      &config.CIDeployEnvironment{},
+	}
+	err := p.Deploy(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error when Read returns a non-not-found error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("expected 'permission denied' in error, got: %v", err)
+	}
+	if driver.updateCalled {
+		t.Error("expected Update NOT to be called when Read returns an error")
+	}
+	if driver.createCalled {
+		t.Error("expected Create NOT to be called when Read returns an error")
 	}
 }


### PR DESCRIPTION
## Summary

- `pluginDeployProvider.Deploy` now calls `driver.Read(ctx, ref)` by name before attempting Update
- If Read finds an existing resource, its `ProviderID` is populated into `ref` so Update targets the exact cloud resource (fixes the 405 → 409 loop)
- If Read returns `ErrResourceNotFound`, Deploy skips Update and goes straight to Create
- Any other Read error surfaces immediately without attempting Update or Create
- The existing Update-then-Create-on-NotFound fallback is preserved as belt-and-suspenders

## Test plan

- [x] `TestPluginDeployProvider_Deploy_ReadsExistingBeforeUpdate` — Read returns ProviderID "abc"; Update called with that ID, Create not called
- [x] `TestPluginDeployProvider_Deploy_ReadNotFoundCreates` — Read returns ErrResourceNotFound; Create called, Update not called
- [x] `TestPluginDeployProvider_Deploy_ReadErrorPropagates` — Read returns permission denied; neither Update nor Create called, error surfaced
- [x] All existing `TestPluginDeployProvider_*` tests continue to pass
- [x] `GOWORK=off go test ./cmd/wfctl/... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)