### PR TITLE
fix(config): move SecretGen/InfraConfig to config package to prevent round-trip data loss

### DIFF
--- a/cmd/wfctl/infra_secrets.go
+++ b/cmd/wfctl/infra_secrets.go
@@ -9,25 +9,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// SecretsConfig is the "secrets:" section of an infra config file.
-type SecretsConfig struct {
-	Provider string         `yaml:"provider"`
-	Config   map[string]any `yaml:"config"`
-	Generate []SecretGen    `yaml:"generate"`
-}
-
-// SecretGen describes a secret to generate and store.
-type SecretGen struct {
-	Key    string `yaml:"key"`
-	Type   string `yaml:"type"`   // e.g. "random_hex", "provider_credential"
-	Length int    `yaml:"length"` // for random generators
-	Source string `yaml:"source"` // for provider_credential
-}
-
-// InfraConfig is the "infra:" top-level section of an infra config file.
-type InfraConfig struct {
-	AutoBootstrap *bool `yaml:"auto_bootstrap"`
-}
+// SecretsConfig, SecretGen and InfraConfig are type aliases for the canonical
+// definitions in the config package. Aliases keep all existing cmd/wfctl code
+// (including test files) working without renaming, while ensuring that any
+// round-trip through config.WorkflowConfig preserves the generate[] and
+// infra.auto_bootstrap fields (which were previously dropped because the local
+// struct definitions were not reflected in config.WorkflowConfig).
+type SecretsConfig = config.SecretsConfig
+type SecretGen = config.SecretGen
+type InfraConfig = config.InfraConfig
 
 // parseSecretsConfig reads the "secrets:" top-level key from a YAML file.
 // Returns nil, nil if the section is absent.

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ type WorkflowConfig struct {
 	CI             *CIConfig                     `json:"ci,omitempty" yaml:"ci,omitempty"`
 	Environments   map[string]*EnvironmentConfig `json:"environments,omitempty" yaml:"environments,omitempty"`
 	Secrets        *SecretsConfig                `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Infra          *InfraConfig                  `json:"infra,omitempty" yaml:"infra,omitempty"`
 	SecretStores   map[string]*SecretStoreConfig `json:"secretStores,omitempty" yaml:"secretStores,omitempty"`
 	Services       map[string]*ServiceConfig     `json:"services,omitempty" yaml:"services,omitempty"`
 	Mesh           *MeshConfig                   `json:"mesh,omitempty" yaml:"mesh,omitempty"`

--- a/config/infra_config.go
+++ b/config/infra_config.go
@@ -1,0 +1,10 @@
+package config
+
+// InfraConfig is the "infra:" top-level section of a workflow config file.
+// It lives in the config package so that WorkflowConfig.Infra is preserved
+// when a config round-trips through LoadFromFile / marshal.
+type InfraConfig struct {
+	// AutoBootstrap controls whether `wfctl infra apply` automatically runs
+	// `wfctl infra bootstrap` when no state backend exists yet.
+	AutoBootstrap *bool `json:"auto_bootstrap,omitempty" yaml:"auto_bootstrap,omitempty"`
+}

--- a/config/round_trip_test.go
+++ b/config/round_trip_test.go
@@ -1,0 +1,105 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// TestWorkflowConfig_RoundTrip_PreservesSecretsGenerateAndInfra is a regression
+// test that verifies secrets.generate[] and infra.auto_bootstrap survive a full
+// round-trip through config.WorkflowConfig (load → marshal → reload).
+//
+// Previously, these fields were only declared on cmd/wfctl-local structs and not
+// reflected in config.WorkflowConfig, so writeEnvResolvedConfig (which marshals
+// via WorkflowConfig) silently dropped them. Moving SecretGen/InfraConfig into
+// the config package fixes the round-trip.
+func TestWorkflowConfig_RoundTrip_PreservesSecretsGenerateAndInfra(t *testing.T) {
+	const src = `
+modules:
+  - name: tf-state
+    type: iac.state
+    config:
+      backend: spaces
+      bucket: my-state
+
+secrets:
+  provider: github
+  generate:
+    - key: JWT_SECRET
+      type: random_hex
+      length: 32
+    - key: SPACES
+      type: provider_credential
+      source: digitalocean.spaces
+
+infra:
+  auto_bootstrap: true
+`
+	// Write the source YAML to a temp file.
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(srcPath, []byte(src), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	// Load through config.LoadFromFile (the same path used by writeEnvResolvedConfig).
+	cfg, err := config.LoadFromFile(srcPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+
+	// Assert fields are present in the loaded struct.
+	if cfg.Secrets == nil {
+		t.Fatal("cfg.Secrets is nil after load")
+	}
+	if len(cfg.Secrets.Generate) != 2 {
+		t.Fatalf("cfg.Secrets.Generate: want 2 entries, got %d", len(cfg.Secrets.Generate))
+	}
+	if cfg.Secrets.Generate[0].Key != "JWT_SECRET" {
+		t.Errorf("Generate[0].Key: want %q, got %q", "JWT_SECRET", cfg.Secrets.Generate[0].Key)
+	}
+	if cfg.Secrets.Generate[1].Source != "digitalocean.spaces" {
+		t.Errorf("Generate[1].Source: want %q, got %q", "digitalocean.spaces", cfg.Secrets.Generate[1].Source)
+	}
+	if cfg.Infra == nil {
+		t.Fatal("cfg.Infra is nil after load")
+	}
+	if cfg.Infra.AutoBootstrap == nil || !*cfg.Infra.AutoBootstrap {
+		t.Error("cfg.Infra.AutoBootstrap: want true, got nil or false")
+	}
+
+	// Marshal back to YAML — this is what writeEnvResolvedConfig does.
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Write marshalled YAML to a new temp file and reload.
+	roundTripPath := filepath.Join(dir, "roundtrip.yaml")
+	if err := os.WriteFile(roundTripPath, out, 0o600); err != nil {
+		t.Fatalf("write roundtrip: %v", err)
+	}
+	cfg2, err := config.LoadFromFile(roundTripPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile (roundtrip): %v", err)
+	}
+
+	// Assert both fields survived the round-trip.
+	if cfg2.Secrets == nil {
+		t.Fatal("cfg2.Secrets is nil after round-trip")
+	}
+	if len(cfg2.Secrets.Generate) != 2 {
+		t.Errorf("after round-trip: Generate: want 2 entries, got %d (generate[] was dropped)", len(cfg2.Secrets.Generate))
+	}
+	if cfg2.Infra == nil {
+		t.Fatal("cfg2.Infra is nil after round-trip (infra section was dropped)")
+	}
+	if cfg2.Infra.AutoBootstrap == nil || !*cfg2.Infra.AutoBootstrap {
+		t.Error("after round-trip: Infra.AutoBootstrap: want true, got nil or false")
+	}
+}

--- a/config/secrets_config.go
+++ b/config/secrets_config.go
@@ -6,6 +6,17 @@ type SecretStoreConfig struct {
 	Config   map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
+// SecretGen describes a secret to generate and store during bootstrap.
+// It lives here (rather than cmd/wfctl) so that WorkflowConfig.Secrets.Generate
+// is preserved when a config round-trips through config.LoadFromFile / marshal.
+type SecretGen struct {
+	Key    string `json:"key" yaml:"key"`
+	Type   string `json:"type" yaml:"type"` // e.g. "random_hex", "provider_credential"
+	Length int    `json:"length,omitempty" yaml:"length,omitempty"` // for random generators
+	Source string `json:"source,omitempty" yaml:"source,omitempty"` // for provider_credential
+	Name   string `json:"name,omitempty" yaml:"name,omitempty"`   // optional human-readable label
+}
+
 // SecretsConfig defines secret management for the application.
 type SecretsConfig struct {
 	// DefaultStore names the store (from secretStores) to use when a secret has no explicit store.
@@ -17,6 +28,8 @@ type SecretsConfig struct {
 	Provider string                 `json:"provider,omitempty" yaml:"provider,omitempty"`
 	Config   map[string]any         `json:"config,omitempty" yaml:"config,omitempty"`
 	Rotation *SecretsRotationConfig `json:"rotation,omitempty" yaml:"rotation,omitempty"`
+	// Generate lists secrets to create during `wfctl infra bootstrap`.
+	Generate []SecretGen `json:"generate,omitempty" yaml:"generate,omitempty"`
 }
 
 // SecretsRotationConfig defines default rotation policy.


### PR DESCRIPTION
## Problem

`cmd/wfctl` declared its own `SecretsConfig`, `SecretGen`, and `InfraConfig` types that were not reflected in `config.WorkflowConfig`. When `writeEnvResolvedConfig` marshalled through `WorkflowConfig`, two fields were silently dropped:

| Field | Why dropped |
|---|---|
| `secrets.generate[]` | `config.SecretsConfig` had no `Generate` field |
| `infra.auto_bootstrap` | `config.WorkflowConfig` had no `Infra` field |

This caused the `--env` regression fixed in PR #455 (`originalCfgFile` workaround). PR #455 is a correct workaround, but the structural root cause remained — any future code path reading from the env-resolved temp config would lose these fields.

## Fix

### config package changes

- **`config/secrets_config.go`**: Add `SecretGen` struct (key/type/length/source/name with `omitempty`) and `Generate []SecretGen` field to `SecretsConfig`
- **`config/infra_config.go`** (new): Add `InfraConfig` with `AutoBootstrap *bool`  
- **`config/config.go`**: Add `Infra *InfraConfig` to `WorkflowConfig`

### cmd/wfctl change (minimal)

**`cmd/wfctl/infra_secrets.go`**: Replace local type declarations with Go type aliases:
```go
type SecretsConfig = config.SecretsConfig
type SecretGen     = config.SecretGen
type InfraConfig   = config.InfraConfig
```

Aliases are transparent — all existing cmd/wfctl code and every test file continue to use the bare type names without any rename. No test files changed.

### Round-trip test

`config/round_trip_test.go`: Loads a YAML with `secrets.generate[]` (2 entries) and `infra.auto_bootstrap: true`, marshals via `yaml.Marshal(cfg)`, writes to a new file, reloads, and asserts both fields survived.

## Compatibility with PR #455

PR #455's `originalCfgFile` guard (`TestBootstrap_EnvFlagPreservesSecretsGenerate`) still passes — it's now belt-and-suspenders: with the structural fix, `parseSecretsConfig` could read from the env-resolved temp file and still see `generate[]`. The workaround is harmless and provides defense-in-depth.

## Test plan

- [x] `TestWorkflowConfig_RoundTrip_PreservesSecretsGenerateAndInfra` — new round-trip test
- [x] `TestBootstrap_EnvFlagPreservesSecretsGenerate` — PR #455 regression test still passes
- [x] `GOWORK=off go test ./config/... ./cmd/wfctl/... -race` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)