### PR TITLE
fix(wfctl): rename lockfile to .wfctl-lock.yaml to fix registry config collision

### DIFF
--- a/cmd/wfctl/build_security_audit.go
+++ b/cmd/wfctl/build_security_audit.go
@@ -162,7 +162,7 @@ func auditBuildSecurity(cfg *config.WorkflowConfig, workDir string) []buildAudit
 	hasPlugins := (cfg.Requires != nil && len(cfg.Requires.Plugins) > 0) ||
 		(cfg.Plugins != nil && len(cfg.Plugins.External) > 0)
 	if hasPlugins {
-		lockPath := filepath.Join(workDir, wfctlYAMLPath)
+		lockPath := filepath.Join(workDir, wfctlLockPath)
 		lf, err := loadPluginLockfile(lockPath)
 		if err != nil || len(lf.Plugins) == 0 {
 			add("WARN", "lockfile", fmt.Sprintf("plugins are declared in config but no plugins lockfile found at %s", lockPath))

--- a/cmd/wfctl/build_security_audit_test.go
+++ b/cmd/wfctl/build_security_audit_test.go
@@ -132,8 +132,8 @@ requires:
 `), 0600); err != nil {
 		t.Fatal(err)
 	}
-	// Write .wfctl.yaml lockfile.
-	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(`plugins:
+	// Write .wfctl-lock.yaml lockfile (new canonical path).
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl-lock.yaml"), []byte(`plugins:
   my-plugin:
     version: 1.0.0
 `), 0600); err != nil {

--- a/cmd/wfctl/multi_registry_test.go
+++ b/cmd/wfctl/multi_registry_test.go
@@ -1055,3 +1055,70 @@ func TestNewMultiRegistryPriorityOrder(t *testing.T) {
 		t.Errorf("second source: got %q, want %q", sources[1].Name(), "low-prio")
 	}
 }
+
+// TestLoadRegistryConfig_LockfileCollision is a regression test for the bug where
+// writing a plugin lockfile to .wfctl.yaml caused subsequent LoadRegistryConfig calls
+// to find no registries section and return zero sources, making every install fail with
+// "not found in any configured registry".
+//
+// The fix: LoadRegistryConfig skips YAML files that lack a "registries" key entirely
+// (i.e., have no top-level "registries:" field), falling back to DefaultRegistryConfig.
+func TestLoadRegistryConfig_LockfileCollision(t *testing.T) {
+	// Simulate a .wfctl.yaml that was written as a lockfile (has plugins: but no registries:).
+	lockfileContent := `plugins:
+  authz:
+    version: v0.3.1
+    repository: GoCodeAlone/workflow-plugin-authz
+    sha256: abc123
+  payments:
+    version: v0.1.0
+    repository: GoCodeAlone/workflow-plugin-payments
+`
+	tmpDir := t.TempDir()
+	wfctlYAML := filepath.Join(tmpDir, ".wfctl.yaml")
+	if err := os.WriteFile(wfctlYAML, []byte(lockfileContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change to tmpDir so LoadRegistryConfig finds our fake .wfctl.yaml.
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	// Also redirect HOME so ~/.config/wfctl/config.yaml is not found.
+	t.Setenv("HOME", tmpDir)
+
+	cfg, err := LoadRegistryConfig("")
+	if err != nil {
+		t.Fatalf("LoadRegistryConfig with lockfile at .wfctl.yaml: %v", err)
+	}
+	// Must fall back to defaults — not return empty sources.
+	if len(cfg.Registries) == 0 {
+		t.Fatal("LoadRegistryConfig returned zero registries when .wfctl.yaml is a lockfile; " +
+			"expected fallback to DefaultRegistryConfig")
+	}
+	// Default primary source must be github.
+	if cfg.Registries[0].Type != "github" {
+		t.Errorf("expected github primary source, got %q", cfg.Registries[0].Type)
+	}
+}
+
+// TestLoadRegistryConfig_ExplicitEmptyRegistries verifies that a file with an
+// explicit "registries: []" is respected (not silently skipped), so users can
+// intentionally configure an empty registry list (e.g., in tests or air-gapped envs).
+func TestLoadRegistryConfig_ExplicitEmptyRegistries(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "custom.yaml")
+	if err := os.WriteFile(cfgPath, []byte("registries: []\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadRegistryConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadRegistryConfig: %v", err)
+	}
+	// Explicit empty registries list must be returned as-is (0 sources).
+	if len(cfg.Registries) != 0 {
+		t.Errorf("expected 0 registries for explicit empty list, got %d: %v", len(cfg.Registries), cfg.Registries)
+	}
+}

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -75,7 +75,7 @@ func runPluginInstall(args []string) error {
 	localPath := fs.String("local", "", "Install from a local plugin directory")
 	fromConfig := fs.String("from-config", "", "Install all requires.plugins[] from a workflow config file")
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin install [options] [<name>[@<version>]]\n\nInstall a plugin from the registry, a URL, a local directory, or from the lockfile.\n\n  wfctl plugin install <name>              Install latest from registry\n  wfctl plugin install <name>@v1.0.0       Install specific version\n  wfctl plugin install --url <url>          Install from a direct download URL\n  wfctl plugin install --local <dir>        Install from a local build directory\n  wfctl plugin install --from-config <f>    Install all requires.plugins[] from workflow config\n  wfctl plugin install                      Install all plugins from .wfctl.yaml\n\nOptions:\n")
+		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin install [options] [<name>[@<version>]]\n\nInstall a plugin from the registry, a URL, a local directory, or from the lockfile.\n\n  wfctl plugin install <name>              Install latest from registry\n  wfctl plugin install <name>@v1.0.0       Install specific version\n  wfctl plugin install --url <url>          Install from a direct download URL\n  wfctl plugin install --local <dir>        Install from a local build directory\n  wfctl plugin install --from-config <f>    Install all requires.plugins[] from workflow config\n  wfctl plugin install                      Install all plugins from .wfctl-lock.yaml\n\nOptions:\n")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -110,7 +110,7 @@ func runPluginInstall(args []string) error {
 		return installFromLocal(*localPath, pluginDirVal)
 	}
 
-	// No args: install all plugins from .wfctl.yaml lockfile.
+	// No args: install all plugins from .wfctl-lock.yaml lockfile.
 	if fs.NArg() < 1 {
 		return installFromLockfile(pluginDirVal, *cfgPath)
 	}
@@ -193,7 +193,7 @@ func runPluginInstall(args []string) error {
 		return err
 	}
 
-	// Update .wfctl.yaml lockfile if name@version was provided.
+	// Update .wfctl-lock.yaml lockfile if name@version was provided.
 	if _, ver := parseNameVersion(nameArg); ver != "" {
 		pluginName = normalizePluginName(pluginName)
 		binaryChecksum := ""

--- a/cmd/wfctl/plugin_install_new_test.go
+++ b/cmd/wfctl/plugin_install_new_test.go
@@ -53,7 +53,7 @@ func minimalPluginJSON(name, version string) []byte {
 // with a valid plugin.json, calls installFromURL, and verifies:
 //   - the plugin binary is extracted to <pluginDir>/<normalizedName>/<normalizedName>
 //   - the plugin.json is written
-//   - the lockfile (.wfctl.yaml in cwd) is updated with a checksum
+//   - the lockfile (.wfctl-lock.yaml in cwd) is updated with a checksum
 func TestInstallFromURL(t *testing.T) {
 	const pluginName = "url-test-plugin"
 	binaryContent := []byte("#!/bin/sh\necho url-test\n")
@@ -71,7 +71,7 @@ func TestInstallFromURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Run inside a temp cwd so .wfctl.yaml ends up there, not the repo root.
+	// Run inside a temp cwd so .wfctl-lock.yaml ends up there, not the repo root.
 	origWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
@@ -105,8 +105,8 @@ func TestInstallFromURL(t *testing.T) {
 	}
 
 	// Lockfile should record the plugin with a checksum. It is written to
-	// .wfctl.yaml in the cwd (cwdDir).
-	lockfilePath := filepath.Join(cwdDir, ".wfctl.yaml")
+	// .wfctl-lock.yaml in the cwd (cwdDir).
+	lockfilePath := filepath.Join(cwdDir, ".wfctl-lock.yaml")
 	lf, loadErr := loadPluginLockfile(lockfilePath)
 	if loadErr != nil {
 		t.Fatalf("load lockfile: %v", loadErr)
@@ -177,7 +177,7 @@ func TestInstallFromURL_NameNormalization(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Run in a temp cwd so .wfctl.yaml lockfile stays isolated.
+	// Run in a temp cwd so .wfctl-lock.yaml lockfile stays isolated.
 	origWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -15,7 +15,7 @@ import (
 func runPluginLock(args []string) error {
 	fs := flag.NewFlagSet("plugin lock", flag.ContinueOnError)
 	cfgPath := fs.String("config", "workflow.yaml", "Path to workflow config file")
-	lockPath := fs.String("lock-file", wfctlYAMLPath, "Path to lockfile to write")
+	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile to write")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}

--- a/cmd/wfctl/plugin_lockfile.go
+++ b/cmd/wfctl/plugin_lockfile.go
@@ -9,6 +9,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// wfctlLockPath is the canonical lockfile path.
+// Historically the lockfile shared the same file as the registry config
+// (.wfctl.yaml), which caused a collision: after the first plugin install wrote
+// the lockfile, subsequent LoadRegistryConfig reads found no "registries:" section
+// and fell back to zero sources.  The lockfile is now written to .wfctl-lock.yaml.
+// Backward-compat: loadPluginLockfile falls back to .wfctl.yaml when the new path
+// is absent, and migrates the plugins section on the first write.
+const wfctlLockPath = ".wfctl-lock.yaml"
+
+// wfctlYAMLPath is kept for backward-compat reads and for the project config
+// (git connect, deploy defaults). It is no longer used as the lockfile write target.
 const wfctlYAMLPath = ".wfctl.yaml"
 
 // PluginLockEntry records a pinned plugin version in the lockfile.
@@ -28,12 +39,23 @@ type PluginLockfile struct {
 
 // loadPluginLockfile reads path and returns the plugins section.
 // If the file does not exist, an empty lockfile is returned without error.
+// When path equals wfctlLockPath and the file does not exist, it falls back to
+// wfctlYAMLPath for backward compatibility with repositories that predate the
+// lockfile rename. Content read from the legacy path is transparently migrated
+// on the next Save call (which writes to wfctlLockPath).
 func loadPluginLockfile(path string) (*PluginLockfile, error) {
 	lf := &PluginLockfile{
 		Plugins: make(map[string]PluginLockEntry),
 		raw:     make(map[string]any),
 	}
 	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) && path == wfctlLockPath {
+		// New lockfile absent — try the legacy .wfctl.yaml for migration.
+		data, err = os.ReadFile(wfctlYAMLPath)
+		if os.IsNotExist(err) {
+			return lf, nil
+		}
+	}
 	if os.IsNotExist(err) {
 		return lf, nil
 	}
@@ -56,15 +78,16 @@ func loadPluginLockfile(path string) (*PluginLockfile, error) {
 	return lf, nil
 }
 
-// installFromLockfile reads .wfctl.yaml and installs all plugins in the
-// plugins section. If no lockfile is found, it prints a helpful message.
+// installFromLockfile reads .wfctl-lock.yaml (with .wfctl.yaml fallback) and
+// installs all plugins in the plugins section. If no lockfile is found, it
+// prints a helpful message.
 func installFromLockfile(pluginDir, cfgPath string) error {
-	lf, err := loadPluginLockfile(wfctlYAMLPath)
+	lf, err := loadPluginLockfile(wfctlLockPath)
 	if err != nil {
 		return fmt.Errorf("load lockfile: %w", err)
 	}
 	if len(lf.Plugins) == 0 {
-		fmt.Println("No plugins pinned in .wfctl.yaml.")
+		fmt.Println("No plugins pinned in .wfctl-lock.yaml.")
 		fmt.Println("Run 'wfctl plugin install <name>@<version>' to install and pin a plugin.")
 		return nil
 	}
@@ -105,11 +128,12 @@ func installFromLockfile(pluginDir, cfgPath string) error {
 	return nil
 }
 
-// updateLockfileWithChecksum adds or updates a plugin entry in .wfctl.yaml with SHA-256 checksum.
-// The sha256Hash must be the hash of the installed binary, not the download archive.
+// updateLockfileWithChecksum adds or updates a plugin entry in .wfctl-lock.yaml
+// with SHA-256 checksum. The sha256Hash must be the hash of the installed binary,
+// not the download archive.
 // Silently no-ops if the lockfile cannot be read or written (install still succeeds).
 func updateLockfileWithChecksum(pluginName, version, repository, registry, sha256Hash string) {
-	lf, err := loadPluginLockfile(wfctlYAMLPath)
+	lf, err := loadPluginLockfile(wfctlLockPath)
 	if err != nil {
 		return
 	}
@@ -122,7 +146,7 @@ func updateLockfileWithChecksum(pluginName, version, repository, registry, sha25
 		Registry:   registry,
 		SHA256:     sha256Hash,
 	}
-	_ = lf.Save(wfctlYAMLPath)
+	_ = lf.Save(wfctlLockPath)
 }
 
 // Save writes the lockfile back to path, updating the plugins section while

--- a/cmd/wfctl/plugin_lockfile_test.go
+++ b/cmd/wfctl/plugin_lockfile_test.go
@@ -130,6 +130,70 @@ func TestPluginLockfile_Save_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestLoadPluginLockfile_BackwardCompatFallback verifies that when wfctlLockPath
+// (.wfctl-lock.yaml) does not exist, loadPluginLockfile transparently reads the
+// legacy .wfctl.yaml so repos created before the rename still work.
+func TestLoadPluginLockfile_BackwardCompatFallback(t *testing.T) {
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// Write plugins to the legacy .wfctl.yaml (no .wfctl-lock.yaml present).
+	legacyContent := `plugins:
+  authz:
+    version: v0.3.1
+    sha256: abc123
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".wfctl.yaml"), []byte(legacyContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	lf, err := loadPluginLockfile(wfctlLockPath)
+	if err != nil {
+		t.Fatalf("loadPluginLockfile (legacy fallback): %v", err)
+	}
+	if _, ok := lf.Plugins["authz"]; !ok {
+		t.Fatalf("expected authz plugin from legacy .wfctl.yaml fallback; entries: %v", lf.Plugins)
+	}
+}
+
+// TestLoadPluginLockfile_NewPathTakesPrecedence verifies that when both
+// .wfctl-lock.yaml and the legacy .wfctl.yaml exist, the new path is used.
+func TestLoadPluginLockfile_NewPathTakesPrecedence(t *testing.T) {
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	newContent := `plugins:
+  authz:
+    version: v1.0.0
+`
+	legacyContent := `plugins:
+  authz:
+    version: v0.1.0
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, wfctlLockPath), []byte(newContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, wfctlYAMLPath), []byte(legacyContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	lf, err := loadPluginLockfile(wfctlLockPath)
+	if err != nil {
+		t.Fatalf("loadPluginLockfile: %v", err)
+	}
+	if got := lf.Plugins["authz"].Version; got != "v1.0.0" {
+		t.Errorf("expected version from new lockfile v1.0.0, got %q (legacy file took precedence)", got)
+	}
+}
+
 func TestPluginInstall_FromConfig_NoRequires(t *testing.T) {
 	dir := t.TempDir()
 	cfg := "modules: []\n"

--- a/cmd/wfctl/plugin_registry.go
+++ b/cmd/wfctl/plugin_registry.go
@@ -129,7 +129,8 @@ func ListPluginNames() ([]string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("registry API returned HTTP %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("registry API returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var entries []githubContentsEntry
 	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {

--- a/cmd/wfctl/registry_config.go
+++ b/cmd/wfctl/registry_config.go
@@ -69,6 +69,21 @@ func LoadRegistryConfig(explicitPath string) (*RegistryConfig, error) {
 		if err != nil {
 			continue
 		}
+		// First, check whether the file contains a "registries" key at all.
+		// A lockfile (plugins: ...) has no such key, and silently treating it as
+		// an empty registry config would cause "no registry sources configured"
+		// for every subsequent plugin install.
+		// We distinguish "key absent" (lockfile / unrelated file → skip) from
+		// "key present but empty" (intentional empty config → respect it).
+		var raw map[string]any
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return nil, fmt.Errorf("parse registry config %s: %w", p, err)
+		}
+		if _, hasKey := raw["registries"]; !hasKey {
+			// No "registries" key — this is probably a lockfile or project config.
+			// Fall through to the next candidate.
+			continue
+		}
 		var cfg RegistryConfig
 		if err := yaml.Unmarshal(data, &cfg); err != nil {
 			return nil, fmt.Errorf("parse registry config %s: %w", p, err)

--- a/cmd/wfctl/registry_validate.go
+++ b/cmd/wfctl/registry_validate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -122,12 +123,19 @@ func ValidateManifest(m *RegistryManifest, opts ValidationOptions) []ValidationE
 					Message: fmt.Sprintf("URL unreachable: %v", err),
 				})
 			} else {
-				resp.Body.Close()
 				if resp.StatusCode >= 400 {
+					body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+					resp.Body.Close()
+					msg := fmt.Sprintf("URL returned HTTP %d", resp.StatusCode)
+					if s := strings.TrimSpace(string(body)); s != "" {
+						msg += ": " + s
+					}
 					errs = append(errs, ValidationError{
 						Field:   fmt.Sprintf("downloads[%d].url", i),
-						Message: fmt.Sprintf("URL returned HTTP %d", resp.StatusCode),
+						Message: msg,
 					})
+				} else {
+					resp.Body.Close()
 				}
 			}
 		}

--- a/cmd/wfctl/update.go
+++ b/cmd/wfctl/update.go
@@ -201,7 +201,8 @@ func fetchLatestRelease() (*githubRelease, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned HTTP %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("GitHub API returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var rel githubRelease


### PR DESCRIPTION
## Summary

- **Root cause**: `.wfctl.yaml` was shared between the plugin lockfile and registry config. After the first `plugin install` wrote `plugins:` to `.wfctl.yaml`, subsequent `LoadRegistryConfig` found no `registries:` section → zero sources → "not found in any configured registry" for every 2nd+ plugin install.
- **Fix 1**: Rename lockfile to `.wfctl-lock.yaml` (`wfctlLockPath`). Backward compat: `loadPluginLockfile` falls back to legacy `.wfctl.yaml` when `.wfctl-lock.yaml` is absent, migrating transparently on next write.
- **Fix 2**: `LoadRegistryConfig` skips YAML files that have no `"registries"` key at all (lockfiles, project configs), falling back to `DefaultRegistryConfig`. Distinguishes "key absent" (skip) from `"registries: []"` (explicit empty list — respected as-is).
- **Bonus (Task #48)**: Added response body to three remaining opaque HTTP error sites: `plugin_registry.go`, `update.go`, `registry_validate.go`.

## Test plan

- [ ] `TestLoadRegistryConfig_LockfileCollision` — regression test: lockfile at `.wfctl.yaml` → falls back to defaults, non-zero sources
- [ ] `TestLoadRegistryConfig_ExplicitEmptyRegistries` — explicit `registries: []` is respected (not skipped)
- [ ] `TestLoadPluginLockfile_BackwardCompatFallback` — legacy `.wfctl.yaml` plugins are read when `.wfctl-lock.yaml` is absent
- [ ] `TestLoadPluginLockfile_NewPathTakesPrecedence` — new path wins when both files exist
- [ ] All existing `./cmd/wfctl/...` tests pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)