### PR TITLE
fix(pipeline): template raw response headers

### DIFF
--- a/module/pipeline_step_raw_response.go
+++ b/module/pipeline_step_raw_response.go
@@ -87,7 +87,7 @@ func (s *RawResponseStep) Execute(_ context.Context, pc *PipelineContext) (*Step
 
 	// Set additional headers
 	for k, v := range s.headers {
-		w.Header().Set(k, v)
+		w.Header().Set(k, s.resolveHeaderValue(v, pc))
 	}
 
 	// Write status code
@@ -132,4 +132,12 @@ func (s *RawResponseStep) resolveBody(pc *PipelineContext) string {
 		return resolved
 	}
 	return ""
+}
+
+func (s *RawResponseStep) resolveHeaderValue(value string, pc *PipelineContext) string {
+	resolved, err := s.tmpl.Resolve(value, pc)
+	if err != nil {
+		return value
+	}
+	return resolved
 }

--- a/module/pipeline_step_raw_response.go
+++ b/module/pipeline_step_raw_response.go
@@ -87,7 +87,11 @@ func (s *RawResponseStep) Execute(_ context.Context, pc *PipelineContext) (*Step
 
 	// Set additional headers
 	for k, v := range s.headers {
-		w.Header().Set(k, s.resolveHeaderValue(v, pc))
+		resolvedValue, err := s.resolveHeaderValue(v, pc)
+		if err != nil {
+			return nil, fmt.Errorf("raw_response step %q: failed to resolve header %q: %w", s.name, k, err)
+		}
+		w.Header().Set(k, resolvedValue)
 	}
 
 	// Write status code
@@ -134,10 +138,6 @@ func (s *RawResponseStep) resolveBody(pc *PipelineContext) string {
 	return ""
 }
 
-func (s *RawResponseStep) resolveHeaderValue(value string, pc *PipelineContext) string {
-	resolved, err := s.tmpl.Resolve(value, pc)
-	if err != nil {
-		return value
-	}
-	return resolved
+func (s *RawResponseStep) resolveHeaderValue(value string, pc *PipelineContext) (string, error) {
+	return s.tmpl.Resolve(value, pc)
 }

--- a/module/pipeline_step_raw_response_test.go
+++ b/module/pipeline_step_raw_response_test.go
@@ -121,6 +121,37 @@ func TestRawResponseStep_CustomHeaders(t *testing.T) {
 	}
 }
 
+func TestRawResponseStep_TemplateHeaders(t *testing.T) {
+	factory := NewRawResponseStepFactory()
+	step, err := factory("redirect", map[string]any{
+		"status":       302,
+		"content_type": "text/plain",
+		"headers": map[string]any{
+			"Location": "{{ .steps.oauth_start.authorization_url }}",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	pc := NewPipelineContext(nil, map[string]any{
+		"_http_response_writer": recorder,
+	})
+	pc.MergeStepOutput("oauth_start", map[string]any{
+		"authorization_url": "https://accounts.example.test/oauth?state=abc",
+	})
+
+	_, err = step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+
+	if got := recorder.Header().Get("Location"); got != "https://accounts.example.test/oauth?state=abc" {
+		t.Fatalf("Location header = %q, want templated authorization URL", got)
+	}
+}
+
 func TestRawResponseStep_TemplateBody(t *testing.T) {
 	factory := NewRawResponseStepFactory()
 	step, err := factory("templated", map[string]any{

--- a/module/pipeline_step_raw_response_test.go
+++ b/module/pipeline_step_raw_response_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -149,6 +150,40 @@ func TestRawResponseStep_TemplateHeaders(t *testing.T) {
 
 	if got := recorder.Header().Get("Location"); got != "https://accounts.example.test/oauth?state=abc" {
 		t.Fatalf("Location header = %q, want templated authorization URL", got)
+	}
+}
+
+func TestRawResponseStep_TemplateHeaderStrictError(t *testing.T) {
+	factory := NewRawResponseStepFactory()
+	step, err := factory("redirect", map[string]any{
+		"status":       302,
+		"content_type": "text/plain",
+		"headers": map[string]any{
+			"Location": "{{ .steps.oauth_start.missing_url }}",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	pc := NewPipelineContext(nil, map[string]any{
+		"_http_response_writer": recorder,
+	})
+	pc.StrictTemplates = true
+	pc.MergeStepOutput("oauth_start", map[string]any{
+		"authorization_url": "https://accounts.example.test/oauth?state=abc",
+	})
+
+	_, err = step.Execute(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected strict template error")
+	}
+	if !strings.Contains(err.Error(), `raw_response step "redirect": failed to resolve header "Location"`) {
+		t.Fatalf("expected header context in error, got: %v", err)
+	}
+	if got := recorder.Header().Get("Location"); got != "" {
+		t.Fatalf("Location header = %q, want unset header after template error", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Resolve raw response header values through the template engine
- Add regression coverage for dynamic Location headers

## Verification
- GOWORK=off go test ./module -run TestRawResponseStep_TemplateHeaders -count=1
- GOWORK=off go test ./module -count=1
- git diff --check

This unblocks Workflow-authored OAuth redirects where the Location header comes from an earlier step output.