### PR TITLE
feat(wfctl): poll HealthCheck until healthy or timeout

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -1037,16 +1037,16 @@ func pollUntilHealthy(ctx context.Context, driver interfaces.ResourceDriver, ref
 
 	for {
 		result, hcErr := driver.HealthCheck(pollCtx, ref)
-		if hcErr != nil {
+		switch {
+		case hcErr != nil:
 			wrapped := wrapIaCError(hcErr)
-			if errors.Is(wrapped, interfaces.ErrTransient) || errors.Is(wrapped, interfaces.ErrRateLimited) {
-				log.Printf("plugin health check %q: transient error, continuing poll: %v", name, hcErr)
-			} else {
+			if !errors.Is(wrapped, interfaces.ErrTransient) && !errors.Is(wrapped, interfaces.ErrRateLimited) {
 				return fmt.Errorf("plugin health check %q: %w", name, wrapped)
 			}
-		} else if result.Healthy {
+			log.Printf("plugin health check %q: transient error, continuing poll: %v", name, hcErr)
+		case result.Healthy:
 			return nil
-		} else {
+		default:
 			lastMsg = result.Message
 		}
 

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -991,6 +991,18 @@ func (p *pluginDeployProvider) doCreate(ctx context.Context, driver interfaces.R
 	return nil
 }
 
+// healthPollInitialInterval is the poll interval for the first healthPollBackoffAfter of waiting.
+var healthPollInitialInterval = 10 * time.Second
+
+// healthPollBackoffInterval is the poll interval after healthPollBackoffAfter has elapsed.
+var healthPollBackoffInterval = 30 * time.Second
+
+// healthPollBackoffAfter is the duration after which the poll interval switches to healthPollBackoffInterval.
+var healthPollBackoffAfter = 60 * time.Second
+
+// healthPollDefaultTimeout is the default maximum time to wait for a healthy result.
+var healthPollDefaultTimeout = 10 * time.Minute
+
 func (p *pluginDeployProvider) HealthCheck(ctx context.Context, cfg DeployConfig) error {
 	if cfg.Env == nil || cfg.Env.HealthCheck == nil {
 		return nil
@@ -1006,18 +1018,61 @@ func (p *pluginDeployProvider) HealthCheck(ctx context.Context, cfg DeployConfig
 		return fmt.Errorf("health check: no ProviderID available — Deploy must run first")
 	}
 	ref := interfaces.ResourceRef{Name: p.resourceName, Type: p.resourceType, ProviderID: p.lastProviderID}
-	var result *interfaces.HealthResult
-	if hcErr := retryOnTransient(ctx, func() error {
-		var err error
-		result, err = driver.HealthCheck(ctx, ref)
+	if err := pollUntilHealthy(ctx, driver, ref, p.resourceName); err != nil {
 		return err
-	}); hcErr != nil {
-		return fmt.Errorf("plugin health check %q: %w", p.resourceName, hcErr)
-	}
-	if !result.Healthy {
-		return fmt.Errorf("plugin health check %q: unhealthy: %s", p.resourceName, result.Message)
 	}
 	return nil
+}
+
+// pollUntilHealthy polls driver.HealthCheck until Healthy=true, context cancels,
+// or the default timeout elapses.  ErrTransient/ErrRateLimited are treated as
+// "keep polling"; any other error fails fast.
+func pollUntilHealthy(ctx context.Context, driver interfaces.ResourceDriver, ref interfaces.ResourceRef, name string) error {
+	deadline := time.Now().Add(healthPollDefaultTimeout)
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	start := time.Now()
+	var lastMsg string
+
+	for {
+		result, hcErr := driver.HealthCheck(pollCtx, ref)
+		if hcErr != nil {
+			wrapped := wrapIaCError(hcErr)
+			if errors.Is(wrapped, interfaces.ErrTransient) || errors.Is(wrapped, interfaces.ErrRateLimited) {
+				log.Printf("plugin health check %q: transient error, continuing poll: %v", name, hcErr)
+			} else {
+				return fmt.Errorf("plugin health check %q: %w", name, wrapped)
+			}
+		} else if result.Healthy {
+			return nil
+		} else {
+			lastMsg = result.Message
+		}
+
+		// Choose poll interval based on elapsed time.
+		interval := healthPollInitialInterval
+		if time.Since(start) >= healthPollBackoffAfter {
+			interval = healthPollBackoffInterval
+		}
+
+		select {
+		case <-pollCtx.Done():
+			if lastMsg != "" {
+				return fmt.Errorf("plugin health check %q: timed out waiting for healthy; last status: %s", name, lastMsg)
+			}
+			return fmt.Errorf("plugin health check %q: timed out waiting for healthy", name)
+		case <-time.After(interval):
+		}
+
+		// Check again after sleeping (context may have expired during sleep).
+		if pollCtx.Err() != nil {
+			if lastMsg != "" {
+				return fmt.Errorf("plugin health check %q: timed out waiting for healthy; last status: %s", name, lastMsg)
+			}
+			return fmt.Errorf("plugin health check %q: timed out waiting for healthy", name)
+		}
+	}
 }
 
 // ── kubernetes provider ───────────────────────────────────────────────────────

--- a/cmd/wfctl/deploy_providers_plugin_test.go
+++ b/cmd/wfctl/deploy_providers_plugin_test.go
@@ -22,6 +22,12 @@ type driverCallResult struct {
 	err error
 }
 
+// hcCallResult holds the outcome of one fake HealthCheck call.
+type hcCallResult struct {
+	result *interfaces.HealthResult
+	err    error
+}
+
 type fakeResourceDriver struct {
 	updateImage  string
 	updateErr    error
@@ -34,6 +40,9 @@ type fakeResourceDriver struct {
 	hcResult      *interfaces.HealthResult
 	hcErr         error
 	lastHCRef     interfaces.ResourceRef
+	// hcResults: if non-empty, each call uses the next entry (last is repeated).
+	hcResults []hcCallResult
+	hcCallN   int
 	createCalled  bool
 	createSpec    interfaces.ResourceSpec
 	createOut     *interfaces.ResourceOutput
@@ -116,6 +125,16 @@ func (d *fakeResourceDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, 
 }
 func (d *fakeResourceDriver) HealthCheck(_ context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
 	d.lastHCRef = ref
+	callIdx := d.hcCallN
+	d.hcCallN++
+	if len(d.hcResults) > 0 {
+		idx := callIdx
+		if idx >= len(d.hcResults) {
+			idx = len(d.hcResults) - 1
+		}
+		r := d.hcResults[idx]
+		return r.result, r.err
+	}
 	if d.hcResult != nil {
 		return d.hcResult, d.hcErr
 	}
@@ -302,6 +321,8 @@ func TestPluginDeployProvider_HealthCheck(t *testing.T) {
 }
 
 func TestPluginDeployProvider_HealthCheck_Unhealthy(t *testing.T) {
+	zeroHealthPollIntervals(t)
+	zeroHealthPollTimeout(t)
 	driver := &fakeResourceDriver{
 		hcResult: &interfaces.HealthResult{Healthy: false, Message: "not ready"},
 	}
@@ -880,5 +901,149 @@ func TestDeploy_AlreadyExistsFallsBackToUpdate(t *testing.T) {
 	}
 	if p.lastProviderID != "race-id" {
 		t.Errorf("lastProviderID: want %q, got %q", "race-id", p.lastProviderID)
+	}
+}
+
+// ── HealthCheck polling ───────────────────────────────────────────────────────
+
+// zeroHealthPollIntervals overrides poll intervals to zero so tests don't sleep.
+func zeroHealthPollIntervals(t *testing.T) {
+	t.Helper()
+	origInitial := healthPollInitialInterval
+	origBackoff := healthPollBackoffInterval
+	origAfter := healthPollBackoffAfter
+	healthPollInitialInterval = 0
+	healthPollBackoffInterval = 0
+	healthPollBackoffAfter = 0
+	t.Cleanup(func() {
+		healthPollInitialInterval = origInitial
+		healthPollBackoffInterval = origBackoff
+		healthPollBackoffAfter = origAfter
+	})
+}
+
+// zeroHealthPollTimeout sets a very short default timeout (1ms) so tests that
+// expect timeout failures finish quickly.
+func zeroHealthPollTimeout(t *testing.T) {
+	t.Helper()
+	orig := healthPollDefaultTimeout
+	healthPollDefaultTimeout = time.Millisecond
+	t.Cleanup(func() { healthPollDefaultTimeout = orig })
+}
+
+func makeHealthPollProvider(driver *fakeResourceDriver, providerID string) *pluginDeployProvider {
+	fake := &fakeIaCProvider{
+		name:    "fake-cloud",
+		drivers: map[string]interfaces.ResourceDriver{"infra.container_service": driver},
+	}
+	return &pluginDeployProvider{
+		provider:       fake,
+		resourceName:   "my-app",
+		resourceType:   "infra.container_service",
+		resourceCfg:    map[string]any{},
+		lastProviderID: providerID,
+	}
+}
+
+func healthCfg() DeployConfig {
+	return DeployConfig{
+		Env: &config.CIDeployEnvironment{
+			HealthCheck: &config.CIHealthCheck{Path: "/healthz"},
+		},
+	}
+}
+
+// TestHealthCheck_HealthyOnFirstCall: HealthCheck returns immediately when
+// driver returns Healthy=true on the first poll.
+func TestHealthCheck_HealthyOnFirstCall(t *testing.T) {
+	zeroHealthPollIntervals(t)
+	driver := &fakeResourceDriver{
+		hcResult: &interfaces.HealthResult{Healthy: true},
+	}
+	p := makeHealthPollProvider(driver, "pid-hc-1")
+	if err := p.HealthCheck(context.Background(), healthCfg()); err != nil {
+		t.Fatalf("HealthCheck: unexpected error: %v", err)
+	}
+	if driver.hcCallN != 1 {
+		t.Errorf("expected 1 HealthCheck call, got %d", driver.hcCallN)
+	}
+}
+
+// TestHealthCheck_HealthyAfterNPolls: HealthCheck returns success after
+// Healthy=false on the first two calls then Healthy=true on the third.
+func TestHealthCheck_HealthyAfterNPolls(t *testing.T) {
+	zeroHealthPollIntervals(t)
+	driver := &fakeResourceDriver{
+		hcResults: []hcCallResult{
+			{result: &interfaces.HealthResult{Healthy: false, Message: "deploying"}},
+			{result: &interfaces.HealthResult{Healthy: false, Message: "deploying"}},
+			{result: &interfaces.HealthResult{Healthy: true}},
+		},
+	}
+	p := makeHealthPollProvider(driver, "pid-hc-2")
+	if err := p.HealthCheck(context.Background(), healthCfg()); err != nil {
+		t.Fatalf("HealthCheck: unexpected error: %v", err)
+	}
+	if driver.hcCallN != 3 {
+		t.Errorf("expected 3 HealthCheck calls, got %d", driver.hcCallN)
+	}
+}
+
+// TestHealthCheck_TransientContinuesPolling: ErrTransient from driver is logged
+// and polling continues; succeeds on the next call.
+func TestHealthCheck_TransientContinuesPolling(t *testing.T) {
+	zeroHealthPollIntervals(t)
+	driver := &fakeResourceDriver{
+		hcResults: []hcCallResult{
+			{err: interfaces.ErrTransient},
+			{result: &interfaces.HealthResult{Healthy: true}},
+		},
+	}
+	p := makeHealthPollProvider(driver, "pid-hc-3")
+	if err := p.HealthCheck(context.Background(), healthCfg()); err != nil {
+		t.Fatalf("HealthCheck: unexpected error: %v", err)
+	}
+	if driver.hcCallN != 2 {
+		t.Errorf("expected 2 HealthCheck calls (transient + success), got %d", driver.hcCallN)
+	}
+}
+
+// TestHealthCheck_UnauthorizedFailsFast: ErrUnauthorized from driver causes
+// HealthCheck to fail immediately without further polling.
+func TestHealthCheck_UnauthorizedFailsFast(t *testing.T) {
+	zeroHealthPollIntervals(t)
+	driver := &fakeResourceDriver{
+		hcResults: []hcCallResult{
+			{err: interfaces.ErrUnauthorized},
+		},
+	}
+	p := makeHealthPollProvider(driver, "pid-hc-4")
+	err := p.HealthCheck(context.Background(), healthCfg())
+	if err == nil {
+		t.Fatal("expected error for ErrUnauthorized")
+	}
+	if !errors.Is(err, interfaces.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized in error chain, got: %v", err)
+	}
+	if driver.hcCallN != 1 {
+		t.Errorf("expected 1 HealthCheck call (no retry on auth error), got %d", driver.hcCallN)
+	}
+}
+
+// TestHealthCheck_TimeoutExceeded: when the context/timeout expires before
+// Healthy=true, HealthCheck returns an error containing the last status message.
+func TestHealthCheck_TimeoutExceeded(t *testing.T) {
+	zeroHealthPollIntervals(t)
+	zeroHealthPollTimeout(t)
+	driver := &fakeResourceDriver{
+		hcResult: &interfaces.HealthResult{Healthy: false, Message: "still deploying"},
+	}
+	p := makeHealthPollProvider(driver, "pid-hc-5")
+	err := p.HealthCheck(context.Background(), healthCfg())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "still deploying") {
+		t.Errorf("expected last status in timeout error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces single-shot `pluginDeployProvider.HealthCheck` with a `pollUntilHealthy` loop
- Polls every 10s for the first 60s, then every 30s, up to a 10-minute default timeout
- `ErrTransient` / `ErrRateLimited` from the driver are logged and polling continues
- Any other error (e.g. `ErrUnauthorized`) fails fast
- `Healthy=false` without error continues polling (resource still deploying)
- Timeout error includes last status message for diagnostics
- Four package-level vars (`healthPollInitialInterval`, `healthPollBackoffInterval`, `healthPollBackoffAfter`, `healthPollDefaultTimeout`) allow zero-sleep overrides in tests

## Test plan

- [x] `TestHealthCheck_HealthyOnFirstCall` — returns immediately on first Healthy=true
- [x] `TestHealthCheck_HealthyAfterNPolls` — succeeds after 2 not-ready + 1 healthy
- [x] `TestHealthCheck_TransientContinuesPolling` — ErrTransient logged, next call succeeds
- [x] `TestHealthCheck_UnauthorizedFailsFast` — ErrUnauthorized stops after 1 call
- [x] `TestHealthCheck_TimeoutExceeded` — timeout error includes last status message
- [x] Existing `TestPluginDeployProvider_HealthCheck_Unhealthy` updated with zero-interval helpers so it finishes via timeout instead of hanging
- [x] Full suite: `GOWORK=off go test ./cmd/wfctl/... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)