### PR TITLE
feat(interfaces): add IaC error sentinels for common response categories

### DIFF
--- a/interfaces/iac_resource_driver.go
+++ b/interfaces/iac_resource_driver.go
@@ -5,9 +5,17 @@ import (
 	"errors"
 )
 
-// ErrResourceNotFound is returned by ResourceDriver methods when the target
-// resource does not exist. Callers should use errors.Is to detect it.
-var ErrResourceNotFound = errors.New("iac: resource not found")
+// Sentinel errors for common IaC resource operation response categories.
+// Use errors.Is to identify them after wrapping.
+var (
+	ErrResourceNotFound      = errors.New("iac: resource not found")      // 404/410
+	ErrResourceAlreadyExists = errors.New("iac: resource already exists") // 409 Conflict
+	ErrRateLimited           = errors.New("iac: rate limited")            // 429
+	ErrTransient             = errors.New("iac: transient error")         // 502/503/504
+	ErrUnauthorized          = errors.New("iac: unauthorized")            // 401
+	ErrForbidden             = errors.New("iac: forbidden")               // 403
+	ErrValidation            = errors.New("iac: validation error")        // 400/422
+)
 
 // ResourceDriver handles CRUD for a single resource type within a provider.
 type ResourceDriver interface {

--- a/interfaces/iac_resource_driver_test.go
+++ b/interfaces/iac_resource_driver_test.go
@@ -1,0 +1,68 @@
+package interfaces_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// TestSentinels_ErrorsIs verifies each sentinel is distinct and identifies itself.
+func TestSentinels_ErrorsIs(t *testing.T) {
+	sentinels := []struct {
+		name string
+		err  error
+	}{
+		{"ErrResourceNotFound", interfaces.ErrResourceNotFound},
+		{"ErrResourceAlreadyExists", interfaces.ErrResourceAlreadyExists},
+		{"ErrRateLimited", interfaces.ErrRateLimited},
+		{"ErrTransient", interfaces.ErrTransient},
+		{"ErrUnauthorized", interfaces.ErrUnauthorized},
+		{"ErrForbidden", interfaces.ErrForbidden},
+		{"ErrValidation", interfaces.ErrValidation},
+	}
+
+	for i, s := range sentinels {
+		if s.err == nil {
+			t.Errorf("%s: sentinel is nil", s.name)
+			continue
+		}
+		// Self-identification.
+		if !errors.Is(s.err, s.err) {
+			t.Errorf("%s: errors.Is(self) = false", s.name)
+		}
+		// Distinctness — no sentinel should match another.
+		for j, other := range sentinels {
+			if i == j {
+				continue
+			}
+			if errors.Is(s.err, other.err) {
+				t.Errorf("%s matches %s — sentinels must be distinct", s.name, other.name)
+			}
+		}
+	}
+}
+
+// TestSentinels_Wrappable verifies a wrapped sentinel still matches via errors.Is.
+func TestSentinels_Wrappable(t *testing.T) {
+	cases := []struct {
+		name     string
+		sentinel error
+	}{
+		{"ErrResourceNotFound", interfaces.ErrResourceNotFound},
+		{"ErrResourceAlreadyExists", interfaces.ErrResourceAlreadyExists},
+		{"ErrRateLimited", interfaces.ErrRateLimited},
+		{"ErrTransient", interfaces.ErrTransient},
+		{"ErrUnauthorized", interfaces.ErrUnauthorized},
+		{"ErrForbidden", interfaces.ErrForbidden},
+		{"ErrValidation", interfaces.ErrValidation},
+	}
+
+	for _, c := range cases {
+		wrapped := fmt.Errorf("operation failed: %w", c.sentinel)
+		if !errors.Is(wrapped, c.sentinel) {
+			t.Errorf("%s: wrapped error not matched by errors.Is", c.name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds seven exported sentinel errors to `interfaces/iac_resource_driver.go` covering the common HTTP status code categories providers and wfctl need to handle
- `ErrResourceNotFound` (404/410), `ErrResourceAlreadyExists` (409), `ErrRateLimited` (429), `ErrTransient` (502/503/504), `ErrUnauthorized` (401), `ErrForbidden` (403), `ErrValidation` (400/422)
- Providers wrap these with `fmt.Errorf("%w", interfaces.ErrXxx)`; callers use `errors.Is` — no coupling to provider-specific error types

## Test plan

- [x] `TestSentinels_ErrorsIs` — each sentinel is non-nil, matches itself, and is distinct from all others
- [x] `TestSentinels_Wrappable` — a `fmt.Errorf("%w", sentinel)` wrapped error still matches via `errors.Is`
- [x] `GOWORK=off go test ./interfaces/... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)