### PR TITLE
fix(wfctl): rewrite plugin archive filenames when pinning versions

### DIFF
--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -824,9 +824,24 @@ func pinManifestToVersion(manifest *RegistryManifest, requestedVersion string) {
 		if rewritten == url && normalizedOld != "" {
 			rewritten = strings.ReplaceAll(url, normalizedOld, normalizedNew)
 		}
+		if normalizedOld != "" {
+			rewritten = rewriteArchiveFilenameVersion(rewritten, normalizedOld, normalizedNew)
+		}
 		manifest.Downloads[i].URL = rewritten
 		manifest.Downloads[i].SHA256 = "" // checksums are for the old version's assets
 	}
+}
+
+func rewriteArchiveFilenameVersion(rawURL, oldVersion, newVersion string) string {
+	if oldVersion == "" || oldVersion == newVersion {
+		return rawURL
+	}
+	idx := strings.LastIndex(rawURL, "/")
+	if idx < 0 {
+		return strings.ReplaceAll(rawURL, oldVersion, newVersion)
+	}
+	prefix, filename := rawURL[:idx+1], rawURL[idx+1:]
+	return prefix + strings.ReplaceAll(filename, oldVersion, newVersion)
 }
 
 // parseNameVersion splits "name@version" into (name, version). Version is empty if absent.

--- a/cmd/wfctl/plugin_version_pin_test.go
+++ b/cmd/wfctl/plugin_version_pin_test.go
@@ -211,6 +211,39 @@ func TestPinManifestToVersion_URLRewritten(t *testing.T) {
 	}
 }
 
+func TestPinManifestToVersion_RewritesVersionedArchiveFilenames(t *testing.T) {
+	manifest := &RegistryManifest{
+		Name:    "workflow-plugin-auth",
+		Version: "0.1.4",
+		Downloads: []PluginDownload{
+			{
+				OS:   "linux",
+				Arch: "amd64",
+				URL:  "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_linux_amd64.tar.gz",
+			},
+			{
+				OS:   "darwin",
+				Arch: "arm64",
+				URL:  "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_darwin_arm64.tar.gz",
+			},
+		},
+	}
+
+	pinManifestToVersion(manifest, "v0.1.5")
+
+	for i, dl := range manifest.Downloads {
+		if !strings.Contains(dl.URL, "/releases/download/v0.1.5/") {
+			t.Errorf("download[%d].URL: want release tag v0.1.5 in %q", i, dl.URL)
+		}
+		if !strings.Contains(dl.URL, "workflow-plugin-auth_0.1.5_") {
+			t.Errorf("download[%d].URL: want archive filename version 0.1.5 in %q", i, dl.URL)
+		}
+		if strings.Contains(dl.URL, "0.1.4") {
+			t.Errorf("download[%d].URL: old version remained in %q", i, dl.URL)
+		}
+	}
+}
+
 // TestPinManifestToVersion_SameVersion verifies that no URL rewriting happens
 // when the requested version matches the manifest version.
 func TestPinManifestToVersion_SameVersion(t *testing.T) {


### PR DESCRIPTION
## Summary
- rewrite versioned archive filenames when wfctl pins a registry manifest to a newer version
- add regression coverage for workflow-plugin-auth style release assets

## Verification
- Red: `GOWORK=off go test ./cmd/wfctl -run TestPinManifestToVersion_RewritesVersionedArchiveFilenames -count=1` failed before the fix because archive filenames stayed at 0.1.4
- Green: `GOWORK=off go test ./cmd/wfctl -run 'TestRunPluginInstall_VersionPinHitsNewURL|TestPinManifestToVersion' -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestPluginInstall|TestInstallFromWfctlLockfile|TestRunPluginInstall' -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `GOWORK=off go build ./cmd/wfctl`
- `git diff --check`
- Dogfood: built fixed wfctl and ran BMW lockfile install from /Users/jon/workspace/_worktrees/bmw-auth-plugin-migration; it installed workflow-plugin-auth v0.1.5 from `workflow-plugin-auth_0.1.5_darwin_arm64.tar.gz` successfully