### PR TITLE
fix(wfctl): use GitHub API two-step flow for private release asset downloads (v0.18.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.4] - 2026-04-23
+
+### Fixed
+
+- **wfctl plugin install private repos** — for `github.com/.../releases/download/...` URLs, when a GitHub token is present, `downloadURL` now uses the two-step GitHub REST API flow (`releases/tags/:tag` to resolve the asset ID, then `releases/assets/:id` with `Accept: application/octet-stream`) instead of a plain GET. The direct download URL redirects to a signed S3 URL which does not propagate the Authorization header, causing 404s on private repos. Falls back to direct GET when no token is set (public repos unaffected).
+
 ## [0.18.3] - 2026-04-23
 
 ### Fixed

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -727,22 +727,133 @@ func parseNameVersion(arg string) (name, ver string) {
 	return arg, ""
 }
 
+// gitHubAPIBaseURL is the GitHub API base URL. It is a package-level variable
+// so tests can override it to point at a local mock server.
+var gitHubAPIBaseURL = "https://api.github.com"
+
+// gitHubToken returns the first non-empty GitHub token from the environment,
+// checking RELEASES_TOKEN, GH_TOKEN, and GITHUB_TOKEN in order.
+func gitHubToken() string {
+	for _, k := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if tok := os.Getenv(k); tok != "" {
+			return tok
+		}
+	}
+	return ""
+}
+
+// parseGitHubReleaseDownloadURL parses a GitHub release download URL of the form
+// https://github.com/OWNER/REPO/releases/download/TAG/FILENAME and returns the
+// components. Returns ok=false for any URL that doesn't match this exact pattern.
+func parseGitHubReleaseDownloadURL(rawURL string) (owner, repo, tag, filename string, ok bool) {
+	u, err := neturl.Parse(rawURL)
+	if err != nil || !strings.HasSuffix(u.Hostname(), "github.com") {
+		return
+	}
+	// Path: /owner/repo/releases/download/tag/filename
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 6 || parts[2] != "releases" || parts[3] != "download" ||
+		parts[0] == "" || parts[1] == "" || parts[4] == "" || parts[5] == "" {
+		return
+	}
+	return parts[0], parts[1], parts[4], parts[5], true
+}
+
+// downloadGitHubReleaseAsset downloads a private GitHub release asset using the
+// two-step REST API flow:
+//  1. GET api.github.com/repos/OWNER/REPO/releases/tags/TAG — find the asset ID
+//     matching filename in the release's assets array.
+//  2. GET api.github.com/repos/OWNER/REPO/releases/assets/:id with
+//     Accept: application/octet-stream — streams the binary content.
+//
+// This is the correct approach for private repos; the plain download URL
+// (github.com/.../releases/download/.../file) redirects to a signed S3 URL and
+// does not propagate the Authorization header correctly.
+func downloadGitHubReleaseAsset(owner, repo, tag, filename, token string) ([]byte, error) {
+	// Step 1: resolve the asset ID from the release metadata.
+	releaseURL := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", gitHubAPIBaseURL, owner, repo, tag) //nolint:gosec // G107
+	req, err := http.NewRequest(http.MethodGet, releaseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GitHub releases API: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub releases API: HTTP %d for %s/%s@%s", resp.StatusCode, owner, repo, tag)
+	}
+
+	var release struct {
+		Assets []struct {
+			ID   int64  `json:"id"`
+			Name string `json:"name"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode GitHub release response: %w", err)
+	}
+
+	var assetID int64
+	for _, a := range release.Assets {
+		if a.Name == filename {
+			assetID = a.ID
+			break
+		}
+	}
+	if assetID == 0 {
+		return nil, fmt.Errorf("asset %q not found in release %s/%s@%s", filename, owner, repo, tag)
+	}
+
+	// Step 2: download the asset binary.
+	assetURL := fmt.Sprintf("%s/repos/%s/%s/releases/assets/%d", gitHubAPIBaseURL, owner, repo, assetID) //nolint:gosec // G107
+	req2, err := http.NewRequest(http.MethodGet, assetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req2.Header.Set("Authorization", "Bearer "+token)
+	req2.Header.Set("Accept", "application/octet-stream")
+
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		return nil, fmt.Errorf("GitHub asset download API: %w", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub asset download API: HTTP %d for asset %d", resp2.StatusCode, assetID)
+	}
+	return io.ReadAll(resp2.Body)
+}
+
 // downloadURL fetches a URL and returns the body bytes.
-// For github.com URLs (matched by hostname, not substring), it injects an
-// Authorization header from the first non-empty env var in: RELEASES_TOKEN,
-// GH_TOKEN, GITHUB_TOKEN. This allows downloading assets from private GitHub
-// repos when a token is available in the environment.
+//
+// For GitHub release download URLs (github.com/OWNER/REPO/releases/download/...),
+// when a token is available it uses the two-step GitHub REST API flow
+// (releases/tags + releases/assets) which correctly handles private repos.
+// Without a token it falls back to a direct GET (works for public repos).
+//
+// For all other github.com URLs a Bearer header is injected when a token is
+// available. Non-GitHub URLs are fetched unauthenticated.
 func downloadURL(rawURL string) ([]byte, error) {
+	// Private GitHub release asset path: use the API two-step flow.
+	if owner, repo, tag, filename, ok := parseGitHubReleaseDownloadURL(rawURL); ok {
+		if tok := gitHubToken(); tok != "" {
+			return downloadGitHubReleaseAsset(owner, repo, tag, filename, tok)
+		}
+	}
+
+	// Public repos and non-release GitHub URLs: direct GET with optional Bearer.
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil) //nolint:gosec // G107: URL comes from registry manifest
 	if err != nil {
 		return nil, err
 	}
 	if parsed, err2 := neturl.Parse(rawURL); err2 == nil && strings.HasSuffix(parsed.Hostname(), "github.com") {
-		for _, envKey := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
-			if tok := os.Getenv(envKey); tok != "" {
-				req.Header.Set("Authorization", "Bearer "+tok)
-				break
-			}
+		if tok := gitHubToken(); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
 		}
 	}
 	resp, err := http.DefaultClient.Do(req)

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
 	engineplugin "github.com/GoCodeAlone/workflow/plugin"
@@ -731,6 +732,11 @@ func parseNameVersion(arg string) (name, ver string) {
 // so tests can override it to point at a local mock server.
 var gitHubAPIBaseURL = "https://api.github.com"
 
+// gitHubAPIClient is used for GitHub API metadata calls (releases/tags,
+// releases/assets). Separate from http.DefaultClient so tests can override it
+// independently. A generous timeout covers large binary asset downloads.
+var gitHubAPIClient = &http.Client{Timeout: 10 * time.Minute}
+
 // gitHubToken returns the first non-empty GitHub token from the environment,
 // checking RELEASES_TOKEN, GH_TOKEN, and GITHUB_TOKEN in order.
 func gitHubToken() string {
@@ -742,17 +748,25 @@ func gitHubToken() string {
 	return ""
 }
 
+// isGitHubHost returns true only for github.com and its subdomains (e.g.
+// api.github.com). Requires the dot separator to avoid matching evilgithub.com.
+func isGitHubHost(host string) bool {
+	h := strings.ToLower(host)
+	return h == "github.com" || strings.HasSuffix(h, ".github.com")
+}
+
 // parseGitHubReleaseDownloadURL parses a GitHub release download URL of the form
 // https://github.com/OWNER/REPO/releases/download/TAG/FILENAME and returns the
-// components. Returns ok=false for any URL that doesn't match this exact pattern.
+// components. Returns ok=false for any URL that doesn't match this exact pattern,
+// including non-HTTPS schemes and non-GitHub hosts.
 func parseGitHubReleaseDownloadURL(rawURL string) (owner, repo, tag, filename string, ok bool) {
 	u, err := neturl.Parse(rawURL)
-	if err != nil || !strings.HasSuffix(u.Hostname(), "github.com") {
+	if err != nil || !strings.EqualFold(u.Scheme, "https") || !isGitHubHost(u.Hostname()) {
 		return
 	}
-	// Path: /owner/repo/releases/download/tag/filename
+	// Path must be exactly: /owner/repo/releases/download/tag/filename (6 segments).
 	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
-	if len(parts) < 6 || parts[2] != "releases" || parts[3] != "download" ||
+	if len(parts) != 6 || parts[2] != "releases" || parts[3] != "download" ||
 		parts[0] == "" || parts[1] == "" || parts[4] == "" || parts[5] == "" {
 		return
 	}
@@ -771,15 +785,22 @@ func parseGitHubReleaseDownloadURL(rawURL string) (owner, repo, tag, filename st
 // does not propagate the Authorization header correctly.
 func downloadGitHubReleaseAsset(owner, repo, tag, filename, token string) ([]byte, error) {
 	// Step 1: resolve the asset ID from the release metadata.
-	releaseURL := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", gitHubAPIBaseURL, owner, repo, tag) //nolint:gosec // G107
+	releaseURL := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", //nolint:gosec // G107
+		gitHubAPIBaseURL,
+		neturl.PathEscape(owner),
+		neturl.PathEscape(repo),
+		neturl.PathEscape(tag),
+	)
 	req, err := http.NewRequest(http.MethodGet, releaseURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "wfctl/"+version)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := gitHubAPIClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GitHub releases API: %w", err)
 	}
@@ -810,15 +831,22 @@ func downloadGitHubReleaseAsset(owner, repo, tag, filename, token string) ([]byt
 	}
 
 	// Step 2: download the asset binary.
-	assetURL := fmt.Sprintf("%s/repos/%s/%s/releases/assets/%d", gitHubAPIBaseURL, owner, repo, assetID) //nolint:gosec // G107
+	assetURL := fmt.Sprintf("%s/repos/%s/%s/releases/assets/%d", //nolint:gosec // G107
+		gitHubAPIBaseURL,
+		neturl.PathEscape(owner),
+		neturl.PathEscape(repo),
+		assetID,
+	)
 	req2, err := http.NewRequest(http.MethodGet, assetURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req2.Header.Set("Authorization", "Bearer "+token)
 	req2.Header.Set("Accept", "application/octet-stream")
+	req2.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req2.Header.Set("User-Agent", "wfctl/"+version)
 
-	resp2, err := http.DefaultClient.Do(req2)
+	resp2, err := gitHubAPIClient.Do(req2)
 	if err != nil {
 		return nil, fmt.Errorf("GitHub asset download API: %w", err)
 	}
@@ -851,7 +879,7 @@ func downloadURL(rawURL string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if parsed, err2 := neturl.Parse(rawURL); err2 == nil && strings.HasSuffix(parsed.Hostname(), "github.com") {
+	if parsed, err2 := neturl.Parse(rawURL); err2 == nil && isGitHubHost(parsed.Hostname()) {
 		if tok := gitHubToken(); tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)
 		}

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -253,8 +253,23 @@ func TestParseGitHubReleaseDownloadURL(t *testing.T) {
 			ok:     false,
 		},
 		{
+			// Suffix-matching but not github.com — must be rejected to prevent token leakage
+			rawURL: "https://evilgithub.com/owner/repo/releases/download/v1.0.0/file.tar.gz",
+			ok:     false,
+		},
+		{
+			// http scheme — must be rejected (only https allowed)
+			rawURL: "http://github.com/owner/repo/releases/download/v1.0.0/file.tar.gz",
+			ok:     false,
+		},
+		{
 			// Too few path segments
 			rawURL: "https://github.com/owner/repo/releases/download/v1.0.0",
+			ok:     false,
+		},
+		{
+			// Extra path segments (len > 6) — must be rejected for exact match
+			rawURL: "https://github.com/owner/repo/releases/download/v1.0.0/file.tar.gz/extra",
 			ok:     false,
 		},
 	}
@@ -323,10 +338,15 @@ func TestDownloadURL_PrivateReleaseAsset(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Override API base URL to point at the mock server.
+	// Override API base URL and client to point at the mock server.
 	origAPIBase := gitHubAPIBaseURL
+	origAPIClient := gitHubAPIClient
 	gitHubAPIBaseURL = srv.URL
-	t.Cleanup(func() { gitHubAPIBaseURL = origAPIBase })
+	gitHubAPIClient = srv.Client()
+	t.Cleanup(func() {
+		gitHubAPIBaseURL = origAPIBase
+		gitHubAPIClient = origAPIClient
+	})
 
 	t.Setenv("RELEASES_TOKEN", wantToken)
 	for _, k := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -106,9 +107,9 @@ func installTestClient(t *testing.T, ct *captureTransport) {
 }
 
 // TestDownloadURL_GitHubAuthHeader verifies that downloadURL injects a Bearer
-// Authorization header for github.com URLs using the first non-empty token env
-// var (RELEASES_TOKEN > GH_TOKEN > GITHUB_TOKEN), and sends no header when none
-// are set.
+// Authorization header for non-release github.com URLs (direct-download path)
+// using the first non-empty token env var (RELEASES_TOKEN > GH_TOKEN >
+// GITHUB_TOKEN), and sends no header when none are set.
 func TestDownloadURL_GitHubAuthHeader(t *testing.T) {
 	const sentinel = "test-token-value"
 
@@ -143,8 +144,9 @@ func TestDownloadURL_GitHubAuthHeader(t *testing.T) {
 				t.Setenv(tc.envKey, sentinel)
 			}
 
-			// Use a real github.com URL — captureTransport redirects it to srv.
-			testURL := "https://github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
+			// Use a non-release github.com URL so we exercise the direct-download
+			// path (not the two-step API flow). captureTransport redirects it to srv.
+			testURL := "https://github.com/GoCodeAlone/plugin/archive/main.tar.gz"
 			if _, err := downloadURL(testURL); err != nil {
 				t.Fatalf("downloadURL: %v", err)
 			}
@@ -195,7 +197,7 @@ func TestDownloadURL_NonGitHubNoAuthHeader(t *testing.T) {
 }
 
 // TestDownloadURL_TokenPriority verifies that RELEASES_TOKEN takes precedence over
-// GH_TOKEN and GITHUB_TOKEN when multiple env vars are set.
+// GH_TOKEN and GITHUB_TOKEN when multiple env vars are set (direct-download path).
 func TestDownloadURL_TokenPriority(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -210,12 +212,168 @@ func TestDownloadURL_TokenPriority(t *testing.T) {
 	t.Setenv("GH_TOKEN", "gh-loses")
 	t.Setenv("GITHUB_TOKEN", "github-loses")
 
-	testURL := "https://github.com/GoCodeAlone/plugin/releases/download/v1.0.0/asset.tar.gz"
+	// Non-release github.com URL exercises the direct-download path.
+	testURL := "https://github.com/GoCodeAlone/plugin/archive/main.tar.gz"
 	if _, err := downloadURL(testURL); err != nil {
 		t.Fatalf("downloadURL: %v", err)
 	}
 	const want = "Bearer releases-wins"
 	if got := ct.gotHeader(); got != want {
 		t.Errorf("Authorization header = %q, want %q", got, want)
+	}
+}
+
+// TestParseGitHubReleaseDownloadURL verifies URL parsing for the GitHub release
+// download pattern.
+func TestParseGitHubReleaseDownloadURL(t *testing.T) {
+	cases := []struct {
+		rawURL   string
+		owner    string
+		repo     string
+		tag      string
+		filename string
+		ok       bool
+	}{
+		{
+			rawURL:   "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-linux-amd64.tar.gz",
+			owner:    "GoCodeAlone",
+			repo:     "workflow-plugin-supply-chain",
+			tag:      "v0.3.0",
+			filename: "workflow-plugin-supply-chain-linux-amd64.tar.gz",
+			ok:       true,
+		},
+		{
+			// Non-release URL
+			rawURL: "https://github.com/GoCodeAlone/plugin/archive/main.tar.gz",
+			ok:     false,
+		},
+		{
+			// Non-GitHub host
+			rawURL: "https://example.com/owner/repo/releases/download/v1.0.0/file.tar.gz",
+			ok:     false,
+		},
+		{
+			// Too few path segments
+			rawURL: "https://github.com/owner/repo/releases/download/v1.0.0",
+			ok:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rawURL, func(t *testing.T) {
+			owner, repo, tag, filename, ok := parseGitHubReleaseDownloadURL(tc.rawURL)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if !tc.ok {
+				return
+			}
+			if owner != tc.owner || repo != tc.repo || tag != tc.tag || filename != tc.filename {
+				t.Errorf("got (%q, %q, %q, %q), want (%q, %q, %q, %q)",
+					owner, repo, tag, filename,
+					tc.owner, tc.repo, tc.tag, tc.filename)
+			}
+		})
+	}
+}
+
+// TestDownloadURL_PrivateReleaseAsset verifies the two-step GitHub API flow used
+// to download assets from private repos. A mock server handles both the
+// releases/tags and releases/assets endpoints.
+func TestDownloadURL_PrivateReleaseAsset(t *testing.T) {
+	const (
+		wantAssetID  = int64(99)
+		wantFilename = "plugin-linux-amd64.tar.gz"
+		wantTag      = "v1.0.0"
+		wantOwner    = "GoCodeAlone"
+		wantRepo     = "test-plugin"
+		wantToken    = "test-secret-token"
+	)
+	wantPayload := []byte("fake tarball bytes")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/releases/tags/%s", wantOwner, wantRepo, wantTag),
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer "+wantToken {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if r.Header.Get("Accept") != "application/vnd.github+json" {
+				http.Error(w, "bad accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"assets":[{"id":%d,"name":%q}]}`, wantAssetID, wantFilename)
+		},
+	)
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/releases/assets/%d", wantOwner, wantRepo, wantAssetID),
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer "+wantToken {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if r.Header.Get("Accept") != "application/octet-stream" {
+				http.Error(w, "bad accept", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(wantPayload) //nolint:errcheck
+		},
+	)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Override API base URL to point at the mock server.
+	origAPIBase := gitHubAPIBaseURL
+	gitHubAPIBaseURL = srv.URL
+	t.Cleanup(func() { gitHubAPIBaseURL = origAPIBase })
+
+	t.Setenv("RELEASES_TOKEN", wantToken)
+	for _, k := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		t.Setenv(k, "")
+	}
+
+	rawURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
+		wantOwner, wantRepo, wantTag, wantFilename)
+	got, err := downloadURL(rawURL)
+	if err != nil {
+		t.Fatalf("downloadURL: %v", err)
+	}
+	if string(got) != string(wantPayload) {
+		t.Errorf("payload = %q, want %q", got, wantPayload)
+	}
+}
+
+// TestDownloadURL_PublicReleaseNoToken verifies that when no token is set,
+// downloadURL falls back to a plain GET for release download URLs (public repos).
+func TestDownloadURL_PublicReleaseNoToken(t *testing.T) {
+	wantPayload := []byte("public tarball bytes")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(wantPayload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	// No token — release URL goes through direct-download path.
+	for _, k := range []string{"RELEASES_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		t.Setenv(k, "")
+	}
+
+	srvURL, _ := url.Parse(srv.URL)
+	ct := &captureTransport{target: srvURL.Host}
+	installTestClient(t, ct)
+
+	rawURL := "https://github.com/GoCodeAlone/public-plugin/releases/download/v1.0.0/plugin.tar.gz"
+	got, err := downloadURL(rawURL)
+	if err != nil {
+		t.Fatalf("downloadURL: %v", err)
+	}
+	if string(got) != string(wantPayload) {
+		t.Errorf("payload = %q, want %q", got, wantPayload)
+	}
+	// No auth header should be sent when there is no token.
+	if hdr := ct.gotHeader(); hdr != "" {
+		t.Errorf("expected no Authorization header with no token, got %q", hdr)
 	}
 }


### PR DESCRIPTION
## Summary

- `github.com/.../releases/download/...` URLs redirect to a signed S3 URL which does not propagate the `Authorization` header, causing 404 on private repos even with a valid token
- Fixes the download flow for private repos by using the GitHub REST API two-step approach when a token is available
- Public repos (no token) continue to use direct GET — no behaviour change for them

## How it works

When `downloadURL` is called with a GitHub release download URL **and** a token is available:
1. `GET api.github.com/repos/OWNER/REPO/releases/tags/TAG` (`Accept: application/vnd.github+json`) — finds the asset ID matching the filename
2. `GET api.github.com/repos/OWNER/REPO/releases/assets/:id` (`Accept: application/octet-stream`) — streams the binary

Falls back to direct GET when no token is set (public repos, non-release URLs, non-GitHub URLs unchanged).

## New helpers

| Symbol | Purpose |
|---|---|
| `gitHubToken()` | DRYs up `RELEASES_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN` resolution |
| `parseGitHubReleaseDownloadURL()` | Hostname-verified URL parser — no path-injection risk |
| `downloadGitHubReleaseAsset()` | Two-step API implementation |
| `gitHubAPIBaseURL` | Package-level var overridable in tests |

## Test plan

- [x] `TestParseGitHubReleaseDownloadURL` — table-driven URL parser unit test
- [x] `TestDownloadURL_PrivateReleaseAsset` — mock mux verifying both API endpoints, headers, payload
- [x] `TestDownloadURL_PublicReleaseNoToken` — fallback direct GET with no token, no auth header sent
- [x] Updated existing tests to non-release paths (routing change)
- [x] All pass with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)