### PR TITLE
feat(wfctl): add `wfctl infra outputs` command

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -35,6 +35,8 @@ func runInfra(args []string) error {
 		return runInfraState(args[1:])
 	case "bootstrap":
 		return runInfraBootstrap(args[1:])
+	case "outputs":
+		return runInfraOutputs(args[1:])
 	default:
 		return infraUsage()
 	}
@@ -53,6 +55,7 @@ Actions:
   destroy   Tear down infrastructure
   import    Import an existing cloud resource into state
   state     Manage IaC state (list, export, import)
+  outputs   Print captured resource outputs from state
 
 Options:
   --config <file>      Config file (default: infra.yaml or config/infra.yaml)

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -158,7 +158,7 @@ func runInfraPlan(args []string) error {
 		return err
 	}
 
-	current := loadCurrentState(cfgFile, envName)
+	current, _ := loadCurrentState(cfgFile, envName) // nil on first run is valid
 
 	plan, err := platform.ComputePlan(desired, current)
 	if err != nil {
@@ -341,20 +341,22 @@ func isContainerType(t string) bool {
 }
 
 // loadCurrentState loads ResourceStates from the configured iac.state backend.
-// Returns nil on any error (first run or unconfigured backend). Uses
-// resolveStateStore so that remote backends (Spaces, S3, etc.) are supported.
-// envName is forwarded to resolveStateStore so per-env backend config
-// (e.g. region, prefix) is applied when reading state.
-func loadCurrentState(cfgFile, envName string) []interfaces.ResourceState {
+// Returns an error when the state store cannot be resolved or read; callers
+// that treat "no prior state" as a valid first-run condition should swallow the
+// error explicitly with a comment. Uses resolveStateStore so that remote
+// backends (Spaces, S3, etc.) are supported. envName is forwarded to
+// resolveStateStore so per-env backend config (e.g. region, prefix) is applied
+// when reading state.
+func loadCurrentState(cfgFile, envName string) ([]interfaces.ResourceState, error) {
 	store, err := resolveStateStore(cfgFile, envName)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("resolve state store: %w", err)
 	}
 	states, err := store.ListResources(context.Background())
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("list state resources: %w", err)
 	}
-	return states
+	return states, nil
 }
 
 // configHashMap delegates to platform.ConfigHash so that the CLI always
@@ -827,7 +829,7 @@ func runInfraApply(args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve secrets provider for infra_output sync: %w", err)
 	}
-	states := loadCurrentState(cfgFile, envName)
+	states, _ := loadCurrentState(cfgFile, envName) // nil on missing/empty state is valid for sync
 	// Only reload the workflow config when env resolution is actually needed:
 	// it is needed only when --env is set AND at least one infra_output secret
 	// generator is configured (otherwise syncInfraOutputSecrets is a no-op for

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -145,8 +145,8 @@ func applyInfraModules(ctx context.Context, cfgFile, envName string) error { //n
 		groups[moduleRef].specs = append(groups[moduleRef].specs, spec)
 	}
 
-	// Load current state once; each provider call filters to its own resources.
-	current := loadCurrentState(cfgFile, envName)
+	// Load current state once; nil on first run is valid (no prior state).
+	current, _ := loadCurrentState(cfgFile, envName)
 
 	// Resolve the state store once; failure is non-fatal (state is best-effort).
 	store, storeErr := resolveStateStore(cfgFile, envName)

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -166,8 +166,10 @@ func infraOutputsEnv(entries []infraOutputEntry) error {
 
 // shellQuote returns a single-quoted POSIX shell literal for any value.
 // Non-string scalars are formatted with %v; maps and slices are rendered as
-// compact JSON. Any single-quote characters inside the value are escaped as
-// the sequence '\”.
+// compact JSON. Single-quote characters inside the value are escaped using
+// the standard POSIX sequence: close the literal, emit a backslash-quoted
+// single-quote, then reopen the literal (the four-character sequence apostrophe
+// backslash apostrophe apostrophe).
 func shellQuote(v any) string {
 	var s string
 	switch tv := v.(type) {

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// infraOutputEntry holds the outputs for a single state resource.
+type infraOutputEntry struct {
+	module  string
+	outputs map[string]any
+}
+
+// runInfraOutputs implements `wfctl infra outputs`.
+// It reads all resource outputs stored in the configured state backend and
+// prints them in the requested format. The command is read-only — it never
+// writes to the state backend or the secrets provider.
+func runInfraOutputs(args []string) error {
+	fs := flag.NewFlagSet("infra outputs", flag.ContinueOnError)
+	var configFlag, envFlag, formatFlag, moduleFlag string
+	fs.StringVar(&configFlag, "config", "", "Config file")
+	fs.StringVar(&configFlag, "c", "", "Config file (short for --config)")
+	fs.StringVar(&envFlag, "env", "", "Environment name (applies per-env state backend config)")
+	fs.StringVar(&envFlag, "e", "", "Environment name (short for --env)")
+	fs.StringVar(&formatFlag, "format", "yaml", "Output format: yaml (default), json, env")
+	fs.StringVar(&formatFlag, "f", "yaml", "Output format (short for --format)")
+	fs.StringVar(&moduleFlag, "module", "", "Restrict output to a single module name")
+	fs.StringVar(&moduleFlag, "m", "", "Module name (short for --module)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfgFile, err := resolveInfraConfig(fs, configFlag)
+	if err != nil {
+		return err
+	}
+
+	states := loadCurrentState(cfgFile, envFlag)
+
+	// Collect modules with non-empty outputs, in stable alphabetical order.
+	var entries []infraOutputEntry
+	for _, s := range states {
+		if len(s.Outputs) == 0 {
+			continue
+		}
+		if moduleFlag != "" && s.Name != moduleFlag {
+			continue
+		}
+		entries = append(entries, infraOutputEntry{module: s.Name, outputs: s.Outputs})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].module < entries[j].module })
+
+	if len(entries) == 0 {
+		fmt.Fprintln(os.Stderr, "No outputs found in state.")
+		return nil
+	}
+
+	switch formatFlag {
+	case "yaml":
+		return infraOutputsYAML(entries)
+	case "json":
+		return infraOutputsJSON(entries)
+	case "env":
+		return infraOutputsEnv(entries)
+	default:
+		return fmt.Errorf("unknown format %q (supported: yaml, json, env)", formatFlag)
+	}
+}
+
+// infraOutputsYAML prints outputs as a YAML document keyed by module name.
+//
+//	bmw-staging-db:
+//	  host: db.example.com
+//	  port: 5432
+//	  uri: postgresql://...
+func infraOutputsYAML(entries []infraOutputEntry) error {
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for _, e := range entries {
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: e.module},
+			outputsToYAMLNode(e.outputs),
+		)
+	}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	enc := yaml.NewEncoder(os.Stdout)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return fmt.Errorf("yaml encode: %w", err)
+	}
+	return enc.Close()
+}
+
+// outputsToYAMLNode converts a map[string]any to a yaml.MappingNode with
+// keys sorted alphabetically for stable output.
+func outputsToYAMLNode(m map[string]any) *yaml.Node {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for _, k := range keys {
+		valNode := &yaml.Node{}
+		if err := valNode.Encode(m[k]); err != nil {
+			valNode = &yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprint(m[k])}
+		}
+		node.Content = append(node.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: k},
+			valNode,
+		)
+	}
+	return node
+}
+
+// infraOutputsJSON prints outputs as a JSON object keyed by module name.
+//
+//	{
+//	  "bmw-staging-db": { "host": "db.example.com", "uri": "postgresql://..." }
+//	}
+func infraOutputsJSON(entries []infraOutputEntry) error {
+	combined := make(map[string]map[string]any, len(entries))
+	for _, e := range entries {
+		combined[e.module] = e.outputs
+	}
+	data, err := json.MarshalIndent(combined, "", "  ")
+	if err != nil {
+		return fmt.Errorf("json encode: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// infraOutputsEnv prints outputs as shell-ready KEY=value lines, with the
+// key formed from the module name and output field name joined by underscores
+// and uppercased:
+//
+//	BMW_STAGING_DB_HOST=db.example.com
+//	BMW_STAGING_DB_URI=postgresql://...
+func infraOutputsEnv(entries []infraOutputEntry) error {
+	for _, e := range entries {
+		prefix := infraEnvVarName(e.module)
+		keys := make([]string, 0, len(e.outputs))
+		for k := range e.outputs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("%s_%s=%v\n", prefix, infraEnvVarName(k), e.outputs[k])
+		}
+	}
+	return nil
+}
+
+// infraEnvVarName converts a module or field name to an environment-variable-
+// safe uppercase string, replacing hyphens and dots with underscores.
+func infraEnvVarName(s string) string {
+	return strings.ToUpper(strings.NewReplacer("-", "_", ".", "_").Replace(s))
+}

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -59,7 +59,8 @@ func runInfraOutputs(args []string) error {
 
 	// Collect modules with non-empty outputs, in stable alphabetical order.
 	var entries []infraOutputEntry
-	for _, s := range states {
+	for i := range states {
+		s := &states[i]
 		if len(s.Outputs) == 0 {
 			continue
 		}

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -44,7 +44,10 @@ func runInfraOutputs(args []string) error {
 		return err
 	}
 
-	states := loadCurrentState(cfgFile, envFlag)
+	states, err := loadCurrentState(cfgFile, envFlag)
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
 
 	// When --env is used, module names in state are stored under their
 	// env-resolved names (e.g. "bmw-database" resolves to "bmw-staging-db"

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -224,8 +224,9 @@ func shellQuote(v any) string {
 	return "'" + escaped + "'"
 }
 
-// infraEnvVarNameInvalidChars matches any character that is not a letter,
-// digit, or underscore — all of which are invalid in environment variable names.
+// infraEnvVarNameInvalidChars matches any character that is NOT alphanumeric
+// or underscore — these are replaced with '_' to produce a valid POSIX shell
+// environment variable name.
 var infraEnvVarNameInvalidChars = regexp.MustCompile(`[^A-Z0-9_]`)
 
 // infraEnvVarName converts a module or field name to an environment-variable-

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/GoCodeAlone/workflow/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -44,13 +45,24 @@ func runInfraOutputs(args []string) error {
 
 	states := loadCurrentState(cfgFile, envFlag)
 
+	// When --env is used, module names in state are stored under their
+	// env-resolved names (e.g. "bmw-database" resolves to "bmw-staging-db"
+	// under --env staging). Resolve --module through the same mechanism so
+	// the caller can pass the base config name and still get a match.
+	resolvedModuleFilter := moduleFlag
+	if moduleFlag != "" && envFlag != "" {
+		if resolved := resolveModuleNameForEnv(cfgFile, moduleFlag, envFlag); resolved != "" {
+			resolvedModuleFilter = resolved
+		}
+	}
+
 	// Collect modules with non-empty outputs, in stable alphabetical order.
 	var entries []infraOutputEntry
 	for _, s := range states {
 		if len(s.Outputs) == 0 {
 			continue
 		}
-		if moduleFlag != "" && s.Name != moduleFlag {
+		if resolvedModuleFilter != "" && s.Name != resolvedModuleFilter {
 			continue
 		}
 		entries = append(entries, infraOutputEntry{module: s.Name, outputs: s.Outputs})
@@ -72,6 +84,29 @@ func runInfraOutputs(args []string) error {
 	default:
 		return fmt.Errorf("unknown format %q (supported: yaml, json, env)", formatFlag)
 	}
+}
+
+// resolveModuleNameForEnv returns the env-resolved name for the module whose
+// base config name equals baseName. If the module has no name override for
+// envName, the baseName is returned unchanged. On any load/parse error the
+// baseName is returned so callers degrade gracefully.
+func resolveModuleNameForEnv(cfgFile, baseName, envName string) string {
+	cfg, err := config.LoadFromFile(cfgFile)
+	if err != nil {
+		return baseName
+	}
+	for i := range cfg.Modules {
+		m := &cfg.Modules[i]
+		if m.Name != baseName {
+			continue
+		}
+		rm, ok := m.ResolveForEnv(envName)
+		if !ok {
+			return baseName // module disabled for this env
+		}
+		return rm.Name
+	}
+	return baseName
 }
 
 // infraOutputsYAML prints outputs as a YAML document keyed by module name.
@@ -140,15 +175,14 @@ func infraOutputsJSON(entries []infraOutputEntry) error {
 
 // infraOutputsEnv prints outputs as shell-ready KEY=value lines, with the
 // key formed from the module name and output field name joined by underscores
-// and uppercased:
+// and uppercased. Values are single-quoted so the output can be safely
+// eval'd by a POSIX shell:
 //
-//	BMW_STAGING_DB_HOST=db.example.com
-//	BMW_STAGING_DB_URI=postgresql://...
+//	BMW_STAGING_DB_HOST='db.example.com'
+//	BMW_STAGING_DB_URI='postgresql://...'
 //
-// Values are single-quoted so the output can be safely eval'd by a POSIX
-// shell regardless of whether the value contains spaces, dollar signs,
-// backslashes, or other special characters. Non-scalar values (maps/slices)
-// are serialised as compact JSON before quoting.
+// Non-scalar values (maps/slices) are serialised as compact JSON before
+// quoting.
 func infraOutputsEnv(entries []infraOutputEntry) error {
 	for _, e := range entries {
 		prefix := infraEnvVarName(e.module)

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -199,25 +200,30 @@ func infraOutputsEnv(entries []infraOutputEntry) error {
 }
 
 // shellQuote returns a single-quoted POSIX shell literal for any value.
-// Non-string scalars are formatted with %v; maps and slices are rendered as
-// compact JSON. Single-quote characters inside the value are escaped using
-// the standard POSIX sequence: close the literal, emit a backslash-quoted
-// single-quote, then reopen the literal (the four-character sequence apostrophe
-// backslash apostrophe apostrophe).
+// Strings are used as-is. Maps and slices of any concrete type are
+// JSON-serialized (via reflection) so callers get valid JSON rather than
+// Go's %v formatting. All other scalars are formatted with %v. Single-quote
+// characters inside the value are escaped using the standard POSIX sequence:
+// close the literal, emit a backslash-quoted single-quote, then reopen the
+// literal (the four-character sequence apostrophe backslash apostrophe
+// apostrophe).
 func shellQuote(v any) string {
 	var s string
 	switch tv := v.(type) {
 	case string:
 		s = tv
-	case map[string]any, []any:
-		b, err := json.Marshal(tv)
-		if err != nil {
-			s = fmt.Sprint(tv)
-		} else {
-			s = string(b)
-		}
 	default:
-		s = fmt.Sprint(tv)
+		rv := reflect.ValueOf(v)
+		if rv.IsValid() && (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) {
+			b, err := json.Marshal(tv)
+			if err != nil {
+				s = fmt.Sprint(tv)
+			} else {
+				s = string(b)
+			}
+		} else {
+			s = fmt.Sprint(tv)
+		}
 	}
 	// Escape single-quotes: end the current literal, emit an escaped ', reopen.
 	escaped := strings.ReplaceAll(s, "'", `'\''`)

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -143,6 +144,11 @@ func infraOutputsJSON(entries []infraOutputEntry) error {
 //
 //	BMW_STAGING_DB_HOST=db.example.com
 //	BMW_STAGING_DB_URI=postgresql://...
+//
+// Values are single-quoted so the output can be safely eval'd by a POSIX
+// shell regardless of whether the value contains spaces, dollar signs,
+// backslashes, or other special characters. Non-scalar values (maps/slices)
+// are serialised as compact JSON before quoting.
 func infraOutputsEnv(entries []infraOutputEntry) error {
 	for _, e := range entries {
 		prefix := infraEnvVarName(e.module)
@@ -152,14 +158,45 @@ func infraOutputsEnv(entries []infraOutputEntry) error {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			fmt.Printf("%s_%s=%v\n", prefix, infraEnvVarName(k), e.outputs[k])
+			fmt.Printf("%s_%s=%s\n", prefix, infraEnvVarName(k), shellQuote(e.outputs[k]))
 		}
 	}
 	return nil
 }
 
+// shellQuote returns a single-quoted POSIX shell literal for any value.
+// Non-string scalars are formatted with %v; maps and slices are rendered as
+// compact JSON. Any single-quote characters inside the value are escaped as
+// the sequence '\”.
+func shellQuote(v any) string {
+	var s string
+	switch tv := v.(type) {
+	case string:
+		s = tv
+	case map[string]any, []any:
+		b, err := json.Marshal(tv)
+		if err != nil {
+			s = fmt.Sprint(tv)
+		} else {
+			s = string(b)
+		}
+	default:
+		s = fmt.Sprint(tv)
+	}
+	// Escape single-quotes: end the current literal, emit an escaped ', reopen.
+	escaped := strings.ReplaceAll(s, "'", `'\''`)
+	return "'" + escaped + "'"
+}
+
+// infraEnvVarNameInvalidChars matches any character that is not a letter,
+// digit, or underscore — all of which are invalid in environment variable names.
+var infraEnvVarNameInvalidChars = regexp.MustCompile(`[^A-Z0-9_]`)
+
 // infraEnvVarName converts a module or field name to an environment-variable-
-// safe uppercase string, replacing hyphens and dots with underscores.
+// safe uppercase identifier. All characters that are not ASCII letters, digits,
+// or underscores (including hyphens, dots, slashes, colons, etc.) are replaced
+// with underscores.
 func infraEnvVarName(s string) string {
-	return strings.ToUpper(strings.NewReplacer("-", "_", ".", "_").Replace(s))
+	upper := strings.ToUpper(s)
+	return infraEnvVarNameInvalidChars.ReplaceAllString(upper, "_")
 }

--- a/cmd/wfctl/infra_outputs.go
+++ b/cmd/wfctl/infra_outputs.go
@@ -195,8 +195,13 @@ var infraEnvVarNameInvalidChars = regexp.MustCompile(`[^A-Z0-9_]`)
 // infraEnvVarName converts a module or field name to an environment-variable-
 // safe uppercase identifier. All characters that are not ASCII letters, digits,
 // or underscores (including hyphens, dots, slashes, colons, etc.) are replaced
-// with underscores.
+// with underscores. A leading digit is prefixed with an underscore because POSIX
+// environment variable names must begin with a letter or underscore.
 func infraEnvVarName(s string) string {
 	upper := strings.ToUpper(s)
-	return infraEnvVarNameInvalidChars.ReplaceAllString(upper, "_")
+	sanitized := infraEnvVarNameInvalidChars.ReplaceAllString(upper, "_")
+	if len(sanitized) > 0 && sanitized[0] >= '0' && sanitized[0] <= '9' {
+		sanitized = "_" + sanitized
+	}
+	return sanitized
 }

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── infraEnvVarName ──────────────────────────────────────────────────────────
+
+func TestInfraEnvVarName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"bmw-staging-db", "BMW_STAGING_DB"},
+		{"uri", "URI"},
+		{"host.name", "HOST_NAME"},
+		{"MY_MODULE", "MY_MODULE"},
+	}
+	for _, tc := range cases {
+		got := infraEnvVarName(tc.in)
+		if got != tc.want {
+			t.Errorf("infraEnvVarName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── infraOutputsEnv ──────────────────────────────────────────────────────────
+
+func TestInfraOutputsEnv(t *testing.T) {
+	entries := []infraOutputEntry{
+		{module: "bmw-staging-db", outputs: map[string]any{"host": "db.example.com", "port": 5432}},
+		{module: "bmw-app", outputs: map[string]any{"url": "https://app.example.com"}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := infraOutputsEnv(entries); err != nil {
+		t.Fatalf("infraOutputsEnv: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	out := buf.String()
+
+	wantLines := []string{
+		"BMW_STAGING_DB_HOST=db.example.com",
+		"BMW_STAGING_DB_PORT=5432",
+		"BMW_APP_URL=https://app.example.com",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(out, line) {
+			t.Errorf("env output missing %q\ngot:\n%s", line, out)
+		}
+	}
+}
+
+// ── infraOutputsJSON ─────────────────────────────────────────────────────────
+
+func TestInfraOutputsJSON(t *testing.T) {
+	entries := []infraOutputEntry{
+		{module: "mydb", outputs: map[string]any{"host": "db.example.com", "port": 5432}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := infraOutputsJSON(entries); err != nil {
+		t.Fatalf("infraOutputsJSON: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var result map[string]map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse JSON output: %v\noutput was:\n%s", err, buf.String())
+	}
+	if _, ok := result["mydb"]; !ok {
+		t.Error("JSON output missing 'mydb' key")
+	}
+	if result["mydb"]["host"] != "db.example.com" {
+		t.Errorf("JSON host = %v, want db.example.com", result["mydb"]["host"])
+	}
+}
+
+// ── infraOutputsYAML ─────────────────────────────────────────────────────────
+
+func TestInfraOutputsYAML(t *testing.T) {
+	entries := []infraOutputEntry{
+		{module: "mydb", outputs: map[string]any{"host": "db.example.com"}},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := infraOutputsYAML(entries); err != nil {
+		t.Fatalf("infraOutputsYAML: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	out := buf.String()
+
+	if !strings.Contains(out, "mydb:") {
+		t.Errorf("YAML output missing 'mydb:'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "host: db.example.com") {
+		t.Errorf("YAML output missing 'host: db.example.com'\ngot:\n%s", out)
+	}
+}
+
+// ── runInfraOutputs integration ──────────────────────────────────────────────
+
+func TestRunInfraOutputs_EmptyState(t *testing.T) {
+	// Create a temp dir as a filesystem state store with no records.
+	dir := t.TempDir()
+
+	cfgFile := writeInfraOutputsTestConfig(t, dir)
+
+	// Capture stderr (the "No outputs found" message goes there).
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := runInfraOutputs([]string{"--config", cfgFile})
+
+	w.Close()
+	os.Stderr = old
+
+	if err != nil {
+		t.Fatalf("runInfraOutputs: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), "No outputs") {
+		t.Errorf("expected 'No outputs' on stderr, got: %s", buf.String())
+	}
+}
+
+func TestRunInfraOutputs_WithState_YAML(t *testing.T) {
+	dir := t.TempDir()
+	writeInfraOutputsStateFile(t, dir, "mydb", map[string]any{"host": "localhost", "port": 5432})
+
+	cfgFile := writeInfraOutputsTestConfig(t, dir)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "yaml"})
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runInfraOutputs yaml: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	out := buf.String()
+
+	if !strings.Contains(out, "mydb:") {
+		t.Errorf("YAML missing 'mydb:', got:\n%s", out)
+	}
+	if !strings.Contains(out, "host: localhost") {
+		t.Errorf("YAML missing 'host: localhost', got:\n%s", out)
+	}
+}
+
+func TestRunInfraOutputs_WithState_JSON(t *testing.T) {
+	dir := t.TempDir()
+	writeInfraOutputsStateFile(t, dir, "mydb", map[string]any{"uri": "postgresql://localhost/db"})
+
+	cfgFile := writeInfraOutputsTestConfig(t, dir)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "json"})
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runInfraOutputs json: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var result map[string]map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("parse JSON: %v\noutput:\n%s", err, buf.String())
+	}
+	if result["mydb"]["uri"] != "postgresql://localhost/db" {
+		t.Errorf("uri = %v, want postgresql://localhost/db", result["mydb"]["uri"])
+	}
+}
+
+func TestRunInfraOutputs_ModuleFilter(t *testing.T) {
+	dir := t.TempDir()
+	writeInfraOutputsStateFile(t, dir, "db-a", map[string]any{"host": "a.example.com"})
+	writeInfraOutputsStateFile(t, dir, "db-b", map[string]any{"host": "b.example.com"})
+
+	cfgFile := writeInfraOutputsTestConfig(t, dir)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInfraOutputs([]string{"--config", cfgFile, "--module", "db-a", "--format", "yaml"})
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runInfraOutputs --module: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	out := buf.String()
+
+	if !strings.Contains(out, "db-a:") {
+		t.Errorf("expected db-a in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "db-b:") {
+		t.Errorf("db-b should be filtered out, got:\n%s", out)
+	}
+}
+
+func TestRunInfraOutputs_UnknownFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeInfraOutputsStateFile(t, dir, "mydb", map[string]any{"host": "localhost"})
+	cfgFile := writeInfraOutputsTestConfig(t, dir)
+
+	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "table"})
+	if err == nil {
+		t.Fatal("expected error for unknown format, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown format") {
+		t.Errorf("error = %v, want 'unknown format'", err)
+	}
+}
+
+func TestRunInfraOutputs_SkipsEmptyOutputs(t *testing.T) {
+	dir := t.TempDir()
+	// Write a state file with empty outputs.
+	writeInfraOutputsStateFileRaw(t, dir, "no-outputs", nil)
+	writeInfraOutputsStateFile(t, dir, "has-outputs", map[string]any{"key": "val"})
+
+	cfgFile := writeInfraOutputsTestConfig(t, dir)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "yaml"})
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runInfraOutputs: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	out := buf.String()
+
+	if strings.Contains(out, "no-outputs") {
+		t.Errorf("resource with empty outputs should be skipped, got:\n%s", out)
+	}
+	if !strings.Contains(out, "has-outputs") {
+		t.Errorf("resource with outputs should appear, got:\n%s", out)
+	}
+}
+
+// ── test helpers ─────────────────────────────────────────────────────────────
+
+// writeInfraOutputsTestConfig writes a minimal infra.yaml that points the
+// filesystem state store at dir, then returns the file path.
+func writeInfraOutputsTestConfig(t *testing.T, stateDir string) string {
+	t.Helper()
+	content := `modules:
+  - name: iac-state
+    type: iac.state
+    config:
+      backend: filesystem
+      directory: ` + stateDir + "\n"
+	f, err := os.CreateTemp(t.TempDir(), "infra-*.yaml")
+	if err != nil {
+		t.Fatalf("create config: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// writeInfraOutputsStateFile writes a JSON state record to stateDir.
+func writeInfraOutputsStateFile(t *testing.T, stateDir, name string, outputs map[string]any) {
+	t.Helper()
+	writeInfraOutputsStateFileRaw(t, stateDir, name, outputs)
+}
+
+func writeInfraOutputsStateFileRaw(t *testing.T, stateDir, name string, outputs map[string]any) {
+	t.Helper()
+	record := iacStateRecord{
+		ResourceID:   name,
+		ResourceType: "infra.database",
+		Provider:     "digitalocean",
+		Status:       "active",
+		Outputs:      outputs,
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal state record: %v", err)
+	}
+	path := stateDir + "/" + name + ".json"
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+}

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -15,8 +15,9 @@ import (
 // captureStdout redirects os.Stdout to a pipe for the duration of fn, drains
 // the pipe in a goroutine to prevent deadlocks when fn writes more than the
 // OS pipe buffer (~64 KB), and returns the captured output alongside any error
-// fn returned. The read end is closed by the goroutine; os.Stdout is restored
-// immediately after fn returns.
+// fn returned. The read end is closed by the drain goroutine. os.Stdout and the
+// write end are restored/closed via defer so that panics inside fn do not leave
+// subsequent tests with a redirected stdout.
 func captureStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -25,6 +26,8 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	}
 	orig := os.Stdout
 	os.Stdout = w
+	defer func() { os.Stdout = orig }() // panic-safe restore
+	defer w.Close()                     // unblocks goroutine if fn panics
 
 	var buf bytes.Buffer
 	done := make(chan struct{})
@@ -32,8 +35,7 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 
 	fnErr := fn()
 
-	w.Close()
-	os.Stdout = orig // restore immediately so later writes in the test are not captured
+	w.Close() // close immediately on normal return so <-done doesn't block
 	<-done
 	return buf.String(), fnErr
 }
@@ -47,6 +49,8 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 	}
 	orig := os.Stderr
 	os.Stderr = w
+	defer func() { os.Stderr = orig }() // panic-safe restore
+	defer w.Close()                     // unblocks goroutine if fn panics
 
 	var buf bytes.Buffer
 	done := make(chan struct{})
@@ -54,10 +58,47 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 
 	fnErr := fn()
 
-	w.Close()
-	os.Stderr = orig // restore immediately so later writes in the test are not captured
+	w.Close() // close immediately on normal return so <-done doesn't block
 	<-done
 	return buf.String(), fnErr
+}
+
+// TestCaptureStdout_RestoresOnPanic verifies that os.Stdout is restored even
+// when the function passed to captureStdout panics.
+func TestCaptureStdout_RestoresOnPanic(t *testing.T) {
+	orig := os.Stdout
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic, got none")
+			}
+		}()
+		captureStdout(t, func() error { //nolint:errcheck
+			panic("intentional test panic")
+		})
+	}()
+	if os.Stdout != orig {
+		t.Error("os.Stdout not restored after panic in fn")
+	}
+}
+
+// TestCaptureStderr_RestoresOnPanic verifies that os.Stderr is restored even
+// when the function passed to captureStderr panics.
+func TestCaptureStderr_RestoresOnPanic(t *testing.T) {
+	orig := os.Stderr
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic, got none")
+			}
+		}()
+		captureStderr(t, func() error { //nolint:errcheck
+			panic("intentional test panic")
+		})
+	}()
+	if os.Stderr != orig {
+		t.Error("os.Stderr not restored after panic in fn")
+	}
 }
 
 // ── infraEnvVarName ──────────────────────────────────────────────────────────

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -20,6 +20,9 @@ func TestInfraEnvVarName(t *testing.T) {
 		{"module/v2:resource", "MODULE_V2_RESOURCE"},
 		{"a\\b", "A_B"},
 		{"a:b:c", "A_B_C"},
+		// Leading digit: POSIX env var names must start with letter or underscore.
+		{"1st-module", "_1ST_MODULE"},
+		{"42", "_42"},
 	}
 	for _, tc := range cases {
 		got := infraEnvVarName(tc.in)

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -1,12 +1,54 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// ── stdout/stderr capture helpers ────────────────────────────────────────────
+
+// captureStdout redirects os.Stdout to a pipe for the duration of fn, then
+// returns the captured output alongside any error fn returned. os.Stdout is
+// restored via t.Cleanup so it is always recovered even when fn panics or
+// t.Fatalf is called from within fn.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("captureStdout: create pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+
+	fnErr := fn()
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out), fnErr
+}
+
+// captureStderr is the stderr equivalent of captureStdout.
+func captureStderr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("captureStderr: create pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = orig })
+
+	fnErr := fn()
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out), fnErr
+}
 
 // ── infraEnvVarName ──────────────────────────────────────────────────────────
 
@@ -64,20 +106,10 @@ func TestInfraOutputsEnv(t *testing.T) {
 		{module: "bmw-app", outputs: map[string]any{"url": "https://app.example.com"}},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	if err := infraOutputsEnv(entries); err != nil {
+	out, err := captureStdout(t, func() error { return infraOutputsEnv(entries) })
+	if err != nil {
 		t.Fatalf("infraOutputsEnv: %v", err)
 	}
-
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	out := buf.String()
 
 	wantLines := []string{
 		"BMW_STAGING_DB_HOST='db.example.com'",
@@ -98,23 +130,14 @@ func TestInfraOutputsJSON(t *testing.T) {
 		{module: "mydb", outputs: map[string]any{"host": "db.example.com", "port": 5432}},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	if err := infraOutputsJSON(entries); err != nil {
+	out, err := captureStdout(t, func() error { return infraOutputsJSON(entries) })
+	if err != nil {
 		t.Fatalf("infraOutputsJSON: %v", err)
 	}
 
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-
 	var result map[string]map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("parse JSON output: %v\noutput was:\n%s", err, buf.String())
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parse JSON output: %v\noutput was:\n%s", err, out)
 	}
 	if _, ok := result["mydb"]; !ok {
 		t.Error("JSON output missing 'mydb' key")
@@ -131,20 +154,10 @@ func TestInfraOutputsYAML(t *testing.T) {
 		{module: "mydb", outputs: map[string]any{"host": "db.example.com"}},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	if err := infraOutputsYAML(entries); err != nil {
+	out, err := captureStdout(t, func() error { return infraOutputsYAML(entries) })
+	if err != nil {
 		t.Fatalf("infraOutputsYAML: %v", err)
 	}
-
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	out := buf.String()
 
 	if !strings.Contains(out, "mydb:") {
 		t.Errorf("YAML output missing 'mydb:'\ngot:\n%s", out)
@@ -157,52 +170,32 @@ func TestInfraOutputsYAML(t *testing.T) {
 // ── runInfraOutputs integration ──────────────────────────────────────────────
 
 func TestRunInfraOutputs_EmptyState(t *testing.T) {
-	// Create a temp dir as a filesystem state store with no records.
 	dir := t.TempDir()
-
 	cfgFile := writeInfraOutputsTestConfig(t, dir)
 
-	// Capture stderr (the "No outputs found" message goes there).
-	old := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-
-	err := runInfraOutputs([]string{"--config", cfgFile})
-
-	w.Close()
-	os.Stderr = old
-
+	// "No outputs found" message goes to stderr.
+	errOut, err := captureStderr(t, func() error {
+		return runInfraOutputs([]string{"--config", cfgFile})
+	})
 	if err != nil {
 		t.Fatalf("runInfraOutputs: %v", err)
 	}
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	if !strings.Contains(buf.String(), "No outputs") {
-		t.Errorf("expected 'No outputs' on stderr, got: %s", buf.String())
+	if !strings.Contains(errOut, "No outputs") {
+		t.Errorf("expected 'No outputs' on stderr, got: %s", errOut)
 	}
 }
 
 func TestRunInfraOutputs_WithState_YAML(t *testing.T) {
 	dir := t.TempDir()
 	writeInfraOutputsStateFile(t, dir, "mydb", map[string]any{"host": "localhost", "port": 5432})
-
 	cfgFile := writeInfraOutputsTestConfig(t, dir)
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "yaml"})
-
-	w.Close()
-	os.Stdout = old
-
+	out, err := captureStdout(t, func() error {
+		return runInfraOutputs([]string{"--config", cfgFile, "--format", "yaml"})
+	})
 	if err != nil {
 		t.Fatalf("runInfraOutputs yaml: %v", err)
 	}
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	out := buf.String()
 
 	if !strings.Contains(out, "mydb:") {
 		t.Errorf("YAML missing 'mydb:', got:\n%s", out)
@@ -215,27 +208,18 @@ func TestRunInfraOutputs_WithState_YAML(t *testing.T) {
 func TestRunInfraOutputs_WithState_JSON(t *testing.T) {
 	dir := t.TempDir()
 	writeInfraOutputsStateFile(t, dir, "mydb", map[string]any{"uri": "postgresql://localhost/db"})
-
 	cfgFile := writeInfraOutputsTestConfig(t, dir)
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "json"})
-
-	w.Close()
-	os.Stdout = old
-
+	out, err := captureStdout(t, func() error {
+		return runInfraOutputs([]string{"--config", cfgFile, "--format", "json"})
+	})
 	if err != nil {
 		t.Fatalf("runInfraOutputs json: %v", err)
 	}
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
 
 	var result map[string]map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Fatalf("parse JSON: %v\noutput:\n%s", err, buf.String())
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parse JSON: %v\noutput:\n%s", err, out)
 	}
 	if result["mydb"]["uri"] != "postgresql://localhost/db" {
 		t.Errorf("uri = %v, want postgresql://localhost/db", result["mydb"]["uri"])
@@ -246,24 +230,14 @@ func TestRunInfraOutputs_ModuleFilter(t *testing.T) {
 	dir := t.TempDir()
 	writeInfraOutputsStateFile(t, dir, "db-a", map[string]any{"host": "a.example.com"})
 	writeInfraOutputsStateFile(t, dir, "db-b", map[string]any{"host": "b.example.com"})
-
 	cfgFile := writeInfraOutputsTestConfig(t, dir)
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := runInfraOutputs([]string{"--config", cfgFile, "--module", "db-a", "--format", "yaml"})
-
-	w.Close()
-	os.Stdout = old
-
+	out, err := captureStdout(t, func() error {
+		return runInfraOutputs([]string{"--config", cfgFile, "--module", "db-a", "--format", "yaml"})
+	})
 	if err != nil {
 		t.Fatalf("runInfraOutputs --module: %v", err)
 	}
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	out := buf.String()
 
 	if !strings.Contains(out, "db-a:") {
 		t.Errorf("expected db-a in output, got:\n%s", out)
@@ -289,27 +263,16 @@ func TestRunInfraOutputs_UnknownFormat(t *testing.T) {
 
 func TestRunInfraOutputs_SkipsEmptyOutputs(t *testing.T) {
 	dir := t.TempDir()
-	// Write a state file with empty outputs.
 	writeInfraOutputsStateFileRaw(t, dir, "no-outputs", nil)
 	writeInfraOutputsStateFile(t, dir, "has-outputs", map[string]any{"key": "val"})
-
 	cfgFile := writeInfraOutputsTestConfig(t, dir)
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := runInfraOutputs([]string{"--config", cfgFile, "--format", "yaml"})
-
-	w.Close()
-	os.Stdout = old
-
+	out, err := captureStdout(t, func() error {
+		return runInfraOutputs([]string{"--config", cfgFile, "--format", "yaml"})
+	})
 	if err != nil {
 		t.Fatalf("runInfraOutputs: %v", err)
 	}
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	out := buf.String()
 
 	if strings.Contains(out, "no-outputs") {
 		t.Errorf("resource with empty outputs should be skipped, got:\n%s", out)
@@ -361,7 +324,7 @@ func writeInfraOutputsStateFileRaw(t *testing.T, stateDir, name string, outputs 
 	if err != nil {
 		t.Fatalf("marshal state record: %v", err)
 	}
-	path := stateDir + "/" + name + ".json"
+	path := filepath.Join(stateDir, name+".json")
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("write state file: %v", err)
 	}

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"os"
@@ -11,10 +12,10 @@ import (
 
 // ── stdout/stderr capture helpers ────────────────────────────────────────────
 
-// captureStdout redirects os.Stdout to a pipe for the duration of fn, then
-// returns the captured output alongside any error fn returned. os.Stdout is
-// restored via t.Cleanup so it is always recovered even when fn panics or
-// t.Fatalf is called from within fn.
+// captureStdout redirects os.Stdout to a pipe for the duration of fn, drains
+// the pipe in a goroutine to prevent deadlocks when fn writes more than the
+// OS pipe buffer (~64 KB), and returns the captured output alongside any error
+// fn returned. os.Stdout is restored via t.Cleanup.
 func captureStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -25,11 +26,15 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	os.Stdout = w
 	t.Cleanup(func() { os.Stdout = orig })
 
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() { io.Copy(&buf, r); close(done) }()
+
 	fnErr := fn()
 
 	w.Close()
-	out, _ := io.ReadAll(r)
-	return string(out), fnErr
+	<-done
+	return buf.String(), fnErr
 }
 
 // captureStderr is the stderr equivalent of captureStdout.
@@ -43,11 +48,15 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 	os.Stderr = w
 	t.Cleanup(func() { os.Stderr = orig })
 
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() { io.Copy(&buf, r); close(done) }()
+
 	fnErr := fn()
 
 	w.Close()
-	out, _ := io.ReadAll(r)
-	return string(out), fnErr
+	<-done
+	return buf.String(), fnErr
 }
 
 // ── infraEnvVarName ──────────────────────────────────────────────────────────
@@ -282,10 +291,44 @@ func TestRunInfraOutputs_SkipsEmptyOutputs(t *testing.T) {
 	}
 }
 
+// TestRunInfraOutputs_EnvModuleFilter verifies that --module accepts the base
+// config name and correctly matches the env-resolved name in state. When
+// --env staging is used, the module "bmw-database" is stored in state as
+// "bmw-staging-db" (per-env name override). The filter must resolve the base
+// name before comparing to state records.
+func TestRunInfraOutputs_EnvModuleFilter(t *testing.T) {
+	dir := t.TempDir()
+	// State holds the resolved name "bmw-staging-db".
+	writeInfraOutputsStateFile(t, dir, "bmw-staging-db", map[string]any{"uri": "postgresql://staging/db"})
+	writeInfraOutputsStateFile(t, dir, "other-module", map[string]any{"key": "val"})
+
+	// Config has "bmw-database" as the base name; per-env staging it resolves to "bmw-staging-db".
+	cfgFile := writeInfraOutputsEnvTestConfig(t, dir)
+
+	out, err := captureStdout(t, func() error {
+		return runInfraOutputs([]string{
+			"--config", cfgFile,
+			"--env", "staging",
+			"--module", "bmw-database", // base config name
+			"--format", "yaml",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runInfraOutputs --env --module: %v", err)
+	}
+
+	if !strings.Contains(out, "bmw-staging-db:") {
+		t.Errorf("expected 'bmw-staging-db:' in output (env-resolved name), got:\n%s", out)
+	}
+	if strings.Contains(out, "other-module") {
+		t.Errorf("other-module should be filtered out, got:\n%s", out)
+	}
+}
+
 // ── test helpers ─────────────────────────────────────────────────────────────
 
-// writeInfraOutputsTestConfig writes a minimal infra.yaml that points the
-// filesystem state store at dir, then returns the file path.
+// writeInfraOutputsTestConfig writes a minimal infra.yaml (no env overrides)
+// that points the filesystem state store at dir, then returns the file path.
 func writeInfraOutputsTestConfig(t *testing.T, stateDir string) string {
 	t.Helper()
 	content := `modules:
@@ -300,6 +343,37 @@ func writeInfraOutputsTestConfig(t *testing.T, stateDir string) string {
 	}
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatalf("write config: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// writeInfraOutputsEnvTestConfig writes a config that has a "bmw-database"
+// module whose per-env staging name resolves to "bmw-staging-db", used by
+// TestRunInfraOutputs_EnvModuleFilter.
+func writeInfraOutputsEnvTestConfig(t *testing.T, stateDir string) string {
+	t.Helper()
+	content := `modules:
+  - name: iac-state
+    type: iac.state
+    config:
+      backend: filesystem
+      directory: ` + stateDir + `
+  - name: bmw-database
+    type: infra.database
+    config:
+      engine: pg
+    environments:
+      staging:
+        config:
+          name: bmw-staging-db
+` + "\n"
+	f, err := os.CreateTemp(t.TempDir(), "infra-env-*.yaml")
+	if err != nil {
+		t.Fatalf("create env config: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write env config: %v", err)
 	}
 	f.Close()
 	return f.Name()

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -15,7 +15,8 @@ import (
 // captureStdout redirects os.Stdout to a pipe for the duration of fn, drains
 // the pipe in a goroutine to prevent deadlocks when fn writes more than the
 // OS pipe buffer (~64 KB), and returns the captured output alongside any error
-// fn returned. os.Stdout is restored via t.Cleanup.
+// fn returned. The read end is closed by the goroutine; os.Stdout is restored
+// immediately after fn returns.
 func captureStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	r, w, err := os.Pipe()

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -16,11 +16,39 @@ func TestInfraEnvVarName(t *testing.T) {
 		{"uri", "URI"},
 		{"host.name", "HOST_NAME"},
 		{"MY_MODULE", "MY_MODULE"},
+		// Characters beyond hyphen/dot must also be sanitised.
+		{"module/v2:resource", "MODULE_V2_RESOURCE"},
+		{"a\\b", "A_B"},
+		{"a:b:c", "A_B_C"},
 	}
 	for _, tc := range cases {
 		got := infraEnvVarName(tc.in)
 		if got != tc.want {
 			t.Errorf("infraEnvVarName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── shellQuote ───────────────────────────────────────────────────────────────
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{"simple", "'simple'"},
+		{"with space", "'with space'"},
+		{"has'quote", `'has'\''quote'`},
+		{"dollar $VAR", "'dollar $VAR'"},
+		{42, "'42'"},
+		{true, "'true'"},
+		// Non-scalar: map serialised as compact JSON then single-quoted.
+		{map[string]any{"k": "v"}, `'{"k":"v"}'`},
+	}
+	for _, tc := range cases {
+		got := shellQuote(tc.in)
+		if got != tc.want {
+			t.Errorf("shellQuote(%v) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }
@@ -49,9 +77,9 @@ func TestInfraOutputsEnv(t *testing.T) {
 	out := buf.String()
 
 	wantLines := []string{
-		"BMW_STAGING_DB_HOST=db.example.com",
-		"BMW_STAGING_DB_PORT=5432",
-		"BMW_APP_URL=https://app.example.com",
+		"BMW_STAGING_DB_HOST='db.example.com'",
+		"BMW_STAGING_DB_PORT='5432'",
+		"BMW_APP_URL='https://app.example.com'",
 	}
 	for _, line := range wantLines {
 		if !strings.Contains(out, line) {

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -27,7 +27,6 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	orig := os.Stdout
 	os.Stdout = w
 	defer func() { os.Stdout = orig }() // panic-safe restore
-	defer w.Close()                     // unblocks goroutine if fn panics
 
 	var buf bytes.Buffer
 	done := make(chan struct{})
@@ -35,7 +34,7 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 
 	fnErr := fn()
 
-	w.Close() // close immediately on normal return so <-done doesn't block
+	w.Close() // single close — drives goroutine to EOF; deferred orig restore runs after
 	<-done
 	return buf.String(), fnErr
 }
@@ -50,7 +49,6 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 	orig := os.Stderr
 	os.Stderr = w
 	defer func() { os.Stderr = orig }() // panic-safe restore
-	defer w.Close()                     // unblocks goroutine if fn panics
 
 	var buf bytes.Buffer
 	done := make(chan struct{})
@@ -58,7 +56,7 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 
 	fnErr := fn()
 
-	w.Close() // close immediately on normal return so <-done doesn't block
+	w.Close() // single close — drives goroutine to EOF; deferred orig restore runs after
 	<-done
 	return buf.String(), fnErr
 }

--- a/cmd/wfctl/infra_outputs_test.go
+++ b/cmd/wfctl/infra_outputs_test.go
@@ -24,15 +24,15 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	}
 	orig := os.Stdout
 	os.Stdout = w
-	t.Cleanup(func() { os.Stdout = orig })
 
 	var buf bytes.Buffer
 	done := make(chan struct{})
-	go func() { io.Copy(&buf, r); close(done) }()
+	go func() { defer r.Close(); io.Copy(&buf, r); close(done) }()
 
 	fnErr := fn()
 
 	w.Close()
+	os.Stdout = orig // restore immediately so later writes in the test are not captured
 	<-done
 	return buf.String(), fnErr
 }
@@ -46,15 +46,15 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 	}
 	orig := os.Stderr
 	os.Stderr = w
-	t.Cleanup(func() { os.Stderr = orig })
 
 	var buf bytes.Buffer
 	done := make(chan struct{})
-	go func() { io.Copy(&buf, r); close(done) }()
+	go func() { defer r.Close(); io.Copy(&buf, r); close(done) }()
 
 	fnErr := fn()
 
 	w.Close()
+	os.Stderr = orig // restore immediately so later writes in the test are not captured
 	<-done
 	return buf.String(), fnErr
 }

--- a/cmd/wfctl/infra_state.go
+++ b/cmd/wfctl/infra_state.go
@@ -66,7 +66,10 @@ func runInfraStateList(args []string) error {
 		}
 	}
 
-	states := loadCurrentState(cfgFile, "")
+	states, err := loadCurrentState(cfgFile, "")
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
 	if len(states) == 0 {
 		fmt.Println("No resources tracked in state.")
 		return nil
@@ -106,10 +109,12 @@ func runInfraStateExport(args []string) error {
 		}
 	}
 
-	states := loadCurrentState(cfgFile, "")
+	states, err := loadCurrentState(cfgFile, "")
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
 
 	var data []byte
-	var err error
 	switch formatVal {
 	case "tfstate":
 		data, err = exportAsTFState(states)

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -90,6 +90,7 @@ graph TD
     infra --> infra-drift["drift"]
     infra --> infra-import["import"]
     infra --> infra-state["state"]
+    infra --> infra-outputs["outputs"]
 
     infra-state --> infra-state-list["list"]
     infra-state --> infra-state-export["export"]
@@ -153,7 +154,7 @@ graph TD
 | **Validation & Inspection** | `validate`, `inspect`, `schema`, `compat check`, `template validate`, `editor-schemas`, `dsl-reference` |
 | **API & Contract** | `api extract`, `contract test`, `diff` |
 | **Deployment** | `deploy docker/kubernetes/helm/cloud`, `build-ui`, `generate github-actions` |
-| **Infrastructure** | `infra plan/apply/destroy/status/drift/import`, `infra state list/export/import` |
+| **Infrastructure** | `infra plan/apply/destroy/status/drift/import/outputs`, `infra state list/export/import` |
 | **CI/CD** | `ci generate`, `generate github-actions` |
 | **Documentation** | `docs generate` |
 | **Plugin Management** | `plugin`, `registry`, `publish` |
@@ -968,6 +969,7 @@ wfctl infra <action> [options] [config.yaml]
 | `destroy` | Tear down all managed infrastructure |
 | `import` | Import existing resources into IaC state |
 | `state` | Manage state storage (list/export/import) |
+| `outputs` | Print resource outputs from state (yaml/json/env formats) |
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -89,6 +89,7 @@ graph TD
     infra --> infra-status["status"]
     infra --> infra-drift["drift"]
     infra --> infra-import["import"]
+    infra --> infra-bootstrap["bootstrap"]
     infra --> infra-state["state"]
     infra --> infra-outputs["outputs"]
 
@@ -154,7 +155,7 @@ graph TD
 | **Validation & Inspection** | `validate`, `inspect`, `schema`, `compat check`, `template validate`, `editor-schemas`, `dsl-reference` |
 | **API & Contract** | `api extract`, `contract test`, `diff` |
 | **Deployment** | `deploy docker/kubernetes/helm/cloud`, `build-ui`, `generate github-actions` |
-| **Infrastructure** | `infra plan/apply/destroy/status/drift/import/outputs`, `infra state list/export/import` |
+| **Infrastructure** | `infra plan/apply/destroy/status/drift/import/bootstrap/outputs`, `infra state list/export/import` |
 | **CI/CD** | `ci generate`, `generate github-actions` |
 | **Documentation** | `docs generate` |
 | **Plugin Management** | `plugin`, `registry`, `publish` |
@@ -968,6 +969,7 @@ wfctl infra <action> [options] [config.yaml]
 | `drift` | Detect configuration drift between desired and actual state |
 | `destroy` | Tear down all managed infrastructure |
 | `import` | Import existing resources into IaC state |
+| `bootstrap` | Generate secrets and initialise state backend before first apply |
 | `state` | Manage state storage (list/export/import) |
 | `outputs` | Print resource outputs from state (yaml/json/env formats) |
 


### PR DESCRIPTION
## Summary

- Adds a read-only `wfctl infra outputs` subcommand that reads all captured resource outputs from the configured IaC state backend and prints them in a requested format.
- Reuses `loadCurrentState()` + `resolveStateStore()` — the exact same path `infra apply` uses for diff; no new backend dependencies or credential requirements.
- Works with all existing backends (filesystem, Spaces, Postgres) and respects per-env state backend config when `--env` is supplied.

## Usage

```
wfctl infra outputs [--env <name>] [-c infra.yaml] [--format yaml|json|env] [--module <name>]
```

**Formats:**

`yaml` (default) — nested by module then field name  
`json` — flat object keyed by module  
`env` — shell-ready `BMW_STAGING_DB_URI=...` lines

## Test plan

- [ ] `wfctl infra outputs --env staging -c infra.yaml` prints YAML of all staging outputs
- [ ] `--format json` emits valid JSON parseable by `jq`
- [ ] `--format env` emits `KEY=value` consumable by `source`
- [ ] `--module <name>` restricts to one module
- [ ] Empty state prints "No outputs found" to stderr, exits 0
- [ ] Unknown `--format` returns an error

10 unit tests cover all cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)