### PR TITLE
fix(wfctl): retain platform URLs in plugin lock

### DIFF
--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -52,6 +52,15 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 		Plugins:     make(map[string]config.WfctlLockPluginEntry),
 	}
 
+	registryConfig, registryErr := LoadRegistryConfig("")
+	if registryErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load registry config while enriching lockfile: %v\n", registryErr)
+	}
+	var registries *MultiRegistry
+	if registryConfig != nil {
+		registries = NewMultiRegistry(registryConfig)
+	}
+
 	for _, p := range m.Plugins {
 		entry := config.WfctlLockPluginEntry{
 			Version: p.Version,
@@ -67,6 +76,13 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 				entry.Platforms = prev.Platforms
 			}
 		}
+		if len(entry.Platforms) == 0 && registries != nil {
+			if platforms, err := lockPlatformsFromRegistry(registries, p.Name, p.Version); err == nil {
+				entry.Platforms = platforms
+			} else {
+				fmt.Fprintf(os.Stderr, "warning: could not enrich %s lock entry from registry: %v\n", p.Name, err)
+			}
+		}
 		newLF.Plugins[p.Name] = entry
 	}
 
@@ -75,6 +91,29 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 	}
 	fmt.Printf("Lockfile written to %s\n", lockPath)
 	return nil
+}
+
+func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version string) (map[string]config.WfctlLockPlatform, error) {
+	manifest, _, err := registries.FetchManifest(pluginName)
+	if err != nil {
+		return nil, err
+	}
+	if version != "" && version != manifest.Version {
+		pinManifestToVersion(manifest, version)
+	}
+
+	platforms := make(map[string]config.WfctlLockPlatform, len(manifest.Downloads))
+	for _, dl := range manifest.Downloads {
+		if dl.OS == "" || dl.Arch == "" || dl.URL == "" {
+			continue
+		}
+		key := dl.OS + "-" + dl.Arch
+		// Registry download SHA values are archive checksums. The lockfile
+		// platform SHA is currently verified against the installed plugin binary,
+		// so copying the archive checksum here would make lockfile installs fail.
+		platforms[key] = config.WfctlLockPlatform{URL: dl.URL}
+	}
+	return platforms, nil
 }
 
 // runPluginLockLegacy is the pre-v0.19.0 behavior: read from workflow.yaml requires.plugins[].

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -52,7 +53,7 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 		Plugins:     make(map[string]config.WfctlLockPluginEntry),
 	}
 
-	registryConfig, registryErr := LoadRegistryConfig("")
+	registryConfig, registryErr := loadPluginLockRegistryConfig(manifestPath, lockPath)
 	if registryErr != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not load registry config while enriching lockfile: %v\n", registryErr)
 	}
@@ -91,6 +92,30 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 	}
 	fmt.Printf("Lockfile written to %s\n", lockPath)
 	return nil
+}
+
+func loadPluginLockRegistryConfig(manifestPath, lockPath string) (*RegistryConfig, error) {
+	seen := make(map[string]bool)
+	for _, basePath := range []string{manifestPath, lockPath} {
+		dir := filepath.Dir(basePath)
+		if dir == "" {
+			dir = "."
+		}
+		cfgPath := filepath.Join(dir, ".wfctl.yaml")
+		if seen[cfgPath] {
+			continue
+		}
+		seen[cfgPath] = true
+
+		cfg, ok, err := loadRegistryConfigFile(cfgPath)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return cfg, nil
+		}
+	}
+	return nil, nil
 }
 
 func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version string) (map[string]config.WfctlLockPlatform, error) {

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -123,8 +124,8 @@ func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version st
 	if err != nil {
 		return nil, err
 	}
-	if version != "" && version != manifest.Version {
-		pinManifestToVersion(manifest, version)
+	if version != "" && !samePluginVersion(version, manifest.Version) {
+		return nil, fmt.Errorf("registry manifest version %q does not match requested version %q", manifest.Version, version)
 	}
 
 	platforms := make(map[string]config.WfctlLockPlatform, len(manifest.Downloads))
@@ -139,6 +140,10 @@ func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version st
 		platforms[key] = config.WfctlLockPlatform{URL: dl.URL}
 	}
 	return platforms, nil
+}
+
+func samePluginVersion(a, b string) bool {
+	return strings.TrimPrefix(a, "v") == strings.TrimPrefix(b, "v")
 }
 
 // runPluginLockLegacy is the pre-v0.19.0 behavior: read from workflow.yaml requires.plugins[].

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,5 +112,87 @@ plugins:
 	}
 	if _, ok := parsed.Plugins["workflow-plugin-bar"]; !ok {
 		t.Error("new plugin workflow-plugin-bar not added")
+	}
+}
+
+func TestPluginLock_FromManifest_PopulatesPlatformURLsFromRegistry(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/plugins/workflow-plugin-foo/manifest.json" {
+			http.NotFound(w, r)
+			return
+		}
+		manifest := RegistryManifest{
+			Name:       "workflow-plugin-foo",
+			Version:    "v1.2.3",
+			Repository: "github.com/GoCodeAlone/workflow-plugin-foo",
+			Downloads: []PluginDownload{
+				{OS: "linux", Arch: "amd64", URL: "https://example.test/foo-linux-amd64.tar.gz", SHA256: "archive-sha-linux"},
+				{OS: "darwin", Arch: "arm64", URL: "https://example.test/foo-darwin-arm64.tar.gz", SHA256: "archive-sha-darwin"},
+			},
+		}
+		data, _ := json.Marshal(manifest)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	registryConfig := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(registryConfig), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
+		t.Fatalf("runPluginLockFromManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+
+	var parsed struct {
+		Plugins map[string]struct {
+			Platforms map[string]struct {
+				URL    string `yaml:"url"`
+				SHA256 string `yaml:"sha256"`
+			} `yaml:"platforms"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+
+	platforms := parsed.Plugins["workflow-plugin-foo"].Platforms
+	if got := platforms["linux-amd64"].URL; got != "https://example.test/foo-linux-amd64.tar.gz" {
+		t.Fatalf("linux-amd64 URL = %q, want registry URL", got)
+	}
+	if got := platforms["darwin-arm64"].URL; got != "https://example.test/foo-darwin-arm64.tar.gz" {
+		t.Fatalf("darwin-arm64 URL = %q, want registry URL", got)
+	}
+	if got := platforms["linux-amd64"].SHA256; got != "" {
+		t.Fatalf("platform sha256 should not copy registry archive checksum into binary-checksum field, got %q", got)
 	}
 }

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -243,3 +243,66 @@ plugins:
 		t.Fatalf("platforms = %v, want no registry enrichment without project-local registry config", platforms)
 	}
 }
+
+func TestPluginLock_FromManifest_SkipsRegistryPlatformURLsForVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/plugins/workflow-plugin-foo/manifest.json" {
+			http.NotFound(w, r)
+			return
+		}
+		manifest := RegistryManifest{
+			Name:    "workflow-plugin-foo",
+			Version: "v1.2.2",
+			Downloads: []PluginDownload{
+				{OS: "linux", Arch: "amd64", URL: "https://cdn.example.test/releases/v1.2.2/foo-linux-amd64.tar.gz"},
+			},
+		}
+		data, _ := json.Marshal(manifest)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	registryConfig := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(registryConfig), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
+		t.Fatalf("runPluginLockFromManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+
+	var parsed struct {
+		Plugins map[string]struct {
+			Platforms map[string]struct {
+				URL string `yaml:"url"`
+			} `yaml:"platforms"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+
+	if platforms := parsed.Plugins["workflow-plugin-foo"].Platforms; len(platforms) != 0 {
+		t.Fatalf("platforms = %v, want no registry enrichment when manifest version mismatches requested version", platforms)
+	}
+}

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -155,15 +155,6 @@ plugins:
 		t.Fatalf("write manifest: %v", err)
 	}
 
-	origWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
-
 	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
 		t.Fatalf("runPluginLockFromManifest: %v", err)
 	}
@@ -194,5 +185,61 @@ plugins:
 	}
 	if got := platforms["linux-amd64"].SHA256; got != "" {
 		t.Fatalf("platform sha256 should not copy registry archive checksum into binary-checksum field, got %q", got)
+	}
+}
+
+func TestPluginLock_FromManifest_DoesNotUseHomeOrDefaultRegistry(t *testing.T) {
+	dir := t.TempDir()
+	homeDir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("plugin lock should not query registry config outside the manifest or lockfile directory: %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	homeConfigPath := filepath.Join(homeDir, ".config", "wfctl", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(homeConfigPath), 0o750); err != nil {
+		t.Fatalf("create home config dir: %v", err)
+	}
+	homeRegistryConfig := "registries:\n  - name: home\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(homeConfigPath, []byte(homeRegistryConfig), 0o600); err != nil {
+		t.Fatalf("write home registry config: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
+		t.Fatalf("runPluginLockFromManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+
+	var parsed struct {
+		Plugins map[string]struct {
+			Platforms map[string]struct {
+				URL string `yaml:"url"`
+			} `yaml:"platforms"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+
+	if platforms := parsed.Plugins["workflow-plugin-foo"].Platforms; len(platforms) != 0 {
+		t.Fatalf("platforms = %v, want no registry enrichment without project-local registry config", platforms)
 	}
 }

--- a/cmd/wfctl/registry_config.go
+++ b/cmd/wfctl/registry_config.go
@@ -79,7 +79,10 @@ func LoadRegistryConfig(explicitPath string) (*RegistryConfig, error) {
 func loadRegistryConfigFile(path string) (*RegistryConfig, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, false, nil
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
 	}
 	// First, check whether the file contains a "registries" key at all.
 	// A lockfile (plugins: ...) has no such key, and silently treating it as

--- a/cmd/wfctl/registry_config.go
+++ b/cmd/wfctl/registry_config.go
@@ -82,7 +82,7 @@ func loadRegistryConfigFile(path string) (*RegistryConfig, bool, error) {
 		if os.IsNotExist(err) {
 			return nil, false, nil
 		}
-		return nil, false, err
+		return nil, false, fmt.Errorf("read registry config %s: %w", path, err)
 	}
 	// First, check whether the file contains a "registries" key at all.
 	// A lockfile (plugins: ...) has no such key, and silently treating it as

--- a/cmd/wfctl/registry_config.go
+++ b/cmd/wfctl/registry_config.go
@@ -65,41 +65,50 @@ func LoadRegistryConfig(explicitPath string) (*RegistryConfig, error) {
 	}
 
 	for _, p := range paths {
-		data, err := os.ReadFile(p)
+		cfg, ok, err := loadRegistryConfigFile(p)
 		if err != nil {
-			continue
+			return nil, err
 		}
-		// First, check whether the file contains a "registries" key at all.
-		// A lockfile (plugins: ...) has no such key, and silently treating it as
-		// an empty registry config would cause "no registry sources configured"
-		// for every subsequent plugin install.
-		// We distinguish "key absent" (lockfile / unrelated file → skip) from
-		// "key present but empty" (intentional empty config → respect it).
-		var raw map[string]any
-		if err := yaml.Unmarshal(data, &raw); err != nil {
-			return nil, fmt.Errorf("parse registry config %s: %w", p, err)
+		if ok {
+			return cfg, nil
 		}
-		if _, hasKey := raw["registries"]; !hasKey {
-			// No "registries" key — this is probably a lockfile or project config.
-			// Fall through to the next candidate.
-			continue
-		}
-		var cfg RegistryConfig
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
-			return nil, fmt.Errorf("parse registry config %s: %w", p, err)
-		}
-		// Ensure defaults
-		for i := range cfg.Registries {
-			if cfg.Registries[i].Branch == "" {
-				cfg.Registries[i].Branch = "main"
-			}
-			if cfg.Registries[i].Type == "" {
-				cfg.Registries[i].Type = "github"
-			}
-		}
-		return &cfg, nil
 	}
 	return DefaultRegistryConfig(), nil
+}
+
+func loadRegistryConfigFile(path string) (*RegistryConfig, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, nil
+	}
+	// First, check whether the file contains a "registries" key at all.
+	// A lockfile (plugins: ...) has no such key, and silently treating it as
+	// an empty registry config would cause "no registry sources configured"
+	// for every subsequent plugin install.
+	// We distinguish "key absent" (lockfile / unrelated file -> skip) from
+	// "key present but empty" (intentional empty config -> respect it).
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, false, fmt.Errorf("parse registry config %s: %w", path, err)
+	}
+	if _, hasKey := raw["registries"]; !hasKey {
+		// No "registries" key - this is probably a lockfile or project config.
+		return nil, false, nil
+	}
+	var cfg RegistryConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, false, fmt.Errorf("parse registry config %s: %w", path, err)
+	}
+	// Ensure defaults.
+	for i := range cfg.Registries {
+		if cfg.Registries[i].Branch == "" {
+			cfg.Registries[i].Branch = "main"
+		}
+		if cfg.Registries[i].Type == "" {
+			cfg.Registries[i].Type = "github"
+		}
+	}
+	return &cfg, true, nil
 }
 
 // SaveRegistryConfig writes a registry config to a YAML file.


### PR DESCRIPTION
## Summary
- Enrich `wfctl plugin lock` entries from the configured plugin registry when a plugin/version has no preserved platform metadata.
- Preserve platform download URLs in `.wfctl-lock.yaml` without copying registry archive checksums into the binary-checksum field.
- Add a regression test covering registry-backed platform URL population.

## Verification
- `GOWORK=off go test ./cmd/wfctl ./config -count=1`
- `GOWORK=off go build -o /tmp/wfctl-lockfix ./cmd/wfctl`
- `git diff --check`

## Notes
This fixes the lockfile degradation found while bumping BMW to `workflow-plugin-auth@v0.1.4` and adding `workflow-plugin-twilio@v0.1.3`.