### PR TITLE
fix(wfctl): preserve iacProvider in installed plugin.json

### DIFF
--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -480,14 +480,19 @@ func runPluginInfo(args []string) error {
 	if m.Repository != "" {
 		fmt.Printf("Repository:   %s\n", m.Repository)
 	}
-	if len(m.ModuleTypes) > 0 {
-		fmt.Printf("Module Types: %s\n", strings.Join(m.ModuleTypes, ", "))
-	}
-	if len(m.StepTypes) > 0 {
-		fmt.Printf("Step Types:   %s\n", strings.Join(m.StepTypes, ", "))
-	}
-	if len(m.TriggerTypes) > 0 {
-		fmt.Printf("Trigger Types: %s\n", strings.Join(m.TriggerTypes, ", "))
+	if m.Capabilities != nil {
+		if len(m.Capabilities.ModuleTypes) > 0 {
+			fmt.Printf("Module Types: %s\n", strings.Join(m.Capabilities.ModuleTypes, ", "))
+		}
+		if len(m.Capabilities.StepTypes) > 0 {
+			fmt.Printf("Step Types:   %s\n", strings.Join(m.Capabilities.StepTypes, ", "))
+		}
+		if len(m.Capabilities.TriggerTypes) > 0 {
+			fmt.Printf("Trigger Types: %s\n", strings.Join(m.Capabilities.TriggerTypes, ", "))
+		}
+		if m.Capabilities.IaCProvider != nil {
+			fmt.Printf("IaC Provider: %s\n", m.Capabilities.IaCProvider.Name)
+		}
 	}
 	if len(m.Tags) > 0 {
 		fmt.Printf("Tags:         %s\n", strings.Join(m.Tags, ", "))
@@ -862,20 +867,27 @@ func safeJoin(base, name string) (string, error) {
 
 // installedPluginJSON is the JSON format for plugin.json written after install.
 // This must be compatible with plugin.PluginManifest so that
-// ExternalPluginManager.LoadPlugin() can validate it.
+// ExternalPluginManager.LoadPlugin() can validate it AND compatible with
+// wfctl's deploy_providers.iacPluginManifest so findIaCPluginDir can read
+// capabilities.iacProvider.name.
 type installedPluginJSON struct {
-	Name         string   `json:"name"`
-	Version      string   `json:"version"`
-	Author       string   `json:"author"`
-	Description  string   `json:"description"`
-	License      string   `json:"license,omitempty"`
-	Repository   string   `json:"repository,omitempty"`
-	Tier         string   `json:"tier,omitempty"`
-	Tags         []string `json:"tags,omitempty"`
-	Type         string   `json:"type,omitempty"`
-	ModuleTypes  []string `json:"moduleTypes,omitempty"`
-	StepTypes    []string `json:"stepTypes,omitempty"`
-	TriggerTypes []string `json:"triggerTypes,omitempty"`
+	Name         string                       `json:"name"`
+	Version      string                       `json:"version"`
+	Author       string                       `json:"author"`
+	Description  string                       `json:"description"`
+	License      string                       `json:"license,omitempty"`
+	Repository   string                       `json:"repository,omitempty"`
+	Tier         string                       `json:"tier,omitempty"`
+	Tags         []string                     `json:"tags,omitempty"`
+	Type         string                       `json:"type,omitempty"`
+	Capabilities *installedPluginCapabilities `json:"capabilities,omitempty"`
+}
+
+type installedPluginCapabilities struct {
+	ModuleTypes  []string             `json:"moduleTypes,omitempty"`
+	StepTypes    []string             `json:"stepTypes,omitempty"`
+	TriggerTypes []string             `json:"triggerTypes,omitempty"`
+	IaCProvider  *RegistryIaCProvider `json:"iacProvider,omitempty"`
 }
 
 // writeInstalledManifest writes a full plugin.json compatible with the engine's
@@ -893,9 +905,12 @@ func writeInstalledManifest(path string, m *RegistryManifest) error {
 		Type:        m.Type,
 	}
 	if m.Capabilities != nil {
-		pj.ModuleTypes = m.Capabilities.ModuleTypes
-		pj.StepTypes = m.Capabilities.StepTypes
-		pj.TriggerTypes = m.Capabilities.TriggerTypes
+		pj.Capabilities = &installedPluginCapabilities{
+			ModuleTypes:  m.Capabilities.ModuleTypes,
+			StepTypes:    m.Capabilities.StepTypes,
+			TriggerTypes: m.Capabilities.TriggerTypes,
+			IaCProvider:  m.Capabilities.IaCProvider,
+		}
 	}
 	data, err := json.MarshalIndent(pj, "", "  ")
 	if err != nil {

--- a/cmd/wfctl/plugin_install_e2e_test.go
+++ b/cmd/wfctl/plugin_install_e2e_test.go
@@ -196,11 +196,14 @@ func TestPluginInstallE2E(t *testing.T) {
 	if pj.Type != "external" {
 		t.Errorf("plugin.json type: got %q, want %q", pj.Type, "external")
 	}
-	if len(pj.ModuleTypes) != 1 || pj.ModuleTypes[0] != "test.module" {
-		t.Errorf("plugin.json moduleTypes: got %v, want [test.module]", pj.ModuleTypes)
+	if pj.Capabilities == nil {
+		t.Fatalf("plugin.json capabilities is nil, want ModuleTypes + StepTypes")
 	}
-	if len(pj.StepTypes) != 1 || pj.StepTypes[0] != "step.test_action" {
-		t.Errorf("plugin.json stepTypes: got %v, want [step.test_action]", pj.StepTypes)
+	if len(pj.Capabilities.ModuleTypes) != 1 || pj.Capabilities.ModuleTypes[0] != "test.module" {
+		t.Errorf("plugin.json capabilities.moduleTypes: got %v, want [test.module]", pj.Capabilities.ModuleTypes)
+	}
+	if len(pj.Capabilities.StepTypes) != 1 || pj.Capabilities.StepTypes[0] != "step.test_action" {
+		t.Errorf("plugin.json capabilities.stepTypes: got %v, want [step.test_action]", pj.Capabilities.StepTypes)
 	}
 
 	// --- Step 7: ExternalPluginManager.DiscoverPlugins ---
@@ -814,7 +817,9 @@ func TestPluginUpdateFallbackToRepo(t *testing.T) {
 		Tier:        "core",
 		License:     "MIT",
 		Repository:  fmt.Sprintf("https://github.com/%s/%s", owner, pluginName),
-		ModuleTypes: []string{"authz.casbin"},
+		Capabilities: &installedPluginCapabilities{
+			ModuleTypes: []string{"authz.casbin"},
+		},
 	}
 	installedJSONBytes, _ := json.Marshal(installedJSON)
 	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), installedJSONBytes, 0640); err != nil {

--- a/cmd/wfctl/plugin_registry.go
+++ b/cmd/wfctl/plugin_registry.go
@@ -44,11 +44,21 @@ type RegistryManifest struct {
 
 // RegistryCapabilities describes what module/step/trigger types a plugin provides.
 type RegistryCapabilities struct {
-	ConfigProvider   bool     `json:"configProvider,omitempty"`
-	ModuleTypes      []string `json:"moduleTypes,omitempty"`
-	StepTypes        []string `json:"stepTypes,omitempty"`
-	TriggerTypes     []string `json:"triggerTypes,omitempty"`
-	WorkflowHandlers []string `json:"workflowHandlers,omitempty"`
+	ConfigProvider   bool                 `json:"configProvider,omitempty"`
+	ModuleTypes      []string             `json:"moduleTypes,omitempty"`
+	StepTypes        []string             `json:"stepTypes,omitempty"`
+	TriggerTypes     []string             `json:"triggerTypes,omitempty"`
+	WorkflowHandlers []string             `json:"workflowHandlers,omitempty"`
+	IaCProvider      *RegistryIaCProvider `json:"iacProvider,omitempty"`
+}
+
+// RegistryIaCProvider describes an IaC provider plugin's provider name and the
+// infra.* resource types it manages. findIaCPluginDir reads this from the
+// installed plugin.json to match a requested provider name (e.g. "digitalocean")
+// to a plugin directory.
+type RegistryIaCProvider struct {
+	Name          string   `json:"name"`
+	ResourceTypes []string `json:"resourceTypes,omitempty"`
 }
 
 // PluginDownload describes a platform-specific binary download for a plugin.


### PR DESCRIPTION
Installed plugin.json was missing the capabilities.iacProvider block, breaking BMW's deploy lookup for 'digitalocean' provider.