### PR TITLE
fix(bootstrap): use S3 API with Spaces keys for bucket creation

### DIFF
--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -142,7 +142,7 @@ func bootstrapDOSpacesBucket(ctx context.Context, bucket, region, accessKey, sec
 		region = "nyc3"
 	}
 	if accessKey == "" || secretKey == "" {
-		return fmt.Errorf("Spaces access key and secret key must be set — " +
+		return fmt.Errorf("spaces access key and secret key must be set — " +
 			"ensure secrets are bootstrapped (step 1) before state backend (step 2); " +
 			"set accessKey/secretKey in the iac.state module config referencing ${SPACES_access_key} and ${SPACES_secret_key}")
 	}

--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/secrets"
@@ -43,38 +45,51 @@ func runInfraBootstrap(args []string) error {
 
 	ctx := context.Background()
 
-	// 1. Bootstrap state backend.
-	if err := bootstrapStateBackend(ctx, cfgFile); err != nil {
-		return fmt.Errorf("bootstrap state backend: %w", err)
-	}
-
-	// 2. Generate and store secrets.
+	// 1. Generate and store secrets FIRST so that Spaces access keys are available
+	//    in the current process environment before bootstrapStateBackend runs.
+	//    (DO Spaces bucket creation requires S3 API auth with the Spaces key pair,
+	//    which is generated here via the provider_credential source.)
 	secretsCfg, err := parseSecretsConfig(cfgFile)
 	if err != nil {
 		return fmt.Errorf("parse secrets config: %w", err)
 	}
-	if secretsCfg == nil || len(secretsCfg.Generate) == 0 {
+
+	if secretsCfg != nil && len(secretsCfg.Generate) > 0 {
+		provider, err := resolveSecretsProvider(secretsCfg)
+		if err != nil {
+			return fmt.Errorf("resolve secrets provider: %w", err)
+		}
+		generated, err := bootstrapSecrets(ctx, provider, secretsCfg)
+		if err != nil {
+			return err
+		}
+		// Export freshly generated secrets to the current process environment so
+		// that bootstrapStateBackend can read them via ${VAR} expansion in the
+		// module config (e.g. accessKey: "${SPACES_access_key}").
+		for k, v := range generated {
+			os.Setenv(k, v) //nolint:errcheck
+		}
+	} else {
 		fmt.Println("No secrets to generate.")
-		return nil
 	}
 
-	provider, err := resolveSecretsProvider(secretsCfg)
-	if err != nil {
-		return fmt.Errorf("resolve secrets provider: %w", err)
+	// 2. Bootstrap state backend (uses Spaces keys now in env from step 1).
+	if err := bootstrapStateBackend(ctx, cfgFile); err != nil {
+		return fmt.Errorf("bootstrap state backend: %w", err)
 	}
 
-	return bootstrapSecrets(ctx, provider, secretsCfg)
+	return nil
 }
 
 // bootstrapDOSpacesBucketFn is the package-level hook used by bootstrapStateBackend.
-// Tests override it to inject a fake HTTP server without touching the filesystem.
+// Tests override it to inject fakes without touching the filesystem or S3.
 var bootstrapDOSpacesBucketFn = bootstrapDOSpacesBucket
 
 // bootstrapStateBackend checks the iac.state config and creates any required
 // backing infrastructure (e.g. a DO Spaces bucket) if it does not already exist.
 // ${VAR} / $VAR references in the module config are expanded via os.ExpandEnv
 // before the config fields are read, so secrets can be injected through the
-// environment (e.g. BUCKET_NAME=my-bucket in CI).
+// environment (e.g. SPACES_access_key=xxx in CI).
 func bootstrapStateBackend(ctx context.Context, cfgFile string) error {
 	iacStates, _, _, err := discoverInfraModules(cfgFile)
 	if err != nil {
@@ -97,60 +112,88 @@ func bootstrapStateBackend(ctx context.Context, cfgFile string) error {
 	if bucket == "" {
 		return fmt.Errorf("iac.state backend=spaces requires 'bucket' in config")
 	}
-	return bootstrapDOSpacesBucketFn(ctx, bucket, region)
+
+	// Read Spaces credentials from the expanded module config.
+	// Convention: the YAML uses accessKey/secretKey (camelCase) or access_key/secret_key (snake_case).
+	accessKey, _ := cfg["accessKey"].(string)
+	if accessKey == "" {
+		accessKey, _ = cfg["access_key"].(string)
+	}
+	secretKey, _ := cfg["secretKey"].(string)
+	if secretKey == "" {
+		secretKey, _ = cfg["secret_key"].(string)
+	}
+
+	return bootstrapDOSpacesBucketFn(ctx, bucket, region, accessKey, secretKey)
+}
+
+// spacesBucketClient is the minimal S3 client interface used by bootstrapDOSpacesBucketWithClient.
+// Keeping it narrow makes it easy to inject fakes in tests.
+type spacesBucketClient interface {
+	HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
 }
 
 // bootstrapDOSpacesBucket creates a DO Spaces bucket if it does not already exist.
-func bootstrapDOSpacesBucket(ctx context.Context, bucket, region string) error {
-	return bootstrapDOSpacesBucketAt(ctx, bucket, region, "https://api.digitalocean.com")
-}
-
-// bootstrapDOSpacesBucketAt is the testable core of bootstrapDOSpacesBucket.
-// apiBase is the DO API base URL (injectable for tests).
-func bootstrapDOSpacesBucketAt(ctx context.Context, bucket, region, apiBase string) error {
-	token := os.Getenv("DIGITALOCEAN_TOKEN")
-	if token == "" {
-		return fmt.Errorf("DIGITALOCEAN_TOKEN not set")
-	}
+// It uses the S3-compatible Spaces API authenticated with Spaces access keys —
+// NOT the DO Bearer token, which is only valid for the DO REST API, not for Spaces.
+func bootstrapDOSpacesBucket(ctx context.Context, bucket, region, accessKey, secretKey string) error {
 	if region == "" {
 		region = "nyc3"
 	}
-
-	// Check if bucket exists using the Spaces Buckets REST API.
-	checkURL := fmt.Sprintf("%s/v2/spaces/buckets/%s", apiBase, bucket)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checkURL, nil)
-	if err != nil {
-		return fmt.Errorf("check bucket %q: %w", bucket, err)
+	if accessKey == "" || secretKey == "" {
+		return fmt.Errorf("Spaces access key and secret key must be set — " +
+			"ensure secrets are bootstrapped (step 1) before state backend (step 2); " +
+			"set accessKey/secretKey in the iac.state module config referencing ${SPACES_access_key} and ${SPACES_secret_key}")
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("check bucket %q: %w", bucket, err)
-	}
-	resp.Body.Close()
+	endpoint := fmt.Sprintf("https://%s.digitaloceanspaces.com", region)
 
-	if resp.StatusCode == http.StatusOK {
+	cfg, cfgErr := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
+	)
+	if cfgErr != nil {
+		return fmt.Errorf("spaces bootstrap: build S3 config: %w", cfgErr)
+	}
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = &endpoint
+		o.UsePathStyle = true
+	})
+	return bootstrapDOSpacesBucketWithClient(ctx, bucket, region, client)
+}
+
+// bootstrapDOSpacesBucketWithClient is the testable core of bootstrapDOSpacesBucket.
+// It uses HeadBucket to check existence and CreateBucket to create if absent.
+func bootstrapDOSpacesBucketWithClient(ctx context.Context, bucket, region string, client spacesBucketClient) error {
+	// Check whether the bucket already exists.
+	_, headErr := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: &bucket})
+	if headErr == nil {
 		fmt.Printf("  state backend: bucket %q already exists — skipped\n", bucket)
 		return nil
 	}
 
-	// Create bucket via POST /v2/spaces/buckets.
-	payload := map[string]string{"name": bucket, "region": region}
-	body, _ := json.Marshal(payload)
-	createReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBase+"/v2/spaces/buckets", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create bucket %q: %w", bucket, err)
+	// HeadBucket returns types.NotFound (HTTP 404) when the bucket does not exist.
+	// Any other error (e.g. 403 Forbidden — bucket owned by another account) is fatal.
+	var notFound *s3types.NotFound
+	if !errors.As(headErr, &notFound) {
+		return fmt.Errorf("check bucket %q: %w", bucket, headErr)
 	}
-	createReq.Header.Set("Authorization", "Bearer "+token)
-	createReq.Header.Set("Content-Type", "application/json")
-	createResp, err := http.DefaultClient.Do(createReq)
-	if err != nil {
-		return fmt.Errorf("create bucket %q: %w", bucket, err)
-	}
-	defer createResp.Body.Close()
-	if createResp.StatusCode != http.StatusCreated && createResp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(createResp.Body)
-		return fmt.Errorf("create bucket %q: HTTP %d: %s", bucket, createResp.StatusCode, respBody)
+
+	// Create the bucket.
+	_, createErr := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: &bucket,
+		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(region),
+		},
+	})
+	if createErr != nil {
+		// BucketAlreadyOwnedByYou: a concurrent create won the race — still OK.
+		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
+		if errors.As(createErr, &alreadyOwned) {
+			fmt.Printf("  state backend: bucket %q already owned — skipped\n", bucket)
+			return nil
+		}
+		return fmt.Errorf("create bucket %q: %w", bucket, createErr)
 	}
 	fmt.Printf("  state backend: created DO Spaces bucket %q in %s\n", bucket, region)
 	return nil
@@ -189,7 +232,12 @@ func expectedStoredKeys(gen SecretGen) []string {
 }
 
 // bootstrapSecrets generates and stores secrets that don't already exist.
-func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *SecretsConfig) error {
+// It returns a map of every key-value pair that was newly generated in this
+// run (skipped/pre-existing keys are NOT included). The caller can export
+// these to the process environment for downstream steps.
+func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *SecretsConfig) (map[string]string, error) {
+	generated := map[string]string{}
+
 	// Cache List() as a set so repeated probes in a bootstrap run only hit
 	// the provider once and subsequent lookups are O(1). Resolved lazily on
 	// the first write-only Get.
@@ -254,7 +302,7 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 		for _, key := range expected {
 			present, err := secretExists(key)
 			if err != nil {
-				return err
+				return generated, err
 			}
 			if !present {
 				allExist = false
@@ -269,7 +317,7 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 		// Generate the secret value.
 		value, err := generateSecret(ctx, gen.Type, genConfig)
 		if err != nil {
-			return fmt.Errorf("generate secret %q: %w", gen.Key, err)
+			return generated, fmt.Errorf("generate secret %q: %w", gen.Key, err)
 		}
 
 		// For provider_credential results (JSON map), store each sub-key.
@@ -279,8 +327,9 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 				for subKey, subVal := range subKeys {
 					fullKey := gen.Key + "_" + subKey
 					if setErr := provider.Set(ctx, fullKey, subVal); setErr != nil {
-						return fmt.Errorf("store secret %q: %w", fullKey, setErr)
+						return generated, fmt.Errorf("store secret %q: %w", fullKey, setErr)
 					}
+					generated[fullKey] = subVal
 					fmt.Printf("  secret %q: created\n", fullKey)
 				}
 				continue
@@ -288,9 +337,10 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 		}
 
 		if err := provider.Set(ctx, gen.Key, value); err != nil {
-			return fmt.Errorf("store secret %q: %w", gen.Key, err)
+			return generated, fmt.Errorf("store secret %q: %w", gen.Key, err)
 		}
+		generated[gen.Key] = value
 		fmt.Printf("  secret %q: created\n", gen.Key)
 	}
-	return nil
+	return generated, nil
 }

--- a/cmd/wfctl/infra_bootstrap_bucket_test.go
+++ b/cmd/wfctl/infra_bootstrap_bucket_test.go
@@ -2,84 +2,127 @@ package main
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-func TestBootstrapDOSpacesBucket_AlreadyExists(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		http.Error(w, "unexpected method", http.StatusInternalServerError)
-	}))
-	defer srv.Close()
+// fakeBucketClient implements spacesBucketClient for unit tests.
+type fakeBucketClient struct {
+	headErr     error // nil → bucket exists; *s3types.NotFound → bucket absent; other → fatal
+	createErr   error
+	headCalled  bool
+	createCalled bool
+	lastBucket  string
+	lastRegion  string
+}
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
-	if err := bootstrapDOSpacesBucketAt(context.Background(), "my-bucket", "nyc3", srv.URL); err != nil {
+func (f *fakeBucketClient) HeadBucket(_ context.Context, input *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	f.headCalled = true
+	if input.Bucket != nil {
+		f.lastBucket = *input.Bucket
+	}
+	if f.headErr != nil {
+		return nil, f.headErr
+	}
+	return &s3.HeadBucketOutput{}, nil
+}
+
+func (f *fakeBucketClient) CreateBucket(_ context.Context, input *s3.CreateBucketInput, _ ...func(*s3.Options)) (*s3.CreateBucketOutput, error) {
+	f.createCalled = true
+	if input.Bucket != nil {
+		f.lastBucket = *input.Bucket
+	}
+	if input.CreateBucketConfiguration != nil {
+		f.lastRegion = string(input.CreateBucketConfiguration.LocationConstraint)
+	}
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &s3.CreateBucketOutput{}, nil
+}
+
+func TestBootstrapDOSpacesBucket_AlreadyExists(t *testing.T) {
+	client := &fakeBucketClient{headErr: nil} // nil → bucket exists (200 OK)
+	if err := bootstrapDOSpacesBucketWithClient(context.Background(), "my-bucket", "nyc3", client); err != nil {
 		t.Fatalf("expected no error when bucket already exists, got: %v", err)
+	}
+	if !client.headCalled {
+		t.Error("expected HeadBucket to be called")
+	}
+	if client.createCalled {
+		t.Error("expected CreateBucket NOT to be called when bucket already exists")
 	}
 }
 
 func TestBootstrapDOSpacesBucket_CreatesNew(t *testing.T) {
-	var postCalled bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			w.WriteHeader(http.StatusNotFound)
-		case http.MethodPost:
-			postCalled = true
-			w.WriteHeader(http.StatusCreated)
-		default:
-			http.Error(w, "unexpected: "+r.Method, http.StatusInternalServerError)
-		}
-	}))
-	defer srv.Close()
-
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
-	if err := bootstrapDOSpacesBucketAt(context.Background(), "my-bucket", "nyc3", srv.URL); err != nil {
+	client := &fakeBucketClient{
+		headErr: &s3types.NotFound{}, // 404 → bucket doesn't exist
+	}
+	if err := bootstrapDOSpacesBucketWithClient(context.Background(), "new-bucket", "nyc3", client); err != nil {
 		t.Fatalf("expected no error creating new bucket, got: %v", err)
 	}
-	if !postCalled {
-		t.Error("expected POST to be called when bucket does not exist")
+	if !client.createCalled {
+		t.Error("expected CreateBucket to be called when bucket does not exist")
+	}
+	if client.lastBucket != "new-bucket" {
+		t.Errorf("CreateBucket bucket: want %q, got %q", "new-bucket", client.lastBucket)
+	}
+	if client.lastRegion != "nyc3" {
+		t.Errorf("CreateBucket region: want %q, got %q", "nyc3", client.lastRegion)
 	}
 }
 
-func TestBootstrapDOSpacesBucket_CreateErrorIncludesBody(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			w.WriteHeader(http.StatusNotFound)
-		case http.MethodPost:
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			w.Write([]byte(`{"id":"unprocessable_entity","message":"region is invalid"}`)) //nolint:errcheck
-		default:
-			http.Error(w, "unexpected: "+r.Method, http.StatusInternalServerError)
-		}
-	}))
-	defer srv.Close()
-
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
-	err := bootstrapDOSpacesBucketAt(context.Background(), "bad-bucket", "invalid-region", srv.URL)
-	if err == nil {
-		t.Fatal("expected error on 4xx create response")
+func TestBootstrapDOSpacesBucket_CreateErrorSurfaced(t *testing.T) {
+	createErr := errors.New("spaces quota exceeded")
+	client := &fakeBucketClient{
+		headErr:   &s3types.NotFound{},
+		createErr: createErr,
 	}
-	if !strings.Contains(err.Error(), "region is invalid") {
-		t.Errorf("expected response body in error, got: %v", err)
+	err := bootstrapDOSpacesBucketWithClient(context.Background(), "bad-bucket", "nyc3", client)
+	if err == nil {
+		t.Fatal("expected error on create failure")
+	}
+	if !strings.Contains(err.Error(), "quota exceeded") {
+		t.Errorf("expected create error in message, got: %v", err)
 	}
 }
 
-func TestBootstrapDOSpacesBucket_MissingToken(t *testing.T) {
-	t.Setenv("DIGITALOCEAN_TOKEN", "")
-	err := bootstrapDOSpacesBucketAt(context.Background(), "my-bucket", "nyc3", "http://unused")
-	if err == nil {
-		t.Fatal("expected error when DIGITALOCEAN_TOKEN unset")
+func TestBootstrapDOSpacesBucket_HeadFatalError(t *testing.T) {
+	// A non-404 HeadBucket error (e.g. 403 Forbidden) must fail fast without creating.
+	client := &fakeBucketClient{
+		headErr: errors.New("403 Forbidden"),
 	}
-	if !strings.Contains(err.Error(), "DIGITALOCEAN_TOKEN") {
-		t.Errorf("expected DIGITALOCEAN_TOKEN in error, got: %v", err)
+	err := bootstrapDOSpacesBucketWithClient(context.Background(), "my-bucket", "nyc3", client)
+	if err == nil {
+		t.Fatal("expected error on fatal HeadBucket failure")
+	}
+	if client.createCalled {
+		t.Error("expected CreateBucket NOT to be called after fatal HeadBucket error")
+	}
+}
+
+func TestBootstrapDOSpacesBucket_AlreadyOwnedIsOK(t *testing.T) {
+	// BucketAlreadyOwnedByYou is a benign race: concurrent create won, we still own it.
+	client := &fakeBucketClient{
+		headErr:   &s3types.NotFound{},
+		createErr: &s3types.BucketAlreadyOwnedByYou{},
+	}
+	if err := bootstrapDOSpacesBucketWithClient(context.Background(), "my-bucket", "nyc3", client); err != nil {
+		t.Fatalf("expected no error for BucketAlreadyOwnedByYou, got: %v", err)
+	}
+}
+
+func TestBootstrapDOSpacesBucket_MissingCredentials(t *testing.T) {
+	// bootstrapDOSpacesBucket (the real entry point) must fail if credentials are absent.
+	err := bootstrapDOSpacesBucket(context.Background(), "my-bucket", "nyc3", "", "")
+	if err == nil {
+		t.Fatal("expected error when access key and secret key are empty")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "access key") {
+		t.Errorf("expected 'access key' in error message, got: %v", err)
 	}
 }

--- a/cmd/wfctl/infra_bootstrap_env_test.go
+++ b/cmd/wfctl/infra_bootstrap_env_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -29,25 +27,22 @@ func writeBootstrapConfig(t *testing.T, yaml string) string {
 // ── TestBootstrap_StateBackendBucketExpanded ─────────────────────────────────
 
 // TestBootstrap_StateBackendBucketExpanded verifies that ${BUCKET_NAME} in the
-// iac.state config is resolved before bootstrapStateBackend issues HTTP calls.
+// iac.state config is resolved before bootstrapStateBackend calls the bucket fn.
 // Without env expansion, the literal "${BUCKET_NAME}" would be used as the
-// bucket name, causing the cloud API to reject it.
+// bucket name.
 func TestBootstrap_StateBackendBucketExpanded(t *testing.T) {
 	t.Setenv("TEST_BS_BUCKET", "my-state-bucket")
 	t.Setenv("TEST_BS_REGION", "sfo3")
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-do-token")
+	t.Setenv("TEST_BS_ACCESS", "ak")
+	t.Setenv("TEST_BS_SECRET", "sk")
 
-	// Track which bucket name the mock server receives.
 	var gotBucket string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// The URL path is /v2/spaces/buckets/<bucket>
-		prefix := "/v2/spaces/buckets/"
-		if len(r.URL.Path) > len(prefix) {
-			gotBucket = r.URL.Path[len(prefix):]
-		}
-		w.WriteHeader(http.StatusOK) // pretend bucket exists
-	}))
-	defer srv.Close()
+	orig := bootstrapDOSpacesBucketFn
+	bootstrapDOSpacesBucketFn = func(_ context.Context, bucket, _, _, _ string) error {
+		gotBucket = bucket
+		return nil
+	}
+	defer func() { bootstrapDOSpacesBucketFn = orig }()
 
 	cfgFile := writeBootstrapConfig(t, `
 modules:
@@ -57,21 +52,16 @@ modules:
       backend: spaces
       bucket: "${TEST_BS_BUCKET}"
       region: "${TEST_BS_REGION}"
+      accessKey: "${TEST_BS_ACCESS}"
+      secretKey: "${TEST_BS_SECRET}"
 `)
-
-	// Swap the injectable DO Spaces function to inject our test server.
-	orig := bootstrapDOSpacesBucketFn
-	bootstrapDOSpacesBucketFn = func(ctx context.Context, bucket, region string) error {
-		return bootstrapDOSpacesBucketAt(ctx, bucket, region, srv.URL)
-	}
-	defer func() { bootstrapDOSpacesBucketFn = orig }()
 
 	if err := bootstrapStateBackend(context.Background(), cfgFile); err != nil {
 		t.Fatalf("bootstrapStateBackend: %v", err)
 	}
 
 	if gotBucket != "my-state-bucket" {
-		t.Errorf("bucket sent to API: want %q, got %q", "my-state-bucket", gotBucket)
+		t.Errorf("bucket: want %q, got %q", "my-state-bucket", gotBucket)
 	}
 }
 
@@ -82,7 +72,6 @@ modules:
 func TestBootstrap_StateBackendEmptyEnvVar(t *testing.T) {
 	// Set to empty to simulate unset (t.Setenv("X", "") still sets the var).
 	t.Setenv("TEST_BS_EMPTY_BUCKET", "")
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
 
 	cfgFile := writeBootstrapConfig(t, `
 modules:
@@ -200,7 +189,7 @@ func TestBootstrap_RepeatedRunIdempotent(t *testing.T) {
 	}
 
 	// First run: generates the secret.
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("first bootstrapSecrets: %v", err)
 	}
 	if callCount != 1 {
@@ -211,7 +200,7 @@ func TestBootstrap_RepeatedRunIdempotent(t *testing.T) {
 	}
 
 	// Second run: secret already exists — generator must NOT be called again.
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("second bootstrapSecrets: %v", err)
 	}
 	if callCount != 1 {
@@ -223,24 +212,21 @@ func TestBootstrap_RepeatedRunIdempotent(t *testing.T) {
 
 // TestBootstrap_StateBackendAccessKeyExpanded verifies that BMW-style
 // ${SPACES_access_key} and ${SPACES_secret_key} references in the iac.state
-// config are expanded by ExpandEnvInMap before the config is used.
-// bootstrapStateBackend expands the full module config — not just bucket/region
-// — so accessKey/secretKey are also available in their resolved form to any
-// downstream state-backend initialisation that reads the same config map.
+// config are expanded by ExpandEnvInMap and the resolved values are passed
+// through to bootstrapDOSpacesBucketFn.
 func TestBootstrap_StateBackendAccessKeyExpanded(t *testing.T) {
 	t.Setenv("TEST_SPACES_ACCESS", "do-spaces-key-abc")
 	t.Setenv("TEST_SPACES_SECRET", "do-spaces-secret-xyz")
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-do-token")
 
-	var gotBucket string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		prefix := "/v2/spaces/buckets/"
-		if len(r.URL.Path) > len(prefix) {
-			gotBucket = r.URL.Path[len(prefix):]
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+	var gotBucket, gotAccessKey, gotSecretKey string
+	orig := bootstrapDOSpacesBucketFn
+	bootstrapDOSpacesBucketFn = func(_ context.Context, bucket, _, accessKey, secretKey string) error {
+		gotBucket = bucket
+		gotAccessKey = accessKey
+		gotSecretKey = secretKey
+		return nil
+	}
+	defer func() { bootstrapDOSpacesBucketFn = orig }()
 
 	cfgFile := writeBootstrapConfig(t, `
 modules:
@@ -254,24 +240,21 @@ modules:
       secretKey: "${TEST_SPACES_SECRET}"
 `)
 
-	orig := bootstrapDOSpacesBucketFn
-	bootstrapDOSpacesBucketFn = func(ctx context.Context, bucket, region string) error {
-		return bootstrapDOSpacesBucketAt(ctx, bucket, region, srv.URL)
-	}
-	defer func() { bootstrapDOSpacesBucketFn = orig }()
-
 	if err := bootstrapStateBackend(context.Background(), cfgFile); err != nil {
 		t.Fatalf("bootstrapStateBackend: %v", err)
 	}
 
-	// Verify the bucket call reached the mock (confirming the full path ran).
 	if gotBucket != "my-state-bucket" {
-		t.Errorf("bucket sent to API: want %q, got %q", "my-state-bucket", gotBucket)
+		t.Errorf("bucket: want %q, got %q", "my-state-bucket", gotBucket)
+	}
+	if gotAccessKey != "do-spaces-key-abc" {
+		t.Errorf("accessKey: want %q, got %q", "do-spaces-key-abc", gotAccessKey)
+	}
+	if gotSecretKey != "do-spaces-secret-xyz" {
+		t.Errorf("secretKey: want %q, got %q", "do-spaces-secret-xyz", gotSecretKey)
 	}
 
-	// Verify accessKey/secretKey were expanded (not passed as literals).
-	// We load the modules independently and apply ExpandEnvInMap — the same
-	// code path bootstrapStateBackend uses — to assert the values.
+	// Verify ExpandEnvInMap produced the right values without mutating original config.
 	iacStates, _, _, err := discoverInfraModules(cfgFile)
 	if err != nil {
 		t.Fatalf("discoverInfraModules: %v", err)
@@ -281,10 +264,10 @@ modules:
 	}
 	expanded := config.ExpandEnvInMap(iacStates[0].Config)
 	if got, _ := expanded["accessKey"].(string); got != "do-spaces-key-abc" {
-		t.Errorf("accessKey: want %q, got %q", "do-spaces-key-abc", got)
+		t.Errorf("expanded accessKey: want %q, got %q", "do-spaces-key-abc", got)
 	}
 	if got, _ := expanded["secretKey"].(string); got != "do-spaces-secret-xyz" {
-		t.Errorf("secretKey: want %q, got %q", "do-spaces-secret-xyz", got)
+		t.Errorf("expanded secretKey: want %q, got %q", "do-spaces-secret-xyz", got)
 	}
 }
 
@@ -297,22 +280,17 @@ modules:
 // override like `bucket: "${STAGING_BUCKET}"` would not be expanded.
 func TestBootstrap_EnvFlagAppliedBeforeSubstitution(t *testing.T) {
 	t.Setenv("TEST_STAGING_BUCKET", "staging-state-bucket")
-	t.Setenv("DIGITALOCEAN_TOKEN", "test-do-token")
+	t.Setenv("TEST_STAGING_ACCESS", "staging-ak")
+	t.Setenv("TEST_STAGING_SECRET", "staging-sk")
 
 	var gotBucket string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		prefix := "/v2/spaces/buckets/"
-		if len(r.URL.Path) > len(prefix) {
-			gotBucket = r.URL.Path[len(prefix):]
-		}
-		w.WriteHeader(http.StatusOK) // bucket already exists
-	}))
-	defer srv.Close()
+	orig := bootstrapDOSpacesBucketFn
+	bootstrapDOSpacesBucketFn = func(_ context.Context, bucket, _, _, _ string) error {
+		gotBucket = bucket
+		return nil
+	}
+	defer func() { bootstrapDOSpacesBucketFn = orig }()
 
-	// The base config uses a placeholder; the staging env override sets the
-	// real bucket name via ${TEST_STAGING_BUCKET}. The env flag must be applied
-	// (merging the staging override) BEFORE ExpandEnvInMap runs so the
-	// resulting bucket is "staging-state-bucket", not "${TEST_STAGING_BUCKET}".
 	cfgFile := writeBootstrapConfig(t, `
 modules:
   - name: tf-state
@@ -321,6 +299,8 @@ modules:
       backend: spaces
       bucket: "default-bucket"
       region: "nyc3"
+      accessKey: "${TEST_STAGING_ACCESS}"
+      secretKey: "${TEST_STAGING_SECRET}"
     environments:
       staging:
         config:
@@ -335,12 +315,6 @@ modules:
 	defer os.Remove(tmpFile)
 
 	// Step 2: bootstrapStateBackend uses the resolved (and env-expanded) config.
-	orig := bootstrapDOSpacesBucketFn
-	bootstrapDOSpacesBucketFn = func(ctx context.Context, bucket, region string) error {
-		return bootstrapDOSpacesBucketAt(ctx, bucket, region, srv.URL)
-	}
-	defer func() { bootstrapDOSpacesBucketFn = orig }()
-
 	if err := bootstrapStateBackend(context.Background(), tmpFile); err != nil {
 		t.Fatalf("bootstrapStateBackend: %v", err)
 	}

--- a/cmd/wfctl/infra_bootstrap_secrets_test.go
+++ b/cmd/wfctl/infra_bootstrap_secrets_test.go
@@ -70,7 +70,7 @@ func TestBootstrapSecrets_WriteOnlyProviderSkipsExisting(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if len(p.stored) != 0 {
@@ -93,7 +93,7 @@ func TestBootstrapSecrets_WriteOnlyProviderGeneratesWhenMissing(t *testing.T) {
 			{Key: "JWT_SECRET", Type: "random_hex", Length: 8},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if _, ok := p.stored["JWT_SECRET"]; !ok {
@@ -111,7 +111,7 @@ func TestBootstrapSecrets_WriteOnlyProviderListUnsupported(t *testing.T) {
 			{Key: "JWT_SECRET", Type: "random_hex", Length: 8},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if len(p.stored) != 1 {
@@ -136,7 +136,7 @@ func TestBootstrapSecrets_ProviderCredentialAllSubKeysPresent(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if len(p.stored) != 0 {
@@ -165,7 +165,7 @@ func TestBootstrapSecrets_ProviderCredentialPartialRegenerates(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if got := p.stored["SPACES_access_key"]; got != "new-access" {
@@ -199,7 +199,7 @@ func TestBootstrapSecrets_ProviderCredentialProbeIgnoresBareKey(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if generateCalls != 1 {

--- a/cmd/wfctl/infra_e2e_integration_test.go
+++ b/cmd/wfctl/infra_e2e_integration_test.go
@@ -101,7 +101,7 @@ secrets:
 		t.Fatal("phase 1: expected secrets config")
 	}
 	p := &fakeSecretsProvider{stored: map[string]string{}}
-	if err := bootstrapSecrets(context.Background(), p, secretsCfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, secretsCfg); err != nil {
 		t.Fatalf("phase 1 bootstrapSecrets: %v", err)
 	}
 	if p.stored["APP_SECRET"] != "deadbeefcafe1234" {

--- a/cmd/wfctl/infra_output_secrets_test.go
+++ b/cmd/wfctl/infra_output_secrets_test.go
@@ -270,7 +270,7 @@ func TestBootstrapSecrets_SkipsInfraOutputGens(t *testing.T) {
 			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
 		},
 	}
-	if err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
+	if _, err := bootstrapSecrets(context.Background(), p, cfg); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if generatorCalled {


### PR DESCRIPTION
## Research Finding

Confirmed the team-lead's analysis via DO API documentation:

**`POST https://api.digitalocean.com/v2/spaces/buckets` does not exist.** DigitalOcean Spaces is entirely S3-compatible — bucket CRUD uses `PUT /<bucket>` on `https://<region>.digitaloceanspaces.com` with AWS Signature V4 signed by Spaces access keys, not a DO Bearer token. The 404 "Your request could not be routed" was the DO API rejecting an unknown path with the wrong auth scheme.

Two bugs confirmed:
1. **Wrong API + auth**: used the non-existent DO REST endpoint with Bearer token instead of S3 API with Spaces key pair
2. **Wrong order**: `bootstrapStateBackend` (bucket creation) ran before `bootstrapSecrets` (Spaces key generation), so the keys didn't exist yet on first run

## Fix

### 1. Reorder bootstrap: secrets first, state backend second

`runInfraBootstrap` now runs `bootstrapSecrets` before `bootstrapStateBackend`. Freshly generated secrets (including `SPACES_access_key`/`SPACES_secret_key`) are exported via `os.Setenv` into the current process environment so the subsequent `bootstrapStateBackend` can read them via `${VAR}` expansion in the `iac.state` module config.

### 2. S3 API with Spaces credentials

Replaced `bootstrapDOSpacesBucketAt` (wrong REST call) with `bootstrapDOSpacesBucketWithClient` backed by `aws-sdk-go-v2/service/s3` (already in go.mod) pointed at `https://<region>.digitaloceanspaces.com`:
- `HeadBucket` → 200 (exists, skip) or `*types.NotFound` (absent, create)
- `CreateBucket` with `LocationConstraint` for the region
- `BucketAlreadyOwnedByYou` treated as success (concurrent race)
- Any non-404 `HeadBucket` error (e.g. 403 Forbidden — different account) fails fast

`bootstrapStateBackend` now reads `accessKey`/`secretKey` from the expanded module config and passes them to `bootstrapDOSpacesBucketFn`.

### 3. `bootstrapSecrets` returns generated values

Changed `bootstrapSecrets` signature from `error` to `(map[string]string, error)` — the map contains only newly generated key-value pairs, which the caller exports to env. Skipped/pre-existing secrets are excluded.

## BMW `infra.yaml` required change

The `iac.state` module config must reference the Spaces credentials:
```yaml
- name: iac-state
  type: iac.state
  config:
    backend: spaces
    bucket: bmw-iac-state
    region: nyc3
    accessKey: "${SPACES_access_key}"
    secretKey: "${SPACES_secret_key}"
```

## Test plan

- [x] `TestBootstrapDOSpacesBucket_AlreadyExists` — HeadBucket 200 → skip
- [x] `TestBootstrapDOSpacesBucket_CreatesNew` — HeadBucket 404 → CreateBucket with correct bucket+region
- [x] `TestBootstrapDOSpacesBucket_CreateErrorSurfaced` — create error propagates
- [x] `TestBootstrapDOSpacesBucket_HeadFatalError` — non-404 HeadBucket fails fast, no create
- [x] `TestBootstrapDOSpacesBucket_AlreadyOwnedIsOK` — BucketAlreadyOwnedByYou treated as success
- [x] `TestBootstrapDOSpacesBucket_MissingCredentials` — empty access key returns actionable error
- [x] `TestBootstrap_StateBackendAccessKeyExpanded` — accessKey/secretKey expanded and passed through
- [x] All existing env/secrets/e2e bootstrap tests pass
- [x] `GOWORK=off go test ./cmd/wfctl/... -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)