### PR TITLE
fix(secrets): use fullaccess grant for DO spaces keys without specific bucket

### DIFF
--- a/secrets/generators.go
+++ b/secrets/generators.go
@@ -149,7 +149,20 @@ func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, er
 		name = "workflow-spaces-key"
 	}
 
-	payload := map[string]any{"name": name, "grants": []map[string]any{{"bucket": "*", "permission": "readwrite"}}}
+	// DO Spaces Keys API requires a concrete bucket name (3-63 chars) when
+	// using "read" / "write" / "readwrite" permissions. A wildcard bucket
+	// value is rejected ("bucket name must be 3 to 63 characters long").
+	// If the caller passes `bucket:` in config, grant that specific bucket;
+	// otherwise use "fullaccess" which needs no bucket and is the right
+	// default for a bootstrap key that manages its own IaC state bucket.
+	bucket, _ := config["bucket"].(string)
+	var grant map[string]any
+	if bucket != "" {
+		grant = map[string]any{"bucket": bucket, "permission": "readwrite"}
+	} else {
+		grant = map[string]any{"permission": "fullaccess"}
+	}
+	payload := map[string]any{"name": name, "grants": []map[string]any{grant}}
 	body, _ := json.Marshal(payload)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.digitalocean.com/v2/spaces/keys", bytes.NewReader(body))

--- a/secrets/generators_test.go
+++ b/secrets/generators_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,6 +125,116 @@ func TestGenerateSecret_ProviderCredential_DOSpaces(t *testing.T) {
 	}
 	if result["secret_key"] != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
 		t.Errorf("secret_key = %q", result["secret_key"])
+	}
+}
+
+// TestGenerateSecret_ProviderCredential_DOSpaces_NoBucket is a regression test
+// for the bug where the DO Spaces Keys API was called with bucket:"*" and rejected
+// with "bucket name must be 3 to 63 characters long".
+// When no bucket is in config the grant must use permission:"fullaccess" with no
+// bucket field — which is both what the API accepts and the right default for a
+// bootstrap key that will manage its own IaC state bucket.
+func TestGenerateSecret_ProviderCredential_DOSpaces_NoBucket(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/spaces/keys" {
+			http.NotFound(w, r)
+			return
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"key": map[string]string{
+				"access_key": "AKIAIOSFODNN7EXAMPLE",
+				"secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("DIGITALOCEAN_TOKEN", "test-do-token")
+	orig := http.DefaultClient.Transport
+	http.DefaultClient.Transport = rewriteTransport{base: srv.URL}
+	defer func() { http.DefaultClient.Transport = orig }()
+
+	_, err := GenerateSecret(context.Background(), "provider_credential", map[string]any{
+		"source": "digitalocean.spaces",
+		"name":   "bootstrap-key",
+		// No "bucket" key — simulates first-time bootstrap before bucket exists.
+	})
+	if err != nil {
+		t.Fatalf("GenerateSecret (no bucket): %v", err)
+	}
+
+	// Parse what was actually sent to the API.
+	var payload map[string]any
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	grants, _ := payload["grants"].([]any)
+	if len(grants) != 1 {
+		t.Fatalf("expected 1 grant, got %d: %v", len(grants), grants)
+	}
+	grant, _ := grants[0].(map[string]any)
+
+	// Must use fullaccess (no bucket field) — DO API rejects bucket:"*".
+	if perm, _ := grant["permission"].(string); perm != "fullaccess" {
+		t.Errorf("grant.permission = %q, want %q (no bucket → fullaccess)", perm, "fullaccess")
+	}
+	if _, hasBucket := grant["bucket"]; hasBucket {
+		t.Errorf("grant must not have a bucket field when no bucket is configured, got: %v", grant)
+	}
+}
+
+// TestGenerateSecret_ProviderCredential_DOSpaces_WithBucket verifies that when a
+// bucket name is supplied in config, the grant uses readwrite permission scoped
+// to that specific bucket.
+func TestGenerateSecret_ProviderCredential_DOSpaces_WithBucket(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/spaces/keys" {
+			http.NotFound(w, r)
+			return
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"key": map[string]string{
+				"access_key": "AKIAIOSFODNN7EXAMPLE",
+				"secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("DIGITALOCEAN_TOKEN", "test-do-token")
+	orig := http.DefaultClient.Transport
+	http.DefaultClient.Transport = rewriteTransport{base: srv.URL}
+	defer func() { http.DefaultClient.Transport = orig }()
+
+	_, err := GenerateSecret(context.Background(), "provider_credential", map[string]any{
+		"source": "digitalocean.spaces",
+		"bucket": "my-state-bucket",
+	})
+	if err != nil {
+		t.Fatalf("GenerateSecret (with bucket): %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	grants, _ := payload["grants"].([]any)
+	if len(grants) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(grants))
+	}
+	grant, _ := grants[0].(map[string]any)
+
+	if perm, _ := grant["permission"].(string); perm != "readwrite" {
+		t.Errorf("grant.permission = %q, want %q", perm, "readwrite")
+	}
+	if b, _ := grant["bucket"].(string); b != "my-state-bucket" {
+		t.Errorf("grant.bucket = %q, want %q", b, "my-state-bucket")
 	}
 }
 


### PR DESCRIPTION
DO Spaces Keys API rejected our `bucket: "*"` wildcard with `HTTP 400 "bucket name must be 3 to 63 characters long"`. When no bucket is specified in config, use permission=fullaccess (no bucket field required).