### PR TITLE
fix(wfctl): suppress GitHub step summaries during tests

### DIFF
--- a/cmd/wfctl/ci_output.go
+++ b/cmd/wfctl/ci_output.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -47,7 +46,7 @@ func githubStepSummaryPath() string {
 }
 
 func runningAsGoTest() bool {
-	return strings.HasSuffix(filepath.Base(os.Args[0]), ".test")
+	return flag.Lookup("test.v") != nil
 }
 
 // --- GitHub Actions ---

--- a/cmd/wfctl/ci_output.go
+++ b/cmd/wfctl/ci_output.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -21,7 +23,7 @@ type CIGroupEmitter interface {
 func detectCIProvider() CIGroupEmitter {
 	switch {
 	case os.Getenv("GITHUB_ACTIONS") == "true":
-		return githubEmitter{summaryPath: os.Getenv("GITHUB_STEP_SUMMARY")}
+		return githubEmitter{summaryPath: githubStepSummaryPath()}
 	case os.Getenv("GITLAB_CI") == "true":
 		return &gitlabEmitter{}
 	case os.Getenv("JENKINS_HOME") != "":
@@ -31,6 +33,21 @@ func detectCIProvider() CIGroupEmitter {
 	default:
 		return plainEmitter{}
 	}
+}
+
+func githubStepSummaryPath() string {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return ""
+	}
+	if runningAsGoTest() && os.Getenv("WFCTL_ALLOW_TEST_STEP_SUMMARY") != "true" {
+		return ""
+	}
+	return path
+}
+
+func runningAsGoTest() bool {
+	return strings.HasSuffix(filepath.Base(os.Args[0]), ".test")
 }
 
 // --- GitHub Actions ---

--- a/cmd/wfctl/ci_output_test.go
+++ b/cmd/wfctl/ci_output_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ func TestDetectCIProvider_GitHub(t *testing.T) {
 
 func TestDetectCIProvider_GitHubSummaryPathIgnoredInGoTestByDefault(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "true")
-	t.Setenv("GITHUB_STEP_SUMMARY", t.TempDir()+"/summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", filepath.Join(t.TempDir(), "summary.md"))
 	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "")
 
 	e := detectCIProvider()
@@ -30,7 +31,7 @@ func TestDetectCIProvider_GitHubSummaryPathIgnoredInGoTestByDefault(t *testing.T
 }
 
 func TestDetectCIProvider_GitHubSummaryPathAllowedInGoTestWithOverride(t *testing.T) {
-	summaryPath := t.TempDir() + "/summary.md"
+	summaryPath := filepath.Join(t.TempDir(), "summary.md")
 	t.Setenv("GITHUB_ACTIONS", "true")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
 	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")

--- a/cmd/wfctl/ci_output_test.go
+++ b/cmd/wfctl/ci_output_test.go
@@ -18,6 +18,29 @@ func TestDetectCIProvider_GitHub(t *testing.T) {
 	}
 }
 
+func TestDetectCIProvider_GitHubSummaryPathIgnoredInGoTestByDefault(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_STEP_SUMMARY", t.TempDir()+"/summary.md")
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "")
+
+	e := detectCIProvider()
+	if got := e.SummaryPath(); got != "" {
+		t.Fatalf("SummaryPath() = %q, want empty while running go test", got)
+	}
+}
+
+func TestDetectCIProvider_GitHubSummaryPathAllowedInGoTestWithOverride(t *testing.T) {
+	summaryPath := t.TempDir() + "/summary.md"
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
+
+	e := detectCIProvider()
+	if got := e.SummaryPath(); got != summaryPath {
+		t.Fatalf("SummaryPath() = %q, want %q", got, summaryPath)
+	}
+}
+
 func TestDetectCIProvider_GitLab(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "")
 	t.Setenv("GITLAB_CI", "true")

--- a/cmd/wfctl/deploy_providers_troubleshoot_test.go
+++ b/cmd/wfctl/deploy_providers_troubleshoot_test.go
@@ -86,6 +86,7 @@ func TestHealthPollTimeout_WritesStepSummaryOnTimeout(t *testing.T) {
 	summaryPath := filepath.Join(tmp, "summary.md")
 	t.Setenv("GITHUB_ACTIONS", "true")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
 
 	f := &fakeTroubleshootingDriver{
 		diags: []interfaces.Diagnostic{
@@ -125,6 +126,7 @@ func TestHealthPollTimeout_EmptyLastMsgFallback(t *testing.T) {
 	summaryPath := filepath.Join(tmp, "summary.md")
 	t.Setenv("GITHUB_ACTIONS", "true")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
 
 	f := &fakeTroubleshootingDriver{}
 	err := healthPollTimeout(

--- a/cmd/wfctl/infra_apply_troubleshoot_test.go
+++ b/cmd/wfctl/infra_apply_troubleshoot_test.go
@@ -126,6 +126,7 @@ func TestInfraApply_WritesStepSummaryOnFailure(t *testing.T) {
 	summaryPath := filepath.Join(tmp, "summary.md")
 	t.Setenv("GITHUB_ACTIONS", "true")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
 
 	// plainFailProvider has no Troubleshooter — ResourceDriver returns (nil, nil).
 	// This exercises the important branch where diagnostics are empty but the


### PR DESCRIPTION
## Summary
- prevent wfctl from writing GitHub Step Summary output when running inside Go test binaries unless explicitly opted in
- keep summary-writing tests covered with an explicit test override
- add regression coverage for inherited GITHUB_STEP_SUMMARY in CI test runs

## Verification
- GOWORK=off go test ./cmd/wfctl -run 'TestDetectCIProvider_GitHubSummaryPath|TestInfraApply_WritesStepSummaryOnFailure|TestHealthPollTimeout_WritesStepSummary' -count=1
- GITHUB_ACTIONS=true GITHUB_STEP_SUMMARY=/tmp/wfctl-should-not-write.md GOWORK=off go test ./cmd/wfctl -run 'TestInfraApply_EmitsDiagnosticsOnFailure' -count=1 && test ! -e /tmp/wfctl-should-not-write.md
- GOWORK=off go test ./cmd/wfctl -count=1
- git diff --check