### PR TITLE
fix(wfctl): inject Authorization header for private GitHub release downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.3] - 2026-04-23
+
+### Fixed
+
+- **wfctl plugin install auth** — `downloadURL` now sends an `Authorization: token <tok>` header for any `github.com` URL. Token resolution order: `RELEASES_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN`. Falls back to unauthenticated for public repos or non-GitHub URLs. Enables `wfctl plugin install` to fetch release assets from private GitHub repositories when a token is present in the environment (e.g. BMW CI with `RELEASES_TOKEN`).
+
 ## [0.18.1] - 2026-04-22
 
 ### Fixed

--- a/cmd/wfctl/plugin_cli_commands.go
+++ b/cmd/wfctl/plugin_cli_commands.go
@@ -131,4 +131,3 @@ func DispatchCLICommand(entry *CLIRegistryEntry, args []string) error {
 func (r CLIRegistry) LookupCLICommand(name string) *CLIRegistryEntry {
 	return r[name]
 }
-

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -727,18 +728,19 @@ func parseNameVersion(arg string) (name, ver string) {
 }
 
 // downloadURL fetches a URL and returns the body bytes.
-// For github.com URLs, it injects an Authorization header from the first non-empty
-// env var in: RELEASES_TOKEN, GH_TOKEN, GITHUB_TOKEN. This allows downloading
-// assets from private GitHub repos when a token is available in the environment.
-func downloadURL(url string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:gosec // G107: URL comes from registry manifest
+// For github.com URLs (matched by hostname, not substring), it injects an
+// Authorization header from the first non-empty env var in: RELEASES_TOKEN,
+// GH_TOKEN, GITHUB_TOKEN. This allows downloading assets from private GitHub
+// repos when a token is available in the environment.
+func downloadURL(rawURL string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil) //nolint:gosec // G107: URL comes from registry manifest
 	if err != nil {
 		return nil, err
 	}
-	if strings.Contains(url, "github.com") {
+	if parsed, err2 := neturl.Parse(rawURL); err2 == nil && strings.HasSuffix(parsed.Hostname(), "github.com") {
 		for _, envKey := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
 			if tok := os.Getenv(envKey); tok != "" {
-				req.Header.Set("Authorization", "token "+tok)
+				req.Header.Set("Authorization", "Bearer "+tok)
 				break
 			}
 		}
@@ -749,7 +751,7 @@ func downloadURL(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, rawURL)
 	}
 	return io.ReadAll(resp.Body)
 }

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -727,8 +727,23 @@ func parseNameVersion(arg string) (name, ver string) {
 }
 
 // downloadURL fetches a URL and returns the body bytes.
+// For github.com URLs, it injects an Authorization header from the first non-empty
+// env var in: RELEASES_TOKEN, GH_TOKEN, GITHUB_TOKEN. This allows downloading
+// assets from private GitHub repos when a token is available in the environment.
 func downloadURL(url string) ([]byte, error) {
-	resp, err := http.Get(url) //nolint:gosec // G107: URL comes from registry manifest
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:gosec // G107: URL comes from registry manifest
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(url, "github.com") {
+		for _, envKey := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+			if tok := os.Getenv(envKey); tok != "" {
+				req.Header.Set("Authorization", "token "+tok)
+				break
+			}
+		}
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -3,10 +3,39 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
+
+// captureTransport is a test http.RoundTripper that:
+//   - captures the Authorization header from each request (race-safe via mutex)
+//   - rewrites the request host to a target test server so real network calls
+//     are never made, even when the URL hostname is "github.com"
+type captureTransport struct {
+	mu     sync.Mutex
+	header string
+	target string // host:port of the httptest.Server
+}
+
+func (ct *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ct.mu.Lock()
+	ct.header = req.Header.Get("Authorization")
+	ct.mu.Unlock()
+	// Clone and redirect to test server.
+	r2 := req.Clone(req.Context())
+	r2.URL.Scheme = "http"
+	r2.URL.Host = ct.target
+	return http.DefaultTransport.RoundTrip(r2)
+}
+
+func (ct *captureTransport) gotHeader() string {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.header
+}
 
 // TestPluginListAcceptsPluginDirFlag verifies that -plugin-dir is accepted by
 // runPluginList and correctly used as the directory to scan.
@@ -67,7 +96,16 @@ func TestPluginListAcceptsLegacyDataDirFlag(t *testing.T) {
 	}
 }
 
-// TestDownloadURL_GitHubAuthHeader verifies that downloadURL injects an
+// installTestClient replaces http.DefaultClient with one using transport ct and
+// restores the original on test cleanup.
+func installTestClient(t *testing.T, ct *captureTransport) {
+	t.Helper()
+	orig := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: ct}
+	t.Cleanup(func() { http.DefaultClient = orig })
+}
+
+// TestDownloadURL_GitHubAuthHeader verifies that downloadURL injects a Bearer
 // Authorization header for github.com URLs using the first non-empty token env
 // var (RELEASES_TOKEN > GH_TOKEN > GITHUB_TOKEN), and sends no header when none
 // are set.
@@ -79,27 +117,25 @@ func TestDownloadURL_GitHubAuthHeader(t *testing.T) {
 		envKey  string
 		wantHdr string
 	}{
-		{"RELEASES_TOKEN", "RELEASES_TOKEN", "token " + sentinel},
-		{"GH_TOKEN", "GH_TOKEN", "token " + sentinel},
-		{"GITHUB_TOKEN", "GITHUB_TOKEN", "token " + sentinel},
+		{"RELEASES_TOKEN", "RELEASES_TOKEN", "Bearer " + sentinel},
+		{"GH_TOKEN", "GH_TOKEN", "Bearer " + sentinel},
+		{"GITHUB_TOKEN", "GITHUB_TOKEN", "Bearer " + sentinel},
 		{"no token", "", ""},
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// Capture the Authorization header the client sends.
-			var gotHdr string
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotHdr = r.Header.Get("Authorization")
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer srv.Close()
 
-			// Build a URL that contains "github.com" as a path segment so the
-			// auth injection logic fires, while actually targeting the test server.
-			testURL := srv.URL + "/github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
+			srvURL, _ := url.Parse(srv.URL)
+			ct := &captureTransport{target: srvURL.Host}
+			installTestClient(t, ct)
 
-			// Set / clear the env var for this sub-test.
+			// Clear all token env vars, then set the one under test.
 			for _, k := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
 				t.Setenv(k, "")
 			}
@@ -107,11 +143,13 @@ func TestDownloadURL_GitHubAuthHeader(t *testing.T) {
 				t.Setenv(tc.envKey, sentinel)
 			}
 
+			// Use a real github.com URL — captureTransport redirects it to srv.
+			testURL := "https://github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
 			if _, err := downloadURL(testURL); err != nil {
 				t.Fatalf("downloadURL: %v", err)
 			}
-			if gotHdr != tc.wantHdr {
-				t.Errorf("Authorization header = %q, want %q", gotHdr, tc.wantHdr)
+			if got := ct.gotHeader(); got != tc.wantHdr {
+				t.Errorf("Authorization header = %q, want %q", got, tc.wantHdr)
 			}
 		})
 	}
@@ -119,43 +157,65 @@ func TestDownloadURL_GitHubAuthHeader(t *testing.T) {
 
 // TestDownloadURL_NonGitHubNoAuthHeader verifies that downloadURL does NOT inject
 // an Authorization header for non-github.com URLs, even when a token env var is set.
+// Also verifies that a URL with "github.com" only in the path (not the hostname)
+// does not trigger injection.
 func TestDownloadURL_NonGitHubNoAuthHeader(t *testing.T) {
-	var gotHdr string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHdr = r.Header.Get("Authorization")
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"plain non-github host", ""},   // filled in per-test using srv.URL
+		{"github.com in path only", ""}, // filled in per-test
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
-	t.Setenv("RELEASES_TOKEN", "should-not-appear")
+	srvURL, _ := url.Parse(srv.URL)
+	cases[0].url = srv.URL + "/some/asset.tar.gz"
+	cases[1].url = srv.URL + "/path/github.com/owner/repo/asset.tar.gz"
 
-	if _, err := downloadURL(srv.URL + "/some/asset.tar.gz"); err != nil {
-		t.Fatalf("downloadURL: %v", err)
-	}
-	if gotHdr != "" {
-		t.Errorf("expected no Authorization header for non-github URL, got %q", gotHdr)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &captureTransport{target: srvURL.Host}
+			installTestClient(t, ct)
+			t.Setenv("RELEASES_TOKEN", "should-not-appear")
+
+			if _, err := downloadURL(tc.url); err != nil {
+				t.Fatalf("downloadURL: %v", err)
+			}
+			if got := ct.gotHeader(); got != "" {
+				t.Errorf("expected no Authorization header, got %q", got)
+			}
+		})
 	}
 }
 
 // TestDownloadURL_TokenPriority verifies that RELEASES_TOKEN takes precedence over
 // GH_TOKEN and GITHUB_TOKEN when multiple env vars are set.
 func TestDownloadURL_TokenPriority(t *testing.T) {
-	var gotHdr string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHdr = r.Header.Get("Authorization")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
+
+	srvURL, _ := url.Parse(srv.URL)
+	ct := &captureTransport{target: srvURL.Host}
+	installTestClient(t, ct)
 
 	t.Setenv("RELEASES_TOKEN", "releases-wins")
 	t.Setenv("GH_TOKEN", "gh-loses")
 	t.Setenv("GITHUB_TOKEN", "github-loses")
 
-	testURL := srv.URL + "/github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
+	testURL := "https://github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
 	if _, err := downloadURL(testURL); err != nil {
 		t.Fatalf("downloadURL: %v", err)
 	}
-	if gotHdr != "token releases-wins" {
-		t.Errorf("Authorization header = %q, want %q", gotHdr, "token releases-wins")
+	const want = "Bearer releases-wins"
+	if got := ct.gotHeader(); got != want {
+		t.Errorf("Authorization header = %q, want %q", got, want)
 	}
 }

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,5 +64,98 @@ func TestPluginListAcceptsLegacyDataDirFlag(t *testing.T) {
 	// Should succeed using -data-dir (deprecated alias).
 	if err := runPluginList([]string{"-data-dir", dir}); err != nil {
 		t.Errorf("-data-dir: runPluginList returned unexpected error: %v", err)
+	}
+}
+
+// TestDownloadURL_GitHubAuthHeader verifies that downloadURL injects an
+// Authorization header for github.com URLs using the first non-empty token env
+// var (RELEASES_TOKEN > GH_TOKEN > GITHUB_TOKEN), and sends no header when none
+// are set.
+func TestDownloadURL_GitHubAuthHeader(t *testing.T) {
+	const sentinel = "test-token-value"
+
+	cases := []struct {
+		name    string
+		envKey  string
+		wantHdr string
+	}{
+		{"RELEASES_TOKEN", "RELEASES_TOKEN", "token " + sentinel},
+		{"GH_TOKEN", "GH_TOKEN", "token " + sentinel},
+		{"GITHUB_TOKEN", "GITHUB_TOKEN", "token " + sentinel},
+		{"no token", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Capture the Authorization header the client sends.
+			var gotHdr string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHdr = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			// Build a URL that contains "github.com" as a path segment so the
+			// auth injection logic fires, while actually targeting the test server.
+			testURL := srv.URL + "/github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
+
+			// Set / clear the env var for this sub-test.
+			for _, k := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+				t.Setenv(k, "")
+			}
+			if tc.envKey != "" {
+				t.Setenv(tc.envKey, sentinel)
+			}
+
+			if _, err := downloadURL(testURL); err != nil {
+				t.Fatalf("downloadURL: %v", err)
+			}
+			if gotHdr != tc.wantHdr {
+				t.Errorf("Authorization header = %q, want %q", gotHdr, tc.wantHdr)
+			}
+		})
+	}
+}
+
+// TestDownloadURL_NonGitHubNoAuthHeader verifies that downloadURL does NOT inject
+// an Authorization header for non-github.com URLs, even when a token env var is set.
+func TestDownloadURL_NonGitHubNoAuthHeader(t *testing.T) {
+	var gotHdr string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHdr = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("RELEASES_TOKEN", "should-not-appear")
+
+	if _, err := downloadURL(srv.URL + "/some/asset.tar.gz"); err != nil {
+		t.Fatalf("downloadURL: %v", err)
+	}
+	if gotHdr != "" {
+		t.Errorf("expected no Authorization header for non-github URL, got %q", gotHdr)
+	}
+}
+
+// TestDownloadURL_TokenPriority verifies that RELEASES_TOKEN takes precedence over
+// GH_TOKEN and GITHUB_TOKEN when multiple env vars are set.
+func TestDownloadURL_TokenPriority(t *testing.T) {
+	var gotHdr string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHdr = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("RELEASES_TOKEN", "releases-wins")
+	t.Setenv("GH_TOKEN", "gh-loses")
+	t.Setenv("GITHUB_TOKEN", "github-loses")
+
+	testURL := srv.URL + "/github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
+	if _, err := downloadURL(testURL); err != nil {
+		t.Fatalf("downloadURL: %v", err)
+	}
+	if gotHdr != "token releases-wins" {
+		t.Errorf("Authorization header = %q, want %q", gotHdr, "token releases-wins")
 	}
 }


### PR DESCRIPTION
## Summary

- `downloadURL` in `cmd/wfctl/plugin_install.go` now sends `Authorization: token <tok>` for any `github.com` URL
- Token resolution order: `RELEASES_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN`
- Falls back to unauthenticated for non-GitHub URLs or when no token is set
- 4 tests added covering all cases (token priority, non-github no-auth, no tokens set)

## Root cause

BMW staging deploy has been failing at `Install external plugins` because `workflow-plugin-supply-chain` is in a **private** GitHub repo. The release asset download 404'd with `HTTP 404 from https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-linux-amd64.tar.gz`.

The CI step already sets `RELEASES_TOKEN` env — wfctl was silently ignoring it for the download.

## Test plan

- [x] `TestDownloadURL_GitHubAuthHeader` — RELEASES_TOKEN / GH_TOKEN / GITHUB_TOKEN / no token
- [x] `TestDownloadURL_NonGitHubNoAuthHeader` — token not injected for non-github URLs
- [x] `TestDownloadURL_TokenPriority` — RELEASES_TOKEN beats GH_TOKEN/GITHUB_TOKEN
- [x] Existing `TestDownloadURL` success/404/500 tests still pass
- [x] Full `./cmd/wfctl/` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)