### PR TITLE
fix(wfctl): avoid local binary checksum in lockfile installs

### DIFF
--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -120,32 +120,17 @@ func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256(t *testing.T) {
 	}
 }
 
-func TestInstallFromWfctlLockfile_PlatformURLUsesLegacyTopLevelSHA256(t *testing.T) {
+func TestVerifyWfctlLockfileChecksums_NoPlatformMetadataUsesLegacyTopLevelSHA256(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
 	pluginDir := filepath.Join(dir, "plugins")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+	authDir := filepath.Join(pluginDir, "auth")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	origWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
-
-	const pluginName = "auth"
 	binaryContent := []byte("#!/bin/sh\necho auth\n")
-	tarball := buildPluginTarGz(t, pluginName, binaryContent, minimalPluginJSON(pluginName, "v1.2.3"))
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.WriteHeader(http.StatusOK)
-		w.Write(tarball) //nolint:errcheck
-	}))
-	defer srv.Close()
+	if err := os.WriteFile(filepath.Join(authDir, "auth"), binaryContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	lf := &config.WfctlLockfile{
 		Version:     1,
@@ -155,20 +140,12 @@ func TestInstallFromWfctlLockfile_PlatformURLUsesLegacyTopLevelSHA256(t *testing
 				Version: "v1.2.3",
 				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
 				SHA256:  sha256Hex(binaryContent),
-				Platforms: map[string]config.WfctlLockPlatform{
-					currentPlatformKey(): {
-						URL: srv.URL + "/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
-					},
-				},
 			},
 		},
 	}
-	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
-		t.Fatal(err)
-	}
 
-	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
-		t.Fatalf("installFromWfctlLockfile should verify platform URL installs with legacy top-level checksum: %v", err)
+	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
+		t.Fatalf("verifyWfctlLockfileChecksums should use legacy top-level checksum when platform metadata is absent: %v", err)
 	}
 }
 
@@ -294,6 +271,40 @@ func TestVerifyWfctlLockfileChecksums_UsesCurrentPlatformSHA256(t *testing.T) {
 
 	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
 		t.Fatalf("verifyWfctlLockfileChecksums should use platform checksum instead of top-level checksum: %v", err)
+	}
+}
+
+func TestVerifyWfctlLockfileChecksums_DoesNotFallbackToTopLevelSHA256WhenPlatformsExist(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "plugins")
+	authDir := filepath.Join(pluginDir, "auth")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binaryContent := []byte("#!/bin/sh\necho auth\n")
+	if err := os.WriteFile(filepath.Join(authDir, "auth"), binaryContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				SHA256:  strings.Repeat("0", 64),
+				Platforms: map[string]config.WfctlLockPlatform{
+					currentPlatformKey(): {
+						URL: "https://example.test/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
+					},
+				},
+			},
+		},
+	}
+
+	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
+		t.Fatalf("verifyWfctlLockfileChecksums should ignore top-level checksum when platform metadata exists without a platform checksum: %v", err)
 	}
 }
 

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -167,6 +169,96 @@ func TestInstallFromWfctlLockfile_PlatformURLUsesLegacyTopLevelSHA256(t *testing
 
 	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
 		t.Fatalf("installFromWfctlLockfile should verify platform URL installs with legacy top-level checksum: %v", err)
+	}
+}
+
+func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	const pluginName = "auth"
+	binaryContent := []byte("#!/bin/sh\necho auth\n")
+	tarball := buildPluginTarGz(t, pluginName, binaryContent, minimalPluginJSON(pluginName, "v1.2.3"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/workflow-plugin-auth/manifest.json":
+			manifest := RegistryManifest{
+				Name:        pluginName,
+				Version:     "v1.2.3",
+				Repository:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				Author:      "tester",
+				Description: "test auth plugin",
+				Type:        "external",
+				Tier:        "community",
+				License:     "MIT",
+				Downloads: []PluginDownload{
+					{
+						OS:     runtime.GOOS,
+						Arch:   runtime.GOARCH,
+						URL:    "http://" + r.Host + "/releases/download/v1.2.3/auth.tar.gz",
+						SHA256: sha256Hex(tarball),
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(manifest)
+		case "/releases/download/v1.2.3/auth.tar.gz":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(tarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	regCfg := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(regCfg), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				SHA256:  "",
+			},
+		},
+	}
+	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
+		t.Fatalf("installFromWfctlLockfile: %v", err)
+	}
+
+	loaded, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load saved lockfile: %v", err)
+	}
+	entry := loaded.Plugins["workflow-plugin-auth"]
+	if entry.SHA256 != "" {
+		t.Fatalf("top-level checksum should remain empty without platform metadata, got %q", entry.SHA256)
+	}
+	if len(entry.Platforms) != 0 {
+		t.Fatalf("platform metadata should not be synthesized, got %#v", entry.Platforms)
 	}
 }
 

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -109,7 +109,7 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 		// installFromURL and runPluginInstall internally call updateLockfileWithChecksum,
 		// which serializes the OLD PluginLockfile format and can strip source/platforms
 		// fields from the on-disk .wfctl-lock.yaml. Overwrite it here with the correct
-		// new format, capturing the binary sha256 while we're at it.
+		// new format, updating only existing platform-scoped binary sha256 data.
 		if lockPath != "" {
 			destDir := filepath.Join(pluginDirVal, fsName)
 			binaryPath := filepath.Join(destDir, fsName)
@@ -118,8 +118,6 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 				if plat, ok := e.Platforms[currentPlatformKey()]; ok {
 					plat.SHA256 = sha
 					e.Platforms[currentPlatformKey()] = plat
-				} else {
-					e.SHA256 = sha
 				}
 				lf.Plugins[name] = e
 			}

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -170,6 +170,9 @@ func expectedWfctlLockfileChecksum(entry config.WfctlLockPluginEntry) string {
 	if plat, ok := entry.Platforms[currentPlatformKey()]; ok && plat.SHA256 != "" {
 		return plat.SHA256
 	}
+	if len(entry.Platforms) > 0 {
+		return ""
+	}
 	return entry.SHA256
 }
 


### PR DESCRIPTION
## Summary
- Prevent lockfile-driven plugin installs from persisting a top-level `sha256` derived from the locally installed binary when the lockfile has no platform metadata.
- Preserve existing platform-scoped behavior: when a current-platform entry exists, its `sha256` may still be updated after a successful install.
- Add a regression test covering registry fallback install from a new-format lockfile with no `platforms` metadata.

## TDD proof
With fix absent/reverted:
```sh
$ GOWORK=off go test ./cmd/wfctl -run TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256 -count=1
FAIL — top-level checksum should remain empty without platform metadata, got "9f8e920ab68819a5eb9c3ebb97f6bcd8f6c8871bc5d46587c181983540b68d3b"
```

With fix restored:
```sh
$ GOWORK=off go test ./cmd/wfctl -run TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256 -count=1
ok   github.com/GoCodeAlone/workflow/cmd/wfctl  1.440s
```

## Verification
```sh
$ GOWORK=off go test ./cmd/wfctl -run 'TestInstallFromWfctlLockfile|TestVerifyWfctlLockfileChecksums|TestRunPluginInstall' -count=1
ok   github.com/GoCodeAlone/workflow/cmd/wfctl  1.468s

$ GOWORK=off go test ./cmd/wfctl -count=1
ok   github.com/GoCodeAlone/workflow/cmd/wfctl  4.973s

$ git diff --check
# no output
```

## Runtime launch transcript
Build:
```sh
$ GOWORK=off go build -o /tmp/wfctl-lockfile-checksum-test ./cmd/wfctl
# exit 0
```

Launch:
```sh
$ /tmp/wfctl-lockfile-checksum-test plugin install --help
Usage: wfctl plugin install [options] [<name>[@<version>]]
...
Options:
  -config string
  -plugin-dir string
  -sha256 string
  -skip-checksum
  -url string
```

Failure-signature scrape: clean.
Verdict: PASS

## Review notes
Self-review ran the requested scope check and bug-class scan. One comment-vs-code drift issue was found and fixed before this PR.
