### PR TITLE
fix: v0.18.10.1 — structpb ref marshaling + infra_apply wiring + summary close error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.10.1] - 2026-04-24
+
+### Fixed
+
+- **`cmd/wfctl/deploy_providers.go`**: `remoteResourceDriver.Troubleshoot` was passing
+  `interfaces.ResourceRef` as a nested struct in the `InvokeService` args map. The gRPC
+  transport (`structpb.NewStruct`) cannot encode Go structs — the plugin received empty args
+  and Troubleshoot was a silent no-op. Args are now flattened to scalar primitives:
+  `ref_name`, `ref_type`, `ref_provider_id`, `failure_msg`.
+- **`cmd/wfctl/infra_apply.go`**: `applyWithProviderAndStore` was passing the `IaCProvider`
+  to `troubleshootAfterFailure`, whose type assertion against `interfaces.Troubleshooter` always
+  failed — the hook was a silent no-op. Now calls `provider.ResourceDriver(ref.Type)` and passes
+  the resulting `ResourceDriver` to `troubleshootAfterFailure`, enabling real plugin-backed
+  diagnostics on `wfctl infra apply` failure.
+- **`cmd/wfctl/ci_output_summary.go`**: `WriteStepSummary` used `defer f.Close()` which
+  discards the close error (potential data loss on buffer flush). Now uses a named return
+  and captures the close error, surfacing it only when there is no prior write error.
+
 ## [0.18.10] - 2026-04-24
 
 ### Added

--- a/cmd/wfctl/ci_output_summary.go
+++ b/cmd/wfctl/ci_output_summary.go
@@ -31,7 +31,7 @@ type PhaseTiming struct {
 
 // WriteStepSummary appends Markdown to the CI provider's summary destination.
 // No-ops when the provider has no summary destination (all non-GHA for now).
-func WriteStepSummary(emitter CIGroupEmitter, in SummaryInput) error {
+func WriteStepSummary(emitter CIGroupEmitter, in SummaryInput) (err error) {
 	path := emitter.SummaryPath()
 	if path == "" {
 		return nil
@@ -40,7 +40,13 @@ func WriteStepSummary(emitter CIGroupEmitter, in SummaryInput) error {
 	if err != nil {
 		return fmt.Errorf("open summary: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		// Capture the close error (may flush buffered writes) and surface it
+		// only when there is no earlier write error to preserve.
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+	}()
 	return renderSummary(f, in)
 }
 

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -689,9 +689,13 @@ func (d *remoteResourceDriver) SensitiveKeys() []string {
 // Returns (nil, nil) silently when the plugin returns Unimplemented so
 // the caller doesn't need to probe for capability — absence is a valid answer.
 func (d *remoteResourceDriver) Troubleshoot(ctx context.Context, ref interfaces.ResourceRef, failureMsg string) ([]interfaces.Diagnostic, error) {
+	// Pass ref as flat primitives — structpb.NewStruct (the gRPC transport)
+	// cannot encode arbitrary Go structs; each field must be a scalar.
 	res, err := d.invoker.InvokeService("ResourceDriver.Troubleshoot", map[string]any{
-		"ref":         ref,
-		"failure_msg": failureMsg,
+		"ref_name":        ref.Name,
+		"ref_provider_id": ref.ProviderID,
+		"ref_type":        ref.Type,
+		"failure_msg":     failureMsg,
 	})
 	if err != nil {
 		if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {

--- a/cmd/wfctl/deploy_providers_remote_driver_test.go
+++ b/cmd/wfctl/deploy_providers_remote_driver_test.go
@@ -556,7 +556,8 @@ func TestRemoteDriver_Troubleshoot_Success(t *testing.T) {
 		},
 	}
 	d := newDriver(si)
-	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "x"}, "boom")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", Type: "app_platform", ProviderID: "abc-123"}
+	diags, err := d.Troubleshoot(context.Background(), ref, "boom")
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -568,6 +569,24 @@ func TestRemoteDriver_Troubleshoot_Success(t *testing.T) {
 	}
 	if diags[0].Detail != "log tail" {
 		t.Errorf("Detail: got %q", diags[0].Detail)
+	}
+
+	// Assert args are flat primitives — structpb.NewStruct (gRPC transport)
+	// cannot encode Go structs; ref must be decomposed to scalar fields.
+	if si.args["ref_name"] != ref.Name {
+		t.Errorf("args[ref_name] = %q, want %q", si.args["ref_name"], ref.Name)
+	}
+	if si.args["ref_type"] != ref.Type {
+		t.Errorf("args[ref_type] = %q, want %q", si.args["ref_type"], ref.Type)
+	}
+	if si.args["ref_provider_id"] != ref.ProviderID {
+		t.Errorf("args[ref_provider_id] = %q, want %q", si.args["ref_provider_id"], ref.ProviderID)
+	}
+	if si.args["failure_msg"] != "boom" {
+		t.Errorf("args[failure_msg] = %q, want %q", si.args["failure_msg"], "boom")
+	}
+	if _, hasOldRef := si.args["ref"]; hasOldRef {
+		t.Error("args must not contain a nested 'ref' struct — structpb cannot encode it")
 	}
 }
 

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -264,12 +264,16 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 			ref.Type = specs[0].Type
 		}
 		em := detectCIProvider()
-		// TODO(v0.18.11): provider is interfaces.IaCProvider, which does not implement
-		// interfaces.Troubleshooter. troubleshootAfterFailure's type assertion always
-		// returns false here — this hook is currently a no-op for all IaC providers.
-		// Full diagnostics require per-ResourceDriver access to be threaded through
-		// applyInfraModules (see task #69).
-		troubleshootAfterFailure(ctx, w, provider, ref, err, infraApplyTroubleshootTimeout, em)
+		// Resolve the ResourceDriver for the failed resource type so
+		// troubleshootAfterFailure can reach a Troubleshooter implementation.
+		// ref.Type is set when we have a single-action or single-spec plan.
+		if ref.Type != "" {
+			if rd, rdErr := provider.ResourceDriver(ref.Type); rdErr == nil {
+				troubleshootAfterFailure(ctx, w, rd, ref, err, infraApplyTroubleshootTimeout, em)
+			}
+			// If ResourceDriver fails we fall through silently — diagnostics are
+			// best-effort and must not mask the original apply error.
+		}
 		return fmt.Errorf("apply: %w", err)
 	}
 	if result != nil {

--- a/cmd/wfctl/infra_apply_troubleshoot_test.go
+++ b/cmd/wfctl/infra_apply_troubleshoot_test.go
@@ -11,14 +11,27 @@ import (
 	"github.com/GoCodeAlone/workflow/interfaces"
 )
 
-// applyFailProvider is an IaCProvider that always fails Apply and implements
-// Troubleshooter so we can verify diagnostics are surfaced on failure.
+// troubleshootingRD satisfies interfaces.ResourceDriver via embedding and adds
+// a Troubleshoot method. Used as the return value of ResourceDriver() so the
+// infra_apply Bug 2 path is actually exercised.
+type troubleshootingRD struct {
+	interfaces.ResourceDriver // embedded — non-overridden methods panic (not called in tests)
+	diags                     []interfaces.Diagnostic
+	tsErr                     error
+	tsCalls                   *int
+}
+
+func (d *troubleshootingRD) Troubleshoot(_ context.Context, _ interfaces.ResourceRef, _ string) ([]interfaces.Diagnostic, error) {
+	*d.tsCalls++
+	return d.diags, d.tsErr
+}
+
+// applyFailProvider is an IaCProvider that always fails Apply and returns a
+// Troubleshooter-capable ResourceDriver via ResourceDriver().
 type applyFailProvider struct {
 	applyCapture
 	applyErr error
-	diags    []interfaces.Diagnostic
-	tsErr    error
-	tsCalls  int
+	tsDriver *troubleshootingRD // nil → ResourceDriver returns (nil, nil)
 }
 
 func (p *applyFailProvider) Apply(_ context.Context, plan *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
@@ -29,13 +42,14 @@ func (p *applyFailProvider) Apply(_ context.Context, plan *interfaces.IaCPlan) (
 	return nil, p.applyErr
 }
 
-func (p *applyFailProvider) Troubleshoot(_ context.Context, _ interfaces.ResourceRef, _ string) ([]interfaces.Diagnostic, error) {
-	p.tsCalls++
-	return p.diags, p.tsErr
+func (p *applyFailProvider) ResourceDriver(_ string) (interfaces.ResourceDriver, error) {
+	if p.tsDriver != nil {
+		return p.tsDriver, nil
+	}
+	return nil, nil
 }
 
-// plainFailProvider is an IaCProvider that always fails Apply but does NOT
-// implement Troubleshooter. Used to verify the non-troubleshooter path is a no-op.
+// plainFailProvider fails Apply and returns a ResourceDriver with no Troubleshoot.
 type plainFailProvider struct {
 	applyCapture
 	applyErr error
@@ -55,16 +69,18 @@ func TestInfraApply_EmitsDiagnosticsOnFailure(t *testing.T) {
 	diags := []interfaces.Diagnostic{
 		{ID: "dep-abc", Phase: "pre_deploy", Cause: "migration failed", At: mustTime("2026-04-24T00:00:00Z")},
 	}
+	tsCalls := 0
 	provider := &applyFailProvider{
 		applyErr: errors.New("API error"),
-		diags:    diags,
+		tsDriver: &troubleshootingRD{diags: diags, tsCalls: &tsCalls},
 	}
 
 	infraApplyTroubleshootTimeout = 5 * time.Second
 	defer func() { infraApplyTroubleshootTimeout = 30 * time.Second }()
 
-	var diagBuf bytes.Buffer
+	// spec.Type must be non-empty so ref.Type is set and ResourceDriver is called.
 	specs := []interfaces.ResourceSpec{{Name: "bmw-staging", Type: "app_platform"}}
+	var diagBuf bytes.Buffer
 	err := applyWithProviderAndStore(context.Background(), provider, "digitalocean", specs, nil, nil, &diagBuf)
 	if err == nil {
 		t.Fatal("expected error from failing apply")
@@ -72,8 +88,8 @@ func TestInfraApply_EmitsDiagnosticsOnFailure(t *testing.T) {
 	if !strings.Contains(err.Error(), "API error") {
 		t.Errorf("original error not preserved: %v", err)
 	}
-	if provider.tsCalls != 1 {
-		t.Errorf("Troubleshoot not called: tsCalls=%d", provider.tsCalls)
+	if tsCalls != 1 {
+		t.Errorf("Troubleshoot not called via ResourceDriver: tsCalls=%d", tsCalls)
 	}
 	out := diagBuf.String()
 	if !strings.Contains(out, "::group::") {
@@ -85,10 +101,8 @@ func TestInfraApply_EmitsDiagnosticsOnFailure(t *testing.T) {
 }
 
 func TestInfraApply_NonTroubleshooterNocrash(t *testing.T) {
-	// plainFailProvider does not implement Troubleshooter — should be a silent no-op.
-	provider := &plainFailProvider{
-		applyErr: errors.New("boom"),
-	}
+	// plainFailProvider.ResourceDriver returns (nil, nil); nil driver → no-op.
+	provider := &plainFailProvider{applyErr: errors.New("boom")}
 	var diagBuf bytes.Buffer
 	specs := []interfaces.ResourceSpec{{Name: "x", Type: "app_platform"}}
 	err := applyWithProviderAndStore(context.Background(), provider, "digitalocean", specs, nil, nil, &diagBuf)


### PR DESCRIPTION
## Summary

Three regressions in v0.18.10 observability code, caught before BMW bumped:

- **Bug 1 (critical)**: `remoteResourceDriver.Troubleshoot` passed `interfaces.ResourceRef` as a nested Go struct in `InvokeService` args. `structpb.NewStruct` cannot encode arbitrary structs — plugin received empty args, Troubleshoot was a silent no-op on all plugin-backed drivers. Flattened to scalar primitives: `ref_name`, `ref_type`, `ref_provider_id`, `failure_msg`.
- **Bug 2 (critical)**: `applyWithProviderAndStore` passed the `IaCProvider` to `troubleshootAfterFailure`. `IaCProvider` does not implement `Troubleshooter` — type assertion always failed, hook was inert. Now calls `provider.ResourceDriver(ref.Type)` and passes the `ResourceDriver` instead.
- **Bug 3 (medium)**: `WriteStepSummary` used `defer f.Close()` discarding the close error (data loss risk). Changed to named return + deferred close capturing the error.

## Test plan

- [ ] `TestRemoteDriver_Troubleshoot_Success` — asserts args are flat primitives, `ref` key absent
- [ ] `TestInfraApply_EmitsDiagnosticsOnFailure` — asserts `Troubleshoot` called via `ResourceDriver()` chain, output contains group markers + cause
- [ ] `TestInfraApply_NonTroubleshooterNocrash` — nil driver from `ResourceDriver()` → silent no-op
- [ ] `GOWORK=off go test -race -short ./cmd/wfctl/... ./interfaces/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)