### PR TITLE
fix: v0.18.1 polish — address review follow-ups on a48a9b7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-04-22
+
+### Fixed
+
+Post-hoc review (two independent agents audited commit `a48a9b7`) surfaced the
+following items; all fixed in #467 (`fix/v0.18.1-polish`).
+
+- **gofmt alignment** — `interfaces/iac_canonical_types.go`, `module/tenants.go`,
+  `cmd/wfctl/scaffold_dockerfile_test.go` had minor formatting drift; corrected.
+- **Missing nil-DB test** — `TestNewSQLTenantRegistry_NilDB` asserts the constructor
+  returns a descriptive error ("cfg.DB is required") when `DB` is nil.
+- **Cache-disabled coverage** — `TestNewSQLTenantRegistry_CacheDisabled` exercises
+  the full `Ensure → GetBySlug → Disable → GetBySlug` sequence with `CacheSize=-1`,
+  proving nil-cache code paths do not panic.
+- **Transient-error propagation** — `TestEnsure_PropagatesNonNotFoundError` guards
+  against a regression where a transient DB error could be silently swallowed and
+  trigger a spurious `INSERT`.
+- **Stale domain-cache invalidation** — `TestUpdate_InvalidatesStaleDomainCache`
+  verifies that after `Update` changes a tenant's domains, the old domain key is
+  evicted from the LRU cache so the next `GetByDomain` goes to the DB.
+- **Mixed-case subdomain matching** — `TestSubdomainSelector_MixedCase` confirms
+  that both the root domain and the incoming host are lowercased before comparison,
+  returning a consistent lowercase tenant key.
+- **Dockerfile validation subtests** — `TestValidateBaseImage_FullyQualifiedRefs`
+  converted to `t.Run` subtests with five additional cases: digest-only ref,
+  registry-with-port, tag+digest combined, empty string, and `docker.io/library/alpine`.
+- **Double-slug in Ensure error** — the outer `fmt.Errorf` in `Ensure` no longer
+  re-embeds the slug (it was already present in the wrapped `GetBySlug` error).
+- **Misleading scaffold comment** — replaced the ambiguous comment at
+  `scaffold_dockerfile.go:181` with a precise description of the colon-after-last-slash
+  heuristic used to distinguish tag separators from registry host:port colons.
+- **Hand-rolled string helpers removed** — `splitByNewline`, `splitLines`, and
+  `joinLines` in `module/tenants_test.go` replaced with `strings.Split` /
+  `strings.Join`.
+
+### Breaking changes
+
+- **`TenantSpec.Slug` must be all-lowercase.** `TenantSpec.Validate()` now returns
+  `ErrValidation` when `Slug != strings.ToLower(Slug)`. Mixed-case slugs were
+  previously accepted and stored verbatim, which caused cache-key collisions and
+  inconsistent URL routing. If you have existing tenants with mixed-case slugs,
+  lowercase the `slug` column before upgrading.
+- **`SubdomainSelector` now returns a lowercase subdomain key.** The host header is
+  already lowercased before suffix matching, so the returned key is always lowercase.
+  `HostSelector` has had this behaviour since v0.18.0; this change makes both
+  selectors consistent. If your code compared the key against a mixed-case string,
+  update the comparison.
+
 ## [0.18.0] - 2026-04-22
 
 ### Added

--- a/cmd/wfctl/scaffold_dockerfile.go
+++ b/cmd/wfctl/scaffold_dockerfile.go
@@ -177,7 +177,8 @@ func imageBaseName(ref string) string {
 	if idx := strings.Index(ref, "@"); idx != -1 {
 		ref = ref[:idx]
 	}
-	// Strip tag (last colon that is not part of a registry host:port).
+	// A colon after the last slash is a tag separator; a colon before the last
+	// slash (e.g. registry host:port) is part of the address.
 	if idx := strings.LastIndex(ref, ":"); idx != -1 && !strings.Contains(ref[idx:], "/") {
 		ref = ref[:idx]
 	}

--- a/cmd/wfctl/scaffold_dockerfile.go
+++ b/cmd/wfctl/scaffold_dockerfile.go
@@ -196,7 +196,7 @@ func validateBaseImage(base string, allowShell bool) error {
 	name := imageBaseName(base)
 
 	for _, s := range shellContainingBases {
-		if name == strings.ToLower(s) {
+		if strings.EqualFold(name, s) {
 			if !allowShell {
 				return fmt.Errorf("base image %q contains a shell — use a distroless image or pass --allow-shell to override", base)
 			}
@@ -205,7 +205,7 @@ func validateBaseImage(base string, allowShell bool) error {
 	}
 
 	for _, w := range glibcWarningBases {
-		if name == strings.ToLower(w) {
+		if strings.EqualFold(name, w) {
 			fmt.Fprintf(os.Stderr, "warning: base image %q has a large attack surface; consider gcr.io/distroless/base-debian12:nonroot\n", base)
 			return nil
 		}

--- a/cmd/wfctl/scaffold_dockerfile_test.go
+++ b/cmd/wfctl/scaffold_dockerfile_test.go
@@ -160,26 +160,43 @@ func TestScaffoldDockerfile_InvalidMode(t *testing.T) {
 }
 
 func TestValidateBaseImage_FullyQualifiedRefs(t *testing.T) {
-	// Fully-qualified ubuntu refs should be blocked the same as short "ubuntu:22.04".
+	// Fully-qualified and edge-case image refs tested via subtests.
 	cases := []struct {
 		image      string
 		allowShell bool
 		wantErr    bool
 	}{
+		// Fully-qualified ubuntu refs blocked same as short "ubuntu:22.04".
 		{"docker.io/library/ubuntu:22.04", false, true},
 		{"docker.io/library/ubuntu:22.04", true, false},
 		{"ghcr.io/org/ubuntu:22.04", false, true},
 		{"ghcr.io/org/ubuntu:22.04", true, false},
-		{"docker.io/library/alpine:3.20", false, false}, // warning only, no error
+		// Alpine: warning only, no error.
+		{"docker.io/library/alpine:3.20", false, false},
+		// Distroless: always allowed.
 		{"gcr.io/distroless/base-debian12:nonroot", false, false},
+		// Digest-only form: base name resolves to "ubuntu" → blocked.
+		{"ubuntu@sha256:aaaabbbbccccdddd0000111122223333", false, true},
+		// Registry with port: base name resolves to "ubuntu" → blocked.
+		{"registry.internal:5000/library/ubuntu:22.04", false, true},
+		// Tag+digest combined: base name resolves to "ubuntu" → blocked.
+		{"ubuntu:22.04@sha256:aaaabbbb11112222", false, true},
+		// Empty string: no match against any blocked or warning base → no error, no panic.
+		{"", false, false},
+		// Allowed minimal base via docker.io path.
+		{"docker.io/library/alpine:3.20", false, false},
 	}
 	for _, tc := range cases {
-		err := validateBaseImage(tc.image, tc.allowShell)
-		if tc.wantErr && err == nil {
-			t.Errorf("validateBaseImage(%q, allowShell=%v): expected error, got nil", tc.image, tc.allowShell)
-		}
-		if !tc.wantErr && err != nil {
-			t.Errorf("validateBaseImage(%q, allowShell=%v): unexpected error: %v", tc.image, tc.allowShell, err)
-		}
+		tc := tc
+		t.Run(tc.image, func(t *testing.T) {
+			t.Helper()
+			err := validateBaseImage(tc.image, tc.allowShell)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateBaseImage(%q, allowShell=%v): expected error, got nil", tc.image, tc.allowShell)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateBaseImage(%q, allowShell=%v): unexpected error: %v", tc.image, tc.allowShell, err)
+			}
+		})
 	}
 }

--- a/cmd/wfctl/scaffold_dockerfile_test.go
+++ b/cmd/wfctl/scaffold_dockerfile_test.go
@@ -162,9 +162,9 @@ func TestScaffoldDockerfile_InvalidMode(t *testing.T) {
 func TestValidateBaseImage_FullyQualifiedRefs(t *testing.T) {
 	// Fully-qualified ubuntu refs should be blocked the same as short "ubuntu:22.04".
 	cases := []struct {
-		image     string
+		image      string
 		allowShell bool
-		wantErr   bool
+		wantErr    bool
 	}{
 		{"docker.io/library/ubuntu:22.04", false, true},
 		{"docker.io/library/ubuntu:22.04", true, false},

--- a/cmd/wfctl/scaffold_dockerfile_test.go
+++ b/cmd/wfctl/scaffold_dockerfile_test.go
@@ -183,8 +183,8 @@ func TestValidateBaseImage_FullyQualifiedRefs(t *testing.T) {
 		{"ubuntu:22.04@sha256:aaaabbbb11112222", false, true},
 		// Empty string: no match against any blocked or warning base → no error, no panic.
 		{"", false, false},
-		// Allowed minimal base via docker.io path.
-		{"docker.io/library/alpine:3.20", false, false},
+		// Busybox via fully-qualified path: shell-containing → blocked without --allow-shell.
+		{"docker.io/library/busybox:1.36", false, true},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/interfaces/iac_canonical_types.go
+++ b/interfaces/iac_canonical_types.go
@@ -3,59 +3,59 @@ package interfaces
 // JobSpec describes a one-off or scheduled job workload.
 // Kind is one of: PRE_DEPLOY, POST_DEPLOY, FAILED_DEPLOY, SCHEDULED.
 type JobSpec struct {
-	Name            string            `json:"name" yaml:"name"`
-	Kind            string            `json:"kind" yaml:"kind"`
-	Image           string            `json:"image,omitempty" yaml:"image,omitempty"`
-	RunCommand      string            `json:"run_command" yaml:"run_command"`
-	EnvVars         map[string]string `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
-	EnvVarsSecret   map[string]string `json:"env_vars_secret,omitempty" yaml:"env_vars_secret,omitempty"`
-	Cron            string            `json:"cron,omitempty" yaml:"cron,omitempty"` // non-empty for SCHEDULED kind
-	Termination     *TerminationSpec  `json:"termination,omitempty" yaml:"termination,omitempty"`
-	Alerts          []AlertSpec       `json:"alerts,omitempty" yaml:"alerts,omitempty"`
-	LogDestinations []LogDestinationSpec `json:"log_destinations,omitempty" yaml:"log_destinations,omitempty"`
-}
-
-// WorkerSpec describes a long-running background worker workload.
-type WorkerSpec struct {
 	Name            string               `json:"name" yaml:"name"`
+	Kind            string               `json:"kind" yaml:"kind"`
 	Image           string               `json:"image,omitempty" yaml:"image,omitempty"`
 	RunCommand      string               `json:"run_command" yaml:"run_command"`
 	EnvVars         map[string]string    `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
 	EnvVarsSecret   map[string]string    `json:"env_vars_secret,omitempty" yaml:"env_vars_secret,omitempty"`
-	InstanceCount   int                  `json:"instance_count" yaml:"instance_count"`
-	Size            string               `json:"size,omitempty" yaml:"size,omitempty"`
-	Autoscaling     *AutoscalingSpec     `json:"autoscaling,omitempty" yaml:"autoscaling,omitempty"`
-	HealthCheck     *HealthCheckSpec     `json:"health_check,omitempty" yaml:"health_check,omitempty"`
-	Resources       *WorkloadResourceSpec `json:"resources,omitempty" yaml:"resources,omitempty"`
+	Cron            string               `json:"cron,omitempty" yaml:"cron,omitempty"` // non-empty for SCHEDULED kind
 	Termination     *TerminationSpec     `json:"termination,omitempty" yaml:"termination,omitempty"`
 	Alerts          []AlertSpec          `json:"alerts,omitempty" yaml:"alerts,omitempty"`
 	LogDestinations []LogDestinationSpec `json:"log_destinations,omitempty" yaml:"log_destinations,omitempty"`
 }
 
+// WorkerSpec describes a long-running background worker workload.
+type WorkerSpec struct {
+	Name            string                `json:"name" yaml:"name"`
+	Image           string                `json:"image,omitempty" yaml:"image,omitempty"`
+	RunCommand      string                `json:"run_command" yaml:"run_command"`
+	EnvVars         map[string]string     `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
+	EnvVarsSecret   map[string]string     `json:"env_vars_secret,omitempty" yaml:"env_vars_secret,omitempty"`
+	InstanceCount   int                   `json:"instance_count" yaml:"instance_count"`
+	Size            string                `json:"size,omitempty" yaml:"size,omitempty"`
+	Autoscaling     *AutoscalingSpec      `json:"autoscaling,omitempty" yaml:"autoscaling,omitempty"`
+	HealthCheck     *HealthCheckSpec      `json:"health_check,omitempty" yaml:"health_check,omitempty"`
+	Resources       *WorkloadResourceSpec `json:"resources,omitempty" yaml:"resources,omitempty"`
+	Termination     *TerminationSpec      `json:"termination,omitempty" yaml:"termination,omitempty"`
+	Alerts          []AlertSpec           `json:"alerts,omitempty" yaml:"alerts,omitempty"`
+	LogDestinations []LogDestinationSpec  `json:"log_destinations,omitempty" yaml:"log_destinations,omitempty"`
+}
+
 // StaticSiteSpec describes a statically-built web front-end.
 type StaticSiteSpec struct {
-	Name         string      `json:"name" yaml:"name"`
-	BuildCommand string      `json:"build_command" yaml:"build_command"`
-	OutputDir    string      `json:"output_dir" yaml:"output_dir"`
+	Name         string            `json:"name" yaml:"name"`
+	BuildCommand string            `json:"build_command" yaml:"build_command"`
+	OutputDir    string            `json:"output_dir" yaml:"output_dir"`
 	EnvVars      map[string]string `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
-	Routes       []RouteSpec `json:"routes,omitempty" yaml:"routes,omitempty"`
-	CORS         *CORSSpec   `json:"cors,omitempty" yaml:"cors,omitempty"`
-	Domains      []DomainSpec `json:"domains,omitempty" yaml:"domains,omitempty"`
-	Alerts       []AlertSpec `json:"alerts,omitempty" yaml:"alerts,omitempty"`
+	Routes       []RouteSpec       `json:"routes,omitempty" yaml:"routes,omitempty"`
+	CORS         *CORSSpec         `json:"cors,omitempty" yaml:"cors,omitempty"`
+	Domains      []DomainSpec      `json:"domains,omitempty" yaml:"domains,omitempty"`
+	Alerts       []AlertSpec       `json:"alerts,omitempty" yaml:"alerts,omitempty"`
 }
 
 // SidecarSpec describes a companion container that shares the network with
 // the main service (e.g. Tailscale, Envoy).
 type SidecarSpec struct {
-	Name              string               `json:"name" yaml:"name"`
-	Image             string               `json:"image,omitempty" yaml:"image,omitempty"`
-	RunCommand        string               `json:"run_command" yaml:"run_command"`
-	EnvVars           map[string]string    `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
-	EnvVarsSecret     map[string]string    `json:"env_vars_secret,omitempty" yaml:"env_vars_secret,omitempty"`
-	Ports             []PortSpec           `json:"ports,omitempty" yaml:"ports,omitempty"`
+	Name              string                `json:"name" yaml:"name"`
+	Image             string                `json:"image,omitempty" yaml:"image,omitempty"`
+	RunCommand        string                `json:"run_command" yaml:"run_command"`
+	EnvVars           map[string]string     `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
+	EnvVarsSecret     map[string]string     `json:"env_vars_secret,omitempty" yaml:"env_vars_secret,omitempty"`
+	Ports             []PortSpec            `json:"ports,omitempty" yaml:"ports,omitempty"`
 	Resources         *WorkloadResourceSpec `json:"resources,omitempty" yaml:"resources,omitempty"`
-	HealthCheck       *HealthCheckSpec     `json:"health_check,omitempty" yaml:"health_check,omitempty"`
-	SharesNetworkWith string               `json:"shares_network_with,omitempty" yaml:"shares_network_with,omitempty"` // name of the service this sidecar attaches to
+	HealthCheck       *HealthCheckSpec      `json:"health_check,omitempty" yaml:"health_check,omitempty"`
+	SharesNetworkWith string                `json:"shares_network_with,omitempty" yaml:"shares_network_with,omitempty"` // name of the service this sidecar attaches to
 }
 
 // PortSpec describes a named port exposed by a service or sidecar.
@@ -141,13 +141,13 @@ type IngressSpec struct {
 
 // IngressRule maps an HTTP match to a backend component.
 type IngressRule struct {
-	Match     string `json:"match" yaml:"match"`     // path prefix or header expression
+	Match     string `json:"match" yaml:"match"`         // path prefix or header expression
 	Component string `json:"component" yaml:"component"` // target service/worker name
 }
 
 // EgressSpec controls outbound traffic policy.
 type EgressSpec struct {
-	Bandwidth string      `json:"bandwidth,omitempty" yaml:"bandwidth,omitempty"` // informational budget, e.g. "1Gbps"
+	Bandwidth string       `json:"bandwidth,omitempty" yaml:"bandwidth,omitempty"` // informational budget, e.g. "1Gbps"
 	Rules     []EgressRule `json:"rules,omitempty" yaml:"rules,omitempty"`
 }
 

--- a/interfaces/tenant_registry.go
+++ b/interfaces/tenant_registry.go
@@ -1,6 +1,9 @@
 package interfaces
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // TenantRegistry persists and retrieves Tenant records.
 type TenantRegistry interface {
@@ -34,13 +37,18 @@ type TenantSpec struct {
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
-// Validate checks that TenantSpec has the required fields.
+// Validate checks that TenantSpec has the required fields and that the slug
+// is well-formed. Slug must be non-empty and all-lowercase; mixed-case slugs
+// are rejected to ensure consistent URL routing and cache key derivation.
 func (s TenantSpec) Validate() error {
 	if s.Name == "" {
 		return fmt.Errorf("%w: tenant name is required", ErrValidation)
 	}
 	if s.Slug == "" {
 		return fmt.Errorf("%w: tenant slug is required", ErrValidation)
+	}
+	if s.Slug != strings.ToLower(s.Slug) {
+		return fmt.Errorf("%w: tenant slug must be lowercase", ErrValidation)
 	}
 	return nil
 }

--- a/interfaces/tenant_registry_test.go
+++ b/interfaces/tenant_registry_test.go
@@ -33,6 +33,16 @@ func TestTenantSpec_Validate(t *testing.T) {
 			spec:    interfaces.TenantSpec{Name: "Acme", Slug: "acme"},
 			wantErr: nil,
 		},
+		{
+			name:    "uppercase slug",
+			spec:    interfaces.TenantSpec{Name: "Acme", Slug: "Acme"},
+			wantErr: interfaces.ErrValidation,
+		},
+		{
+			name:    "mixed-case slug",
+			spec:    interfaces.TenantSpec{Name: "Acme", Slug: "ACME-Corp"},
+			wantErr: interfaces.ErrValidation,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/module/tenant_selectors_test.go
+++ b/module/tenant_selectors_test.go
@@ -76,6 +76,35 @@ func TestSubdomainSelector_Match(t *testing.T) {
 	}
 }
 
+func TestSubdomainSelector_MixedCase(t *testing.T) {
+	cases := []struct {
+		rootDomain string
+		host       string
+		wantKey    string
+	}{
+		// Mixed-case host with mixed-case root domain.
+		{rootDomain: "Example.com", host: "ACME.EXAMPLE.COM", wantKey: "acme"},
+		// Mixed-case host with lowercase root domain.
+		{rootDomain: "example.com", host: "Acme.Example.com", wantKey: "acme"},
+	}
+	for _, tc := range cases {
+		sel := &SubdomainSelector{RootDomain: tc.rootDomain}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Host = tc.host
+
+		key, matched, err := sel.Match(req)
+		if err != nil {
+			t.Fatalf("Match(%q): unexpected error: %v", tc.host, err)
+		}
+		if !matched {
+			t.Errorf("Match(%q): expected matched=true", tc.host)
+		}
+		if key != tc.wantKey {
+			t.Errorf("Match(%q): got key %q, want %q", tc.host, key, tc.wantKey)
+		}
+	}
+}
+
 func TestSubdomainSelector_NoSubdomain(t *testing.T) {
 	sel := &SubdomainSelector{RootDomain: "example.com"}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/module/tenants.go
+++ b/module/tenants.go
@@ -195,7 +195,7 @@ func (r *SQLTenantRegistry) Ensure(spec interfaces.TenantSpec) (interfaces.Tenan
 		return existing, nil
 	}
 	if !errors.Is(err, interfaces.ErrResourceNotFound) {
-		return interfaces.Tenant{}, fmt.Errorf("ensure tenant %q: lookup: %w", spec.Slug, err)
+		return interfaces.Tenant{}, fmt.Errorf("ensure tenant: lookup: %w", err)
 	}
 
 	domainsJSON, _ := json.Marshal(spec.Domains)

--- a/module/tenants.go
+++ b/module/tenants.go
@@ -53,8 +53,8 @@ type SQLTenantRegistry struct {
 
 // SQLTenantRegistryConfig is the constructor configuration.
 type SQLTenantRegistryConfig struct {
-	DB        *sql.DB
-	Schema    TenantSchemaConfig
+	DB     *sql.DB
+	Schema TenantSchemaConfig
 	// CacheSize controls the in-memory LRU cache size.
 	//   < 0 — disable cache entirely (no LRU)
 	//   0   — use default (256 entries)

--- a/module/tenants_test.go
+++ b/module/tenants_test.go
@@ -2,14 +2,189 @@ package module
 
 import (
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
+
+// ---------------------------------------------------------------------------
+// Minimal database/sql/driver mock for unit tests that need a *sql.DB but
+// do not have access to a real PostgreSQL instance.  Tests that use the mock
+// push pre-programmed responses via tenantMockPushQuery / tenantMockPushExec
+// before exercising the registry methods.
+// ---------------------------------------------------------------------------
+
+func init() {
+	sql.Register("workflow_tenant_mock", &tenantMockDriver{})
+}
+
+// tenantQueryResp is a pre-programmed response for a Query (SELECT / INSERT RETURNING / UPDATE RETURNING).
+type tenantQueryResp struct {
+	err  error            // non-nil → returned as query error (surfaces via row.Scan)
+	cols []string         // column names
+	rows [][]driver.Value // nil or empty → io.EOF → sql.ErrNoRows
+}
+
+// tenantExecResp is a pre-programmed response for an Exec (UPDATE / DELETE without RETURNING).
+type tenantExecResp struct {
+	err error
+	n   int64 // RowsAffected
+}
+
+var (
+	tenantMockMu         sync.Mutex
+	tenantMockQueryQueue []*tenantQueryResp
+	tenantMockExecQueue  []*tenantExecResp
+)
+
+func tenantMockPushQuery(r *tenantQueryResp) {
+	tenantMockMu.Lock()
+	tenantMockQueryQueue = append(tenantMockQueryQueue, r)
+	tenantMockMu.Unlock()
+}
+
+func tenantMockPushExec(r *tenantExecResp) {
+	tenantMockMu.Lock()
+	tenantMockExecQueue = append(tenantMockExecQueue, r)
+	tenantMockMu.Unlock()
+}
+
+func tenantMockPopQuery() *tenantQueryResp {
+	tenantMockMu.Lock()
+	defer tenantMockMu.Unlock()
+	if len(tenantMockQueryQueue) == 0 {
+		return &tenantQueryResp{} // empty rows → sql.ErrNoRows
+	}
+	r := tenantMockQueryQueue[0]
+	tenantMockQueryQueue = tenantMockQueryQueue[1:]
+	return r
+}
+
+func tenantMockPopExec() *tenantExecResp {
+	tenantMockMu.Lock()
+	defer tenantMockMu.Unlock()
+	if len(tenantMockExecQueue) == 0 {
+		return &tenantExecResp{n: 0}
+	}
+	r := tenantMockExecQueue[0]
+	tenantMockExecQueue = tenantMockExecQueue[1:]
+	return r
+}
+
+func tenantMockClear() {
+	tenantMockMu.Lock()
+	tenantMockQueryQueue = nil
+	tenantMockExecQueue = nil
+	tenantMockMu.Unlock()
+}
+
+// openMockDB opens a *sql.DB backed by the mock driver and registers cleanup.
+func openMockDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("workflow_tenant_mock", "")
+	if err != nil {
+		t.Fatalf("sql.Open mock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// tenantColNames are the columns that scanTenant expects (must match selectSQL order).
+var tenantColNames = []string{"id", "slug", "name", "domains", "metadata", "is_active"}
+
+// tenantDriverRow builds a driver.Value slice for scanTenant.
+func tenantDriverRow(ten interfaces.Tenant) []driver.Value {
+	domains, _ := json.Marshal(ten.Domains)
+	metadata, _ := json.Marshal(ten.Metadata)
+	if ten.Metadata == nil {
+		metadata = []byte("{}")
+	}
+	if ten.Domains == nil {
+		domains = []byte("[]")
+	}
+	return []driver.Value{ten.ID, ten.Slug, ten.Name, domains, metadata, ten.IsActive}
+}
+
+// --- driver.Driver ---
+
+type tenantMockDriver struct{}
+
+func (d *tenantMockDriver) Open(string) (driver.Conn, error) { return &tenantMockConn{}, nil }
+
+// --- driver.Conn ---
+
+type tenantMockConn struct{}
+
+func (c *tenantMockConn) Prepare(query string) (driver.Stmt, error) {
+	return &tenantMockStmt{}, nil
+}
+func (c *tenantMockConn) Close() error              { return nil }
+func (c *tenantMockConn) Begin() (driver.Tx, error) { return &tenantMockTx{}, nil }
+
+// --- driver.Tx ---
+
+type tenantMockTx struct{}
+
+func (t *tenantMockTx) Commit() error   { return nil }
+func (t *tenantMockTx) Rollback() error { return nil }
+
+// --- driver.Stmt ---
+
+type tenantMockStmt struct{}
+
+func (s *tenantMockStmt) Close() error  { return nil }
+func (s *tenantMockStmt) NumInput() int { return -1 } // variadic
+
+func (s *tenantMockStmt) Query(args []driver.Value) (driver.Rows, error) {
+	r := tenantMockPopQuery()
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &tenantMockRows{cols: r.cols, data: r.rows}, nil
+}
+
+func (s *tenantMockStmt) Exec(args []driver.Value) (driver.Result, error) {
+	r := tenantMockPopExec()
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &tenantMockExecResult{n: r.n}, nil
+}
+
+// --- driver.Rows ---
+
+type tenantMockRows struct {
+	cols []string
+	data [][]driver.Value
+	pos  int
+}
+
+func (r *tenantMockRows) Columns() []string { return r.cols }
+func (r *tenantMockRows) Close() error      { return nil }
+func (r *tenantMockRows) Next(dest []driver.Value) error {
+	if r.pos >= len(r.data) {
+		return io.EOF
+	}
+	copy(dest, r.data[r.pos])
+	r.pos++
+	return nil
+}
+
+// --- driver.Result ---
+
+type tenantMockExecResult struct{ n int64 }
+
+func (r *tenantMockExecResult) LastInsertId() (int64, error) { return 0, nil }
+func (r *tenantMockExecResult) RowsAffected() (int64, error) { return r.n, nil }
 
 // TestSQLTenantRegistry_Interface verifies compile-time conformance.
 func TestSQLTenantRegistry_Interface(t *testing.T) {
@@ -241,4 +416,178 @@ func splitByNewline(s string) []string {
 }
 func containsGoose(s string) bool {
 	return strings.Contains(s, "+goose")
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests using the mock driver
+// ---------------------------------------------------------------------------
+
+// TestNewSQLTenantRegistry_NilDB asserts that NewSQLTenantRegistry returns a
+// non-nil error containing "cfg.DB is required" when DB is nil.
+func TestNewSQLTenantRegistry_NilDB(t *testing.T) {
+	_, err := NewSQLTenantRegistry(SQLTenantRegistryConfig{})
+	if err == nil {
+		t.Fatal("expected error for nil DB")
+	}
+	if !strings.Contains(err.Error(), "cfg.DB is required") {
+		t.Errorf("error should mention 'cfg.DB is required', got: %v", err)
+	}
+}
+
+// TestNewSQLTenantRegistry_CacheDisabled verifies that CacheSize=-1 produces a
+// registry with a nil cache, and that all cache-adjacent code paths (Ensure →
+// GetBySlug → Disable → GetBySlug) do not panic when the cache is absent.
+func TestNewSQLTenantRegistry_CacheDisabled(t *testing.T) {
+	tenantMockClear()
+
+	ten := interfaces.Tenant{
+		ID:       "t-nocache-1",
+		Slug:     "nocache",
+		Name:     "No Cache Test",
+		Domains:  []string{"nocache.example.com"},
+		IsActive: true,
+	}
+	disabledTen := ten
+	disabledTen.IsActive = false
+
+	// Ensure → GetBySlug (empty, not found).
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: nil})
+	// Ensure → INSERT RETURNING.
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: [][]driver.Value{tenantDriverRow(ten)}})
+	// GetBySlug.
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: [][]driver.Value{tenantDriverRow(ten)}})
+	// Disable → GetByID.
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: [][]driver.Value{tenantDriverRow(ten)}})
+	// Disable → ExecContext (UPDATE SET is_active=FALSE).
+	tenantMockPushExec(&tenantExecResp{n: 1})
+	// GetBySlug after disable.
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: [][]driver.Value{tenantDriverRow(disabledTen)}})
+
+	db := openMockDB(t)
+	reg, err := NewSQLTenantRegistry(SQLTenantRegistryConfig{DB: db, CacheSize: -1})
+	if err != nil {
+		t.Fatalf("NewSQLTenantRegistry: %v", err)
+	}
+
+	// Cache must be nil for CacheSize=-1.
+	if reg.cache != nil {
+		t.Error("expected nil cache for CacheSize=-1")
+	}
+
+	// Exercise the sequence — must not panic with nil cache.
+	spec := interfaces.TenantSpec{Name: ten.Name, Slug: ten.Slug, Domains: ten.Domains}
+	got, err := reg.Ensure(spec)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if got.ID != ten.ID {
+		t.Errorf("Ensure: unexpected ID %q", got.ID)
+	}
+
+	got2, err := reg.GetBySlug(ten.Slug)
+	if err != nil {
+		t.Fatalf("GetBySlug: %v", err)
+	}
+	if got2.Slug != ten.Slug {
+		t.Errorf("GetBySlug: unexpected slug %q", got2.Slug)
+	}
+
+	if err := reg.Disable(got.ID); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	got3, err := reg.GetBySlug(ten.Slug)
+	if err != nil {
+		t.Fatalf("GetBySlug after Disable: %v", err)
+	}
+	if got3.IsActive {
+		t.Error("expected is_active=false after Disable")
+	}
+}
+
+// TestEnsure_PropagatesNonNotFoundError verifies that a transient DB error
+// (neither sql.ErrNoRows nor ErrResourceNotFound) is propagated by Ensure
+// rather than treated as a "not found" and triggering an INSERT.
+func TestEnsure_PropagatesNonNotFoundError(t *testing.T) {
+	tenantMockClear()
+
+	transientErr := errors.New("transient: connection reset by peer")
+
+	// GetBySlug (inside Ensure) returns a transient error.
+	tenantMockPushQuery(&tenantQueryResp{err: transientErr})
+
+	db := openMockDB(t)
+	reg, err := NewSQLTenantRegistry(SQLTenantRegistryConfig{DB: db})
+	if err != nil {
+		t.Fatalf("NewSQLTenantRegistry: %v", err)
+	}
+
+	spec := interfaces.TenantSpec{Name: "Acme", Slug: "acme"}
+	_, err = reg.Ensure(spec)
+	if err == nil {
+		t.Fatal("expected error from Ensure on transient DB error")
+	}
+	if !errors.Is(err, transientErr) {
+		t.Errorf("Ensure error should wrap transient error via %%w; got: %v", err)
+	}
+}
+
+// TestUpdate_InvalidatesStaleDomainCache verifies that after calling Update with
+// changed domains, the stale "old.example.com" domain cache entry is evicted so
+// that a subsequent GetByDomain goes to the DB (not a stale cache hit).
+func TestUpdate_InvalidatesStaleDomainCache(t *testing.T) {
+	tenantMockClear()
+
+	oldTen := interfaces.Tenant{
+		ID:       "t-cache-1",
+		Slug:     "acme-cache",
+		Name:     "Acme Cache Test",
+		Domains:  []string{"old.example.com"},
+		IsActive: true,
+	}
+	updatedTen := interfaces.Tenant{
+		ID:       "t-cache-1",
+		Slug:     "acme-cache",
+		Name:     "Acme Cache Test",
+		Domains:  []string{"new.example.com"},
+		IsActive: true,
+	}
+
+	// GetByDomain("old.example.com") → old tenant.
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: [][]driver.Value{tenantDriverRow(oldTen)}})
+	// Update → GetByID hits cache (no extra mock needed) → UPDATE RETURNING.
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: [][]driver.Value{tenantDriverRow(updatedTen)}})
+	// GetByDomain("old.example.com") after update → empty (not found).
+	tenantMockPushQuery(&tenantQueryResp{cols: tenantColNames, rows: nil})
+
+	db := openMockDB(t)
+	reg, err := NewSQLTenantRegistry(SQLTenantRegistryConfig{DB: db, CacheSize: 32})
+	if err != nil {
+		t.Fatalf("NewSQLTenantRegistry: %v", err)
+	}
+
+	// Prime cache via GetByDomain.
+	got, err := reg.GetByDomain("old.example.com")
+	if err != nil {
+		t.Fatalf("GetByDomain: %v", err)
+	}
+	if got.ID != oldTen.ID {
+		t.Fatalf("GetByDomain returned wrong tenant: %+v", got)
+	}
+
+	// GetByDomain also caches "id:t-cache-1"; Update.GetByID will hit cache.
+	newDomains := []string{"new.example.com"}
+	updated, err := reg.Update(oldTen.ID, interfaces.TenantPatch{Domains: newDomains})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updated.Domains) == 0 || updated.Domains[0] != "new.example.com" {
+		t.Errorf("Update returned wrong domains: %v", updated.Domains)
+	}
+
+	// Old domain must now be a cache miss → DB path → ErrResourceNotFound.
+	_, err = reg.GetByDomain("old.example.com")
+	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+		t.Errorf("GetByDomain after Update: want ErrResourceNotFound, got %v", err)
+	}
 }

--- a/module/tenants_test.go
+++ b/module/tenants_test.go
@@ -378,44 +378,15 @@ func newTestSQLRegistry(t *testing.T, dsn string) (*SQLTenantRegistry, interface
 }
 
 // stripGooseAnnotations removes goose comment directives so SQL can be executed directly.
-func stripGooseAnnotations(sql string) string {
-	var lines []string
-	for _, line := range splitLines(sql) {
-		if len(line) > 0 && line[0] == '-' && containsGoose(line) {
+func stripGooseAnnotations(s string) string {
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		if len(line) > 0 && line[0] == '-' && strings.Contains(line, "+goose") {
 			continue
 		}
-		lines = append(lines, line)
+		kept = append(kept, line)
 	}
-	return joinLines(lines)
-}
-
-func splitLines(s string) []string {
-	return splitByNewline(s)
-}
-func joinLines(lines []string) string {
-	var sb strings.Builder
-	for _, l := range lines {
-		sb.WriteString(l)
-		sb.WriteByte('\n')
-	}
-	return sb.String()
-}
-func splitByNewline(s string) []string {
-	var out []string
-	start := 0
-	for i, c := range s {
-		if c == '\n' {
-			out = append(out, s[start:i])
-			start = i + 1
-		}
-	}
-	if start < len(s) {
-		out = append(out, s[start:])
-	}
-	return out
-}
-func containsGoose(s string) bool {
-	return strings.Contains(s, "+goose")
+	return strings.Join(kept, "\n")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Commit `a48a9b7` (fix: address 11 Copilot review comments on v0.18.0) was pushed directly to `main`, bypassing PR review. Two independent post-hoc review agents then audited that commit and produced this consolidated follow-up list. All items are addressed here.

## What changed (4 commits)

| SHA | Description |
|-----|-------------|
| `b8dab6b` | **gofmt** — `interfaces/iac_canonical_types.go`, `module/tenants.go`, `cmd/wfctl/scaffold_dockerfile_test.go` had minor formatting drift |
| `c6f0256` | **Tests** — 5 new tests + mock `database/sql/driver` + 5 new `t.Run` subtest rows in scaffold test |
| `3c2a488` | **Enforce lowercase slug** — `TenantSpec.Validate` rejects `Slug != strings.ToLower(Slug)`; CHANGELOG `v0.18.1` section |
| `b7ce2c5` | **Polish** — Ensure error no longer double-embeds slug; scaffold comment clarified; hand-rolled split/join helpers removed |

## Review findings addressed

- **gofmt drift** (`b8dab6b`) — three files had alignment issues introduced in the v0.18.0 batch commit
- **Missing nil-DB test** (`c6f0256`) — `TestNewSQLTenantRegistry_NilDB` asserts the constructor returns a descriptive error when `DB` is nil
- **Cache-disabled coverage** (`c6f0256`) — `TestNewSQLTenantRegistry_CacheDisabled` exercises Ensure→GetBySlug→Disable→GetBySlug with `CacheSize=-1`, proving nil-cache paths do not panic
- **Transient-error propagation** (`c6f0256`) — `TestEnsure_PropagatesNonNotFoundError` guards against a regression where a transient DB error could trigger a spurious INSERT
- **Stale domain-cache invalidation** (`c6f0256`) — `TestUpdate_InvalidatesStaleDomainCache` verifies old domain key is evicted after `Update` changes domains
- **Mixed-case subdomain matching** (`c6f0256`) — `TestSubdomainSelector_MixedCase` confirms host and root domain are lowercased consistently
- **Dockerfile validation subtests** (`c6f0256`) — converted to `t.Run`; added digest-only, registry-with-port, tag+digest, empty-string, alpine rows
- **Lowercase slug enforcement** (`3c2a488`) — `TenantSpec.Validate` now rejects mixed-case slugs with `ErrValidation`
- **Double-slug in Ensure error** (`b7ce2c5`) — `fmt.Errorf("ensure tenant %q: lookup: %w")` was embedding slug twice (also present in wrapped `GetBySlug` error); now `"ensure tenant: lookup: %w"`
- **Misleading scaffold comment** (`b7ce2c5`) — replaced `// Strip tag (last colon that is not part of a registry host:port)` with precise description of the colon-after-last-slash heuristic
- **Hand-rolled test helpers** (`b7ce2c5`) — `splitByNewline`/`splitLines`/`joinLines` removed; `stripGooseAnnotations` uses `strings.Split`/`strings.Join`

## Breaking changes

- **`TenantSpec.Slug` must be all-lowercase.** Mixed-case slugs now return `ErrValidation`. If you have existing tenants with mixed-case slugs, lowercase the `slug` column before upgrading.
- **`SubdomainSelector` returns a lowercase subdomain key.** The host header is lowercased before suffix matching. Consistent with `HostSelector` behaviour since v0.18.0.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test -race -short ./interfaces/... ./module/... ./cmd/wfctl/... ./plugin/external/sdk/...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — no output on branch-touched files
- [x] Local code-reviewer approved before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)