### PR TITLE
fix(plugin): registry fetch diagnostics + double-v success message

### DIFF
--- a/cmd/wfctl/multi_registry.go
+++ b/cmd/wfctl/multi_registry.go
@@ -56,6 +56,10 @@ func normalizePluginName(name string) string {
 	return strings.TrimPrefix(name, "workflow-plugin-")
 }
 
+// debugRegistryLog is true when the WFCTL_DEBUG environment variable is non-empty.
+// It enables per-source trace logging in FetchManifest to aid CI diagnostics.
+var debugRegistryLog = os.Getenv("WFCTL_DEBUG") != ""
+
 // FetchManifest tries each source in priority order, returning the first successful result.
 // It first tries the original name across all sources; if the original name differs from
 // its normalized form (after stripping the "workflow-plugin-" prefix) and no source
@@ -64,13 +68,35 @@ func normalizePluginName(name string) string {
 // Trying the original name first prevents name collisions where both "auth" (a builtin
 // module plugin) and "workflow-plugin-auth" (an external plugin) exist in the registry —
 // the caller's intent is respected rather than conflating the two.
+//
+// Set WFCTL_DEBUG=1 to enable per-source trace logging on stderr.
 func (m *MultiRegistry) FetchManifest(name string) (*RegistryManifest, string, error) {
+	// Guard against misconfigured / empty registries early so the error message
+	// is actionable rather than "not found in any configured registry" with no
+	// hint about why.
+	if len(m.sources) == 0 {
+		return nil, "", fmt.Errorf("plugin %q not found: no registry sources configured"+
+			" (missing .wfctl.yaml? run `wfctl registry list` or set WFCTL_DEBUG=1)", name)
+	}
+
 	normalized := normalizePluginName(name)
+	if debugRegistryLog {
+		fmt.Fprintf(os.Stderr, "[wfctl debug] FetchManifest %q: %d source(s), normalized=%q\n",
+			name, len(m.sources), normalized)
+	}
 
 	// Try the original name first across all sources.
 	var lastErr error
 	for _, src := range m.sources {
 		manifest, err := src.FetchManifest(name)
+		if debugRegistryLog {
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[wfctl debug]   %s (original %q): %v\n", src.Name(), name, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "[wfctl debug]   %s (original %q): found v%s\n",
+					src.Name(), name, strings.TrimPrefix(manifest.Version, "v"))
+			}
+		}
 		if err == nil {
 			return manifest, src.Name(), nil
 		}
@@ -82,8 +108,20 @@ func (m *MultiRegistry) FetchManifest(name string) (*RegistryManifest, string, e
 	// prefix (e.g. passing "auth" resolves to the registry entry named "auth"
 	// when no entry named "auth" exists under the full original name).
 	if normalized != name {
+		if debugRegistryLog {
+			fmt.Fprintf(os.Stderr, "[wfctl debug] FetchManifest %q: original not found, retrying as normalized %q\n",
+				name, normalized)
+		}
 		for _, src := range m.sources {
 			manifest, err := src.FetchManifest(normalized)
+			if debugRegistryLog {
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "[wfctl debug]   %s (normalized %q): %v\n", src.Name(), normalized, err)
+				} else {
+					fmt.Fprintf(os.Stderr, "[wfctl debug]   %s (normalized %q): found v%s\n",
+						src.Name(), normalized, strings.TrimPrefix(manifest.Version, "v"))
+				}
+			}
 			if err == nil {
 				return manifest, src.Name(), nil
 			}

--- a/cmd/wfctl/multi_registry_test.go
+++ b/cmd/wfctl/multi_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -464,6 +465,52 @@ func TestMultiRegistryFetchNotFound(t *testing.T) {
 	_, _, err := mr.FetchManifest("does-not-exist")
 	if err == nil {
 		t.Fatal("expected error when plugin not found in any registry")
+	}
+}
+
+// TestMultiRegistryFetchNoSources verifies that an empty MultiRegistry returns a
+// clear, actionable error rather than the generic "not found in any configured
+// registry" message (which would be misleading when the real problem is zero sources).
+func TestMultiRegistryFetchNoSources(t *testing.T) {
+	mr := NewMultiRegistryFromSources() // zero sources
+	_, _, err := mr.FetchManifest("any-plugin")
+	if err == nil {
+		t.Fatal("expected error for empty registry")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no registry sources configured") {
+		t.Errorf("error should mention empty sources, got: %q", msg)
+	}
+}
+
+// TestMultiRegistryDebugLogging verifies that setting WFCTL_DEBUG produces
+// trace lines on stderr. We test this by checking the package-level
+// debugRegistryLog flag can be flipped and the function path is exercised.
+// (We do not capture stderr output — just confirm no panic / data race.)
+func TestMultiRegistryDebugLogging_NoSourcesPanic(t *testing.T) {
+	// Temporarily enable debug logging.
+	orig := debugRegistryLog
+	debugRegistryLog = true
+	t.Cleanup(func() { debugRegistryLog = orig })
+
+	src := &mockRegistrySource{
+		name: "test",
+		manifests: map[string]*RegistryManifest{
+			"myplugin": {Name: "myplugin", Version: "v1.0.0"},
+		},
+	}
+	mr := NewMultiRegistryFromSources(src)
+
+	// Should succeed without panicking even with debug on.
+	manifest, srcName, err := mr.FetchManifest("myplugin")
+	if err != nil {
+		t.Fatalf("FetchManifest: %v", err)
+	}
+	if manifest.Name != "myplugin" {
+		t.Errorf("name: got %q, want %q", manifest.Name, "myplugin")
+	}
+	if srcName != "test" {
+		t.Errorf("source: got %q, want %q", srcName, "test")
 	}
 }
 

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -261,7 +261,9 @@ func installPluginFromManifest(dataDir, pluginName string, manifest *RegistryMan
 		return fmt.Errorf("post-install verification failed: %w", verifyErr)
 	}
 
-	fmt.Printf("Installed %s v%s to %s\n", manifest.Name, manifest.Version, destDir)
+	// Strip any existing "v" prefix from the version before printing so that
+	// manifests that store "v0.6.1" don't produce "Installed X vv0.6.1".
+	fmt.Printf("Installed %s v%s to %s\n", manifest.Name, strings.TrimPrefix(manifest.Version, "v"), destDir)
 	return nil
 }
 
@@ -564,7 +566,7 @@ func installFromURL(url, pluginDir string) error {
 	}
 	updateLockfileWithChecksum(pluginName, pj.Version, pj.Repository, "", checksum)
 
-	fmt.Printf("Installed %s v%s to %s\n", pluginName, pj.Version, destDir)
+	fmt.Printf("Installed %s v%s to %s\n", pluginName, strings.TrimPrefix(pj.Version, "v"), destDir)
 	return nil
 }
 
@@ -642,7 +644,7 @@ func installFromLocal(srcDir, pluginDir string) error {
 	}
 	updateLockfileWithChecksum(pluginName, pj.Version, "", "", binaryChecksum)
 
-	fmt.Printf("Installed %s v%s from %s to %s\n", pluginName, pj.Version, srcDir, destDir)
+	fmt.Printf("Installed %s v%s from %s to %s\n", pluginName, strings.TrimPrefix(pj.Version, "v"), srcDir, destDir)
 	return nil
 }
 

--- a/cmd/wfctl/plugin_version_pin_test.go
+++ b/cmd/wfctl/plugin_version_pin_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,85 @@ import (
 	"sync/atomic"
 	"testing"
 )
+
+// TestInstallPluginFromManifest_NoDoubleVInSuccessMessage verifies that when a
+// manifest's Version field already starts with "v" (e.g. "v0.6.1"), the success
+// line printed by installPluginFromManifest reads "Installed X v0.6.1 ..." not
+// "Installed X vv0.6.1 ...".
+func TestInstallPluginFromManifest_NoDoubleVInSuccessMessage(t *testing.T) {
+	const pluginName = "payments"
+	const version = "v0.6.1" // manifest stores version WITH v prefix
+
+	binaryContent := []byte("#!/bin/sh\necho payments\n")
+	tarball := buildPluginTarGz(t, pluginName, binaryContent, minimalPluginJSON(pluginName, version))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/plugins/"+pluginName+"/manifest.json" {
+			m := RegistryManifest{
+				Name:        pluginName,
+				Version:     version, // "v0.6.1" — already has v prefix
+				Author:      "tester",
+				Description: "test",
+				Type:        "external",
+				Tier:        "community",
+				License:     "MIT",
+				Downloads: []PluginDownload{
+					{OS: runtime.GOOS, Arch: runtime.GOARCH,
+						URL: "http://" + r.Host + "/dl/" + pluginName + ".tar.gz"},
+				},
+			}
+			data, _ := json.Marshal(m)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(data) //nolint:errcheck
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, ".tar.gz") {
+			w.Write(tarball) //nolint:errcheck
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfgDir := t.TempDir()
+	regCfg := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	regCfgPath := filepath.Join(cfgDir, "registry.yaml")
+	if err := os.WriteFile(regCfgPath, []byte(regCfg), 0600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	origWD, _ := os.Getwd()
+	_ = os.Chdir(t.TempDir())
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	// Capture stdout to check the success message.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	pluginsDir := t.TempDir()
+	installErr := runPluginInstall([]string{
+		"--config", regCfgPath,
+		"--plugin-dir", pluginsDir,
+		pluginName,
+	})
+
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if installErr != nil {
+		t.Fatalf("runPluginInstall: %v", installErr)
+	}
+	if strings.Contains(output, "vv") {
+		t.Errorf("success message contains double-v: %q", output)
+	}
+	if !strings.Contains(output, "v0.6.1") {
+		t.Errorf("success message should contain v0.6.1: %q", output)
+	}
+}
 
 // TestPinManifestToVersion_VPrefixMismatchSameVersion verifies that when the
 // registry manifest stores a version without a "v" prefix (e.g. "0.6.1") but the


### PR DESCRIPTION
## Summary
- Adds per-source debug logging in MultiRegistry.FetchManifest so failures show which source returned what
- Defensive empty-sources check returns a clearer error
- Fixes the cosmetic `Installed X vv0.6.2` double-v in the install success message

## Why
BMW Deploy logs showed `plugin 'workflow-plugin-payments' not found in any configured registry` even though the same binary works locally for that plugin. The registry-side debug logs + defensive empty-sources check will let us see exactly which source rejected what on the next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)