### PR TITLE
docs: wfctl SHA-256 verification by default — design doc

### DIFF
--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -134,15 +134,25 @@ unless `--skip-checksum` is passed.
 
 ### 4. Lockfile write-back
 
-After a successful verified install (via manifest SHA or auto-fetched checksums.txt),
-write the verified SHA256 to `WfctlLockPluginEntry.SHA256` in `.wfctl-lock.yaml` — the
-top-level per-plugin binary hash field. On subsequent installs (same plugin version), this
-field is already checked and enforced by `installFromLockfile` / `installFromWfctlLockfile`
-(both paths already hard-fail on SHA mismatch when the field is non-empty).
+Plugin releases ship as archives (e.g. `.tar.gz`). The integrity check verifies the
+**archive** SHA against `checksums.txt` (or the manifest `sha256` field). After extraction,
+the installed **binary** may have a different hash than the archive.
 
-Note: `WfctlLockPlatform.SHA256` is a separate per-platform hash for the download archive.
-This design writes to `WfctlLockPluginEntry.SHA256` (the installed binary hash), matching
-the write-back pattern in `installFromWfctlLockfile`.
+Two distinct SHAs are involved:
+
+- **Archive SHA** — verified at download time against `checksums.txt` (or manifest). This
+  is what goreleaser signs and publishes. Stored in `WfctlLockPlatform.SHA256` (the
+  per-platform archive hash already recorded by the existing lockfile write-back path in
+  `installFromWfctlLockfile`).
+- **Binary SHA** — computed after extraction from the archive. Stored in
+  `WfctlLockPluginEntry.SHA256` (the top-level per-plugin installed-binary hash). This is
+  the value enforced on lockfile reinstalls by `installFromLockfile` and
+  `installFromWfctlLockfile` (both already hard-fail on mismatch when non-empty).
+
+This design adds write-back of the **binary SHA** to `WfctlLockPluginEntry.SHA256` after a
+successful first install. On subsequent installs (same plugin version), the lockfile
+enforces this binary-level hash without requiring a network round-trip — the archive SHA
+path (`checksums.txt` fetch) is skipped entirely for lockfile reinstalls.
 
 ### 5. Escape hatch: `--skip-checksum`
 

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -134,25 +134,29 @@ unless `--skip-checksum` is passed.
 
 ### 4. Lockfile write-back
 
-Plugin releases ship as archives (e.g. `.tar.gz`). The integrity check verifies the
-**archive** SHA against `checksums.txt` (or the manifest `sha256` field). After extraction,
-the installed **binary** may have a different hash than the archive.
+Both `WfctlLockPlatform.SHA256` and `WfctlLockPluginEntry.SHA256` represent
+**installed-binary SHAs** — hashes of the extracted plugin binary on disk, NOT of the
+download archive. This is confirmed by `installFromWfctlLockfile`, which verifies both
+fields against `hashFileSHA256(destDir/fsName)` after extraction.
 
-Two distinct SHAs are involved:
+The archive SHA verified against `checksums.txt` at download time is a separate,
+transient check — it is not stored in any lockfile field.
 
-- **Archive SHA** — verified at download time against `checksums.txt` (or manifest). This
-  is what goreleaser signs and publishes. Stored in `WfctlLockPlatform.SHA256` (the
-  per-platform archive hash already recorded by the existing lockfile write-back path in
-  `installFromWfctlLockfile`).
-- **Binary SHA** — computed after extraction from the archive. Stored in
-  `WfctlLockPluginEntry.SHA256` (the top-level per-plugin installed-binary hash). This is
-  the value enforced on lockfile reinstalls by `installFromLockfile` and
-  `installFromWfctlLockfile` (both already hard-fail on mismatch when non-empty).
+Current write-back behavior:
 
-This design adds write-back of the **binary SHA** to `WfctlLockPluginEntry.SHA256` after a
-successful first install. On subsequent installs (same plugin version), the lockfile
-enforces this binary-level hash without requiring a network round-trip — the archive SHA
-path (`checksums.txt` fetch) is skipped entirely for lockfile reinstalls.
+- `WfctlLockPluginEntry.SHA256` (top-level binary hash): written by `installFromWfctlLockfile`
+  after each successful install via `hashFileSHA256(binaryPath)`. Enforced on subsequent
+  reinstalls by both `installFromLockfile` and `installFromWfctlLockfile` (hard-fail on
+  mismatch when non-empty).
+- `WfctlLockPlatform.SHA256` (per-platform binary hash): verified when non-empty, but
+  **not written** by any current code path — it must be pre-populated externally (e.g. by
+  `wfctl plugin lock` or a future write-back).
+
+This design adds write-back of the binary SHA to `WfctlLockPluginEntry.SHA256` in the
+`installPluginFromManifest` path (first install from a registry manifest or `--url`). The
+`installFromWfctlLockfile` path already writes this field. On subsequent installs (same
+plugin version), the lockfile enforces the binary-level hash without a network round-trip
+— the `checksums.txt` fetch is skipped entirely for lockfile reinstalls.
 
 ### 5. Escape hatch: `--skip-checksum`
 

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -82,17 +82,19 @@ logic layered on top (the lockfile fields already exist; using them is additive)
 **`installPluginFromManifest`** is modified as follows:
 
 ```
-download binary
+download binary archive
 if manifest SHA256 non-empty:
-    verify against manifest SHA256
+    verify archive against manifest SHA256
 elif binary URL is a GitHub release URL:
     fetch checksums.txt from same owner/repo/tag
-    if found: parse and verify
+    if found: parse and verify archive hash
     if not found or asset not listed: return error
     (unless --skip-checksum is set)
 else (non-GitHub URL, no SHA in manifest):
     return error unless --skip-checksum
-write verified SHA to lockfile entry
+extract binary from archive
+compute binary SHA256 post-extraction
+write binary SHA to WfctlLockPluginEntry.SHA256 in lockfile
 ```
 
 The `checksums.txt` format is the goreleaser standard:
@@ -107,9 +109,15 @@ derives the `checksums.txt` URL from the release asset URL (stripping the asset 
 appending `checksums.txt`), downloads it, parses each `<sha256hex>  <filename>` line, and
 returns the expected SHA256 hex for the asset matching the basename of `downloadURL`.
 
-`assetName` is derived internally as `path.Base(url.PathUnescape(downloadURL))` — the
-URL-decoded last path segment — so that URL-encoded characters in filenames are normalised
-before matching against plain-text `checksums.txt` entries.
+`assetName` is derived internally by parsing the URL first, then URL-decoding only the path
+component before extracting the basename — equivalent to:
+```go
+u, _ := url.Parse(downloadURL)
+assetName, _ := url.PathUnescape(path.Base(u.Path))
+```
+This avoids passing the full raw URL string (which includes query/fragment text) to
+`path.Base`, and ensures URL-encoded characters in filenames are decoded before matching
+against plain-text `checksums.txt` entries.
 
 The `wfctl update` path is refactored to call this same helper, replacing its current
 `findChecksumAsset(rel.Assets)` + `verifyAssetChecksum` pattern — the new helper derives the
@@ -125,9 +133,11 @@ When a user specifies `--url <url>` directly:
 - If the URL matches the GitHub release download pattern and no `--sha256` is given:
   auto-fetch `checksums.txt` via `lookupChecksumForURL`. Fail if the file is absent or the
   asset is not listed. The match uses the same constraints as `parseGitHubReleaseDownloadURL`:
-  HTTPS scheme only, host must be `github.com` or a `*.github.com` subdomain (the dot
-  separator prevents matching lookalike domains such as `evilgithub.com`), and path must be
-  exactly `/owner/repo/releases/download/tag/filename`.
+  HTTPS scheme only; host lowercased and compared — must equal `github.com` or have a
+  `.github.com` suffix (the dot separator prevents `evilgithub.com` from matching; trailing
+  dots stripped before comparison); no userinfo component (`user:pass@`) allowed; no
+  non-default port (port field must be empty, implying 443); path must be exactly
+  `/owner/repo/releases/download/tag/filename` (six non-empty segments).
 - For any other URL with no `--sha256`: fail with a clear error explaining how to provide
   a hash or use `--skip-checksum`.
 
@@ -160,11 +170,14 @@ Current write-back behavior:
   **not written** by any current code path — it must be pre-populated externally (e.g. by
   `wfctl plugin lock` or a future write-back).
 
-This design adds write-back of the binary SHA to `WfctlLockPluginEntry.SHA256` in the
-`installPluginFromManifest` path (first install from a registry manifest or `--url`). The
-`installFromWfctlLockfile` path already writes this field. On subsequent installs (same
-plugin version), the lockfile enforces the binary-level hash without a network round-trip
-— the `checksums.txt` fetch is skipped entirely for lockfile reinstalls.
+This design adds post-extraction binary SHA write-back to `WfctlLockPluginEntry.SHA256` in
+the `installPluginFromManifest` path (first install from a registry manifest or `--url`):
+after the archive is verified and extracted, `hashFileSHA256` is called on the installed
+binary and the result is written to `WfctlLockPluginEntry.SHA256`. The archive hash
+verified against `checksums.txt` is NOT written to the lockfile. The
+`installFromWfctlLockfile` path already performs this binary SHA write-back. On subsequent
+installs (same plugin version), the lockfile enforces the binary-level hash without a
+network round-trip — the `checksums.txt` fetch is skipped entirely for lockfile reinstalls.
 
 ### 5. Escape hatch: `--skip-checksum`
 
@@ -184,17 +197,29 @@ other flags.
 
 ## Error messages
 
-When verification fails or SHA is unavailable:
-
+**Case A — GitHub release URL, `checksums.txt` absent or asset not listed:**
 ```
-error: plugin "foo" downloaded from <url> has no SHA-256 in its manifest and
-no checksums.txt was found at <release-url>/checksums.txt.
+error: plugin "foo": no SHA-256 in manifest and checksums.txt not found or
+asset not listed at https://github.com/OWNER/REPO/releases/download/TAG/checksums.txt
 
 To proceed without verification (not recommended):
   wfctl plugin install --skip-checksum foo
 
 To add verification, ask the plugin author to publish a checksums.txt
 alongside their release assets (goreleaser does this automatically).
+```
+The derived checksums.txt URL is always printed verbatim so users can curl it manually.
+
+**Case B — Non-GitHub URL, no `--sha256` provided:**
+```
+error: plugin "foo": URL https://example.com/plugin.tar.gz is not a GitHub
+release URL and no --sha256 was provided; cannot verify integrity.
+
+Provide a checksum:
+  wfctl plugin install --url https://example.com/plugin.tar.gz --sha256 <hex>
+
+Or proceed without verification (not recommended):
+  wfctl plugin install --skip-checksum --url https://example.com/plugin.tar.gz foo
 ```
 
 When the checksum mismatches:

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -31,7 +31,7 @@ there is no manifest SHA to check against.
 | `wfctl plugin install --url <url>` | ⚠️ no verification | ❌ requires `--sha256 <hex>` or auto-fetch |
 | `wfctl update` (self-update) — `checksums.txt` present | ✅ verifies | unchanged |
 | `wfctl update` — `checksums.txt` absent | ⚠️ skips silently | ❌ fails closed |
-| Lockfile-based reinstalls (`.wfctl-lock.yaml` SHA present) | ⚠️ not enforced | ✅ use lockfile SHA |
+| Lockfile-based reinstalls (`.wfctl-lock.yaml` SHA present) | ✅ already enforced — hard-fails on mismatch | unchanged |
 | `setup-wfctl` action | ⚠️ no verification | out of scope (separate repo) |
 
 ---
@@ -99,21 +99,32 @@ The `checksums.txt` format is the goreleaser standard:
 ```
 <sha256hex>  <filename>
 ```
-Parsing reuses the same logic already in `verifyAssetChecksum` (used by `wfctl update`).
+Parsing uses the goreleaser standard format (`<sha256hex>  <filename>`), the same format as
+the existing `verifyAssetChecksum` in `update.go`.
 
-The function that derives the `checksums.txt` URL from a release asset URL is extracted
-into a shared helper so both `plugin install` and `wfctl update` use identical logic.
+A new shared helper `lookupChecksumForURL(downloadURL, assetName string) (string, error)` is
+added. It derives the checksums.txt URL from the release asset URL (stripping the asset
+filename and appending `checksums.txt`), downloads it, and returns the expected SHA256 hex.
+The `wfctl update` path is refactored to call this same helper, replacing its current
+`findChecksumAsset(rel.Assets)` + `verifyAssetChecksum` pattern — the new helper derives the
+URL from the asset's `BrowserDownloadURL` directly rather than searching the API asset list
+for a `checksums.txt` entry. Both paths become consistent and share the same verification
+logic.
 
 ### 2. Plugin install with `--url`
 
 When a user specifies `--url <url>` directly:
 
 - If `--sha256 <hex>` is also provided: download, verify, succeed.
-- If the URL is a GitHub release asset and no `--sha256` is given: auto-fetch
-  `checksums.txt` as above.
-- Otherwise: fail with a message explaining how to supply the expected hash.
+- If the URL matches the GitHub release download pattern
+  (`github.com/<owner>/<repo>/releases/download/<tag>/<file>`) and no `--sha256` is given:
+  auto-fetch `checksums.txt` from the same release tag (via `lookupChecksumForURL`). Fail if
+  the file is absent or the asset is not listed.
+- For any other URL with no `--sha256`: fail with a clear error explaining how to provide
+  a hash or use `--skip-checksum`.
 
-This prevents `--url` from being a silent bypass for the integrity policy.
+This prevents `--url` from being a silent bypass for the integrity policy regardless of
+whether the user provides an explicit hash or relies on auto-fetch for GitHub releases.
 
 ### 3. `wfctl update` hardening
 
@@ -124,12 +135,14 @@ unless `--skip-checksum` is passed.
 ### 4. Lockfile write-back
 
 After a successful verified install (via manifest SHA or auto-fetched checksums.txt),
-write the verified SHA256 to the corresponding `WfctlLockPlatform.SHA256` field in
-`.wfctl-lock.yaml`. On subsequent installs (same plugin version), use the lockfile SHA as
-the authoritative source — skip the extra `checksums.txt` HTTP call.
+write the verified SHA256 to `WfctlLockPluginEntry.SHA256` in `.wfctl-lock.yaml` — the
+top-level per-plugin binary hash field. On subsequent installs (same plugin version), this
+field is already checked and enforced by `installFromLockfile` / `installFromWfctlLockfile`
+(both paths already hard-fail on SHA mismatch when the field is non-empty).
 
-This field already exists in the lockfile schema (`WfctlLockPlatform.SHA256`); this
-change makes it load-on-install and enforce-on-reinstall.
+Note: `WfctlLockPlatform.SHA256` is a separate per-platform hash for the download archive.
+This design writes to `WfctlLockPluginEntry.SHA256` (the installed binary hash), matching
+the write-back pattern in `installFromWfctlLockfile`.
 
 ### 5. Escape hatch: `--skip-checksum`
 
@@ -141,8 +154,9 @@ warning: --skip-checksum is set; binary integrity not verified
 ```
 
 The flag name `--skip-checksum` is intentionally longer than `--no-verify` to create
-friction and make it visible in CI logs. It is not documented in `--help` short form; it
-appears in the extended help only.
+friction and make it visible in CI logs. It is registered via the standard Go `flag` package
+and appears in `wfctl plugin install --help` and `wfctl update --help` output alongside all
+other flags.
 
 ---
 
@@ -185,8 +199,11 @@ download → SHA-256 verify (this design) → cosign verify (install_verify hook
 ```
 
 This design does not change the cosign hook path. The two layers can coexist: SHA-256
-runs unconditionally on every install; cosign runs only when `verify.signature_identity`
-is configured in `app.yaml`'s `requires.plugins` entry.
+verification runs by default on every install and is fail-closed — a binary that cannot be
+verified does not install. It can be bypassed with `--skip-checksum` (emits a warning), or
+implicitly skipped for a lockfile entry with an empty SHA (the SHA is recorded on first
+successful install). Cosign verification runs only when `verify.signature_identity` is
+configured in `app.yaml`'s `requires.plugins` entry.
 
 ---
 

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -31,7 +31,7 @@ there is no manifest SHA to check against.
 | `wfctl plugin install --url <url>` | ⚠️ no verification | ❌ requires `--sha256 <hex>` or auto-fetch |
 | `wfctl update` (self-update) — `checksums.txt` present | ✅ verifies | unchanged |
 | `wfctl update` — `checksums.txt` absent | ⚠️ skips silently | ❌ fails closed |
-| Lockfile-based reinstalls (`wfctl-lock.yaml` SHA present) | ⚠️ not enforced | ✅ use lockfile SHA |
+| Lockfile-based reinstalls (`.wfctl-lock.yaml` SHA present) | ⚠️ not enforced | ✅ use lockfile SHA |
 | `setup-wfctl` action | ⚠️ no verification | out of scope (separate repo) |
 
 ---

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -169,7 +169,7 @@ error: plugin "foo" downloaded from <url> has no SHA-256 in its manifest and
 no checksums.txt was found at <release-url>/checksums.txt.
 
 To proceed without verification (not recommended):
-  wfctl plugin install foo --skip-checksum
+  wfctl plugin install --skip-checksum foo
 
 To add verification, ask the plugin author to publish a checksums.txt
 alongside their release assets (goreleaser does this automatically).

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -132,12 +132,17 @@ When a user specifies `--url <url>` directly:
 - If `--sha256 <hex>` is also provided: download, verify, succeed.
 - If the URL matches the GitHub release download pattern and no `--sha256` is given:
   auto-fetch `checksums.txt` via `lookupChecksumForURL`. Fail if the file is absent or the
-  asset is not listed. The match uses the same constraints as `parseGitHubReleaseDownloadURL`:
-  HTTPS scheme only; host lowercased and compared — must equal `github.com` or have a
-  `.github.com` suffix (the dot separator prevents `evilgithub.com` from matching; trailing
-  dots stripped before comparison); no userinfo component (`user:pass@`) allowed; no
-  non-default port (port field must be empty, implying 443); path must be exactly
-  `/owner/repo/releases/download/tag/filename` (six non-empty segments).
+  asset is not listed. The match delegates to `parseGitHubReleaseDownloadURL`, whose current
+  baseline checks are: HTTPS scheme only (`strings.EqualFold(scheme, "https")`); host passes
+  `isGitHubHost` (lowercased, must equal `github.com` or have `.github.com` suffix — the dot
+  prevents `evilgithub.com` matching); path exactly six non-empty segments
+  `/owner/repo/releases/download/tag/filename`.
+
+  **NEW hardening this design adds to `parseGitHubReleaseDownloadURL`**: reject URLs with a
+  userinfo component (`user:pass@host`) and reject URLs with a non-default port. These are
+  not enforced today — `u.Hostname()` strips the port before `isGitHubHost` is called, so
+  `https://github.com:8080/...` currently passes. The implementation should explicitly check
+  `u.User == nil` and `u.Port() == ""`.
 - For any other URL with no `--sha256`: fail with a clear error explaining how to provide
   a hash or use `--skip-checksum`.
 
@@ -154,8 +159,16 @@ unless `--skip-checksum` is passed.
 
 Both `WfctlLockPlatform.SHA256` and `WfctlLockPluginEntry.SHA256` represent
 **installed-binary SHAs** — hashes of the extracted plugin binary on disk, NOT of the
-download archive. This is confirmed by `installFromWfctlLockfile`, which verifies both
-fields against `hashFileSHA256(destDir/fsName)` after extraction.
+download archive. Both resolve to the same file path (`filepath.Join(destDir, fsName)`)
+but use different verification functions in `installFromWfctlLockfile`:
+
+- `WfctlLockPlatform.SHA256`: verified via `hashFileSHA256(filepath.Join(destDir, fsName))`
+  (streaming `io.Copy` into `sha256.New()`).
+- `WfctlLockPluginEntry.SHA256`: verified via `verifyInstalledChecksum(destDir, fsName, sha)`
+  which does `sha256.Sum256(os.ReadFile(filepath.Join(destDir, fsName)))` (in-memory).
+
+Both functions hash the same binary; the implementation approach differs (streaming vs
+in-memory). The write-back also uses `hashFileSHA256` on the same path.
 
 The archive SHA verified against `checksums.txt` at download time is a separate,
 transient check — it is not stored in any lockfile field.

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -104,10 +104,17 @@ The `checksums.txt` format is the goreleaser standard:
 Parsing uses the goreleaser standard format (`<sha256hex>  <filename>`), the same format as
 the existing `verifyAssetChecksum` in `update.go`.
 
-A new shared helper `lookupChecksumForURL(downloadURL string) (string, error)` is added. It
-derives the `checksums.txt` URL from the release asset URL (stripping the asset filename and
-appending `checksums.txt`), downloads it, parses each `<sha256hex>  <filename>` line, and
-returns the expected SHA256 hex for the asset matching the basename of `downloadURL`.
+Two new shared helpers are added:
+
+`parseChecksumsTxt(body string) (map[string]string, error)` — parses a goreleaser-style
+`checksums.txt` body into a `map[filename → sha256hex]`. Each line must match
+`<sha256hex>  <filename>`; malformed lines return an error. This is a pure function with no
+I/O, making it directly unit-testable.
+
+`lookupChecksumForURL(downloadURL string) (string, error)` — derives the `checksums.txt`
+URL from the release asset URL (strips the asset filename, appends `checksums.txt`),
+downloads it, delegates to `parseChecksumsTxt`, and returns the expected SHA256 hex for
+the asset matching the basename of `downloadURL`.
 
 `assetName` is derived internally by parsing the URL first, then URL-decoding only the path
 component before extracting the basename — equivalent to:
@@ -290,7 +297,7 @@ workflow as a follow-up.
 
 ## Testing
 
-- Unit: `verifyChecksum` (existing), `parseChecksumsTxt` (new helper), lockfile write-back
+- Unit: `verifyChecksum` (existing), `parseChecksumsTxt` (new — valid input, malformed lines, missing asset), `lookupChecksumForURL` (mock HTTP), lockfile write-back
 - Integration: mock HTTP server serving a release asset + `checksums.txt` — install
   succeeds with correct hash, fails with tampered hash, fails with missing checksums.txt
   (no `--skip-checksum`), succeeds with `--skip-checksum`

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -1,0 +1,227 @@
+# Design: wfctl SHA-256 Verification by Default for Binary Downloads
+
+**Date**: 2026-04-25
+**Status**: Draft — awaiting approval before implementation
+
+---
+
+## Motivation
+
+wfctl downloads external plugin binaries at install time. Today SHA-256 verification is
+**opt-in**: the check runs only when the registry manifest includes a `sha256` field. If
+the field is absent the download proceeds silently without any integrity check.
+
+Similarly, `wfctl update` (self-update) verifies against a `checksums.txt` release asset
+*only if the asset exists* — no failure when it is absent.
+
+The goal of this change is to make verification **fail-closed by default**: a binary
+download that cannot be verified must not succeed without an explicit opt-out.
+
+A related gap is `--url` installs, where a user supplies a download URL directly and
+there is no manifest SHA to check against.
+
+---
+
+## Scope
+
+| Surface | Current | Target |
+|---|---|---|
+| `wfctl plugin install` — registry manifest with SHA | ✅ verifies | unchanged |
+| `wfctl plugin install` — registry manifest without SHA | ⚠️ skips silently | ❌ fails closed |
+| `wfctl plugin install --url <url>` | ⚠️ no verification | ❌ requires `--sha256 <hex>` or auto-fetch |
+| `wfctl update` (self-update) — `checksums.txt` present | ✅ verifies | unchanged |
+| `wfctl update` — `checksums.txt` absent | ⚠️ skips silently | ❌ fails closed |
+| Lockfile-based reinstalls (`wfctl-lock.yaml` SHA present) | ⚠️ not enforced | ✅ use lockfile SHA |
+| `setup-wfctl` action | ⚠️ no verification | out of scope (separate repo) |
+
+---
+
+## Approaches Considered
+
+### Approach A — Strict fail-closed on missing SHA, no auto-fetch
+
+Change the `if dl.SHA256 != ""` guard to a hard failure when SHA is absent. Every
+registry manifest must include a `sha256` field. Provide `--skip-checksum` as an escape
+hatch.
+
+**Pro**: Simple, no extra HTTP calls, deterministic.  
+**Con**: Breaks any plugin manifest not yet publishing SHA256. Requires coordinated
+manifest updates across all plugins before landing.
+
+### Approach B — Auto-fetch `checksums.txt` with fail-closed fallback *(recommended)*
+
+When `dl.SHA256 == ""`, attempt to fetch a goreleaser-style `checksums.txt` file from
+the same GitHub release (same tag, same repo). Parse it to find the expected hash for the
+downloaded asset. If the file is found and the asset matches: verify and continue. If the
+file is not found or the asset is not listed: fail with a clear error.
+
+**Pro**: Works immediately for all GoCodeAlone plugins (goreleaser publishes
+`checksums.txt` for every release). Zero manifest changes required. Mirrors the pattern
+already used by `wfctl update`. Lockfile records the verified SHA, so CI reinstalls skip
+the extra HTTP call.  
+**Con**: One extra HTTP request per first install of a manifest-less plugin.
+
+### Approach C — Lockfile-first, checksums.txt as fallback
+
+On install, check the lockfile for a recorded SHA256 first. Use it if present (no HTTP
+call). Fall back to Approach B for cache misses. This is the long-term evolution once
+lockfile adoption is higher.
+
+**Pro**: Zero extra HTTP calls for lockfile users; reproducible CI.  
+**Con**: Adds lockfile as a dependency before it has wide adoption.
+
+**Chosen approach**: B as the implementation baseline, with Approach C's lockfile-first
+logic layered on top (the lockfile fields already exist; using them is additive).
+
+---
+
+## Design
+
+### 1. Plugin install: auto-fetch `checksums.txt`
+
+**`installPluginFromManifest`** is modified as follows:
+
+```
+download binary
+if manifest SHA256 non-empty:
+    verify against manifest SHA256
+elif binary URL is a GitHub release URL:
+    fetch checksums.txt from same owner/repo/tag
+    if found: parse and verify
+    if not found or asset not listed: return error
+    (unless --skip-checksum is set)
+else (non-GitHub URL, no SHA in manifest):
+    return error unless --skip-checksum
+write verified SHA to lockfile entry
+```
+
+The `checksums.txt` format is the goreleaser standard:
+```
+<sha256hex>  <filename>
+```
+Parsing reuses the same logic already in `verifyAssetChecksum` (used by `wfctl update`).
+
+The function that derives the `checksums.txt` URL from a release asset URL is extracted
+into a shared helper so both `plugin install` and `wfctl update` use identical logic.
+
+### 2. Plugin install with `--url`
+
+When a user specifies `--url <url>` directly:
+
+- If `--sha256 <hex>` is also provided: download, verify, succeed.
+- If the URL is a GitHub release asset and no `--sha256` is given: auto-fetch
+  `checksums.txt` as above.
+- Otherwise: fail with a message explaining how to supply the expected hash.
+
+This prevents `--url` from being a silent bypass for the integrity policy.
+
+### 3. `wfctl update` hardening
+
+The self-update path already calls `findChecksumAsset`. Change the guard from
+`if checksumAsset != nil` to a hard failure when no checksum asset is found,
+unless `--skip-checksum` is passed.
+
+### 4. Lockfile write-back
+
+After a successful verified install (via manifest SHA or auto-fetched checksums.txt),
+write the verified SHA256 to the corresponding `WfctlLockPlatform.SHA256` field in
+`.wfctl-lock.yaml`. On subsequent installs (same plugin version), use the lockfile SHA as
+the authoritative source — skip the extra `checksums.txt` HTTP call.
+
+This field already exists in the lockfile schema (`WfctlLockPlatform.SHA256`); this
+change makes it load-on-install and enforce-on-reinstall.
+
+### 5. Escape hatch: `--skip-checksum`
+
+A flag `--skip-checksum` is added to `wfctl plugin install` and `wfctl update`. When set,
+all SHA256 checks are bypassed with a stderr warning:
+
+```
+warning: --skip-checksum is set; binary integrity not verified
+```
+
+The flag name `--skip-checksum` is intentionally longer than `--no-verify` to create
+friction and make it visible in CI logs. It is not documented in `--help` short form; it
+appears in the extended help only.
+
+---
+
+## Error messages
+
+When verification fails or SHA is unavailable:
+
+```
+error: plugin "foo" downloaded from <url> has no SHA-256 in its manifest and
+no checksums.txt was found at <release-url>/checksums.txt.
+
+To proceed without verification (not recommended):
+  wfctl plugin install foo --skip-checksum
+
+To add verification, ask the plugin author to publish a checksums.txt
+alongside their release assets (goreleaser does this automatically).
+```
+
+When the checksum mismatches:
+
+```
+error: checksum mismatch for "foo":
+  got:  <actual-hex>
+  want: <expected-hex>
+This may indicate a corrupted download or a supply-chain attack.
+```
+
+---
+
+## Interaction with supply-chain plugin
+
+SHA-256 verification is the **integrity layer**: it confirms the downloaded bytes match
+what the release published. The supply-chain plugin (cosign `install_verify` hook) is the
+**authenticity layer**: it confirms the binary was signed by the expected OIDC identity.
+
+These are independent and complementary:
+
+```
+download → SHA-256 verify (this design) → cosign verify (install_verify hook, opt-in)
+```
+
+This design does not change the cosign hook path. The two layers can coexist: SHA-256
+runs unconditionally on every install; cosign runs only when `verify.signature_identity`
+is configured in `app.yaml`'s `requires.plugins` entry.
+
+---
+
+## Migration path
+
+| Plugin source | Current SHA status | After this change |
+|---|---|---|
+| GoCodeAlone registry plugins (goreleaser) | SHA absent in manifest | Auto-fetched from `checksums.txt` — transparent |
+| Third-party plugin, goreleaser build | SHA absent | Auto-fetched — transparent |
+| Third-party plugin, no goreleaser | SHA absent, no `checksums.txt` | Fails; author must publish checksum or user uses `--skip-checksum` |
+| Any plugin, manifest already has SHA | SHA present | Unchanged behavior |
+| Lockfile reinstall | SHA in lockfile | Used directly — no HTTP call |
+
+No changes to existing registry manifests are required to unblock this landing. The
+`checksums.txt` auto-fetch handles all GoCodeAlone-published plugins immediately.
+
+Publishing SHA256 directly in registry manifests remains the preferred long-term form
+(eliminates the extra HTTP call on first install) and should be added to the goreleaser
+workflow as a follow-up.
+
+---
+
+## Testing
+
+- Unit: `verifyChecksum` (existing), `parseChecksumsTxt` (new helper), lockfile write-back
+- Integration: mock HTTP server serving a release asset + `checksums.txt` — install
+  succeeds with correct hash, fails with tampered hash, fails with missing checksums.txt
+  (no `--skip-checksum`), succeeds with `--skip-checksum`
+- `wfctl update` test: mock release without checksums.txt → hard failure
+
+---
+
+## Out of scope
+
+- `setup-wfctl` GitHub Action (separate repo — tracked separately)
+- Adding SHA256 to existing registry manifest JSON files (follow-up)
+- Publishing `checksums.txt` URLs in registry manifests (follow-up)
+- Cosign verification changes (separate supply-chain concern)

--- a/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
+++ b/docs/plans/2026-04-25-wfctl-sha256-verification-design.md
@@ -102,9 +102,15 @@ The `checksums.txt` format is the goreleaser standard:
 Parsing uses the goreleaser standard format (`<sha256hex>  <filename>`), the same format as
 the existing `verifyAssetChecksum` in `update.go`.
 
-A new shared helper `lookupChecksumForURL(downloadURL, assetName string) (string, error)` is
-added. It derives the checksums.txt URL from the release asset URL (stripping the asset
-filename and appending `checksums.txt`), downloads it, and returns the expected SHA256 hex.
+A new shared helper `lookupChecksumForURL(downloadURL string) (string, error)` is added. It
+derives the `checksums.txt` URL from the release asset URL (stripping the asset filename and
+appending `checksums.txt`), downloads it, parses each `<sha256hex>  <filename>` line, and
+returns the expected SHA256 hex for the asset matching the basename of `downloadURL`.
+
+`assetName` is derived internally as `path.Base(url.PathUnescape(downloadURL))` — the
+URL-decoded last path segment — so that URL-encoded characters in filenames are normalised
+before matching against plain-text `checksums.txt` entries.
+
 The `wfctl update` path is refactored to call this same helper, replacing its current
 `findChecksumAsset(rel.Assets)` + `verifyAssetChecksum` pattern — the new helper derives the
 URL from the asset's `BrowserDownloadURL` directly rather than searching the API asset list
@@ -116,10 +122,12 @@ logic.
 When a user specifies `--url <url>` directly:
 
 - If `--sha256 <hex>` is also provided: download, verify, succeed.
-- If the URL matches the GitHub release download pattern
-  (`github.com/<owner>/<repo>/releases/download/<tag>/<file>`) and no `--sha256` is given:
-  auto-fetch `checksums.txt` from the same release tag (via `lookupChecksumForURL`). Fail if
-  the file is absent or the asset is not listed.
+- If the URL matches the GitHub release download pattern and no `--sha256` is given:
+  auto-fetch `checksums.txt` via `lookupChecksumForURL`. Fail if the file is absent or the
+  asset is not listed. The match uses the same constraints as `parseGitHubReleaseDownloadURL`:
+  HTTPS scheme only, host must be `github.com` or a `*.github.com` subdomain (the dot
+  separator prevents matching lookalike domains such as `evilgithub.com`), and path must be
+  exactly `/owner/repo/releases/download/tag/filename`.
 - For any other URL with no `--sha256`: fail with a clear error explaining how to provide
   a hash or use `--skip-checksum`.
 
@@ -216,8 +224,10 @@ This design does not change the cosign hook path. The two layers can coexist: SH
 verification runs by default on every install and is fail-closed — a binary that cannot be
 verified does not install. It can be bypassed with `--skip-checksum` (emits a warning), or
 implicitly skipped for a lockfile entry with an empty SHA (the SHA is recorded on first
-successful install). Cosign verification runs only when `verify.signature_identity` is
-configured in `app.yaml`'s `requires.plugins` entry.
+successful install). Cosign verification runs only when `verify.signature` is set to `required` in
+`app.yaml`'s `requires.plugins[*].verify` entry (`PluginVerifyConfig.Signature`).
+The `verify` block also controls `sbom` (SBOM presence) and `vuln_policy` (OSV scan
+policy) — all independent of SHA-256 integrity verification.
 
 ---
 


### PR DESCRIPTION
## Summary

Design document for making SHA-256 verification fail-closed by default across all wfctl binary download paths.

## What this PR contains

- `docs/plans/2026-04-25-wfctl-sha256-verification-design.md` — design doc only; no code changes

## Key decisions documented

- **Approach B** (auto-fetch `checksums.txt`) chosen: when a registry manifest has no SHA,
  fetch goreleaser's `checksums.txt` from the same GitHub release tag; fail if absent or
  asset not listed.
- **`--url` policy**: three cases —
  - `--sha256 <hex>` provided: verify against it.
  - GitHub release URL (`github.com/<owner>/<repo>/releases/download/<tag>/<file>`): auto-fetch
    `checksums.txt` from the same tag.
  - Any other URL, no `--sha256`: fail with a message; `--skip-checksum` to bypass.
- **Lockfile SHA** (`WfctlLockPluginEntry.SHA256`) already enforced on reinstall — unchanged;
  this design records the SHA on first install to enable that path.
- **Shared helper** `lookupChecksumForURL`: replaces `wfctl update`'s current
  `findChecksumAsset + verifyAssetChecksum` pattern so both plugin install and self-update
  use identical URL-derivation logic.
- **`--skip-checksum`**: standard `flag` package flag, visible in `--help` output.
- **"Unconditional" claim corrected**: verification is fail-closed by default; `--skip-checksum`
  and empty-SHA lockfile entries are documented bypass paths.

## Round 3 corrections (6 Copilot findings)

1. Scope table: lockfile enforcement was already implemented — corrected from "not enforced" to "already enforced"
2. Checksums.txt helper: clarified `lookupChecksumForURL` replaces rather than wraps the existing `wfctl update` pattern
3. Lockfile write-back: field is `WfctlLockPluginEntry.SHA256`, not `WfctlLockPlatform.SHA256`
4. `--url` policy: three cases made explicit to resolve contradiction with earlier "requires explicit --sha256" language
5. `--skip-checksum` visibility: removed false "extended help only" claim
6. Supply-chain section: "unconditionally" replaced with accurate "fail-closed by default; bypassable with --skip-checksum"

## Test plan

- [x] Design doc only — no executable changes in this PR
- [ ] Copilot review passes (×2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)