### PR TITLE
Fix wfctl platform lockfile checksum semantics

### DIFF
--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -112,8 +112,8 @@ func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256AsArchiveChecksum(t *
 		t.Fatalf("load saved lockfile: %v", err)
 	}
 	entry := loaded.Plugins["workflow-plugin-auth"]
-	if entry.SHA256 != strings.Repeat("0", 64) {
-		t.Fatalf("top-level checksum should remain unchanged when current platform checksum exists: got %q", entry.SHA256)
+	if entry.SHA256 != "" {
+		t.Fatalf("top-level checksum should be omitted when current platform checksum exists: got %q", entry.SHA256)
 	}
 	if got := entry.Platforms[currentPlatformKey()].SHA256; got != sha256Hex(tarball) {
 		t.Fatalf("current platform checksum = %q, want archive checksum %q", got, sha256Hex(tarball))

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -117,6 +118,71 @@ func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256AsArchiveChecksum(t *
 	}
 	if got := entry.Platforms[currentPlatformKey()].SHA256; got != sha256Hex(tarball) {
 		t.Fatalf("current platform checksum = %q, want archive checksum %q", got, sha256Hex(tarball))
+	}
+}
+
+func TestInstallFromWfctlLockfile_MissingCurrentPlatformDoesNotFallbackToRegistry(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	var registryHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		registryHits.Add(1)
+		http.Error(w, "registry must not be used", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	regCfg := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(regCfg), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	otherPlatform := "linux-amd64"
+	if otherPlatform == currentPlatformKey() {
+		otherPlatform = "darwin-arm64"
+	}
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				Platforms: map[string]config.WfctlLockPlatform{
+					otherPlatform: {
+						URL:    "https://example.test/workflow-plugin-auth-" + otherPlatform + ".tar.gz",
+						SHA256: sha256Hex([]byte("auth archive for " + otherPlatform)),
+					},
+				},
+			},
+		},
+	}
+	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+		t.Fatal(err)
+	}
+
+	err = installFromWfctlLockfile(pluginDir, lockPath, lf)
+	if err == nil {
+		t.Fatal("expected missing current platform error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing current platform") || !strings.Contains(err.Error(), currentPlatformKey()) {
+		t.Fatalf("error = %q, want clear missing current platform message for %s", err, currentPlatformKey())
+	}
+	if got := registryHits.Load(); got != 0 {
+		t.Fatalf("registry was queried %d times; lockfile platform metadata should be authoritative", got)
 	}
 }
 

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -55,7 +55,7 @@ func TestInstallFromWfctlLockfile_SHA256MismatchFails(t *testing.T) {
 	}
 }
 
-func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256(t *testing.T) {
+func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256AsArchiveChecksum(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
 	pluginDir := filepath.Join(dir, "plugins")
@@ -93,7 +93,7 @@ func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256(t *testing.T) {
 				Platforms: map[string]config.WfctlLockPlatform{
 					currentPlatformKey(): {
 						URL:    srv.URL + "/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
-						SHA256: sha256Hex(binaryContent),
+						SHA256: sha256Hex(tarball),
 					},
 				},
 			},
@@ -115,8 +115,8 @@ func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256(t *testing.T) {
 	if entry.SHA256 != strings.Repeat("0", 64) {
 		t.Fatalf("top-level checksum should remain unchanged when current platform checksum exists: got %q", entry.SHA256)
 	}
-	if got := entry.Platforms[currentPlatformKey()].SHA256; got != sha256Hex(binaryContent) {
-		t.Fatalf("current platform checksum = %q, want %q", got, sha256Hex(binaryContent))
+	if got := entry.Platforms[currentPlatformKey()].SHA256; got != sha256Hex(tarball) {
+		t.Fatalf("current platform checksum = %q, want archive checksum %q", got, sha256Hex(tarball))
 	}
 }
 
@@ -239,97 +239,7 @@ func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256
 	}
 }
 
-func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256(t *testing.T) {
-	dir := t.TempDir()
-	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
-	pluginDir := filepath.Join(dir, "plugins")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	origWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
-
-	const pluginName = "auth"
-	binaryContent := []byte("#!/bin/sh\necho auth\n")
-	tarball := buildPluginTarGz(t, pluginName, binaryContent, minimalPluginJSON(pluginName, "v1.2.3"))
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/plugins/workflow-plugin-auth/manifest.json":
-			manifest := RegistryManifest{
-				Name:        pluginName,
-				Version:     "v1.2.3",
-				Repository:  "github.com/GoCodeAlone/workflow-plugin-auth",
-				Author:      "tester",
-				Description: "test auth plugin",
-				Type:        "external",
-				Tier:        "community",
-				License:     "MIT",
-				Downloads: []PluginDownload{
-					{
-						OS:     runtime.GOOS,
-						Arch:   runtime.GOARCH,
-						URL:    "http://" + r.Host + "/releases/download/v1.2.3/auth.tar.gz",
-						SHA256: sha256Hex(tarball),
-					},
-				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(manifest)
-		case "/releases/download/v1.2.3/auth.tar.gz":
-			w.Header().Set("Content-Type", "application/octet-stream")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(tarball)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
-
-	regCfg := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
-	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(regCfg), 0o600); err != nil {
-		t.Fatalf("write registry config: %v", err)
-	}
-
-	lf := &config.WfctlLockfile{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Plugins: map[string]config.WfctlLockPluginEntry{
-			"workflow-plugin-auth": {
-				Version: "v1.2.3",
-				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
-				SHA256:  "",
-			},
-		},
-	}
-	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
-		t.Fatalf("installFromWfctlLockfile: %v", err)
-	}
-
-	loaded, err := config.LoadWfctlLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("load saved lockfile: %v", err)
-	}
-	entry := loaded.Plugins["workflow-plugin-auth"]
-	if entry.SHA256 != "" {
-		t.Fatalf("top-level checksum should remain empty without platform metadata, got %q", entry.SHA256)
-	}
-	if len(entry.Platforms) != 0 {
-		t.Fatalf("platform metadata should not be synthesized, got %#v", entry.Platforms)
-	}
-}
-
-func TestVerifyWfctlLockfileChecksums_UsesCurrentPlatformSHA256(t *testing.T) {
+func TestVerifyWfctlLockfileChecksums_IgnoresPlatformArchiveSHA256(t *testing.T) {
 	dir := t.TempDir()
 	pluginDir := filepath.Join(dir, "plugins")
 	authDir := filepath.Join(pluginDir, "auth")
@@ -352,7 +262,7 @@ func TestVerifyWfctlLockfileChecksums_UsesCurrentPlatformSHA256(t *testing.T) {
 				Platforms: map[string]config.WfctlLockPlatform{
 					currentPlatformKey(): {
 						URL:    "https://example.test/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
-						SHA256: sha256Hex(binaryContent),
+						SHA256: strings.Repeat("1", 64),
 					},
 				},
 			},
@@ -360,7 +270,7 @@ func TestVerifyWfctlLockfileChecksums_UsesCurrentPlatformSHA256(t *testing.T) {
 	}
 
 	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
-		t.Fatalf("verifyWfctlLockfileChecksums should use platform checksum instead of top-level checksum: %v", err)
+		t.Fatalf("verifyWfctlLockfileChecksums should not verify platform archive checksums against installed binaries: %v", err)
 	}
 }
 
@@ -435,7 +345,7 @@ func TestInstallFromWfctlLockfile_PlatformSHA256IsCaseInsensitive(t *testing.T) 
 				Platforms: map[string]config.WfctlLockPlatform{
 					currentPlatformKey(): {
 						URL:    srv.URL + "/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
-						SHA256: strings.ToUpper(sha256Hex(binaryContent)),
+						SHA256: strings.ToUpper(sha256Hex(tarball)),
 					},
 				},
 			},

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -239,6 +239,96 @@ func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256
 	}
 }
 
+func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	const pluginName = "auth"
+	binaryContent := []byte("#!/bin/sh\necho auth\n")
+	tarball := buildPluginTarGz(t, pluginName, binaryContent, minimalPluginJSON(pluginName, "v1.2.3"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/workflow-plugin-auth/manifest.json":
+			manifest := RegistryManifest{
+				Name:        pluginName,
+				Version:     "v1.2.3",
+				Repository:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				Author:      "tester",
+				Description: "test auth plugin",
+				Type:        "external",
+				Tier:        "community",
+				License:     "MIT",
+				Downloads: []PluginDownload{
+					{
+						OS:     runtime.GOOS,
+						Arch:   runtime.GOARCH,
+						URL:    "http://" + r.Host + "/releases/download/v1.2.3/auth.tar.gz",
+						SHA256: sha256Hex(tarball),
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(manifest)
+		case "/releases/download/v1.2.3/auth.tar.gz":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(tarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	regCfg := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(regCfg), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				SHA256:  "",
+			},
+		},
+	}
+	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
+		t.Fatalf("installFromWfctlLockfile: %v", err)
+	}
+
+	loaded, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load saved lockfile: %v", err)
+	}
+	entry := loaded.Plugins["workflow-plugin-auth"]
+	if entry.SHA256 != "" {
+		t.Fatalf("top-level checksum should remain empty without platform metadata, got %q", entry.SHA256)
+	}
+	if len(entry.Platforms) != 0 {
+		t.Fatalf("platform metadata should not be synthesized, got %#v", entry.Platforms)
+	}
+}
+
 func TestVerifyWfctlLockfileChecksums_UsesCurrentPlatformSHA256(t *testing.T) {
 	dir := t.TempDir()
 	pluginDir := filepath.Join(dir, "plugins")

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -239,6 +239,102 @@ func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256
 	}
 }
 
+func TestRunPluginInstall_DoesNotRewriteNewFormatLockfile(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	const pluginName = "auth"
+	binaryContent := []byte("#!/bin/sh\necho auth\n")
+	tarball := buildPluginTarGz(t, pluginName, binaryContent, minimalPluginJSON(pluginName, "v1.2.3"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/workflow-plugin-auth/manifest.json":
+			manifest := RegistryManifest{
+				Name:        pluginName,
+				Version:     "v1.2.3",
+				Repository:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				Author:      "tester",
+				Description: "test auth plugin",
+				Type:        "external",
+				Tier:        "community",
+				License:     "MIT",
+				Downloads: []PluginDownload{
+					{
+						OS:     runtime.GOOS,
+						Arch:   runtime.GOARCH,
+						URL:    "http://" + r.Host + "/releases/download/v1.2.3/auth.tar.gz",
+						SHA256: sha256Hex(tarball),
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(manifest)
+		case "/releases/download/v1.2.3/auth.tar.gz":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(tarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	regCfg := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(regCfg), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				SHA256:  strings.Repeat("0", 64),
+				Platforms: map[string]config.WfctlLockPlatform{
+					currentPlatformKey(): {
+						URL:    "https://example.test/original.tar.gz",
+						SHA256: "archive-sha-from-lock",
+					},
+				},
+			},
+		},
+	}
+	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runPluginInstall([]string{"--plugin-dir", pluginDir, "workflow-plugin-auth@v1.2.3"}); err != nil {
+		t.Fatalf("runPluginInstall: %v", err)
+	}
+
+	loaded, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load lockfile: %v", err)
+	}
+	entry := loaded.Plugins["workflow-plugin-auth"]
+	if entry.SHA256 != "" {
+		t.Fatalf("direct install should not write host binary sha into new-format lockfile, got %q", entry.SHA256)
+	}
+	platform := entry.Platforms[currentPlatformKey()]
+	if platform.URL != "https://example.test/original.tar.gz" || platform.SHA256 != "archive-sha-from-lock" {
+		t.Fatalf("direct install should not rewrite platform lock data, got %#v", platform)
+	}
+}
+
 func TestVerifyWfctlLockfileChecksums_IgnoresPlatformArchiveSHA256(t *testing.T) {
 	dir := t.TempDir()
 	pluginDir := filepath.Join(dir, "plugins")
@@ -357,9 +453,6 @@ func TestInstallFromWfctlLockfile_PlatformSHA256IsCaseInsensitive(t *testing.T) 
 
 	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
 		t.Fatalf("installFromWfctlLockfile should accept uppercase platform checksum: %v", err)
-	}
-	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
-		t.Fatalf("verifyWfctlLockfileChecksums should accept uppercase platform checksum: %v", err)
 	}
 }
 

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -13,8 +13,8 @@ import (
 
 // installFromWfctlLockfile installs all plugins recorded in a config.WfctlLockfile.
 // For each plugin:
-//   - If a platform URL is recorded, download from that URL.
-//   - After install, verify sha256 when non-empty (hard fail on mismatch).
+//   - If a platform URL is recorded, download from that URL and verify its archive SHA.
+//   - For legacy entries without platforms, verify top-level sha256 as a binary SHA.
 //   - If no platform URL, fall back to registry lookup via the existing install path.
 //
 // lockPath is the on-disk path for .wfctl-lock.yaml. After each successful install
@@ -49,33 +49,10 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 		// If we have platform-specific URL, install from that URL.
 		platKey := currentPlatformKey()
 		if plat, ok := entry.Platforms[platKey]; ok && plat.URL != "" {
-			destDir := filepath.Join(pluginDirVal, fsName)
-			// Only skip download-level integrity enforcement when a binary hash is
-			// recorded for post-install verification. Without a binary hash, allow
-			// GitHub release URLs to auto-verify via checksums.txt; non-GitHub URLs
-			// without a hash fail closed to prevent unverified installs.
-			skipChecksum := expectedWfctlLockfileChecksum(entry) != ""
-			if err := installFromURL(plat.URL, pluginDirVal, "", skipChecksum); err != nil {
+			if err := installFromURL(plat.URL, pluginDirVal, plat.SHA256, false); err != nil {
 				fmt.Fprintf(os.Stderr, "error installing %s from URL: %v\n", name, err)
 				failed = append(failed, name)
 				continue
-			}
-			// Verify platform-specific sha256 if present.
-			if plat.SHA256 != "" {
-				binary := filepath.Join(destDir, fsName)
-				got, err := hashFileSHA256(binary)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "CHECKSUM ERROR for %s: %v\n", name, err)
-					_ = os.RemoveAll(destDir)
-					failed = append(failed, name)
-					continue
-				}
-				if !strings.EqualFold(got, plat.SHA256) {
-					fmt.Fprintf(os.Stderr, "CHECKSUM MISMATCH for %s: got %s, want %s\n", name, got, plat.SHA256)
-					_ = os.RemoveAll(destDir)
-					failed = append(failed, name)
-					continue
-				}
 			}
 			installed = true
 		}
@@ -93,9 +70,9 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 			}
 		}
 
-		// Verify the installed binary against the current platform checksum when
-		// present; fall back to the top-level checksum for legacy lockfiles.
-		if expectedSHA256 := expectedWfctlLockfileChecksum(entry); expectedSHA256 != "" {
+		// Verify the installed binary only for legacy lockfiles that have no
+		// platform metadata. Platform checksums are archive/artifact checksums.
+		if expectedSHA256 := legacyWfctlLockfileBinaryChecksum(entry); expectedSHA256 != "" {
 			destDir := filepath.Join(pluginDirVal, fsName)
 			if verifyErr := verifyInstalledChecksum(destDir, fsName, expectedSHA256); verifyErr != nil {
 				fmt.Fprintf(os.Stderr, "CHECKSUM MISMATCH for %s: %v\n", name, verifyErr)
@@ -108,19 +85,9 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 		// Re-save the new-format lockfile after each successful install.
 		// installFromURL and runPluginInstall internally call updateLockfileWithChecksum,
 		// which serializes the OLD PluginLockfile format and can strip source/platforms
-		// fields from the on-disk .wfctl-lock.yaml. Overwrite it here with the correct
-		// new format, updating only existing platform-scoped binary sha256 data.
+		// fields from the on-disk .wfctl-lock.yaml. Overwrite it here with the
+		// original new-format data without recording host-specific binary hashes.
 		if lockPath != "" {
-			destDir := filepath.Join(pluginDirVal, fsName)
-			binaryPath := filepath.Join(destDir, fsName)
-			if sha, hashErr := hashFileSHA256(binaryPath); hashErr == nil && !strings.EqualFold(sha, expectedWfctlLockfileChecksum(entry)) {
-				e := lf.Plugins[name]
-				if plat, ok := e.Platforms[currentPlatformKey()]; ok {
-					plat.SHA256 = sha
-					e.Platforms[currentPlatformKey()] = plat
-				}
-				lf.Plugins[name] = e
-			}
 			if saveErr := config.SaveWfctlLockfile(lockPath, lf); saveErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not persist lockfile after installing %s: %v\n", name, saveErr)
 			}
@@ -133,9 +100,9 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 	return nil
 }
 
-// verifyWfctlLockfileChecksums checks sha256 of already-installed plugin binaries
-// against the lockfile. Platform-specific checksums take precedence over the
-// top-level checksum for the current OS/architecture.
+// verifyWfctlLockfileChecksums checks legacy top-level sha256 values against
+// already-installed plugin binaries. Platform checksums are archive/artifact
+// checksums and are verified during download, not against extracted binaries.
 // Returns an error if any mismatch is detected.
 func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile) error {
 	// Sort plugin names for deterministic verification order and predictable error messages.
@@ -148,7 +115,7 @@ func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile)
 	var mismatches []string
 	for _, name := range names {
 		entry := lf.Plugins[name]
-		expectedSHA256 := expectedWfctlLockfileChecksum(entry)
+		expectedSHA256 := legacyWfctlLockfileBinaryChecksum(entry)
 		if expectedSHA256 == "" {
 			continue
 		}
@@ -166,10 +133,7 @@ func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile)
 	return nil
 }
 
-func expectedWfctlLockfileChecksum(entry config.WfctlLockPluginEntry) string {
-	if plat, ok := entry.Platforms[currentPlatformKey()]; ok && plat.SHA256 != "" {
-		return plat.SHA256
-	}
+func legacyWfctlLockfileBinaryChecksum(entry config.WfctlLockPluginEntry) string {
 	if len(entry.Platforms) > 0 {
 		return ""
 	}

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -48,7 +48,20 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 
 		// If we have platform-specific URL, install from that URL.
 		platKey := currentPlatformKey()
-		if plat, ok := entry.Platforms[platKey]; ok && plat.URL != "" {
+		if len(entry.Platforms) > 0 {
+			plat, ok := entry.Platforms[platKey]
+			if !ok {
+				errMsg := fmt.Sprintf("%s (missing current platform %s in lockfile)", name, platKey)
+				fmt.Fprintf(os.Stderr, "error installing %s: %s\n", name, errMsg)
+				failed = append(failed, errMsg)
+				continue
+			}
+			if plat.URL == "" {
+				errMsg := fmt.Sprintf("%s (missing URL for current platform %s in lockfile)", name, platKey)
+				fmt.Fprintf(os.Stderr, "error installing %s: %s\n", name, errMsg)
+				failed = append(failed, errMsg)
+				continue
+			}
 			if err := installFromURL(plat.URL, pluginDirVal, plat.SHA256, false); err != nil {
 				fmt.Fprintf(os.Stderr, "error installing %s from URL: %v\n", name, err)
 				failed = append(failed, name)

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -68,23 +68,29 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 			Version: p.Version,
 			Source:  p.Source,
 		}
-		// Preserve existing sha256/platforms only when both version AND source match.
-		// A source change means the binary origin changed, so cached checksums are stale.
+		var previous *config.WfctlLockPluginEntry
 		if existing != nil {
 			if prev, ok := existing.Plugins[p.Name]; ok &&
 				prev.Version == p.Version &&
 				prev.Source == p.Source {
-				entry.Platforms = prev.Platforms
-				if len(entry.Platforms) == 0 {
-					entry.SHA256 = prev.SHA256
-				}
+				previous = &prev
 			}
 		}
-		if len(entry.Platforms) == 0 && registries != nil {
+
+		if registries != nil {
 			if platforms, err := lockPlatformsFromRegistry(registries, p.Name, p.Version); err == nil {
 				entry.Platforms = platforms
 			} else {
 				fmt.Fprintf(os.Stderr, "warning: could not enrich %s lock entry from registry: %v\n", p.Name, err)
+			}
+		}
+
+		// Preserve existing data only when registry enrichment is unavailable or
+		// failed. A source/version change means cached origin data is stale.
+		if len(entry.Platforms) == 0 && previous != nil {
+			entry.Platforms = previous.Platforms
+			if len(entry.Platforms) == 0 {
+				entry.SHA256 = previous.SHA256
 			}
 		}
 		newLF.Plugins[p.Name] = entry

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -82,12 +82,15 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 		if registries != nil {
 			if platforms, err := lockPlatformsFromRegistry(registries, p.Name, p.Version); err == nil {
 				entry.Platforms = platforms
-			} else if errors.Is(err, errInvalidRegistrySHA256) {
-				return fmt.Errorf("lock platform metadata for %s@%s: %w", p.Name, p.Version, err)
-			} else if previousHasPlatforms {
-				return fmt.Errorf("refresh platform metadata for %s@%s: %w", p.Name, p.Version, err)
 			} else {
-				fmt.Fprintf(os.Stderr, "warning: could not enrich %s lock entry from registry: %v\n", p.Name, err)
+				switch {
+				case errors.Is(err, errInvalidRegistrySHA256):
+					return fmt.Errorf("lock platform metadata for %s@%s: %w", p.Name, p.Version, err)
+				case previousHasPlatforms:
+					return fmt.Errorf("refresh platform metadata for %s@%s: %w", p.Name, p.Version, err)
+				default:
+					fmt.Fprintf(os.Stderr, "warning: could not enrich %s lock entry from registry: %v\n", p.Name, err)
+				}
 			}
 		} else if previousHasPlatforms {
 			return fmt.Errorf("refresh platform metadata for %s@%s: no project-local registry config available", p.Name, p.Version)

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -74,8 +74,10 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 			if prev, ok := existing.Plugins[p.Name]; ok &&
 				prev.Version == p.Version &&
 				prev.Source == p.Source {
-				entry.SHA256 = prev.SHA256
 				entry.Platforms = prev.Platforms
+				if len(entry.Platforms) == 0 {
+					entry.SHA256 = prev.SHA256
+				}
 			}
 		}
 		if len(entry.Platforms) == 0 && registries != nil {

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -134,10 +134,7 @@ func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version st
 			continue
 		}
 		key := dl.OS + "-" + dl.Arch
-		// Registry download SHA values are archive checksums. The lockfile
-		// platform SHA is currently verified against the installed plugin binary,
-		// so copying the archive checksum here would make lockfile installs fail.
-		platforms[key] = config.WfctlLockPlatform{URL: dl.URL}
+		platforms[key] = config.WfctlLockPlatform{URL: dl.URL, SHA256: dl.SHA256}
 	}
 	return platforms, nil
 }

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -76,20 +77,26 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 				previous = &prev
 			}
 		}
+		previousHasPlatforms := previous != nil && len(previous.Platforms) > 0
 
 		if registries != nil {
 			if platforms, err := lockPlatformsFromRegistry(registries, p.Name, p.Version); err == nil {
 				entry.Platforms = platforms
+			} else if errors.Is(err, errInvalidRegistrySHA256) {
+				return fmt.Errorf("lock platform metadata for %s@%s: %w", p.Name, p.Version, err)
+			} else if previousHasPlatforms {
+				return fmt.Errorf("refresh platform metadata for %s@%s: %w", p.Name, p.Version, err)
 			} else {
 				fmt.Fprintf(os.Stderr, "warning: could not enrich %s lock entry from registry: %v\n", p.Name, err)
 			}
+		} else if previousHasPlatforms {
+			return fmt.Errorf("refresh platform metadata for %s@%s: no project-local registry config available", p.Name, p.Version)
 		}
 
-		// Preserve existing data only when registry enrichment is unavailable or
-		// failed. A source/version change means cached origin data is stale.
+		// Preserve existing top-level checksums only for legacy entries. Platform
+		// metadata must be refreshed from the registry instead of copied forward.
 		if len(entry.Platforms) == 0 && previous != nil {
-			entry.Platforms = previous.Platforms
-			if len(entry.Platforms) == 0 {
+			if len(previous.Platforms) == 0 {
 				entry.SHA256 = previous.SHA256
 			}
 		}
@@ -127,6 +134,8 @@ func loadPluginLockRegistryConfig(manifestPath, lockPath string) (*RegistryConfi
 	return nil, nil
 }
 
+var errInvalidRegistrySHA256 = errors.New("invalid sha256")
+
 func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version string) (map[string]config.WfctlLockPlatform, error) {
 	manifest, _, err := registries.FetchManifest(pluginName)
 	if err != nil {
@@ -137,12 +146,18 @@ func lockPlatformsFromRegistry(registries *MultiRegistry, pluginName, version st
 	}
 
 	platforms := make(map[string]config.WfctlLockPlatform, len(manifest.Downloads))
-	for _, dl := range manifest.Downloads {
+	for i, dl := range manifest.Downloads {
 		if dl.OS == "" || dl.Arch == "" || dl.URL == "" {
 			continue
 		}
+		if !sha256Regex.MatchString(dl.SHA256) {
+			return nil, fmt.Errorf("%w for %s download %d (%s/%s): must be a 64-character hex string", errInvalidRegistrySHA256, pluginName, i, dl.OS, dl.Arch)
+		}
 		key := dl.OS + "-" + dl.Arch
 		platforms[key] = config.WfctlLockPlatform{URL: dl.URL, SHA256: dl.SHA256}
+	}
+	if len(platforms) == 0 {
+		return nil, fmt.Errorf("no usable platform downloads for %s@%s", pluginName, version)
 	}
 	return platforms, nil
 }

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -115,7 +115,7 @@ plugins:
 	}
 }
 
-func TestPluginLock_FromManifest_PopulatesPlatformURLsFromRegistry(t *testing.T) {
+func TestPluginLock_FromManifest_PopulatesPlatformURLsAndSHA256FromRegistry(t *testing.T) {
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "wfctl.yaml")
 	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
@@ -183,8 +183,11 @@ plugins:
 	if got := platforms["darwin-arm64"].URL; got != "https://example.test/foo-darwin-arm64.tar.gz" {
 		t.Fatalf("darwin-arm64 URL = %q, want registry URL", got)
 	}
-	if got := platforms["linux-amd64"].SHA256; got != "" {
-		t.Fatalf("platform sha256 should not copy registry archive checksum into binary-checksum field, got %q", got)
+	if got := platforms["linux-amd64"].SHA256; got != "archive-sha-linux" {
+		t.Fatalf("linux-amd64 SHA256 = %q, want registry archive checksum", got)
+	}
+	if got := platforms["darwin-arm64"].SHA256; got != "archive-sha-darwin" {
+		t.Fatalf("darwin-arm64 SHA256 = %q, want registry archive checksum", got)
 	}
 }
 

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -191,6 +191,93 @@ plugins:
 	}
 }
 
+func TestPluginLock_FromManifest_RefreshesExistingPlatformSHA256FromRegistry(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/plugins/workflow-plugin-foo/manifest.json" {
+			http.NotFound(w, r)
+			return
+		}
+		manifest := RegistryManifest{
+			Name:       "workflow-plugin-foo",
+			Version:    "v1.2.3",
+			Repository: "github.com/GoCodeAlone/workflow-plugin-foo",
+			Downloads: []PluginDownload{
+				{OS: "linux", Arch: "amd64", URL: "https://example.test/fresh-linux-amd64.tar.gz", SHA256: "fresh-archive-sha"},
+			},
+		}
+		data, _ := json.Marshal(manifest)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	registryConfig := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(registryConfig), 0o600); err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	existing := `version: 1
+generated_at: 2026-04-26T00:00:00Z
+plugins:
+  workflow-plugin-foo:
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+    sha256: stale-binary-sha
+    platforms:
+      linux-amd64:
+        url: https://example.test/stale-linux-amd64.tar.gz
+        sha256: stale-platform-sha
+`
+	if err := os.WriteFile(lockPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("write existing lockfile: %v", err)
+	}
+
+	if err := runPluginLockFromManifest(manifestPath, lockPath); err != nil {
+		t.Fatalf("runPluginLockFromManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	var parsed struct {
+		Plugins map[string]struct {
+			SHA256    string `yaml:"sha256"`
+			Platforms map[string]struct {
+				URL    string `yaml:"url"`
+				SHA256 string `yaml:"sha256"`
+			} `yaml:"platforms"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+	entry := parsed.Plugins["workflow-plugin-foo"]
+	if entry.SHA256 != "" {
+		t.Fatalf("platform lock entry should not preserve top-level sha256, got %q", entry.SHA256)
+	}
+	platform := entry.Platforms["linux-amd64"]
+	if platform.URL != "https://example.test/fresh-linux-amd64.tar.gz" {
+		t.Fatalf("platform URL = %q, want fresh registry URL", platform.URL)
+	}
+	if platform.SHA256 != "fresh-archive-sha" {
+		t.Fatalf("platform SHA256 = %q, want fresh registry archive checksum", platform.SHA256)
+	}
+}
+
 func TestPluginLock_FromManifest_DoesNotUseHomeOrDefaultRegistry(t *testing.T) {
 	dir := t.TempDir()
 	homeDir := t.TempDir()

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -130,8 +131,8 @@ func TestPluginLock_FromManifest_PopulatesPlatformURLsAndSHA256FromRegistry(t *t
 			Version:    "v1.2.3",
 			Repository: "github.com/GoCodeAlone/workflow-plugin-foo",
 			Downloads: []PluginDownload{
-				{OS: "linux", Arch: "amd64", URL: "https://example.test/foo-linux-amd64.tar.gz", SHA256: "archive-sha-linux"},
-				{OS: "darwin", Arch: "arm64", URL: "https://example.test/foo-darwin-arm64.tar.gz", SHA256: "archive-sha-darwin"},
+				{OS: "linux", Arch: "amd64", URL: "https://example.test/foo-linux-amd64.tar.gz", SHA256: sha256Hex([]byte("foo linux amd64 archive"))},
+				{OS: "darwin", Arch: "arm64", URL: "https://example.test/foo-darwin-arm64.tar.gz", SHA256: sha256Hex([]byte("foo darwin arm64 archive"))},
 			},
 		}
 		data, _ := json.Marshal(manifest)
@@ -183,10 +184,10 @@ plugins:
 	if got := platforms["darwin-arm64"].URL; got != "https://example.test/foo-darwin-arm64.tar.gz" {
 		t.Fatalf("darwin-arm64 URL = %q, want registry URL", got)
 	}
-	if got := platforms["linux-amd64"].SHA256; got != "archive-sha-linux" {
+	if got, want := platforms["linux-amd64"].SHA256, sha256Hex([]byte("foo linux amd64 archive")); got != want {
 		t.Fatalf("linux-amd64 SHA256 = %q, want registry archive checksum", got)
 	}
-	if got := platforms["darwin-arm64"].SHA256; got != "archive-sha-darwin" {
+	if got, want := platforms["darwin-arm64"].SHA256, sha256Hex([]byte("foo darwin arm64 archive")); got != want {
 		t.Fatalf("darwin-arm64 SHA256 = %q, want registry archive checksum", got)
 	}
 }
@@ -206,7 +207,7 @@ func TestPluginLock_FromManifest_RefreshesExistingPlatformSHA256FromRegistry(t *
 			Version:    "v1.2.3",
 			Repository: "github.com/GoCodeAlone/workflow-plugin-foo",
 			Downloads: []PluginDownload{
-				{OS: "linux", Arch: "amd64", URL: "https://example.test/fresh-linux-amd64.tar.gz", SHA256: "fresh-archive-sha"},
+				{OS: "linux", Arch: "amd64", URL: "https://example.test/fresh-linux-amd64.tar.gz", SHA256: sha256Hex([]byte("fresh foo linux amd64 archive"))},
 			},
 		}
 		data, _ := json.Marshal(manifest)
@@ -273,8 +274,177 @@ plugins:
 	if platform.URL != "https://example.test/fresh-linux-amd64.tar.gz" {
 		t.Fatalf("platform URL = %q, want fresh registry URL", platform.URL)
 	}
-	if platform.SHA256 != "fresh-archive-sha" {
+	if want := sha256Hex([]byte("fresh foo linux amd64 archive")); platform.SHA256 != want {
 		t.Fatalf("platform SHA256 = %q, want fresh registry archive checksum", platform.SHA256)
+	}
+}
+
+func TestPluginLock_FromManifest_FailsWhenExistingPlatformsCannotBeRefreshed(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest RegistryManifest
+		status   int
+	}{
+		{
+			name: "registry error",
+			manifest: RegistryManifest{
+				Name:    "workflow-plugin-foo",
+				Version: "v1.2.3",
+			},
+			status: http.StatusInternalServerError,
+		},
+		{
+			name: "version mismatch",
+			manifest: RegistryManifest{
+				Name:    "workflow-plugin-foo",
+				Version: "v1.2.2",
+				Downloads: []PluginDownload{
+					{OS: "linux", Arch: "amd64", URL: "https://example.test/foo-linux-amd64.tar.gz", SHA256: sha256Hex([]byte("foo v1.2.2 linux amd64 archive"))},
+				},
+			},
+			status: http.StatusOK,
+		},
+		{
+			name: "no usable downloads",
+			manifest: RegistryManifest{
+				Name:    "workflow-plugin-foo",
+				Version: "v1.2.3",
+				Downloads: []PluginDownload{
+					{OS: "linux", Arch: "", URL: "https://example.test/foo-linux-amd64.tar.gz", SHA256: sha256Hex([]byte("foo unusable archive"))},
+				},
+			},
+			status: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			manifestPath := filepath.Join(dir, "wfctl.yaml")
+			lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/plugins/workflow-plugin-foo/manifest.json" {
+					http.NotFound(w, r)
+					return
+				}
+				if tt.status != http.StatusOK {
+					http.Error(w, "registry unavailable", tt.status)
+					return
+				}
+				data, _ := json.Marshal(tt.manifest)
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(data) //nolint:errcheck
+			}))
+			defer srv.Close()
+
+			registryConfig := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+			if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(registryConfig), 0o600); err != nil {
+				t.Fatalf("write registry config: %v", err)
+			}
+
+			manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+			if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+			existing := `version: 1
+generated_at: 2026-04-26T00:00:00Z
+plugins:
+  workflow-plugin-foo:
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+    platforms:
+      linux-amd64:
+        url: https://example.test/stale-linux-amd64.tar.gz
+        sha256: ` + sha256Hex([]byte("stale foo linux amd64 archive")) + `
+`
+			if err := os.WriteFile(lockPath, []byte(existing), 0o600); err != nil {
+				t.Fatalf("write existing lockfile: %v", err)
+			}
+
+			err := runPluginLockFromManifest(manifestPath, lockPath)
+			if err == nil {
+				t.Fatal("expected plugin lock to fail rather than preserve stale platform metadata")
+			}
+			if !strings.Contains(err.Error(), "refresh platform metadata") {
+				t.Fatalf("error = %q, want clear stale platform refresh failure", err)
+			}
+			data, readErr := os.ReadFile(lockPath)
+			if readErr != nil {
+				t.Fatalf("read lockfile: %v", readErr)
+			}
+			if string(data) != existing {
+				t.Fatalf("lockfile was rewritten after failed platform refresh:\n%s", data)
+			}
+		})
+	}
+}
+
+func TestPluginLock_FromManifest_RejectsInvalidRegistrySHA256(t *testing.T) {
+	tests := []struct {
+		name   string
+		sha256 string
+	}{
+		{name: "empty", sha256: ""},
+		{name: "short", sha256: "abc123"},
+		{name: "non hex", sha256: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			manifestPath := filepath.Join(dir, "wfctl.yaml")
+			lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/plugins/workflow-plugin-foo/manifest.json" {
+					http.NotFound(w, r)
+					return
+				}
+				manifest := RegistryManifest{
+					Name:    "workflow-plugin-foo",
+					Version: "v1.2.3",
+					Downloads: []PluginDownload{
+						{OS: "linux", Arch: "amd64", URL: "https://example.test/foo-linux-amd64.tar.gz", SHA256: tt.sha256},
+					},
+				}
+				data, _ := json.Marshal(manifest)
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(data) //nolint:errcheck
+			}))
+			defer srv.Close()
+
+			registryConfig := "registries:\n  - name: test\n    type: static\n    url: " + srv.URL + "\n    priority: 0\n"
+			if err := os.WriteFile(filepath.Join(dir, ".wfctl.yaml"), []byte(registryConfig), 0o600); err != nil {
+				t.Fatalf("write registry config: %v", err)
+			}
+
+			manifest := `version: 1
+plugins:
+  - name: workflow-plugin-foo
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-foo
+`
+			if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+
+			err := runPluginLockFromManifest(manifestPath, lockPath)
+			if err == nil {
+				t.Fatal("expected invalid registry sha256 to be rejected")
+			}
+			if !strings.Contains(err.Error(), "invalid sha256") {
+				t.Fatalf("error = %q, want invalid sha256 message", err)
+			}
+			if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+				t.Fatalf("lockfile should not be written after invalid registry sha256; stat err=%v", statErr)
+			}
+		})
 	}
 }
 

--- a/cmd/wfctl/plugin_lockfile.go
+++ b/cmd/wfctl/plugin_lockfile.go
@@ -144,6 +144,10 @@ func installFromLockfile(pluginDir, cfgPath string) error {
 // not the download archive.
 // Silently no-ops if the lockfile cannot be read or written (install still succeeds).
 func updateLockfileWithChecksum(pluginName, version, repository, registry, sha256Hash string) {
+	if newLF, err := config.LoadWfctlLockfile(wfctlLockPath); err == nil && newLF.Version > 0 {
+		return
+	}
+
 	lf, err := loadPluginLockfile(wfctlLockPath)
 	if err != nil {
 		return

--- a/config/wfctl_lockfile.go
+++ b/config/wfctl_lockfile.go
@@ -91,7 +91,9 @@ func SaveWfctlLockfile(path string, lf *WfctlLockfile) error {
 		}
 		addField("version", entry.Version)
 		addField("source", entry.Source)
-		addField("sha256", entry.SHA256)
+		if len(entry.Platforms) == 0 {
+			addField("sha256", entry.SHA256)
+		}
 
 		if len(entry.Platforms) > 0 {
 			platKeys := make([]string, 0, len(entry.Platforms))

--- a/config/wfctl_lockfile_test.go
+++ b/config/wfctl_lockfile_test.go
@@ -16,11 +16,11 @@ func TestWfctlLockfile_RoundTrip(t *testing.T) {
 			"workflow-plugin-digitalocean": {
 				Version: "v0.7.6",
 				Source:  "github.com/GoCodeAlone/workflow-plugin-digitalocean",
-				SHA256:  "abc123",
+				SHA256:  "legacy-binary-sha",
 				Platforms: map[string]WfctlLockPlatform{
 					"linux-amd64": {
 						URL:    "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.6/plugin-linux-amd64.tar.gz",
-						SHA256: "def456",
+						SHA256: "archive-sha",
 					},
 				},
 			},
@@ -46,15 +46,51 @@ func TestWfctlLockfile_RoundTrip(t *testing.T) {
 	if entry.Version != "v0.7.6" {
 		t.Errorf("version = %q, want v0.7.6", entry.Version)
 	}
-	if entry.SHA256 != "abc123" {
-		t.Errorf("sha256 = %q, want abc123", entry.SHA256)
+	if entry.SHA256 != "" {
+		t.Errorf("sha256 = %q, want empty when platform archive checksums exist", entry.SHA256)
 	}
 	plat, ok := entry.Platforms["linux-amd64"]
 	if !ok {
 		t.Fatal("platform linux-amd64 missing")
 	}
-	if plat.SHA256 != "def456" {
-		t.Errorf("platform sha256 = %q, want def456", plat.SHA256)
+	if plat.SHA256 != "archive-sha" {
+		t.Errorf("platform sha256 = %q, want archive-sha", plat.SHA256)
+	}
+}
+
+func TestWfctlLockfile_SaveOmitsTopLevelSHA256WhenPlatformsExist(t *testing.T) {
+	lf := WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+		Plugins: map[string]WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				SHA256:  "legacy-binary-sha",
+				Platforms: map[string]WfctlLockPlatform{
+					"linux-amd64": {
+						URL:    "https://example.test/auth-linux-amd64.tar.gz",
+						SHA256: "archive-sha-linux",
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".wfctl-lock.yaml")
+	if err := SaveWfctlLockfile(path, &lf); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	if strings.Contains(string(data), "\n        sha256: legacy-binary-sha") {
+		t.Fatalf("lockfile should not write top-level sha256 when platforms exist:\n%s", data)
+	}
+	if !strings.Contains(string(data), "sha256: archive-sha-linux") {
+		t.Fatalf("lockfile should preserve platform archive sha256:\n%s", data)
 	}
 }
 

--- a/config/wfctl_lockfile_test.go
+++ b/config/wfctl_lockfile_test.go
@@ -86,7 +86,7 @@ func TestWfctlLockfile_SaveOmitsTopLevelSHA256WhenPlatformsExist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read lockfile: %v", err)
 	}
-	if strings.Contains(string(data), "\n        sha256: legacy-binary-sha") {
+	if strings.Contains(string(data), "sha256: legacy-binary-sha") {
 		t.Fatalf("lockfile should not write top-level sha256 when platforms exist:\n%s", data)
 	}
 	if !strings.Contains(string(data), "sha256: archive-sha-linux") {


### PR DESCRIPTION
## Summary
- treat platform lockfile checksums as archive checksums verified during download
- keep top-level sha256 legacy-only and avoid writing it when platform metadata exists
- prevent lockfile installs from falling back to live registry when current platform metadata is missing
- refresh platform metadata from registry during `wfctl plugin lock` and reject stale/invalid platform checksums

## Verification
- `git diff --check origin/main`
- `GOWORK=off go test ./cmd/wfctl ./config`

## Review
- Implementation reviewed by antagonistic subagent after fixes: SHIP-IT
- Earlier review findings addressed: missing current platform fallback, stale platform preservation, invalid registry sha values