### PR TITLE
fix(bootstrap): parse secrets from original config when --env is set

### DIFF
--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -33,7 +33,14 @@ func runInfraBootstrap(args []string) error {
 		return err
 	}
 
+	// originalCfgFile is used for parseSecretsConfig so that the secrets.generate[]
+	// block is always read from the original YAML. writeEnvResolvedConfig marshals
+	// via config.WorkflowConfig which has no Generate field, so the generate[] section
+	// would be silently dropped from the env-resolved temp file.
+	originalCfgFile := cfgFile
+
 	// If --env is set, resolve the config for that environment before bootstrapping.
+	// cfgFile is reassigned to the temp path; originalCfgFile retains the original.
 	if envName != "" {
 		tmp, resErr := writeEnvResolvedConfig(cfgFile, envName)
 		if resErr != nil {
@@ -49,7 +56,9 @@ func runInfraBootstrap(args []string) error {
 	//    in the current process environment before bootstrapStateBackend runs.
 	//    (DO Spaces bucket creation requires S3 API auth with the Spaces key pair,
 	//    which is generated here via the provider_credential source.)
-	secretsCfg, err := parseSecretsConfig(cfgFile)
+	// Use originalCfgFile — not cfgFile — so the generate[] block is not lost
+	// in the env-resolved temp file's round-trip through config.WorkflowConfig.
+	secretsCfg, err := parseSecretsConfig(originalCfgFile)
 	if err != nil {
 		return fmt.Errorf("parse secrets config: %w", err)
 	}

--- a/cmd/wfctl/infra_bootstrap_env_test.go
+++ b/cmd/wfctl/infra_bootstrap_env_test.go
@@ -325,6 +325,69 @@ modules:
 	}
 }
 
+// ── TestBootstrap_EnvFlagPreservesSecretsGenerate ────────────────────────────
+
+// TestBootstrap_EnvFlagPreservesSecretsGenerate is a regression test for the
+// bug where --env caused parseSecretsConfig to read from the env-resolved temp
+// file, which was marshalled via config.WorkflowConfig (no Generate field) and
+// silently dropped the secrets.generate[] block. The result was "No secrets to
+// generate." followed by "access key must be set" because the Spaces keys were
+// never generated.
+//
+// Fix: runInfraBootstrap must call parseSecretsConfig(originalCfgFile), not
+// parseSecretsConfig(cfgFile) after cfgFile was reassigned to the temp path.
+func TestBootstrap_EnvFlagPreservesSecretsGenerate(t *testing.T) {
+	t.Setenv("TEST_STAGING_SECRET_BUCKET", "staging-bucket")
+	t.Setenv("TEST_STAGING_SECRET_REGION", "sfo3")
+
+	// Track whether bootstrapSecrets was called with a non-empty Generate list.
+	var observedGenerateLen int
+	withStubGenerator(t, func(_ context.Context, _ string, _ map[string]any) (string, error) {
+		observedGenerateLen++ // called once per generated secret
+		return "generated-value", nil
+	})
+
+	// Stub the bucket function so no real S3 call is made.
+	orig := bootstrapDOSpacesBucketFn
+	bootstrapDOSpacesBucketFn = func(_ context.Context, _, _, _, _ string) error { return nil }
+	defer func() { bootstrapDOSpacesBucketFn = orig }()
+
+	// Config has both environments.staging override AND secrets.generate[].
+	// The env resolution will flatten the staging config into modules, but must
+	// NOT drop the secrets block.
+	cfgFile := writeBootstrapConfig(t, `
+modules:
+  - name: tf-state
+    type: iac.state
+    config:
+      backend: spaces
+      bucket: "${TEST_STAGING_SECRET_BUCKET}"
+      region: "${TEST_STAGING_SECRET_REGION}"
+      accessKey: "ak"
+      secretKey: "sk"
+    environments:
+      staging:
+        config:
+          bucket: "${TEST_STAGING_SECRET_BUCKET}"
+
+secrets:
+  provider: env
+  generate:
+    - key: JWT_SECRET
+      type: random_hex
+      length: 32
+`)
+
+	if err := runInfraBootstrap([]string{"--config", cfgFile, "--env", "staging"}); err != nil {
+		t.Fatalf("runInfraBootstrap: %v", err)
+	}
+
+	// The generator must have been called (secrets.generate was not dropped).
+	if observedGenerateLen == 0 {
+		t.Error("secrets.generate[] was not processed — generate[] block was likely dropped by env-resolved config round-trip")
+	}
+}
+
 // ── fakeSecretsProvider ──────────────────────────────────────────────────────
 
 // fakeSecretsProvider is a simple in-memory secrets provider for tests.


### PR DESCRIPTION
## Problem

`wfctl infra bootstrap --env staging` printed "No secrets to generate." and then failed with "access key must be set" — even though `infra.yaml` had a full `secrets.generate:` block.

**Root cause**: `runInfraBootstrap` reassigned `cfgFile` to the env-resolved temp path before calling `parseSecretsConfig`. `writeEnvResolvedConfig` marshals via `config.WorkflowConfig` which has no `Generate` field (that field lives only in `cmd/wfctl/infra_secrets.go`'s `SecretsConfig`). The `secrets.generate[]` block was silently dropped during the YAML → struct → YAML round-trip, so `parseSecretsConfig` saw an empty generate list.

## Fix

One-line capture of `originalCfgFile` before `cfgFile` is reassigned:

```go
originalCfgFile := cfgFile   // ← added

if envName != "" {
    tmp, _ := writeEnvResolvedConfig(cfgFile, envName)
    cfgFile = tmp             // env-resolved temp (modules only)
}

secretsCfg, err := parseSecretsConfig(originalCfgFile)  // ← was cfgFile
```

`bootstrapStateBackend` continues to use `cfgFile` (env-resolved) so per-environment `iac.state` overrides (region, bucket, etc.) are still applied correctly.

## Test plan

- [x] `TestBootstrap_EnvFlagPreservesSecretsGenerate` — regression test: `runInfraBootstrap` with `--env staging` on a config with both `environments.staging` and `secrets.generate[]` verifies the generator is called (generate[] block not dropped)
- [x] All existing bootstrap tests pass
- [x] `GOWORK=off go test ./cmd/wfctl/... -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)