### PR TITLE
fix(secrets): include DO API response body in spaces key create errors

### DIFF
--- a/secrets/generators.go
+++ b/secrets/generators.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"os"
@@ -165,7 +166,8 @@ func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("secrets: DO spaces key create: HTTP %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", fmt.Errorf("secrets: DO spaces key create: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var result struct {


### PR DESCRIPTION
Same pattern as PR #458 for GitHub: BMW Bootstrap hit `HTTP 400` with no body from DO Spaces key creation. This surfaces the response so we can diagnose.