### PR TITLE
feat: v0.19.0-alpha.1 — plugin manifest + lockfile split (Feature A)

### DIFF
--- a/cmd/wfctl/migrate.go
+++ b/cmd/wfctl/migrate.go
@@ -40,10 +40,16 @@ Options:
 
 	if len(args) == 0 {
 		fs.Usage()
-		return fmt.Errorf("subcommand required: status, diff, or apply")
+		return fmt.Errorf("subcommand required: status, diff, apply, or plugins")
 	}
 
 	subcmd := args[0]
+
+	// Handle non-DB subcommands before opening the database.
+	if subcmd == "plugins" {
+		return runMigratePlugins(args[1:])
+	}
+
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
 	}

--- a/cmd/wfctl/migrate.go
+++ b/cmd/wfctl/migrate.go
@@ -27,11 +27,13 @@ Subcommands:
   status    Show applied and pending migrations
   diff      Show pending migrations without applying them
   apply     Apply pending migrations
+  plugins   Migrate requires.plugins[] from app.yaml → wfctl.yaml + .wfctl-lock.yaml
 
 Examples:
   wfctl migrate status --db workflow.db
   wfctl migrate diff --db workflow.db
   wfctl migrate apply --db workflow.db
+  wfctl migrate plugins --config workflow.yaml
 
 Options:
 `)

--- a/cmd/wfctl/migrate_plugins.go
+++ b/cmd/wfctl/migrate_plugins.go
@@ -9,8 +9,9 @@ import (
 
 // runMigratePlugins migrates requires.plugins[] from app.yaml into wfctl.yaml
 // (manifest) and .wfctl-lock.yaml (lockfile).
-// On --auto, it additionally strips the version/source fields from app.yaml inline
-// plugin entries (leaving just the name as a capability declaration).
+// It is safe to re-run (idempotent): plugins already present in wfctl.yaml are skipped.
+// Stripping the inline fields from app.yaml after migration is a manual step in v0.19.0;
+// automated stripping (--auto) is deferred to v0.20.0.
 func runMigratePlugins(args []string) error {
 	fs := flag.NewFlagSet("migrate plugins", flag.ContinueOnError)
 	cfgPath := fs.String("config", "workflow.yaml", "Path to workflow app config")

--- a/cmd/wfctl/migrate_plugins.go
+++ b/cmd/wfctl/migrate_plugins.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// runMigratePlugins migrates requires.plugins[] from app.yaml into wfctl.yaml
+// (manifest) and .wfctl-lock.yaml (lockfile).
+// On --auto, it additionally strips the version/source fields from app.yaml inline
+// plugin entries (leaving just the name as a capability declaration).
+func runMigratePlugins(args []string) error {
+	fs := flag.NewFlagSet("migrate plugins", flag.ContinueOnError)
+	cfgPath := fs.String("config", "workflow.yaml", "Path to workflow app config")
+	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest to create/update")
+	lockPath := fs.String("lock-file", wfctlLockPath, "Path to .wfctl-lock.yaml to create/update")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage: wfctl migrate plugins [options]
+
+Migrate requires.plugins[] from app.yaml into wfctl.yaml + .wfctl-lock.yaml.
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg, err := config.LoadFromFile(*cfgPath)
+	if err != nil {
+		return fmt.Errorf("load config %s: %w", *cfgPath, err)
+	}
+
+	if cfg.Requires == nil || len(cfg.Requires.Plugins) == 0 {
+		fmt.Println("No requires.plugins[] found in config — nothing to migrate.")
+		return nil
+	}
+
+	// Load or initialize manifest.
+	m, err := loadOrInitManifest(*manifestPath)
+	if err != nil {
+		return err
+	}
+
+	// Build set of names already in manifest to avoid duplicates.
+	existing := make(map[string]bool, len(m.Plugins))
+	for _, p := range m.Plugins {
+		existing[p.Name] = true
+	}
+
+	added := 0
+	for _, req := range cfg.Requires.Plugins {
+		if existing[req.Name] {
+			continue
+		}
+		entry := config.WfctlPluginEntry{
+			Name:    req.Name,
+			Version: req.Version,
+			Source:  req.Source,
+		}
+		if req.Auth != nil {
+			entry.Auth = &config.WfctlPluginAuth{Env: req.Auth.Env}
+		}
+		m.Plugins = append(m.Plugins, entry)
+		existing[req.Name] = true
+		added++
+	}
+
+	if added == 0 {
+		fmt.Println("All plugins already present in manifest — nothing to add.")
+	} else {
+		if err := config.SaveWfctlManifest(*manifestPath, m); err != nil {
+			return fmt.Errorf("save manifest: %w", err)
+		}
+		fmt.Printf("Migrated %d plugin(s) to %s\n", added, *manifestPath)
+	}
+
+	// Re-lock to produce/update .wfctl-lock.yaml.
+	return runPluginLockFromManifest(*manifestPath, *lockPath)
+}

--- a/cmd/wfctl/migrate_plugins.go
+++ b/cmd/wfctl/migrate_plugins.go
@@ -46,15 +46,16 @@ Options:
 		return err
 	}
 
-	// Build set of names already in manifest to avoid duplicates.
+	// Build set of normalized names already in manifest to avoid duplicates.
+	// Normalize both sides so "foo" and "workflow-plugin-foo" are treated as the same plugin.
 	existing := make(map[string]bool, len(m.Plugins))
 	for _, p := range m.Plugins {
-		existing[p.Name] = true
+		existing[normalizePluginName(p.Name)] = true
 	}
 
 	added := 0
 	for _, req := range cfg.Requires.Plugins {
-		if existing[req.Name] {
+		if existing[normalizePluginName(req.Name)] {
 			continue
 		}
 		entry := config.WfctlPluginEntry{
@@ -66,7 +67,7 @@ Options:
 			entry.Auth = &config.WfctlPluginAuth{Env: req.Auth.Env}
 		}
 		m.Plugins = append(m.Plugins, entry)
-		existing[req.Name] = true
+		existing[normalizePluginName(req.Name)] = true
 		added++
 	}
 

--- a/cmd/wfctl/migrate_plugins_test.go
+++ b/cmd/wfctl/migrate_plugins_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+const appYAMLWithPlugins = `modules: []
+requires:
+  plugins:
+    - name: workflow-plugin-digitalocean
+      version: v0.7.6
+      source: github.com/GoCodeAlone/workflow-plugin-digitalocean
+    - name: workflow-plugin-supply-chain
+      version: v0.3.0
+      source: github.com/GoCodeAlone/workflow-plugin-supply-chain
+`
+
+func TestMigratePlugins_CreatesManifestAndLockfile(t *testing.T) {
+	dir := t.TempDir()
+	appYAMLPath := filepath.Join(dir, "workflow.yaml")
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	if err := os.WriteFile(appYAMLPath, []byte(appYAMLWithPlugins), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runMigratePlugins([]string{
+		"--config", appYAMLPath,
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+	})
+	if err != nil {
+		t.Fatalf("runMigratePlugins: %v", err)
+	}
+
+	// Verify manifest created.
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if len(m.Plugins) != 2 {
+		t.Fatalf("want 2 plugins, got %d: %+v", len(m.Plugins), m.Plugins)
+	}
+	var foundDO, foundSC bool
+	for _, p := range m.Plugins {
+		switch p.Name {
+		case "workflow-plugin-digitalocean":
+			foundDO = true
+			if p.Version != "v0.7.6" {
+				t.Errorf("do version = %q, want v0.7.6", p.Version)
+			}
+			if p.Source != "github.com/GoCodeAlone/workflow-plugin-digitalocean" {
+				t.Errorf("do source = %q", p.Source)
+			}
+		case "workflow-plugin-supply-chain":
+			foundSC = true
+			if p.Version != "v0.3.0" {
+				t.Errorf("sc version = %q, want v0.3.0", p.Version)
+			}
+		}
+	}
+	if !foundDO || !foundSC {
+		t.Errorf("missing plugins; foundDO=%v foundSC=%v", foundDO, foundSC)
+	}
+
+	// Verify lockfile created.
+	lf, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load lockfile: %v", err)
+	}
+	if _, ok := lf.Plugins["workflow-plugin-digitalocean"]; !ok {
+		t.Error("workflow-plugin-digitalocean not in lockfile")
+	}
+	if _, ok := lf.Plugins["workflow-plugin-supply-chain"]; !ok {
+		t.Error("workflow-plugin-supply-chain not in lockfile")
+	}
+}
+
+func TestMigratePlugins_NoRequires(t *testing.T) {
+	dir := t.TempDir()
+	appYAMLPath := filepath.Join(dir, "workflow.yaml")
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	content := "modules: []\n"
+	if err := os.WriteFile(appYAMLPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runMigratePlugins([]string{
+		"--config", appYAMLPath,
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+	})
+	if err != nil {
+		t.Fatalf("runMigratePlugins with no requires: %v", err)
+	}
+}
+
+func TestMigratePlugins_IdempotentOnSecondRun(t *testing.T) {
+	dir := t.TempDir()
+	appYAMLPath := filepath.Join(dir, "workflow.yaml")
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	if err := os.WriteFile(appYAMLPath, []byte(appYAMLWithPlugins), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{
+		"--config", appYAMLPath,
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+	}
+	if err := runMigratePlugins(args); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := runMigratePlugins(args); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Plugins) != 2 {
+		t.Errorf("want 2 plugins after idempotent run, got %d", len(m.Plugins))
+	}
+}

--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -48,14 +48,16 @@ func pluginUsage() error {
 	fmt.Fprintf(flag.CommandLine.Output(), `Usage: wfctl plugin <subcommand> [options]
 
 Subcommands:
+  add      Add a plugin to wfctl.yaml manifest
+  lock     Regenerate .wfctl-lock.yaml from wfctl.yaml manifest
   init     Scaffold a new plugin project
   docs     Generate documentation for an existing plugin
   test     Run a plugin through its full lifecycle in a test harness
   search   Search the plugin registry
-  install  Install a plugin from the registry
+  install  Install plugins (reads .wfctl-lock.yaml when present)
   list     List installed plugins
   update   Update an installed plugin to its latest version
-  remove   Uninstall a plugin
+  remove   Uninstall a plugin (also removes from manifest + lockfile)
   validate Validate a plugin manifest from the registry or a local file
   info     Show details about an installed plugin
   deps     List dependencies for a plugin

--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -21,6 +21,10 @@ func runPlugin(args []string) error {
 		return runPluginTest(args[1:])
 	case "search":
 		return runPluginSearch(args[1:])
+	case "add":
+		return runPluginAdd(args[1:])
+	case "lock":
+		return runPluginLock(args[1:])
 	case "install":
 		return runPluginInstall(args[1:])
 	case "list":

--- a/cmd/wfctl/plugin_add.go
+++ b/cmd/wfctl/plugin_add.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+func runPluginAdd(args []string) error {
+	fs := flag.NewFlagSet("plugin add", flag.ContinueOnError)
+	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
+	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: wfctl plugin add <name>[@version]")
+	}
+	spec := fs.Args()[0]
+	name, version, _ := strings.Cut(spec, "@")
+	if name == "" {
+		return fmt.Errorf("invalid plugin spec %q: name required", spec)
+	}
+
+	m, err := loadOrInitManifest(*manifestPath)
+	if err != nil {
+		return err
+	}
+
+	// Check for duplicate.
+	for _, p := range m.Plugins {
+		if p.Name == name {
+			return fmt.Errorf("plugin %q already in manifest; use wfctl plugin update to change version", name)
+		}
+	}
+
+	m.Plugins = append(m.Plugins, config.WfctlPluginEntry{
+		Name:    name,
+		Version: version,
+	})
+
+	if err := config.SaveWfctlManifest(*manifestPath, m); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+	fmt.Printf("Added %s@%s to wfctl.yaml\n", name, version)
+
+	// Re-lock to refresh lockfile.
+	return runPluginLockFromManifest(*manifestPath, *lockPath)
+}
+
+// loadOrInitManifest loads an existing wfctl.yaml or returns an empty manifest.
+func loadOrInitManifest(path string) (*config.WfctlManifest, error) {
+	m, err := config.LoadWfctlManifest(path)
+	if err != nil {
+		// File doesn't exist — start fresh.
+		return &config.WfctlManifest{Version: 1}, nil
+	}
+	return m, nil
+}

--- a/cmd/wfctl/plugin_add.go
+++ b/cmd/wfctl/plugin_add.go
@@ -13,11 +13,12 @@ func runPluginAdd(args []string) error {
 	fs := flag.NewFlagSet("plugin add", flag.ContinueOnError)
 	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
 	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile")
+	sourceFlag := fs.String("source", "", "Plugin source (e.g. github.com/org/repo); optional for registry plugins")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() < 1 {
-		return fmt.Errorf("usage: wfctl plugin add <name>[@version]")
+		return fmt.Errorf("usage: wfctl plugin add <name>[@version] [--source <repo>]")
 	}
 	spec := fs.Args()[0]
 	name, version, _ := strings.Cut(spec, "@")
@@ -30,16 +31,19 @@ func runPluginAdd(args []string) error {
 		return err
 	}
 
-	// Check for duplicate.
+	// Check for duplicate — compare by normalized name so both
+	// "workflow-plugin-foo" and "foo" are treated as the same entry.
+	normName := normalizePluginName(name)
 	for _, p := range m.Plugins {
-		if p.Name == name {
-			return fmt.Errorf("plugin %q already in manifest; use wfctl plugin update to change version", name)
+		if normalizePluginName(p.Name) == normName {
+			return fmt.Errorf("plugin %q already in manifest; use wfctl plugin update to change version", p.Name)
 		}
 	}
 
 	m.Plugins = append(m.Plugins, config.WfctlPluginEntry{
 		Name:    name,
 		Version: version,
+		Source:  *sourceFlag,
 	})
 
 	if err := config.SaveWfctlManifest(*manifestPath, m); err != nil {

--- a/cmd/wfctl/plugin_add.go
+++ b/cmd/wfctl/plugin_add.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -44,18 +45,25 @@ func runPluginAdd(args []string) error {
 	if err := config.SaveWfctlManifest(*manifestPath, m); err != nil {
 		return fmt.Errorf("save manifest: %w", err)
 	}
-	fmt.Printf("Added %s@%s to wfctl.yaml\n", name, version)
+	if version != "" {
+		fmt.Printf("Added %s@%s to wfctl.yaml\n", name, version)
+	} else {
+		fmt.Printf("Added %s to wfctl.yaml\n", name)
+	}
 
 	// Re-lock to refresh lockfile.
 	return runPluginLockFromManifest(*manifestPath, *lockPath)
 }
 
 // loadOrInitManifest loads an existing wfctl.yaml or returns an empty manifest.
+// Only swallows file-not-found; parse errors and permission errors are returned.
 func loadOrInitManifest(path string) (*config.WfctlManifest, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return &config.WfctlManifest{Version: 1}, nil
+	}
 	m, err := config.LoadWfctlManifest(path)
 	if err != nil {
-		// File doesn't exist — start fresh.
-		return &config.WfctlManifest{Version: 1}, nil
+		return nil, fmt.Errorf("load manifest %s: %w", path, err)
 	}
 	return m, nil
 }

--- a/cmd/wfctl/plugin_add_test.go
+++ b/cmd/wfctl/plugin_add_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+func TestPluginAdd_NewPlugin(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	// Start with an existing manifest.
+	existing := `version: 1
+plugins:
+  - name: workflow-plugin-existing
+    version: v1.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-existing
+`
+	if err := os.WriteFile(manifestPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runPluginAdd([]string{
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+		"workflow-plugin-foo@v1.2.3",
+	})
+	if err != nil {
+		t.Fatalf("runPluginAdd: %v", err)
+	}
+
+	// Verify manifest updated.
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if len(m.Plugins) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(m.Plugins))
+	}
+	var found bool
+	for _, p := range m.Plugins {
+		if p.Name == "workflow-plugin-foo" && p.Version == "v1.2.3" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("workflow-plugin-foo@v1.2.3 not found in manifest: %+v", m.Plugins)
+	}
+
+	// Verify lockfile created.
+	lf, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load lockfile: %v", err)
+	}
+	if _, ok := lf.Plugins["workflow-plugin-foo"]; !ok {
+		t.Errorf("workflow-plugin-foo not in lockfile; entries: %v", lf.Plugins)
+	}
+}
+
+func TestPluginAdd_NoVersion(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	err := runPluginAdd([]string{
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+		"workflow-plugin-noversion",
+	})
+	if err != nil {
+		t.Fatalf("runPluginAdd without version: %v", err)
+	}
+
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if len(m.Plugins) != 1 || m.Plugins[0].Name != "workflow-plugin-noversion" {
+		t.Errorf("unexpected manifest: %+v", m.Plugins)
+	}
+}
+
+func TestPluginAdd_DuplicateReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	initial := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runPluginAdd([]string{
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+		"workflow-plugin-foo@v2.0.0",
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate plugin")
+	}
+}
+
+func TestPluginAdd_MissingNameReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	err := runPluginAdd([]string{
+		"--manifest", manifestPath,
+		"--lock-file", lockPath,
+	})
+	if err == nil {
+		t.Fatal("expected error when no plugin name provided")
+	}
+}

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -426,6 +426,8 @@ func runPluginRemove(args []string) error {
 	var pluginDirVal string
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
+	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
+	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin remove [options] <name>\n\nUninstall a plugin.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -439,9 +441,17 @@ func runPluginRemove(args []string) error {
 	}
 
 	pluginName := fs.Arg(0)
+
+	// Remove from manifest + lockfile when those files exist.
+	if err := removeFromManifestAndLockfile(pluginName, *manifestPath, *lockPath); err != nil {
+		return err
+	}
+
 	pluginDir := filepath.Join(pluginDirVal, pluginName)
 	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-		return fmt.Errorf("plugin %q is not installed", pluginName)
+		// Binary wasn't installed (manifest-only removal is valid).
+		fmt.Printf("Removed plugin %q from manifest\n", pluginName)
+		return nil
 	}
 	if err := os.RemoveAll(pluginDir); err != nil {
 		return fmt.Errorf("remove plugin %q: %w", pluginName, err)

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -454,15 +454,25 @@ func runPluginRemove(args []string) error {
 	}
 
 	pluginName := fs.Arg(0)
+	pluginDir := filepath.Join(pluginDirVal, pluginName)
+	binaryInstalled := true
+	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+		binaryInstalled = false
+	}
+
+	// Check if the plugin is in the manifest.
+	inManifest := pluginExistsInManifest(pluginName, *manifestPath)
+
+	if !binaryInstalled && !inManifest {
+		return fmt.Errorf("plugin %q is not installed", pluginName)
+	}
 
 	// Remove from manifest + lockfile when those files exist.
 	if err := removeFromManifestAndLockfile(pluginName, *manifestPath, *lockPath); err != nil {
 		return err
 	}
 
-	pluginDir := filepath.Join(pluginDirVal, pluginName)
-	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-		// Binary wasn't installed (manifest-only removal is valid).
+	if !binaryInstalled {
 		fmt.Printf("Removed plugin %q from manifest\n", pluginName)
 		return nil
 	}

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -348,6 +348,9 @@ func runPluginUpdate(args []string) error {
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
 	cfgPath := fs.String("config", "", "Registry config file path")
+	pinVersion := fs.String("version", "", "Pin to this specific version in wfctl.yaml (skips registry lookup)")
+	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
+	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin update [options] <name>\n\nUpdate an installed plugin to its latest version.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -361,6 +364,16 @@ func runPluginUpdate(args []string) error {
 	}
 
 	pluginName := fs.Arg(0)
+
+	// --version: pin a specific version in the manifest without hitting registry.
+	if *pinVersion != "" {
+		if err := updateManifestVersion(pluginName, *pinVersion, *manifestPath, *lockPath); err != nil {
+			return err
+		}
+		fmt.Printf("Pinned %s@%s in wfctl.yaml\n", pluginName, *pinVersion)
+		return nil
+	}
+
 	pluginDir := filepath.Join(pluginDirVal, pluginName)
 	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
 		return fmt.Errorf("plugin %q is not installed", pluginName)

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -461,7 +461,10 @@ func runPluginRemove(args []string) error {
 	}
 
 	// Check if the plugin is in the manifest.
-	inManifest := pluginExistsInManifest(pluginName, *manifestPath)
+	inManifest, manifestErr := pluginExistsInManifest(pluginName, *manifestPath)
+	if manifestErr != nil {
+		return fmt.Errorf("check manifest: %w", manifestErr)
+	}
 
 	if !binaryInstalled && !inManifest {
 		return fmt.Errorf("plugin %q is not installed", pluginName)

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -471,7 +471,10 @@ func runPluginRemove(args []string) error {
 
 	// Check lockfile as well: covers the legacy case where no manifest exists
 	// but the plugin was recorded in .wfctl-lock.yaml.
-	inLockfile := pluginExistsInLockfile(pluginName, *lockPath)
+	inLockfile, lockfileErr := pluginExistsInLockfile(pluginName, *lockPath)
+	if lockfileErr != nil {
+		return fmt.Errorf("check lockfile: %w", lockfileErr)
+	}
 
 	if !binaryInstalled && !inManifest && !inLockfile {
 		return fmt.Errorf("plugin %q is not installed", pluginName)

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -454,7 +454,10 @@ func runPluginRemove(args []string) error {
 	}
 
 	pluginName := fs.Arg(0)
-	pluginDir := filepath.Join(pluginDirVal, pluginName)
+	// Normalize name for filesystem paths: installs use short names (e.g. "digitalocean"),
+	// but the CLI accepts full names too (e.g. "workflow-plugin-digitalocean").
+	fsName := normalizePluginName(pluginName)
+	pluginDir := filepath.Join(pluginDirVal, fsName)
 	binaryInstalled := true
 	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
 		binaryInstalled = false
@@ -466,7 +469,11 @@ func runPluginRemove(args []string) error {
 		return fmt.Errorf("check manifest: %w", manifestErr)
 	}
 
-	if !binaryInstalled && !inManifest {
+	// Check lockfile as well: covers the legacy case where no manifest exists
+	// but the plugin was recorded in .wfctl-lock.yaml.
+	inLockfile := pluginExistsInLockfile(pluginName, *lockPath)
+
+	if !binaryInstalled && !inManifest && !inLockfile {
 		return fmt.Errorf("plugin %q is not installed", pluginName)
 	}
 

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+func TestInstallFromWfctlLockfile_SHA256MismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a lockfile with a non-empty sha256.
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-foo": {
+				Version: "v1.0.0",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-foo",
+				SHA256:  "expected-sha256-that-wont-match",
+			},
+		},
+	}
+	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake plugin binary with wrong content.
+	fooDir := filepath.Join(pluginDir, "workflow-plugin-foo")
+	if err := os.MkdirAll(fooDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fooDir, "workflow-plugin-foo"), []byte("wrong content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := verifyWfctlLockfileChecksums(pluginDir, lf)
+	if err == nil {
+		t.Fatal("expected sha256 mismatch error, got nil")
+	}
+}
+
+func TestInstallFromWfctlLockfile_SHA256EmptySkipsVerification(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-foo": {
+				Version: "v1.0.0",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-foo",
+				SHA256:  "", // empty — skip verification
+			},
+		},
+	}
+
+	// No plugin binary present; should succeed because sha256 is empty.
+	err := verifyWfctlLockfileChecksums(pluginDir, lf)
+	if err != nil {
+		t.Fatalf("expected no error when sha256 is empty, got: %v", err)
+	}
+}
+
+func TestInstallFromWfctlLockfile_SHA256MatchPasses(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "plugins")
+
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-foo": {
+				Version: "v1.0.0",
+				SHA256:  "", // alpha.1: leave empty so we don't need real binaries
+			},
+		},
+	}
+
+	// With empty sha256, should always pass.
+	err := verifyWfctlLockfileChecksums(pluginDir, lf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -74,7 +74,11 @@ func TestInstallFromWfctlLockfile_SHA256EmptySkipsVerification(t *testing.T) {
 	}
 }
 
-func TestInstallFromWfctlLockfile_SHA256MatchPasses(t *testing.T) {
+// TestVerifyWfctlLockfileChecksums_EmptyEntryAlwaysPasses verifies that when a
+// plugin's top-level sha256 field is empty, the check is skipped entirely.
+// Alpha.1 lockfiles often have empty sha256 (no real download performed), so
+// this must be a no-op rather than a hard failure.
+func TestVerifyWfctlLockfileChecksums_EmptyEntryAlwaysPasses(t *testing.T) {
 	dir := t.TempDir()
 	pluginDir := filepath.Join(dir, "plugins")
 
@@ -84,14 +88,14 @@ func TestInstallFromWfctlLockfile_SHA256MatchPasses(t *testing.T) {
 		Plugins: map[string]config.WfctlLockPluginEntry{
 			"workflow-plugin-foo": {
 				Version: "v1.0.0",
-				SHA256:  "", // alpha.1: leave empty so we don't need real binaries
+				SHA256:  "", // empty — skip verification; no binary needed
 			},
 		},
 	}
 
-	// With empty sha256, should always pass.
+	// No plugin binary present; should succeed because sha256 is empty.
 	err := verifyWfctlLockfileChecksums(pluginDir, lf)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected no error when sha256 is empty, got: %v", err)
 	}
 }

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -33,12 +33,14 @@ func TestInstallFromWfctlLockfile_SHA256MismatchFails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a fake plugin binary with wrong content.
-	fooDir := filepath.Join(pluginDir, "workflow-plugin-foo")
+	// Create a fake plugin binary at the NORMALIZED path.
+	// verifyWfctlLockfileChecksums calls normalizePluginName("workflow-plugin-foo") → "foo",
+	// so the binary must live at plugins/foo/foo, not plugins/workflow-plugin-foo/workflow-plugin-foo.
+	fooDir := filepath.Join(pluginDir, "foo")
 	if err := os.MkdirAll(fooDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(fooDir, "workflow-plugin-foo"), []byte("wrong content"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(fooDir, "foo"), []byte("wrong content"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// installFromWfctlLockfile installs all plugins recorded in a config.WfctlLockfile.
+// For each plugin:
+//   - If a platform URL is recorded, download from that URL.
+//   - After install, verify sha256 when non-empty (hard fail on mismatch).
+//   - If no platform URL, fall back to registry lookup via the existing install path.
+//
+// This is the authoritative install path when .wfctl-lock.yaml (new format) is present.
+func installFromWfctlLockfile(pluginDirVal string, lf *config.WfctlLockfile) error {
+	if len(lf.Plugins) == 0 {
+		fmt.Println("No plugins pinned in .wfctl-lock.yaml.")
+		return nil
+	}
+
+	var failed []string
+	for name, entry := range lf.Plugins {
+		fmt.Fprintf(os.Stderr, "Installing %s@%s...\n", name, entry.Version)
+
+		installed := false
+		// If we have platform-specific URL, install from that URL.
+		platKey := currentPlatformKey()
+		if plat, ok := entry.Platforms[platKey]; ok && plat.URL != "" {
+			destDir := filepath.Join(pluginDirVal, name)
+			if err := installFromURL(plat.URL, pluginDirVal); err != nil {
+				fmt.Fprintf(os.Stderr, "error installing %s from URL: %v\n", name, err)
+				failed = append(failed, name)
+				continue
+			}
+			// Verify platform-specific sha256 if present.
+			if plat.SHA256 != "" {
+				binary := filepath.Join(destDir, name)
+				got, err := hashFileSHA256(binary)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "CHECKSUM ERROR for %s: %v\n", name, err)
+					_ = os.RemoveAll(destDir)
+					failed = append(failed, name)
+					continue
+				}
+				if got != plat.SHA256 {
+					fmt.Fprintf(os.Stderr, "CHECKSUM MISMATCH for %s: got %s, want %s\n", name, got, plat.SHA256)
+					_ = os.RemoveAll(destDir)
+					failed = append(failed, name)
+					continue
+				}
+			}
+			installed = true
+		}
+
+		if !installed {
+			// Fall back to name@version registry install.
+			spec := name
+			if entry.Version != "" {
+				spec = name + "@" + entry.Version
+			}
+			if err := runPluginInstall([]string{"--plugin-dir", pluginDirVal, spec}); err != nil {
+				fmt.Fprintf(os.Stderr, "error installing %s: %v\n", name, err)
+				failed = append(failed, name)
+				continue
+			}
+		}
+
+		// Verify top-level binary sha256 if present.
+		if entry.SHA256 != "" {
+			destDir := filepath.Join(pluginDirVal, name)
+			if verifyErr := verifyInstalledChecksum(destDir, name, entry.SHA256); verifyErr != nil {
+				fmt.Fprintf(os.Stderr, "CHECKSUM MISMATCH for %s: %v\n", name, verifyErr)
+				_ = os.RemoveAll(destDir)
+				failed = append(failed, name)
+				continue
+			}
+		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to install: %s", strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// verifyWfctlLockfileChecksums checks sha256 of already-installed plugin binaries
+// against the lockfile. Only checks plugins with non-empty sha256 entries.
+// Returns an error if any mismatch is detected.
+func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile) error {
+	var mismatches []string
+	for name, entry := range lf.Plugins {
+		if entry.SHA256 == "" {
+			continue
+		}
+		destDir := filepath.Join(pluginDirVal, name)
+		if err := verifyInstalledChecksum(destDir, name, entry.SHA256); err != nil {
+			mismatches = append(mismatches, fmt.Sprintf("%s: %v", name, err))
+		}
+	}
+	if len(mismatches) > 0 {
+		return fmt.Errorf("checksum mismatches:\n  %s", strings.Join(mismatches, "\n  "))
+	}
+	return nil
+}
+
+// currentPlatformKey returns the GOOS-GOARCH key used in WfctlLockPlatform maps.
+func currentPlatformKey() string {
+	return fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -128,8 +128,16 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 // against the lockfile. Only checks plugins with non-empty sha256 entries.
 // Returns an error if any mismatch is detected.
 func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile) error {
+	// Sort plugin names for deterministic verification order and predictable error messages.
+	names := make([]string, 0, len(lf.Plugins))
+	for name := range lf.Plugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	var mismatches []string
-	for name, entry := range lf.Plugins {
+	for _, name := range names {
+		entry := lf.Plugins[name]
 		if entry.SHA256 == "" {
 			continue
 		}

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -23,15 +24,28 @@ func installFromWfctlLockfile(pluginDirVal string, lf *config.WfctlLockfile) err
 		return nil
 	}
 
+	// Sort plugin names for deterministic install order.
+	names := make([]string, 0, len(lf.Plugins))
+	for name := range lf.Plugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	var failed []string
-	for name, entry := range lf.Plugins {
+	for _, name := range names {
+		entry := lf.Plugins[name]
 		fmt.Fprintf(os.Stderr, "Installing %s@%s...\n", name, entry.Version)
 
+		// Normalize name for filesystem paths — the install layer uses short names
+		// (e.g. "digitalocean") while the manifest/lockfile stores full names
+		// (e.g. "workflow-plugin-digitalocean").
+		fsName := normalizePluginName(name)
 		installed := false
+
 		// If we have platform-specific URL, install from that URL.
 		platKey := currentPlatformKey()
 		if plat, ok := entry.Platforms[platKey]; ok && plat.URL != "" {
-			destDir := filepath.Join(pluginDirVal, name)
+			destDir := filepath.Join(pluginDirVal, fsName)
 			if err := installFromURL(plat.URL, pluginDirVal); err != nil {
 				fmt.Fprintf(os.Stderr, "error installing %s from URL: %v\n", name, err)
 				failed = append(failed, name)
@@ -39,7 +53,7 @@ func installFromWfctlLockfile(pluginDirVal string, lf *config.WfctlLockfile) err
 			}
 			// Verify platform-specific sha256 if present.
 			if plat.SHA256 != "" {
-				binary := filepath.Join(destDir, name)
+				binary := filepath.Join(destDir, fsName)
 				got, err := hashFileSHA256(binary)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "CHECKSUM ERROR for %s: %v\n", name, err)
@@ -70,10 +84,10 @@ func installFromWfctlLockfile(pluginDirVal string, lf *config.WfctlLockfile) err
 			}
 		}
 
-		// Verify top-level binary sha256 if present.
+		// Verify top-level binary sha256 if present (uses normalized fs name).
 		if entry.SHA256 != "" {
-			destDir := filepath.Join(pluginDirVal, name)
-			if verifyErr := verifyInstalledChecksum(destDir, name, entry.SHA256); verifyErr != nil {
+			destDir := filepath.Join(pluginDirVal, fsName)
+			if verifyErr := verifyInstalledChecksum(destDir, fsName, entry.SHA256); verifyErr != nil {
 				fmt.Fprintf(os.Stderr, "CHECKSUM MISMATCH for %s: %v\n", name, verifyErr)
 				_ = os.RemoveAll(destDir)
 				failed = append(failed, name)
@@ -97,8 +111,11 @@ func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile)
 		if entry.SHA256 == "" {
 			continue
 		}
-		destDir := filepath.Join(pluginDirVal, name)
-		if err := verifyInstalledChecksum(destDir, name, entry.SHA256); err != nil {
+		// Normalize name for filesystem path — manifest stores full names,
+		// install layer uses short names (strips "workflow-plugin-" prefix).
+		fsName := normalizePluginName(name)
+		destDir := filepath.Join(pluginDirVal, fsName)
+		if err := verifyInstalledChecksum(destDir, fsName, entry.SHA256); err != nil {
 			mismatches = append(mismatches, fmt.Sprintf("%s: %v", name, err))
 		}
 	}

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -17,8 +17,12 @@ import (
 //   - After install, verify sha256 when non-empty (hard fail on mismatch).
 //   - If no platform URL, fall back to registry lookup via the existing install path.
 //
+// lockPath is the on-disk path for .wfctl-lock.yaml. After each successful install
+// the new-format lockfile is re-saved so that the old-format write performed by
+// installFromURL/updateLockfileWithChecksum does not corrupt the new-format file.
+//
 // This is the authoritative install path when .wfctl-lock.yaml (new format) is present.
-func installFromWfctlLockfile(pluginDirVal string, lf *config.WfctlLockfile) error {
+func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLockfile) error {
 	if len(lf.Plugins) == 0 {
 		fmt.Println("No plugins pinned in .wfctl-lock.yaml.")
 		return nil
@@ -92,6 +96,24 @@ func installFromWfctlLockfile(pluginDirVal string, lf *config.WfctlLockfile) err
 				_ = os.RemoveAll(destDir)
 				failed = append(failed, name)
 				continue
+			}
+		}
+
+		// Re-save the new-format lockfile after each successful install.
+		// installFromURL and runPluginInstall internally call updateLockfileWithChecksum,
+		// which serializes the OLD PluginLockfile format and can strip source/platforms
+		// fields from the on-disk .wfctl-lock.yaml. Overwrite it here with the correct
+		// new format, capturing the binary sha256 while we're at it.
+		if lockPath != "" {
+			destDir := filepath.Join(pluginDirVal, fsName)
+			binaryPath := filepath.Join(destDir, fsName)
+			if sha, hashErr := hashFileSHA256(binaryPath); hashErr == nil && sha != entry.SHA256 {
+				e := lf.Plugins[name]
+				e.SHA256 = sha
+				lf.Plugins[name] = e
+			}
+			if saveErr := config.SaveWfctlLockfile(lockPath, lf); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not persist lockfile after installing %s: %v\n", name, saveErr)
 			}
 		}
 	}

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -3,29 +3,85 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
 	"gopkg.in/yaml.v3"
-	"os"
 )
 
-// runPluginLock regenerates the plugin lockfile from requires.plugins[] in the
-// workflow config. Pins each declared plugin at its declared version (or "latest"
-// if no version is specified).
+// runPluginLock regenerates the plugin lockfile.
+// If wfctl.yaml (manifest) exists, it reads from there.
+// Otherwise it falls back to requires.plugins[] in the workflow config.
 func runPluginLock(args []string) error {
 	fs := flag.NewFlagSet("plugin lock", flag.ContinueOnError)
 	cfgPath := fs.String("config", "workflow.yaml", "Path to workflow config file")
+	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
 	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile to write")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	cfg, err := config.LoadFromFile(*cfgPath)
+	// Prefer wfctl.yaml manifest if it exists.
+	if _, err := os.Stat(*manifestPath); err == nil {
+		return runPluginLockFromManifest(*manifestPath, *lockPath)
+	}
+
+	// Fall back to legacy workflow.yaml requires.plugins[].
+	return runPluginLockLegacy(*cfgPath, *lockPath)
+}
+
+// runPluginLockFromManifest regenerates .wfctl-lock.yaml from a wfctl.yaml manifest.
+// Existing sha256/platform data is preserved for plugins that are already locked
+// at the same version.
+func runPluginLockFromManifest(manifestPath, lockPath string) error {
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+
+	// Load existing lockfile so we can preserve sha256 for unchanged versions.
+	var existing *config.WfctlLockfile
+	if lf, err := config.LoadWfctlLockfile(lockPath); err == nil {
+		existing = lf
+	}
+
+	newLF := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Plugins:     make(map[string]config.WfctlLockPluginEntry),
+	}
+
+	for _, p := range m.Plugins {
+		entry := config.WfctlLockPluginEntry{
+			Version: p.Version,
+			Source:  p.Source,
+		}
+		// Preserve existing sha256/platforms if version matches.
+		if existing != nil {
+			if prev, ok := existing.Plugins[p.Name]; ok && prev.Version == p.Version {
+				entry.SHA256 = prev.SHA256
+				entry.Platforms = prev.Platforms
+			}
+		}
+		newLF.Plugins[p.Name] = entry
+	}
+
+	if err := config.SaveWfctlLockfile(lockPath, newLF); err != nil {
+		return fmt.Errorf("write lockfile: %w", err)
+	}
+	fmt.Printf("Lockfile written to %s\n", lockPath)
+	return nil
+}
+
+// runPluginLockLegacy is the pre-v0.19.0 behavior: read from workflow.yaml requires.plugins[].
+func runPluginLockLegacy(cfgPath, lockPath string) error {
+	cfg, err := config.LoadFromFile(cfgPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	lf, _ := loadPluginLockfile(*lockPath)
+	lf, _ := loadPluginLockfile(lockPath)
 	if lf == nil {
 		lf = &PluginLockfile{}
 	}
@@ -45,9 +101,9 @@ func runPluginLock(args []string) error {
 	if err != nil {
 		return fmt.Errorf("marshal lockfile: %w", err)
 	}
-	if err := os.WriteFile(*lockPath, data, 0600); err != nil {
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
 		return fmt.Errorf("write lockfile: %w", err)
 	}
-	fmt.Printf("Lockfile written to %s\n", *lockPath)
+	fmt.Printf("Lockfile written to %s\n", lockPath)
 	return nil
 }

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -57,9 +57,12 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 			Version: p.Version,
 			Source:  p.Source,
 		}
-		// Preserve existing sha256/platforms if version matches.
+		// Preserve existing sha256/platforms only when both version AND source match.
+		// A source change means the binary origin changed, so cached checksums are stale.
 		if existing != nil {
-			if prev, ok := existing.Plugins[p.Name]; ok && prev.Version == p.Version {
+			if prev, ok := existing.Plugins[p.Name]; ok &&
+				prev.Version == p.Version &&
+				prev.Source == p.Source {
 				entry.SHA256 = prev.SHA256
 				entry.Platforms = prev.Platforms
 			}

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPluginLock_FromManifest(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
+		t.Fatalf("runPluginLockFromManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+
+	var parsed struct {
+		Plugins map[string]struct {
+			Version string `yaml:"version"`
+			Source  string `yaml:"source"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+	entry, ok := parsed.Plugins["workflow-plugin-foo"]
+	if !ok {
+		t.Fatalf("plugin 'workflow-plugin-foo' not found in lockfile; got: %v", parsed.Plugins)
+	}
+	if entry.Version != "v1.2.3" {
+		t.Errorf("version = %q, want v1.2.3", entry.Version)
+	}
+	if entry.Source != "github.com/GoCodeAlone/workflow-plugin-foo" {
+		t.Errorf("source = %q, want github.com/GoCodeAlone/workflow-plugin-foo", entry.Source)
+	}
+}
+
+func TestPluginLock_FromManifest_PreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	// Pre-populate lockfile with sha256 for an existing plugin.
+	existingLock := `version: 1
+generated_at: "2026-01-01T00:00:00Z"
+plugins:
+  workflow-plugin-foo:
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+    sha256: existing-sha256
+`
+	if err := os.WriteFile(lockPath, []byte(existingLock), 0o600); err != nil {
+		t.Fatalf("write existing lockfile: %v", err)
+	}
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+  - name: workflow-plugin-bar
+    version: v2.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-bar
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
+		t.Fatalf("runPluginLockFromManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+
+	var parsed struct {
+		Plugins map[string]struct {
+			Version string `yaml:"version"`
+			SHA256  string `yaml:"sha256"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+
+	foo := parsed.Plugins["workflow-plugin-foo"]
+	if foo.SHA256 != "existing-sha256" {
+		t.Errorf("existing sha256 not preserved: got %q, want existing-sha256", foo.SHA256)
+	}
+	if _, ok := parsed.Plugins["workflow-plugin-bar"]; !ok {
+		t.Error("new plugin workflow-plugin-bar not added")
+	}
+}

--- a/cmd/wfctl/plugin_lockfile.go
+++ b/cmd/wfctl/plugin_lockfile.go
@@ -22,6 +22,9 @@ const wfctlLockPath = ".wfctl-lock.yaml"
 // (git connect, deploy defaults). It is no longer used as the lockfile write target.
 const wfctlYAMLPath = ".wfctl.yaml"
 
+// wfctlManifestPath is the canonical path for the human-editable plugin manifest.
+const wfctlManifestPath = "wfctl.yaml"
+
 // PluginLockEntry records a pinned plugin version in the lockfile.
 type PluginLockEntry struct {
 	Version    string `yaml:"version"`

--- a/cmd/wfctl/plugin_lockfile.go
+++ b/cmd/wfctl/plugin_lockfile.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoCodeAlone/workflow/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -81,10 +82,17 @@ func loadPluginLockfile(path string) (*PluginLockfile, error) {
 	return lf, nil
 }
 
-// installFromLockfile reads .wfctl-lock.yaml (with .wfctl.yaml fallback) and
-// installs all plugins in the plugins section. If no lockfile is found, it
-// prints a helpful message.
+// installFromLockfile reads .wfctl-lock.yaml and installs all plugins.
+// If the lockfile is in the new config.WfctlLockfile format (has version field),
+// it uses installFromWfctlLockfile which supports platform URLs and sha256 verification.
+// Otherwise it falls back to the legacy PluginLockfile behavior.
 func installFromLockfile(pluginDir, cfgPath string) error {
+	// Try new WfctlLockfile format first.
+	if newLF, err := config.LoadWfctlLockfile(wfctlLockPath); err == nil && newLF.Version > 0 {
+		return installFromWfctlLockfile(pluginDir, newLF)
+	}
+
+	// Legacy path.
 	lf, err := loadPluginLockfile(wfctlLockPath)
 	if err != nil {
 		return fmt.Errorf("load lockfile: %w", err)

--- a/cmd/wfctl/plugin_lockfile.go
+++ b/cmd/wfctl/plugin_lockfile.go
@@ -89,7 +89,7 @@ func loadPluginLockfile(path string) (*PluginLockfile, error) {
 func installFromLockfile(pluginDir, cfgPath string) error {
 	// Try new WfctlLockfile format first.
 	if newLF, err := config.LoadWfctlLockfile(wfctlLockPath); err == nil && newLF.Version > 0 {
-		return installFromWfctlLockfile(pluginDir, newLF)
+		return installFromWfctlLockfile(pluginDir, wfctlLockPath, newLF)
 	}
 
 	// Legacy path.

--- a/cmd/wfctl/plugin_remove.go
+++ b/cmd/wfctl/plugin_remove.go
@@ -31,7 +31,7 @@ func removeFromManifestAndLockfile(name, manifestPath, lockPath string) error {
 		if err != nil {
 			return fmt.Errorf("load manifest: %w", err)
 		}
-		filtered := m.Plugins[:0]
+		filtered := make([]config.WfctlPluginEntry, 0, len(m.Plugins))
 		for _, p := range m.Plugins {
 			if p.Name != name {
 				filtered = append(filtered, p)

--- a/cmd/wfctl/plugin_remove.go
+++ b/cmd/wfctl/plugin_remove.go
@@ -1,25 +1,32 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/GoCodeAlone/workflow/config"
 )
 
-// pluginExistsInManifest returns true if pluginName is listed in the manifest at manifestPath.
-// Returns false when the file doesn't exist or the plugin isn't in it.
-func pluginExistsInManifest(name, manifestPath string) bool {
+// pluginExistsInManifest returns (true, nil) when name (or its normalized form)
+// is listed in the manifest. Returns (false, nil) when the file doesn't exist or
+// the plugin isn't in it. Returns (false, err) on parse or permission errors.
+func pluginExistsInManifest(name, manifestPath string) (bool, error) {
 	m, err := config.LoadWfctlManifest(manifestPath)
 	if err != nil {
-		return false
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
+	normName := normalizePluginName(name)
 	for _, p := range m.Plugins {
-		if p.Name == name {
-			return true
+		if p.Name == name || normalizePluginName(p.Name) == normName {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // removeFromManifestAndLockfile removes a plugin entry from wfctl.yaml and

--- a/cmd/wfctl/plugin_remove.go
+++ b/cmd/wfctl/plugin_remove.go
@@ -9,6 +9,23 @@ import (
 	"github.com/GoCodeAlone/workflow/config"
 )
 
+// pluginExistsInLockfile returns true when name (or its normalized form) is
+// recorded in the lockfile. Returns false when the file doesn't exist or the
+// plugin isn't in it. Errors loading the lockfile are treated as "not found".
+func pluginExistsInLockfile(name, lockPath string) bool {
+	lf, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		return false
+	}
+	normName := normalizePluginName(name)
+	for k := range lf.Plugins {
+		if k == name || normalizePluginName(k) == normName {
+			return true
+		}
+	}
+	return false
+}
+
 // pluginExistsInManifest returns (true, nil) when name (or its normalized form)
 // is listed in the manifest. Returns (false, nil) when the file doesn't exist or
 // the plugin isn't in it. Returns (false, err) on parse or permission errors.
@@ -31,7 +48,11 @@ func pluginExistsInManifest(name, manifestPath string) (bool, error) {
 
 // removeFromManifestAndLockfile removes a plugin entry from wfctl.yaml and
 // .wfctl-lock.yaml if those files exist. Silently no-ops when files are absent.
+// Both the raw name and its normalized form are matched so that "foo" and
+// "workflow-plugin-foo" refer to the same plugin.
 func removeFromManifestAndLockfile(name, manifestPath, lockPath string) error {
+	normName := normalizePluginName(name)
+
 	// Remove from manifest if it exists.
 	if _, err := os.Stat(manifestPath); err == nil {
 		m, err := config.LoadWfctlManifest(manifestPath)
@@ -40,7 +61,7 @@ func removeFromManifestAndLockfile(name, manifestPath, lockPath string) error {
 		}
 		filtered := make([]config.WfctlPluginEntry, 0, len(m.Plugins))
 		for _, p := range m.Plugins {
-			if p.Name != name {
+			if p.Name != name && normalizePluginName(p.Name) != normName {
 				filtered = append(filtered, p)
 			}
 		}
@@ -50,13 +71,18 @@ func removeFromManifestAndLockfile(name, manifestPath, lockPath string) error {
 		}
 	}
 
-	// Remove from lockfile if it exists.
+	// Remove from lockfile if it exists. Lockfile keys may use either full names
+	// or short names, so normalize both sides before comparing.
 	if _, err := os.Stat(lockPath); err == nil {
 		lf, err := config.LoadWfctlLockfile(lockPath)
 		if err != nil {
 			return fmt.Errorf("load lockfile: %w", err)
 		}
-		delete(lf.Plugins, name)
+		for k := range lf.Plugins {
+			if k == name || normalizePluginName(k) == normName {
+				delete(lf.Plugins, k)
+			}
+		}
 		if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
 			return fmt.Errorf("save lockfile: %w", err)
 		}

--- a/cmd/wfctl/plugin_remove.go
+++ b/cmd/wfctl/plugin_remove.go
@@ -7,6 +7,21 @@ import (
 	"github.com/GoCodeAlone/workflow/config"
 )
 
+// pluginExistsInManifest returns true if pluginName is listed in the manifest at manifestPath.
+// Returns false when the file doesn't exist or the plugin isn't in it.
+func pluginExistsInManifest(name, manifestPath string) bool {
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		return false
+	}
+	for _, p := range m.Plugins {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // removeFromManifestAndLockfile removes a plugin entry from wfctl.yaml and
 // .wfctl-lock.yaml if those files exist. Silently no-ops when files are absent.
 func removeFromManifestAndLockfile(name, manifestPath, lockPath string) error {

--- a/cmd/wfctl/plugin_remove.go
+++ b/cmd/wfctl/plugin_remove.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// removeFromManifestAndLockfile removes a plugin entry from wfctl.yaml and
+// .wfctl-lock.yaml if those files exist. Silently no-ops when files are absent.
+func removeFromManifestAndLockfile(name, manifestPath, lockPath string) error {
+	// Remove from manifest if it exists.
+	if _, err := os.Stat(manifestPath); err == nil {
+		m, err := config.LoadWfctlManifest(manifestPath)
+		if err != nil {
+			return fmt.Errorf("load manifest: %w", err)
+		}
+		filtered := m.Plugins[:0]
+		for _, p := range m.Plugins {
+			if p.Name != name {
+				filtered = append(filtered, p)
+			}
+		}
+		m.Plugins = filtered
+		if err := config.SaveWfctlManifest(manifestPath, m); err != nil {
+			return fmt.Errorf("save manifest: %w", err)
+		}
+	}
+
+	// Remove from lockfile if it exists.
+	if _, err := os.Stat(lockPath); err == nil {
+		lf, err := config.LoadWfctlLockfile(lockPath)
+		if err != nil {
+			return fmt.Errorf("load lockfile: %w", err)
+		}
+		delete(lf.Plugins, name)
+		if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+			return fmt.Errorf("save lockfile: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/wfctl/plugin_remove.go
+++ b/cmd/wfctl/plugin_remove.go
@@ -9,21 +9,24 @@ import (
 	"github.com/GoCodeAlone/workflow/config"
 )
 
-// pluginExistsInLockfile returns true when name (or its normalized form) is
-// recorded in the lockfile. Returns false when the file doesn't exist or the
-// plugin isn't in it. Errors loading the lockfile are treated as "not found".
-func pluginExistsInLockfile(name, lockPath string) bool {
+// pluginExistsInLockfile returns (true, nil) when name (or its normalized form)
+// is recorded in the lockfile. Returns (false, nil) when the file doesn't exist
+// or the plugin isn't in it. Returns (false, err) on parse or permission errors.
+func pluginExistsInLockfile(name, lockPath string) (bool, error) {
 	lf, err := config.LoadWfctlLockfile(lockPath)
 	if err != nil {
-		return false
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
 	normName := normalizePluginName(name)
 	for k := range lf.Plugins {
 		if k == name || normalizePluginName(k) == normName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // pluginExistsInManifest returns (true, nil) when name (or its normalized form)

--- a/cmd/wfctl/plugin_remove_test.go
+++ b/cmd/wfctl/plugin_remove_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+func TestPluginRemove_RemovesFromManifestAndLockfile(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+
+	// Create manifest with two plugins.
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+  - name: workflow-plugin-bar
+    version: v2.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-bar
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create lockfile with both plugins.
+	lf := &config.WfctlLockfile{
+		Version: 1,
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-foo": {Version: "v1.0.0", Source: "github.com/GoCodeAlone/workflow-plugin-foo"},
+			"workflow-plugin-bar": {Version: "v2.0.0", Source: "github.com/GoCodeAlone/workflow-plugin-bar"},
+		},
+	}
+	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake installed plugin binary dir.
+	fooDir := filepath.Join(pluginDir, "workflow-plugin-foo")
+	if err := os.MkdirAll(fooDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := removeFromManifestAndLockfile("workflow-plugin-foo", manifestPath, lockPath)
+	if err != nil {
+		t.Fatalf("removeFromManifestAndLockfile: %v", err)
+	}
+
+	// Verify manifest no longer has workflow-plugin-foo.
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	for _, p := range m.Plugins {
+		if p.Name == "workflow-plugin-foo" {
+			t.Errorf("workflow-plugin-foo still in manifest after remove")
+		}
+	}
+	if len(m.Plugins) != 1 || m.Plugins[0].Name != "workflow-plugin-bar" {
+		t.Errorf("unexpected manifest: %+v", m.Plugins)
+	}
+
+	// Verify lockfile no longer has workflow-plugin-foo.
+	loaded, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load lockfile: %v", err)
+	}
+	if _, ok := loaded.Plugins["workflow-plugin-foo"]; ok {
+		t.Error("workflow-plugin-foo still in lockfile after remove")
+	}
+	if _, ok := loaded.Plugins["workflow-plugin-bar"]; !ok {
+		t.Error("workflow-plugin-bar should remain in lockfile")
+	}
+}
+
+func TestPluginRemove_NoManifestNoError(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	// No manifest or lockfile — should succeed silently.
+	err := removeFromManifestAndLockfile("workflow-plugin-foo", manifestPath, lockPath)
+	if err != nil {
+		t.Fatalf("expected no error when manifest absent, got: %v", err)
+	}
+}

--- a/cmd/wfctl/plugin_update_manifest.go
+++ b/cmd/wfctl/plugin_update_manifest.go
@@ -19,9 +19,10 @@ func updateManifestVersion(name, newVersion, manifestPath, lockPath string) erro
 		return fmt.Errorf("load manifest: %w", err)
 	}
 
+	normName := normalizePluginName(name)
 	found := false
 	for i, p := range m.Plugins {
-		if p.Name == name {
+		if p.Name == name || normalizePluginName(p.Name) == normName {
 			m.Plugins[i].Version = newVersion
 			found = true
 			break

--- a/cmd/wfctl/plugin_update_manifest.go
+++ b/cmd/wfctl/plugin_update_manifest.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// updateManifestVersion updates a plugin's version in wfctl.yaml and re-locks.
+// Returns an error if the plugin is not found in the manifest.
+func updateManifestVersion(name, newVersion, manifestPath, lockPath string) error {
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		return fmt.Errorf("manifest %s not found; run wfctl plugin add first", manifestPath)
+	}
+
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+
+	found := false
+	for i, p := range m.Plugins {
+		if p.Name == name {
+			m.Plugins[i].Version = newVersion
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("plugin %q not found in manifest; use wfctl plugin add first", name)
+	}
+
+	if err := config.SaveWfctlManifest(manifestPath, m); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+
+	// Re-lock so sha256 is cleared for the new version.
+	return runPluginLockFromManifest(manifestPath, lockPath)
+}

--- a/cmd/wfctl/plugin_update_test.go
+++ b/cmd/wfctl/plugin_update_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+func TestUpdateManifestVersion_UpdatesVersion(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+  - name: workflow-plugin-bar
+    version: v2.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-bar
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateManifestVersion("workflow-plugin-foo", "v1.5.0", manifestPath, lockPath); err != nil {
+		t.Fatalf("updateManifestVersion: %v", err)
+	}
+
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	for _, p := range m.Plugins {
+		if p.Name == "workflow-plugin-foo" {
+			if p.Version != "v1.5.0" {
+				t.Errorf("version = %q, want v1.5.0", p.Version)
+			}
+			return
+		}
+	}
+	t.Error("workflow-plugin-foo not found in manifest")
+}
+
+func TestUpdateManifestVersion_OtherPluginsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+  - name: workflow-plugin-bar
+    version: v2.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-bar
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateManifestVersion("workflow-plugin-foo", "v1.5.0", manifestPath, lockPath); err != nil {
+		t.Fatalf("updateManifestVersion: %v", err)
+	}
+
+	m, err := config.LoadWfctlManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	for _, p := range m.Plugins {
+		if p.Name == "workflow-plugin-bar" && p.Version != "v2.0.0" {
+			t.Errorf("workflow-plugin-bar version changed unexpectedly: %q", p.Version)
+		}
+	}
+}
+
+func TestUpdateManifestVersion_NotInManifestReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := updateManifestVersion("workflow-plugin-nonexistent", "v1.5.0", manifestPath, lockPath)
+	if err == nil {
+		t.Fatal("expected error when plugin not in manifest")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -373,6 +373,7 @@ func LoadFromBytes(data []byte) (*WorkflowConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config bytes: %w", err)
 	}
+	warnIfInlinePluginVersions(&cfg)
 	return &cfg, nil
 }
 
@@ -384,6 +385,7 @@ func LoadFromString(yamlContent string) (*WorkflowConfig, error) {
 	if err := yaml.Unmarshal([]byte(yamlContent), &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config string: %w", err)
 	}
+	warnIfInlinePluginVersions(&cfg)
 	return &cfg, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -251,6 +251,9 @@ func loadFromFileWithImports(filepath string, seen map[string]bool) (*WorkflowCo
 	// Apply hardened defaults for ci.build.security after all merging is done.
 	cfg.applyBuildDefaults()
 
+	// Emit deprecation warning when inline plugin version/source fields are present.
+	warnIfInlinePluginVersions(&cfg)
+
 	return &cfg, nil
 }
 

--- a/config/plugin_deprecation.go
+++ b/config/plugin_deprecation.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// inlinePluginDeprecationOnce ensures the warning fires at most once per process run.
+var inlinePluginDeprecationOnce sync.Once
+
+// resetInlinePluginDeprecationOnce resets the once for tests that need to observe
+// the warning independently. Must only be called from test code.
+func resetInlinePluginDeprecationOnce() {
+	inlinePluginDeprecationOnce = sync.Once{}
+}
+
+// warnIfInlinePluginVersions emits a deprecation notice to stderr when a WorkflowConfig
+// contains requires.plugins[] entries with non-empty version or source fields.
+// The warning fires at most once per process lifetime.
+func warnIfInlinePluginVersions(cfg *WorkflowConfig) {
+	if cfg == nil || cfg.Requires == nil {
+		return
+	}
+	for _, p := range cfg.Requires.Plugins {
+		if p.Version != "" || p.Source != "" {
+			inlinePluginDeprecationOnce.Do(func() {
+				fmt.Fprintln(os.Stderr,
+					"[DEPRECATED] requires.plugins[].version and requires.plugins[].source in app.yaml "+
+						"are deprecated. Run 'wfctl migrate plugins' to migrate to wfctl.yaml + "+
+						".wfctl-lock.yaml.")
+			})
+			return
+		}
+	}
+}

--- a/config/plugin_deprecation.go
+++ b/config/plugin_deprecation.go
@@ -9,12 +9,6 @@ import (
 // inlinePluginDeprecationOnce ensures the warning fires at most once per process run.
 var inlinePluginDeprecationOnce sync.Once
 
-// resetInlinePluginDeprecationOnce resets the once for tests that need to observe
-// the warning independently. Must only be called from test code.
-func resetInlinePluginDeprecationOnce() {
-	inlinePluginDeprecationOnce = sync.Once{}
-}
-
 // warnIfInlinePluginVersions emits a deprecation notice to stderr when a WorkflowConfig
 // contains requires.plugins[] entries with non-empty version or source fields.
 // The warning fires at most once per process lifetime.

--- a/config/plugin_deprecation_test.go
+++ b/config/plugin_deprecation_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInlinePluginVersion_EmitsDeprecationWarning(t *testing.T) {
+	// Reset the once so each test gets a fresh run.
+	inlinePluginDeprecationOnce.Do(func() {}) // no-op to ensure it's initialized
+	resetInlinePluginDeprecationOnce()
+
+	// Capture stderr.
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	_, err := LoadFromString(`
+modules: []
+requires:
+  plugins:
+    - name: workflow-plugin-foo
+      version: v1.0.0
+      source: github.com/GoCodeAlone/workflow-plugin-foo
+`)
+	if err != nil {
+		t.Fatalf("LoadFromString: %v", err)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stderr = old
+
+	output := buf.String()
+	if !strings.Contains(output, "deprecated") && !strings.Contains(output, "wfctl migrate plugins") {
+		t.Errorf("expected deprecation warning on stderr, got: %q", output)
+	}
+}
+
+func TestInlinePluginNameOnly_NoDeprecationWarning(t *testing.T) {
+	resetInlinePluginDeprecationOnce()
+
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	_, err := LoadFromString(`
+modules: []
+requires:
+  plugins:
+    - name: workflow-plugin-foo
+`)
+	if err != nil {
+		t.Fatalf("LoadFromString: %v", err)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stderr = old
+
+	output := buf.String()
+	if strings.Contains(output, "deprecated") {
+		t.Errorf("unexpected deprecation warning for name-only plugin: %q", output)
+	}
+}

--- a/config/plugin_deprecation_test.go
+++ b/config/plugin_deprecation_test.go
@@ -5,8 +5,16 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 )
+
+// resetInlinePluginDeprecationOnce resets the once guard so each test gets a
+// fresh run. Defined here (test file) so the reset helper is not part of the
+// production binary.
+func resetInlinePluginDeprecationOnce() {
+	inlinePluginDeprecationOnce = sync.Once{}
+}
 
 func TestInlinePluginVersion_EmitsDeprecationWarning(t *testing.T) {
 	// Reset the once so each test gets a fresh run.

--- a/config/plugin_deprecation_test.go
+++ b/config/plugin_deprecation_test.go
@@ -15,6 +15,7 @@ func TestInlinePluginVersion_EmitsDeprecationWarning(t *testing.T) {
 
 	// Capture stderr.
 	old := os.Stderr
+	t.Cleanup(func() { os.Stderr = old })
 	r, w, _ := os.Pipe()
 	os.Stderr = w
 
@@ -45,6 +46,7 @@ func TestInlinePluginNameOnly_NoDeprecationWarning(t *testing.T) {
 	resetInlinePluginDeprecationOnce()
 
 	old := os.Stderr
+	t.Cleanup(func() { os.Stderr = old })
 	r, w, _ := os.Pipe()
 	os.Stderr = w
 

--- a/config/wfctl_lockfile.go
+++ b/config/wfctl_lockfile.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// WfctlLockfile is the structure of .wfctl-lock.yaml — the machine-generated lockfile.
+// It is derived from wfctl.yaml and must not be hand-edited.
+// Plugin keys are sorted alphabetically for deterministic git diffs.
+type WfctlLockfile struct {
+	Version     int                             `yaml:"version"`
+	GeneratedAt time.Time                       `yaml:"generated_at"`
+	Plugins     map[string]WfctlLockPluginEntry `yaml:"plugins"`
+}
+
+// WfctlLockPluginEntry is the locked record for a single plugin.
+type WfctlLockPluginEntry struct {
+	Version   string                       `yaml:"version"`
+	Source    string                       `yaml:"source"`
+	SHA256    string                       `yaml:"sha256"`
+	Platforms map[string]WfctlLockPlatform `yaml:"platforms,omitempty"`
+}
+
+// WfctlLockPlatform holds platform-specific download info.
+type WfctlLockPlatform struct {
+	URL    string `yaml:"url"`
+	SHA256 string `yaml:"sha256"`
+}
+
+// LoadWfctlLockfile reads and parses a .wfctl-lock.yaml file.
+func LoadWfctlLockfile(path string) (*WfctlLockfile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read lockfile %s: %w", path, err)
+	}
+	var lf WfctlLockfile
+	if err := yaml.Unmarshal(data, &lf); err != nil {
+		return nil, fmt.Errorf("parse lockfile %s: %w", path, err)
+	}
+	return &lf, nil
+}
+
+// SaveWfctlLockfile writes a lockfile to disk with sorted plugin keys for determinism.
+func SaveWfctlLockfile(path string, lf *WfctlLockfile) error {
+	// Build a sorted yaml.Node to ensure deterministic key order.
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+	addStr := func(key, val string) {
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: val},
+		)
+	}
+	addInt := func(key string, val int) {
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: fmt.Sprintf("%d", val)},
+		)
+	}
+
+	addInt("version", lf.Version)
+	addStr("generated_at", lf.GeneratedAt.UTC().Format(time.RFC3339))
+
+	// Sort plugin keys.
+	names := make([]string, 0, len(lf.Plugins))
+	for k := range lf.Plugins {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	pluginsNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for _, name := range names {
+		entry := lf.Plugins[name]
+		entryNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+		addField := func(k, v string) {
+			entryNode.Content = append(entryNode.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: k},
+				&yaml.Node{Kind: yaml.ScalarNode, Value: v},
+			)
+		}
+		addField("version", entry.Version)
+		addField("source", entry.Source)
+		addField("sha256", entry.SHA256)
+
+		if len(entry.Platforms) > 0 {
+			platKeys := make([]string, 0, len(entry.Platforms))
+			for pk := range entry.Platforms {
+				platKeys = append(platKeys, pk)
+			}
+			sort.Strings(platKeys)
+			platNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			for _, pk := range platKeys {
+				p := entry.Platforms[pk]
+				pNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+				pNode.Content = append(pNode.Content,
+					&yaml.Node{Kind: yaml.ScalarNode, Value: "url"},
+					&yaml.Node{Kind: yaml.ScalarNode, Value: p.URL},
+					&yaml.Node{Kind: yaml.ScalarNode, Value: "sha256"},
+					&yaml.Node{Kind: yaml.ScalarNode, Value: p.SHA256},
+				)
+				platNode.Content = append(platNode.Content,
+					&yaml.Node{Kind: yaml.ScalarNode, Value: pk},
+					pNode,
+				)
+			}
+			entryNode.Content = append(entryNode.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "platforms"},
+				platNode,
+			)
+		}
+
+		pluginsNode.Content = append(pluginsNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: name},
+			entryNode,
+		)
+	}
+
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "plugins"},
+		pluginsNode,
+	)
+
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal lockfile: %w", err)
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/config/wfctl_lockfile.go
+++ b/config/wfctl_lockfile.go
@@ -47,6 +47,11 @@ func LoadWfctlLockfile(path string) (*WfctlLockfile, error) {
 
 // SaveWfctlLockfile writes a lockfile to disk with sorted plugin keys for determinism.
 func SaveWfctlLockfile(path string, lf *WfctlLockfile) error {
+	// Default zero GeneratedAt to now so the field is always meaningful.
+	if lf.GeneratedAt.IsZero() {
+		lf.GeneratedAt = time.Now().UTC()
+	}
+
 	// Build a sorted yaml.Node to ensure deterministic key order.
 	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 

--- a/config/wfctl_lockfile_test.go
+++ b/config/wfctl_lockfile_test.go
@@ -60,7 +60,7 @@ func TestWfctlLockfile_RoundTrip(t *testing.T) {
 
 func TestWfctlLockfile_DeterministicOutput(t *testing.T) {
 	// Two lockfiles with identical content should produce byte-identical YAML.
-	make := func() WfctlLockfile {
+	mkLockfile := func() WfctlLockfile {
 		return WfctlLockfile{
 			Version:     1,
 			GeneratedAt: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
@@ -73,10 +73,10 @@ func TestWfctlLockfile_DeterministicOutput(t *testing.T) {
 	dir := t.TempDir()
 	p1 := filepath.Join(dir, "lock1.yaml")
 	p2 := filepath.Join(dir, "lock2.yaml")
-	if err := SaveWfctlLockfile(p1, func() *WfctlLockfile { l := make(); return &l }()); err != nil {
+	if err := SaveWfctlLockfile(p1, func() *WfctlLockfile { l := mkLockfile(); return &l }()); err != nil {
 		t.Fatal(err)
 	}
-	if err := SaveWfctlLockfile(p2, func() *WfctlLockfile { l := make(); return &l }()); err != nil {
+	if err := SaveWfctlLockfile(p2, func() *WfctlLockfile { l := mkLockfile(); return &l }()); err != nil {
 		t.Fatal(err)
 	}
 	b1, _ := os.ReadFile(p1)

--- a/config/wfctl_lockfile_test.go
+++ b/config/wfctl_lockfile_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWfctlLockfile_RoundTrip(t *testing.T) {
+	lf := WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+		Plugins: map[string]WfctlLockPluginEntry{
+			"workflow-plugin-digitalocean": {
+				Version: "v0.7.6",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-digitalocean",
+				SHA256:  "abc123",
+				Platforms: map[string]WfctlLockPlatform{
+					"linux-amd64": {
+						URL:    "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.6/plugin-linux-amd64.tar.gz",
+						SHA256: "def456",
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".wfctl-lock.yaml")
+	if err := SaveWfctlLockfile(path, &lf); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := LoadWfctlLockfile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Version != 1 {
+		t.Errorf("version = %d, want 1", loaded.Version)
+	}
+	entry, ok := loaded.Plugins["workflow-plugin-digitalocean"]
+	if !ok {
+		t.Fatal("plugin entry missing after round-trip")
+	}
+	if entry.Version != "v0.7.6" {
+		t.Errorf("version = %q, want v0.7.6", entry.Version)
+	}
+	if entry.SHA256 != "abc123" {
+		t.Errorf("sha256 = %q, want abc123", entry.SHA256)
+	}
+	plat, ok := entry.Platforms["linux-amd64"]
+	if !ok {
+		t.Fatal("platform linux-amd64 missing")
+	}
+	if plat.SHA256 != "def456" {
+		t.Errorf("platform sha256 = %q, want def456", plat.SHA256)
+	}
+}
+
+func TestWfctlLockfile_DeterministicOutput(t *testing.T) {
+	// Two lockfiles with identical content should produce byte-identical YAML.
+	make := func() WfctlLockfile {
+		return WfctlLockfile{
+			Version:     1,
+			GeneratedAt: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+			Plugins: map[string]WfctlLockPluginEntry{
+				"b-plugin": {Version: "v1.0.0", Source: "github.com/b/b", SHA256: "bbb"},
+				"a-plugin": {Version: "v2.0.0", Source: "github.com/a/a", SHA256: "aaa"},
+			},
+		}
+	}
+	dir := t.TempDir()
+	p1 := filepath.Join(dir, "lock1.yaml")
+	p2 := filepath.Join(dir, "lock2.yaml")
+	if err := SaveWfctlLockfile(p1, func() *WfctlLockfile { l := make(); return &l }()); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveWfctlLockfile(p2, func() *WfctlLockfile { l := make(); return &l }()); err != nil {
+		t.Fatal(err)
+	}
+	b1, _ := os.ReadFile(p1)
+	b2, _ := os.ReadFile(p2)
+	if string(b1) != string(b2) {
+		t.Errorf("non-deterministic output:\n--- lock1 ---\n%s\n--- lock2 ---\n%s", b1, b2)
+	}
+	// Also assert plugin keys appear in alphabetical order.
+	idx_a := strings.Index(string(b1), "a-plugin")
+	idx_b := strings.Index(string(b1), "b-plugin")
+	if idx_a > idx_b {
+		t.Errorf("expected a-plugin before b-plugin in output, got a@%d b@%d", idx_a, idx_b)
+	}
+}
+
+func TestWfctlLockfile_NotFound(t *testing.T) {
+	_, err := LoadWfctlLockfile("/nonexistent/.wfctl-lock.yaml")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/config/wfctl_lockfile_test.go
+++ b/config/wfctl_lockfile_test.go
@@ -93,7 +93,9 @@ func TestWfctlLockfile_DeterministicOutput(t *testing.T) {
 	// Also assert plugin keys appear in alphabetical order.
 	idx_a := strings.Index(string(b1), "a-plugin")
 	idx_b := strings.Index(string(b1), "b-plugin")
-	if idx_a > idx_b {
+	if idx_a < 0 || idx_b < 0 {
+		t.Errorf("expected both a-plugin and b-plugin in output; a@%d b@%d", idx_a, idx_b)
+	} else if idx_a > idx_b {
 		t.Errorf("expected a-plugin before b-plugin in output, got a@%d b@%d", idx_a, idx_b)
 	}
 }

--- a/config/wfctl_lockfile_test.go
+++ b/config/wfctl_lockfile_test.go
@@ -79,8 +79,14 @@ func TestWfctlLockfile_DeterministicOutput(t *testing.T) {
 	if err := SaveWfctlLockfile(p2, func() *WfctlLockfile { l := mkLockfile(); return &l }()); err != nil {
 		t.Fatal(err)
 	}
-	b1, _ := os.ReadFile(p1)
-	b2, _ := os.ReadFile(p2)
+	b1, err := os.ReadFile(p1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(p2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if string(b1) != string(b2) {
 		t.Errorf("non-deterministic output:\n--- lock1 ---\n%s\n--- lock2 ---\n%s", b1, b2)
 	}

--- a/config/wfctl_manifest.go
+++ b/config/wfctl_manifest.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// WfctlManifest is the structure of wfctl.yaml — the human-editable plugin manifest.
+// It lists plugins with their declared versions and sources.
+// The machine-generated lockfile (.wfctl-lock.yaml) is derived from this manifest.
+type WfctlManifest struct {
+	Version int                `yaml:"version"`
+	Plugins []WfctlPluginEntry `yaml:"plugins"`
+}
+
+// WfctlPluginEntry is a single plugin declared in wfctl.yaml.
+type WfctlPluginEntry struct {
+	Name    string             `yaml:"name"`
+	Version string             `yaml:"version"`
+	Source  string             `yaml:"source"`
+	Auth    *WfctlPluginAuth   `yaml:"auth,omitempty"`
+	Verify  *WfctlPluginVerify `yaml:"verify,omitempty"`
+}
+
+// WfctlPluginAuth holds auth configuration for private plugin registries.
+type WfctlPluginAuth struct {
+	Env string `yaml:"env"`
+}
+
+// WfctlPluginVerify holds sigstore/cosign identity for supply-chain verification.
+type WfctlPluginVerify struct {
+	Identity string `yaml:"identity"`
+}
+
+// LoadWfctlManifest reads and parses a wfctl.yaml manifest file.
+func LoadWfctlManifest(path string) (*WfctlManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	var m WfctlManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// SaveWfctlManifest writes a manifest to disk in canonical YAML form.
+func SaveWfctlManifest(path string, m *WfctlManifest) error {
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/config/wfctl_manifest.go
+++ b/config/wfctl_manifest.go
@@ -18,8 +18,8 @@ type WfctlManifest struct {
 // WfctlPluginEntry is a single plugin declared in wfctl.yaml.
 type WfctlPluginEntry struct {
 	Name    string             `yaml:"name"`
-	Version string             `yaml:"version"`
-	Source  string             `yaml:"source"`
+	Version string             `yaml:"version,omitempty"`
+	Source  string             `yaml:"source,omitempty"`
 	Auth    *WfctlPluginAuth   `yaml:"auth,omitempty"`
 	Verify  *WfctlPluginVerify `yaml:"verify,omitempty"`
 }

--- a/config/wfctl_manifest_test.go
+++ b/config/wfctl_manifest_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWfctlManifest_LoadsPluginEntries(t *testing.T) {
+	raw := []byte(`
+version: 1
+plugins:
+  - name: workflow-plugin-digitalocean
+    version: v0.7.6
+    source: github.com/GoCodeAlone/workflow-plugin-digitalocean
+    auth:
+      env: GH_TOKEN
+  - name: workflow-plugin-supply-chain
+    version: v0.3.0
+    source: github.com/GoCodeAlone/workflow-plugin-supply-chain
+    verify:
+      identity: "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/.github/workflows/release.yml@refs/tags/v0.3.0"
+`)
+	var m WfctlManifest
+	if err := yaml.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Version != 1 {
+		t.Errorf("version = %d, want 1", m.Version)
+	}
+	if len(m.Plugins) != 2 {
+		t.Fatalf("plugins count = %d, want 2", len(m.Plugins))
+	}
+	p := m.Plugins[0]
+	if p.Name != "workflow-plugin-digitalocean" || p.Version != "v0.7.6" {
+		t.Errorf("plugin[0] = %+v", p)
+	}
+	if p.Auth == nil || p.Auth.Env != "GH_TOKEN" {
+		t.Errorf("plugin[0].auth = %+v", p.Auth)
+	}
+	p2 := m.Plugins[1]
+	if p2.Verify == nil || p2.Verify.Identity == "" {
+		t.Errorf("plugin[1].verify = %+v", p2.Verify)
+	}
+}
+
+func TestWfctlManifest_EmptyPluginsList(t *testing.T) {
+	raw := []byte("version: 1\nplugins: []\n")
+	var m WfctlManifest
+	if err := yaml.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(m.Plugins) != 0 {
+		t.Errorf("want 0 plugins, got %d", len(m.Plugins))
+	}
+}
+
+func TestWfctlManifest_LoadFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wfctl.yaml")
+	content := []byte("version: 1\nplugins:\n  - name: foo\n    version: v1.0.0\n    source: github.com/foo/bar\n")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	m, err := LoadWfctlManifest(path)
+	if err != nil {
+		t.Fatalf("LoadWfctlManifest: %v", err)
+	}
+	if len(m.Plugins) != 1 || m.Plugins[0].Name != "foo" {
+		t.Errorf("unexpected manifest: %+v", m)
+	}
+}
+
+func TestWfctlManifest_LoadFromFile_NotFound(t *testing.T) {
+	_, err := LoadWfctlManifest("/nonexistent/wfctl.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}


### PR DESCRIPTION
## Summary

Implements Feature A from the v0.19.0 architectural cleanup plan: separating the human-editable plugin manifest from the machine-generated lockfile.

- **config.WfctlManifest** — new `wfctl.yaml` format with `name/version/source/auth/verify` per plugin (no sha256)
- **config.WfctlLockfile** — `.wfctl-lock.yaml` with deterministic sorted-key YAML output, platform URLs, sha256 checksums
- **wfctl plugin lock** — regenerates `.wfctl-lock.yaml` from `wfctl.yaml`; preserves existing sha256 for unchanged versions
- **wfctl plugin add `<name>[@version]`** — adds plugin to manifest + re-locks; duplicate check
- **wfctl plugin remove** — removes plugin from manifest + lockfile in addition to binary; error if plugin not found in either
- **wfctl plugin update --version `<v>`** — pins a specific version in manifest without registry lookup, then re-locks
- **wfctl plugin install** — when `.wfctl-lock.yaml` is new format (`version: 1`), delegates to `installFromWfctlLockfile`; verifies sha256 when non-empty (hard fail); falls back to legacy `PluginLockfile` path
- **wfctl migrate plugins** — one-time migration from `app.yaml` inline `requires.plugins[]` → `wfctl.yaml` + `.wfctl-lock.yaml`; idempotent
- **Deprecation warning** — emitted at most once per process when `app.yaml` has inline `plugin.version` or `plugin.source` fields

## Migration path

```bash
# One-time migration (existing repos)
wfctl migrate plugins --config workflow.yaml

# Day-to-day workflow
wfctl plugin add workflow-plugin-digitalocean@v0.7.6
wfctl plugin install   # reads .wfctl-lock.yaml
```

## Test plan
- [ ] `go test ./config/ -run TestWfctlManifest` — A1 passes
- [ ] `go test ./config/ -run TestWfctlLockfile` — A2 passes
- [ ] `go test ./cmd/wfctl/ -run TestPluginLock` — A3 passes
- [ ] `go test ./cmd/wfctl/ -run TestPluginAdd` — A4 passes
- [ ] `go test ./cmd/wfctl/ -run TestPluginRemove` — A5 passes
- [ ] `go test ./cmd/wfctl/ -run TestUpdateManifest` — A6 passes
- [ ] `go test ./cmd/wfctl/ -run TestInstallFromWfctlLockfile` — A7 passes
- [ ] `go test ./cmd/wfctl/ -run TestMigratePlugins` — A8 passes
- [ ] `go test ./config/ -run TestInlinePlugin` — A9 passes
- [ ] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)