### PR TITLE
Add provider-executed migration repair to wfctl

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -394,6 +394,24 @@ func (r *remoteIaCProvider) ResolveSizing(resourceType string, size interfaces.S
 	return &sizing, nil
 }
 
+func (r *remoteIaCProvider) RepairDirtyMigration(_ context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
+	reqAny, err := jsonToAny(req)
+	if err != nil {
+		return nil, fmt.Errorf("IaCProvider.RepairDirtyMigration: marshal request: %w", err)
+	}
+	res, err := r.invoker.InvokeService("IaCProvider.RepairDirtyMigration", map[string]any{
+		"request": reqAny,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var result interfaces.MigrationRepairResult
+	if err := anyToStruct(res, &result); err != nil {
+		return nil, fmt.Errorf("IaCProvider.RepairDirtyMigration: decode result: %w", err)
+	}
+	return &result, nil
+}
+
 func (r *remoteIaCProvider) ResourceDriver(resourceType string) (interfaces.ResourceDriver, error) {
 	return &remoteResourceDriver{invoker: r.invoker, resourceType: resourceType}, nil
 }

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -188,6 +188,10 @@ type remoteServiceInvoker interface {
 	InvokeService(method string, args map[string]any) (map[string]any, error)
 }
 
+type remoteServiceContextInvoker interface {
+	InvokeServiceContext(ctx context.Context, method string, args map[string]any) (map[string]any, error)
+}
+
 // remoteIaCProvider implements interfaces.IaCProvider by routing every method
 // through InvokeService to the plugin subprocess. Only the methods needed by
 // wfctl ci run deploy are fully implemented; the rest return a clear error.
@@ -394,14 +398,23 @@ func (r *remoteIaCProvider) ResolveSizing(resourceType string, size interfaces.S
 	return &sizing, nil
 }
 
-func (r *remoteIaCProvider) RepairDirtyMigration(_ context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
+func (r *remoteIaCProvider) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
 	reqAny, err := jsonToAny(req)
 	if err != nil {
 		return nil, fmt.Errorf("IaCProvider.RepairDirtyMigration: marshal request: %w", err)
 	}
-	res, err := r.invoker.InvokeService("IaCProvider.RepairDirtyMigration", map[string]any{
+	args := map[string]any{
 		"request": reqAny,
-	})
+	}
+	var res map[string]any
+	if invoker, ok := r.invoker.(remoteServiceContextInvoker); ok {
+		res, err = invoker.InvokeServiceContext(ctx, "IaCProvider.RepairDirtyMigration", args)
+	} else {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		res, err = r.invoker.InvokeService("IaCProvider.RepairDirtyMigration", args)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wfctl/deploy_providers_dispatch_matrix_test.go
+++ b/cmd/wfctl/deploy_providers_dispatch_matrix_test.go
@@ -319,6 +319,16 @@ func TestDispatchMatrix_RemoteIaCProvider(t *testing.T) {
 			},
 		},
 		{
+			name:         "RepairDirtyMigration",
+			wantMethod:   "IaCProvider.RepairDirtyMigration",
+			requiredKeys: []string{"request"},
+			invoke: func(p *remoteIaCProvider, ri *recordingInvoker) error {
+				ri.resp = map[string]any{}
+				_, err := p.RepairDirtyMigration(ctx, interfaces.MigrationRepairRequest{})
+				return err
+			},
+		},
+		{
 			// BootstrapStateBackend sends cfg directly as the args map (no wrapper key).
 			// When cfg is nil/empty InvokeService must still be called (args may be nil).
 			name:         "BootstrapStateBackend_nilCfg",

--- a/cmd/wfctl/deploy_providers_remote_iac_test.go
+++ b/cmd/wfctl/deploy_providers_remote_iac_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -484,4 +485,46 @@ func TestRemoteIaCProvider_RepairDirtyMigration_DecodeError(t *testing.T) {
 	if !strings.Contains(err.Error(), "IaCProvider.RepairDirtyMigration: decode result") {
 		t.Fatalf("error %q missing decode context", err)
 	}
+}
+
+func TestRemoteIaCProvider_RepairDirtyMigration_UsesContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ci := &contextRecordingInvoker{resp: map[string]any{
+		"status": interfaces.MigrationRepairStatusSucceeded,
+	}}
+	p := &remoteIaCProvider{invoker: ci}
+
+	_, err := p.RepairDirtyMigration(ctx, interfaces.MigrationRepairRequest{})
+	if err == nil {
+		t.Fatal("expected canceled context error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if !ci.usedContext {
+		t.Fatal("RepairDirtyMigration did not use context-aware invoker")
+	}
+	if ci.fallbackUsed {
+		t.Fatal("RepairDirtyMigration used context-free fallback")
+	}
+}
+
+type contextRecordingInvoker struct {
+	resp         map[string]any
+	usedContext  bool
+	fallbackUsed bool
+}
+
+func (c *contextRecordingInvoker) InvokeService(_ string, _ map[string]any) (map[string]any, error) {
+	c.fallbackUsed = true
+	return c.resp, nil
+}
+
+func (c *contextRecordingInvoker) InvokeServiceContext(ctx context.Context, _ string, _ map[string]any) (map[string]any, error) {
+	c.usedContext = true
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.resp, nil
 }

--- a/cmd/wfctl/deploy_providers_remote_iac_test.go
+++ b/cmd/wfctl/deploy_providers_remote_iac_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -420,5 +421,67 @@ func TestRemoteIaC_ResolveSizing_Error(t *testing.T) {
 	_, err := p.ResolveSizing("infra.database", interfaces.SizeXL, nil)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// ── Migration Repair ────────────────────────────────────────────────────────
+
+func TestRemoteIaCProvider_RepairDirtyMigration(t *testing.T) {
+	si := &stubInvoker{resp: map[string]any{
+		"provider_job_id": "job-123",
+		"status":          interfaces.MigrationRepairStatusSucceeded,
+		"applied":         []any{"20260426000006"},
+		"logs":            "repair complete",
+	}}
+	p := newIaCProvider(si)
+
+	result, err := p.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-app",
+		DatabaseResourceName: "bmw-db",
+		JobImage:             "registry.example/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260426000004",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		Env:                  map[string]string{"DATABASE_URL": "postgres://example"},
+		TimeoutSeconds:       600,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: unexpected error: %v", err)
+	}
+	if si.method != "IaCProvider.RepairDirtyMigration" {
+		t.Errorf("method: got %q, want IaCProvider.RepairDirtyMigration", si.method)
+	}
+	request, ok := si.args["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request arg: got %T, want map[string]any", si.args["request"])
+	}
+	if request["expected_dirty_version"] != "20260426000005" {
+		t.Errorf("expected_dirty_version arg: got %v", request["expected_dirty_version"])
+	}
+	if result.ProviderJobID != "job-123" {
+		t.Errorf("ProviderJobID: got %q", result.ProviderJobID)
+	}
+	if result.Status != interfaces.MigrationRepairStatusSucceeded {
+		t.Errorf("Status: got %q", result.Status)
+	}
+	if len(result.Applied) != 1 || result.Applied[0] != "20260426000006" {
+		t.Errorf("Applied: got %v", result.Applied)
+	}
+}
+
+func TestRemoteIaCProvider_RepairDirtyMigration_DecodeError(t *testing.T) {
+	si := &stubInvoker{resp: map[string]any{
+		"status": 123,
+	}}
+	p := newIaCProvider(si)
+
+	_, err := p.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{})
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !strings.Contains(err.Error(), "IaCProvider.RepairDirtyMigration: decode result") {
+		t.Fatalf("error %q missing decode context", err)
 	}
 }

--- a/cmd/wfctl/destructive_gate.go
+++ b/cmd/wfctl/destructive_gate.go
@@ -66,7 +66,7 @@ func writeDestructiveApprovalArtifact(path string, decision destructiveDecision)
 	}
 	data = append(data, '\n')
 	if dir := filepath.Dir(path); dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
 			return fmt.Errorf("create destructive approval artifact directory: %w", err)
 		}
 	}

--- a/cmd/wfctl/destructive_gate.go
+++ b/cmd/wfctl/destructive_gate.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+const destructiveApprovalArtifactName = "wfctl-destructive-approval.json"
+
+type destructiveDecision struct {
+	Operation            string `json:"operation"`
+	Env                  string `json:"env"`
+	App                  string `json:"app,omitempty"`
+	Database             string `json:"database,omitempty"`
+	ExpectedDirtyVersion string `json:"expected_dirty_version,omitempty"`
+	ForceVersion         string `json:"force_version,omitempty"`
+	RequiresApproval     bool   `json:"requires_approval"`
+}
+
+func requireDestructiveApproval(decision destructiveDecision, approved bool, artifactPath string) (*interfaces.MigrationRepairResult, error) {
+	if !destructiveEnvRequiresApproval(decision.Env) || approved {
+		return nil, nil
+	}
+
+	decision.RequiresApproval = true
+	path := destructiveApprovalArtifactPath(artifactPath)
+	if err := writeDestructiveApprovalArtifact(path, decision); err != nil {
+		return nil, err
+	}
+
+	return &interfaces.MigrationRepairResult{
+		Status: interfaces.MigrationRepairStatusApprovalRequired,
+	}, fmt.Errorf("approval required for destructive operation %q in environment %q; review %s and rerun with approval", decision.Operation, decision.Env, path)
+}
+
+func destructiveEnvRequiresApproval(env string) bool {
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "dev", "local", "test":
+		return false
+	default:
+		return true
+	}
+}
+
+func destructiveApprovalArtifactPath(artifactPath string) string {
+	if strings.TrimSpace(artifactPath) != "" {
+		return artifactPath
+	}
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		if runnerTemp := strings.TrimSpace(os.Getenv("RUNNER_TEMP")); runnerTemp != "" {
+			return filepath.Join(runnerTemp, destructiveApprovalArtifactName)
+		}
+	}
+	return destructiveApprovalArtifactName
+}
+
+func writeDestructiveApprovalArtifact(path string, decision destructiveDecision) error {
+	data, err := json.Marshal(decision)
+	if err != nil {
+		return fmt.Errorf("encode destructive approval artifact: %w", err)
+	}
+	data = append(data, '\n')
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create destructive approval artifact directory: %w", err)
+		}
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write destructive approval artifact: %w", err)
+	}
+	return nil
+}

--- a/cmd/wfctl/destructive_gate_test.go
+++ b/cmd/wfctl/destructive_gate_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+func TestDestructiveGate_StagingWithoutApprovalWritesExplicitArtifact(t *testing.T) {
+	artifactPath := filepath.Join(t.TempDir(), "approval.json")
+
+	result, err := requireDestructiveApproval(testDestructiveDecision("staging"), false, artifactPath)
+	if err == nil {
+		t.Fatal("expected approval error")
+	}
+	if !strings.Contains(err.Error(), "approval required") {
+		t.Fatalf("error = %q, want approval required", err)
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusApprovalRequired {
+		t.Fatalf("result = %+v, want status %q", result, interfaces.MigrationRepairStatusApprovalRequired)
+	}
+
+	decision := readDestructiveDecisionArtifact(t, artifactPath)
+	assertDestructiveDecision(t, decision, "staging")
+}
+
+func TestDestructiveGate_StagingWithoutApprovalWritesDefaultLocalArtifact(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("RUNNER_TEMP", "")
+	t.Chdir(dir)
+
+	result, err := requireDestructiveApproval(testDestructiveDecision("staging"), false, "")
+	if err == nil {
+		t.Fatal("expected approval error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusApprovalRequired {
+		t.Fatalf("result = %+v, want status %q", result, interfaces.MigrationRepairStatusApprovalRequired)
+	}
+
+	artifactPath := filepath.Join(dir, "wfctl-destructive-approval.json")
+	decision := readDestructiveDecisionArtifact(t, artifactPath)
+	assertDestructiveDecision(t, decision, "staging")
+}
+
+func TestDestructiveGate_ProdWithoutApprovalWritesDefaultArtifact(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("RUNNER_TEMP", "")
+	t.Chdir(dir)
+
+	result, err := requireDestructiveApproval(testDestructiveDecision("prod"), false, "")
+	if err == nil {
+		t.Fatal("expected approval error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusApprovalRequired {
+		t.Fatalf("result = %+v, want status %q", result, interfaces.MigrationRepairStatusApprovalRequired)
+	}
+
+	artifactPath := filepath.Join(dir, "wfctl-destructive-approval.json")
+	decision := readDestructiveDecisionArtifact(t, artifactPath)
+	assertDestructiveDecision(t, decision, "prod")
+}
+
+func TestDestructiveGate_GitHubActionsDefaultsArtifactToRunnerTemp(t *testing.T) {
+	runnerTemp := t.TempDir()
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("RUNNER_TEMP", runnerTemp)
+
+	result, err := requireDestructiveApproval(testDestructiveDecision("staging"), false, "")
+	if err == nil {
+		t.Fatal("expected approval error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusApprovalRequired {
+		t.Fatalf("result = %+v, want status %q", result, interfaces.MigrationRepairStatusApprovalRequired)
+	}
+
+	artifactPath := filepath.Join(runnerTemp, "wfctl-destructive-approval.json")
+	decision := readDestructiveDecisionArtifact(t, artifactPath)
+	assertDestructiveDecision(t, decision, "staging")
+}
+
+func TestDestructiveGate_DevExecutesWithoutExplicitApproval(t *testing.T) {
+	result, err := requireDestructiveApproval(testDestructiveDecision("dev"), false, filepath.Join(t.TempDir(), "approval.json"))
+	if err != nil {
+		t.Fatalf("requireDestructiveApproval: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %+v, want nil", result)
+	}
+}
+
+func TestDestructiveGate_StagingWithApprovalExecutes(t *testing.T) {
+	artifactPath := filepath.Join(t.TempDir(), "approval.json")
+
+	result, err := requireDestructiveApproval(testDestructiveDecision("staging"), true, artifactPath)
+	if err != nil {
+		t.Fatalf("requireDestructiveApproval: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %+v, want nil", result)
+	}
+	if _, err := os.Stat(artifactPath); !os.IsNotExist(err) {
+		t.Fatalf("artifact exists after approved gate: stat err = %v", err)
+	}
+}
+
+func testDestructiveDecision(env string) destructiveDecision {
+	return destructiveDecision{
+		Operation:            "migration_repair_dirty",
+		Env:                  env,
+		App:                  "bmw-app",
+		Database:             "bmw-database",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+	}
+}
+
+func readDestructiveDecisionArtifact(t *testing.T, path string) destructiveDecision {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read approval artifact: %v", err)
+	}
+	if !strings.Contains(string(data), `"operation":"migration_repair_dirty"`) {
+		t.Fatalf("artifact %s missing compact operation JSON: %s", path, data)
+	}
+	var decision destructiveDecision
+	if err := json.Unmarshal(data, &decision); err != nil {
+		t.Fatalf("decode approval artifact: %v", err)
+	}
+	return decision
+}
+
+func assertDestructiveDecision(t *testing.T, got destructiveDecision, env string) {
+	t.Helper()
+	if got.Operation != "migration_repair_dirty" {
+		t.Fatalf("operation = %q", got.Operation)
+	}
+	if got.Env != env {
+		t.Fatalf("env = %q, want %q", got.Env, env)
+	}
+	if got.App != "bmw-app" {
+		t.Fatalf("app = %q", got.App)
+	}
+	if got.Database != "bmw-database" {
+		t.Fatalf("database = %q", got.Database)
+	}
+	if got.ExpectedDirtyVersion != "20260426000005" {
+		t.Fatalf("expected_dirty_version = %q", got.ExpectedDirtyVersion)
+	}
+	if got.ForceVersion != "20260422000001" {
+		t.Fatalf("force_version = %q", got.ForceVersion)
+	}
+	if !got.RequiresApproval {
+		t.Fatal("requires_approval = false, want true")
+	}
+}

--- a/cmd/wfctl/migrate.go
+++ b/cmd/wfctl/migrate.go
@@ -45,7 +45,7 @@ Options:
 
 	if len(args) == 0 {
 		fs.Usage()
-		return fmt.Errorf("subcommand required: status, diff, apply, or plugins")
+		return fmt.Errorf("subcommand required: status, diff, apply, plugins, or repair-dirty")
 	}
 
 	subcmd := args[0]

--- a/cmd/wfctl/migrate.go
+++ b/cmd/wfctl/migrate.go
@@ -28,12 +28,15 @@ Subcommands:
   diff      Show pending migrations without applying them
   apply     Apply pending migrations
   plugins   Migrate requires.plugins[] from app.yaml → wfctl.yaml + .wfctl-lock.yaml
+  repair-dirty
+            Repair a known dirty golang-migrate metadata state via an IaC provider job
 
 Examples:
   wfctl migrate status --db workflow.db
   wfctl migrate diff --db workflow.db
   wfctl migrate apply --db workflow.db
   wfctl migrate plugins --config workflow.yaml
+  wfctl migrate repair-dirty --config infra.yaml --env staging --database db --app app --job-image image --expected-dirty-version 20260426000005 --force-version 20260422000001 --confirm-force FORCE_MIGRATION_METADATA
 
 Options:
 `)
@@ -50,6 +53,9 @@ Options:
 	// Handle non-DB subcommands before opening the database.
 	if subcmd == "plugins" {
 		return runMigratePlugins(args[1:])
+	}
+	if subcmd == "repair-dirty" {
+		return runMigrateRepairDirty(args[1:])
 	}
 
 	if err := fs.Parse(args[1:]); err != nil {

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -172,15 +172,17 @@ Options:
 			result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusSucceeded}
 		}
 	}
+	if err == nil {
+		if statusErr := validateMigrationRepairResultStatus(result.Status); statusErr != nil {
+			return statusErr
+		}
+	}
 	printMigrationRepairResult(out, result, jobEnvMap)
 	if summaryErr := writeMigrationRepairSummary(result, envName, appName, jobEnvMap); summaryErr != nil && err == nil {
 		err = summaryErr
 	}
 	if err != nil {
 		return redactMigrationRepairError(err, jobEnvMap)
-	}
-	if err := validateMigrationRepairResultStatus(result.Status); err != nil {
-		return err
 	}
 	if result.Status != interfaces.MigrationRepairStatusSucceeded {
 		return fmt.Errorf("migration repair finished with status %s", result.Status)
@@ -305,16 +307,16 @@ func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envNa
 	diagnostics := redactMigrationRepairDiagnostics(result.Diagnostics, secrets)
 	if result.Logs != "" {
 		diagnostics = append(diagnostics, interfaces.Diagnostic{
-			ID:     result.ProviderJobID,
-			Phase:  result.Status,
+			ID:     redactMigrationRepairSecrets(result.ProviderJobID, secrets),
+			Phase:  redactMigrationRepairSecrets(result.Status, secrets),
 			Cause:  "migration repair logs",
 			Detail: redactMigrationRepairSecrets(result.Logs, secrets),
 		})
 	}
 	if len(diagnostics) == 0 && result.ProviderJobID != "" {
 		diagnostics = append(diagnostics, interfaces.Diagnostic{
-			ID:    result.ProviderJobID,
-			Phase: result.Status,
+			ID:    redactMigrationRepairSecrets(result.ProviderJobID, secrets),
+			Phase: redactMigrationRepairSecrets(result.Status, secrets),
 			Cause: "provider job",
 		})
 	}

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -73,7 +73,7 @@ func runMigrateRepairDirtyWithOutput(args []string, out io.Writer) error {
 
 Run a guarded dirty migration metadata repair inside a provider-managed runtime.
 
-Required guard flags:
+Required guard flags for non-dev environments:
   --expected-dirty-version <version>
   --force-version <version>
   --confirm-force FORCE_MIGRATION_METADATA

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -95,24 +95,25 @@ Options:
 		return err
 	}
 
-	appSpec, err := findMigrateRepairInfraSpecByName(cfgPath, envName, appName)
+	appSpec, err := findMigrateRepairCanonicalSpecByName(cfgPath, envName, appName)
 	if err != nil {
 		return err
 	}
-	dbSpec, err := findMigrateRepairInfraSpecByName(cfgPath, envName, databaseName)
+	dbSpec, err := findMigrateRepairCanonicalSpecByName(cfgPath, envName, databaseName)
 	if err != nil {
 		return err
+	}
+	appProviderRef := resourceSpecProviderRef(appSpec)
+	dbProviderRef := resourceSpecProviderRef(dbSpec)
+	if appProviderRef == "" || dbProviderRef == "" {
+		return fmt.Errorf("app %q and database %q must both resolve a provider module", appSpec.Name, dbSpec.Name)
+	}
+	if appProviderRef != dbProviderRef {
+		return fmt.Errorf("app %q and database %q must reference the same provider module, got %q and %q", appSpec.Name, dbSpec.Name, appProviderRef, dbProviderRef)
 	}
 	appProviderType, appProviderCfg, err := resolveProviderForSpec(cfgPath, envName, appSpec)
 	if err != nil {
 		return err
-	}
-	dbProviderType, _, err := resolveProviderForSpec(cfgPath, envName, dbSpec)
-	if err != nil {
-		return err
-	}
-	if appProviderType != dbProviderType {
-		return fmt.Errorf("app %q provider %q does not match database %q provider %q", appSpec.Name, appProviderType, dbSpec.Name, dbProviderType)
 	}
 
 	req := interfaces.MigrationRepairRequest{
@@ -184,32 +185,28 @@ Options:
 	return nil
 }
 
-func findMigrateRepairInfraSpecByName(cfgFile, envName, name string) (interfaces.ResourceSpec, error) {
+func findMigrateRepairCanonicalSpecByName(cfgFile, envName, name string) (interfaces.ResourceSpec, error) {
 	if strings.TrimSpace(name) == "" {
 		return interfaces.ResourceSpec{}, fmt.Errorf("infra resource name is required")
 	}
-	cfg, err := config.LoadFromFile(cfgFile)
+	specs, err := parseInfraResourceSpecsForEnv(cfgFile, envName)
 	if err != nil {
-		return interfaces.ResourceSpec{}, fmt.Errorf("load %s: %w", cfgFile, err)
+		return interfaces.ResourceSpec{}, err
 	}
-	for i := range cfg.Modules {
-		m := &cfg.Modules[i]
-		if !isInfraType(m.Type) {
-			continue
-		}
-		if envName == "" {
-			if m.Name == name {
-				r := &config.ResolvedModule{Name: m.Name, Type: m.Type, Config: config.ExpandEnvInMap(m.Config)}
-				return resourceSpecFromResolvedModule(r), nil
+	if envName != "" {
+		if resolvedNames, err := findMigrateRepairResolvedNames(cfgFile, envName, name); err != nil {
+			return interfaces.ResourceSpec{}, err
+		} else if len(resolvedNames) > 0 {
+			for _, spec := range specs {
+				if resolvedNames[spec.Name] || resolvedNames[resourceSpecNameFromConfig(spec.Config)] {
+					return spec, nil
+				}
 			}
-			continue
 		}
-		resolved, ok := m.ResolveForEnv(envName)
-		if !ok {
-			continue
-		}
-		if m.Name == name || resolved.Name == name {
-			return resourceSpecFromResolvedModule(resolved), nil
+	}
+	for _, spec := range specs {
+		if spec.Name == name || resourceSpecNameFromConfig(spec.Config) == name {
+			return spec, nil
 		}
 	}
 	if envName != "" {
@@ -218,13 +215,48 @@ func findMigrateRepairInfraSpecByName(cfgFile, envName, name string) (interfaces
 	return interfaces.ResourceSpec{}, fmt.Errorf("infra resource %q not found in %s", name, cfgFile)
 }
 
+func findMigrateRepairResolvedNames(cfgFile, envName, name string) (map[string]bool, error) {
+	cfg, err := config.LoadFromFile(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", cfgFile, err)
+	}
+	for i := range cfg.Modules {
+		m := &cfg.Modules[i]
+		if !isInfraType(m.Type) || m.Name != name {
+			continue
+		}
+		resolved, ok := m.ResolveForEnv(envName)
+		if !ok {
+			return map[string]bool{}, nil
+		}
+		names := map[string]bool{
+			resolved.Name: true,
+		}
+		if resolved.Config != nil {
+			if configName, _ := resolved.Config["name"].(string); strings.TrimSpace(configName) != "" {
+				names[strings.TrimSpace(configName)] = true
+			}
+		}
+		return names, nil
+	}
+	return map[string]bool{}, nil
+}
+
+func resourceSpecNameFromConfig(cfg map[string]any) string {
+	if cfg == nil {
+		return ""
+	}
+	name, _ := cfg["name"].(string)
+	return strings.TrimSpace(name)
+}
+
 func collectMigrationRepairEnv(jobEnv, jobEnvFromEnv []string) (map[string]string, error) {
 	out := map[string]string{}
 	for _, entry := range jobEnv {
 		key, value, ok := strings.Cut(entry, "=")
 		key = strings.TrimSpace(key)
 		if !ok || key == "" {
-			return nil, fmt.Errorf("--job-env must be KEY=VALUE, got %q", entry)
+			return nil, fmt.Errorf("--job-env must be KEY=VALUE with a non-empty key")
 		}
 		out[key] = value
 	}

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -269,7 +269,7 @@ func collectMigrationRepairEnv(jobEnv, jobEnvFromEnv []string) (map[string]strin
 			return nil, fmt.Errorf("--job-env-from-env requires a variable name")
 		}
 		value, ok := os.LookupEnv(key)
-		if !ok || value == "" {
+		if !ok {
 			return nil, fmt.Errorf("--job-env-from-env %s is not set", key)
 		}
 		out[key] = value
@@ -300,10 +300,7 @@ func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envNa
 	if result == nil || os.Getenv("GITHUB_STEP_SUMMARY") == "" {
 		return nil
 	}
-	outcome := strings.ToUpper(result.Status)
-	if outcome == "" {
-		outcome = "UNKNOWN"
-	}
+	outcome := migrationRepairSummaryOutcome(result.Status)
 	diagnostics := redactMigrationRepairDiagnostics(result.Diagnostics, secrets)
 	if result.Logs != "" {
 		diagnostics = append(diagnostics, interfaces.Diagnostic{
@@ -327,6 +324,13 @@ func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envNa
 		Outcome:     outcome,
 		Diagnostics: diagnostics,
 	})
+}
+
+func migrationRepairSummaryOutcome(status string) string {
+	if status == interfaces.MigrationRepairStatusSucceeded {
+		return "SUCCESS"
+	}
+	return "FAILED"
 }
 
 func redactMigrationRepairDiagnostics(diagnostics []interfaces.Diagnostic, secrets map[string]string) []interfaces.Diagnostic {

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -179,7 +179,10 @@ Options:
 	if err != nil {
 		return redactMigrationRepairError(err, jobEnvMap)
 	}
-	if result.Status != "" && result.Status != interfaces.MigrationRepairStatusSucceeded {
+	if err := validateMigrationRepairResultStatus(result.Status); err != nil {
+		return err
+	}
+	if result.Status != interfaces.MigrationRepairStatusSucceeded {
 		return fmt.Errorf("migration repair finished with status %s", result.Status)
 	}
 	return nil
@@ -330,6 +333,8 @@ func redactMigrationRepairDiagnostics(diagnostics []interfaces.Diagnostic, secre
 	}
 	redacted := make([]interfaces.Diagnostic, 0, len(diagnostics))
 	for _, diagnostic := range diagnostics {
+		diagnostic.ID = redactMigrationRepairSecrets(diagnostic.ID, secrets)
+		diagnostic.Phase = redactMigrationRepairSecrets(diagnostic.Phase, secrets)
 		diagnostic.Cause = redactMigrationRepairSecrets(diagnostic.Cause, secrets)
 		diagnostic.Detail = redactMigrationRepairSecrets(diagnostic.Detail, secrets)
 		redacted = append(redacted, diagnostic)
@@ -351,4 +356,18 @@ func redactMigrationRepairError(err error, secrets map[string]string) error {
 		return nil
 	}
 	return fmt.Errorf("%s", redactMigrationRepairSecrets(err.Error(), secrets))
+}
+
+func validateMigrationRepairResultStatus(status string) error {
+	switch status {
+	case "":
+		return fmt.Errorf("empty migration repair status from provider")
+	case interfaces.MigrationRepairStatusSucceeded,
+		interfaces.MigrationRepairStatusFailed,
+		interfaces.MigrationRepairStatusApprovalRequired,
+		interfaces.MigrationRepairStatusUnsupported:
+		return nil
+	default:
+		return fmt.Errorf("unknown migration repair status %q from provider", status)
+	}
 }

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -73,10 +73,12 @@ func runMigrateRepairDirtyWithOutput(args []string, out io.Writer) error {
 
 Run a guarded dirty migration metadata repair inside a provider-managed runtime.
 
-Required guard flags for non-dev environments:
+Always required guard flags:
   --expected-dirty-version <version>
   --force-version <version>
   --confirm-force FORCE_MIGRATION_METADATA
+
+Additional approval required when destructive approval gating applies:
   --approve-destructive
 
 Options:
@@ -143,7 +145,7 @@ Options:
 	}
 	if result, err := requireDestructiveApproval(decision, approveDestructive, approvalArtifact); err != nil {
 		printMigrationRepairResult(out, result, nil)
-		_ = writeMigrationRepairSummary(result, envName, appName, nil)
+		_ = writeMigrationRepairSummary(result, envName, appSpec.Name, nil)
 		return err
 	}
 
@@ -158,7 +160,7 @@ Options:
 	if !ok {
 		result := &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusUnsupported}
 		printMigrationRepairResult(out, result, nil)
-		_ = writeMigrationRepairSummary(result, envName, appName, nil)
+		_ = writeMigrationRepairSummary(result, envName, appSpec.Name, nil)
 		return fmt.Errorf("provider %q does not support migration repair", appProviderType)
 	}
 
@@ -176,7 +178,7 @@ Options:
 		return redactMigrationRepairError(statusErr, jobEnvMap)
 	}
 	printMigrationRepairResult(out, result, jobEnvMap)
-	if summaryErr := writeMigrationRepairSummary(result, envName, appName, jobEnvMap); summaryErr != nil && err == nil {
+	if summaryErr := writeMigrationRepairSummary(result, envName, appSpec.Name, jobEnvMap); summaryErr != nil && err == nil {
 		err = summaryErr
 	}
 	if err != nil {

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -141,7 +141,7 @@ Options:
 		ForceVersion:         forceVersion,
 	}
 	if result, err := requireDestructiveApproval(decision, approveDestructive, approvalArtifact); err != nil {
-		printMigrationRepairResult(out, result)
+		printMigrationRepairResult(out, result, nil)
 		_ = writeMigrationRepairSummary(result, envName, appName, nil)
 		return err
 	}
@@ -156,7 +156,7 @@ Options:
 	repairer, ok := provider.(interfaces.ProviderMigrationRepairer)
 	if !ok {
 		result := &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusUnsupported}
-		printMigrationRepairResult(out, result)
+		printMigrationRepairResult(out, result, nil)
 		_ = writeMigrationRepairSummary(result, envName, appName, nil)
 		return fmt.Errorf("provider %q does not support migration repair", appProviderType)
 	}
@@ -171,12 +171,12 @@ Options:
 			result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusSucceeded}
 		}
 	}
-	printMigrationRepairResult(out, result)
+	printMigrationRepairResult(out, result, jobEnvMap)
 	if summaryErr := writeMigrationRepairSummary(result, envName, appName, jobEnvMap); summaryErr != nil && err == nil {
 		err = summaryErr
 	}
 	if err != nil {
-		return err
+		return redactMigrationRepairError(err, jobEnvMap)
 	}
 	if result.Status != "" && result.Status != interfaces.MigrationRepairStatusSucceeded {
 		return fmt.Errorf("migration repair finished with status %s", result.Status)
@@ -245,7 +245,7 @@ func collectMigrationRepairEnv(jobEnv, jobEnvFromEnv []string) (map[string]strin
 	return out, nil
 }
 
-func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepairResult) {
+func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepairResult, secrets map[string]string) {
 	if result == nil {
 		return
 	}
@@ -255,7 +255,7 @@ func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepai
 		fmt.Fprintf(out, "migration repair: %s\n", result.Status)
 	}
 	if strings.TrimSpace(result.Logs) != "" {
-		fmt.Fprintln(out, redactMigrationRepairSecrets(result.Logs, nil))
+		fmt.Fprintln(out, redactMigrationRepairSecrets(result.Logs, secrets))
 	}
 }
 
@@ -267,7 +267,7 @@ func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envNa
 	if outcome == "" {
 		outcome = "UNKNOWN"
 	}
-	diagnostics := result.Diagnostics
+	diagnostics := redactMigrationRepairDiagnostics(result.Diagnostics, secrets)
 	if result.Logs != "" {
 		diagnostics = append(diagnostics, interfaces.Diagnostic{
 			ID:     result.ProviderJobID,
@@ -292,6 +292,19 @@ func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envNa
 	})
 }
 
+func redactMigrationRepairDiagnostics(diagnostics []interfaces.Diagnostic, secrets map[string]string) []interfaces.Diagnostic {
+	if len(diagnostics) == 0 {
+		return nil
+	}
+	redacted := make([]interfaces.Diagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		diagnostic.Cause = redactMigrationRepairSecrets(diagnostic.Cause, secrets)
+		diagnostic.Detail = redactMigrationRepairSecrets(diagnostic.Detail, secrets)
+		redacted = append(redacted, diagnostic)
+	}
+	return redacted
+}
+
 func redactMigrationRepairSecrets(value string, secrets map[string]string) string {
 	for _, secret := range secrets {
 		if secret != "" {
@@ -299,4 +312,11 @@ func redactMigrationRepairSecrets(value string, secrets map[string]string) strin
 		}
 	}
 	return value
+}
+
+func redactMigrationRepairError(err error, secrets map[string]string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s", redactMigrationRepairSecrets(err.Error(), secrets))
 }

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+const migrationRepairOperation = "migration_repair_dirty"
+
+type stringListFlag []string
+
+func (s *stringListFlag) String() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(*s, ",")
+}
+
+func (s *stringListFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func runMigrateRepairDirty(args []string) error {
+	return runMigrateRepairDirtyWithOutput(args, os.Stdout)
+}
+
+func runMigrateRepairDirtyWithOutput(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("migrate repair-dirty", flag.ContinueOnError)
+	fs.SetOutput(out)
+	var cfgPath string
+	var envName string
+	var databaseName string
+	var appName string
+	var jobImage string
+	var sourceDir string
+	var expectedDirtyVersion string
+	var forceVersion string
+	var thenUp bool
+	var upIfClean bool
+	var confirmForce string
+	var approveDestructive bool
+	var approvalArtifact string
+	var timeout time.Duration
+	var jobEnv stringListFlag
+	var jobEnvFromEnv stringListFlag
+	fs.StringVar(&cfgPath, "config", "infra.yaml", "Infrastructure config file")
+	fs.StringVar(&envName, "env", "", "Environment name")
+	fs.StringVar(&databaseName, "database", "", "Database module name")
+	fs.StringVar(&appName, "app", "", "App/container service module name")
+	fs.StringVar(&jobImage, "job-image", "", "Migration job image")
+	fs.StringVar(&sourceDir, "source-dir", "/migrations", "Migration source directory in the job image")
+	fs.StringVar(&expectedDirtyVersion, "expected-dirty-version", "", "Dirty migration version expected before repair")
+	fs.StringVar(&forceVersion, "force-version", "", "Version to force migration metadata to before running pending migrations")
+	fs.BoolVar(&thenUp, "then-up", false, "Run pending migrations after metadata repair")
+	fs.BoolVar(&upIfClean, "up-if-clean", false, "Run pending migrations if database is already clean")
+	fs.StringVar(&confirmForce, "confirm-force", "", "Required confirmation string: FORCE_MIGRATION_METADATA")
+	fs.BoolVar(&approveDestructive, "approve-destructive", false, "Approve the destructive metadata repair operation")
+	fs.StringVar(&approvalArtifact, "approval-artifact", "", "Path to write destructive approval artifact")
+	fs.DurationVar(&timeout, "timeout", 10*time.Minute, "Provider job timeout")
+	fs.Var(&jobEnv, "job-env", "Environment variable for provider job as KEY=VALUE; repeatable")
+	fs.Var(&jobEnvFromEnv, "job-env-from-env", "Read environment variable from current process into provider job; repeatable")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage: wfctl migrate repair-dirty [options]
+
+Run a guarded dirty migration metadata repair inside a provider-managed runtime.
+
+Required guard flags:
+  --expected-dirty-version <version>
+  --force-version <version>
+  --confirm-force FORCE_MIGRATION_METADATA
+  --approve-destructive
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+
+	jobEnvMap, err := collectMigrationRepairEnv(jobEnv, jobEnvFromEnv)
+	if err != nil {
+		return err
+	}
+
+	appSpec, err := findMigrateRepairInfraSpecByName(cfgPath, envName, appName)
+	if err != nil {
+		return err
+	}
+	dbSpec, err := findMigrateRepairInfraSpecByName(cfgPath, envName, databaseName)
+	if err != nil {
+		return err
+	}
+	appProviderType, appProviderCfg, err := resolveProviderForSpec(cfgPath, envName, appSpec)
+	if err != nil {
+		return err
+	}
+	dbProviderType, _, err := resolveProviderForSpec(cfgPath, envName, dbSpec)
+	if err != nil {
+		return err
+	}
+	if appProviderType != dbProviderType {
+		return fmt.Errorf("app %q provider %q does not match database %q provider %q", appSpec.Name, appProviderType, dbSpec.Name, dbProviderType)
+	}
+
+	req := interfaces.MigrationRepairRequest{
+		AppResourceName:      appSpec.Name,
+		DatabaseResourceName: dbSpec.Name,
+		JobImage:             jobImage,
+		SourceDir:            sourceDir,
+		ExpectedDirtyVersion: expectedDirtyVersion,
+		ForceVersion:         forceVersion,
+		ThenUp:               thenUp,
+		UpIfClean:            upIfClean,
+		ConfirmForce:         confirmForce,
+		Env:                  jobEnvMap,
+		TimeoutSeconds:       int(timeout.Seconds()),
+	}
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	decision := destructiveDecision{
+		Operation:            migrationRepairOperation,
+		Env:                  envName,
+		App:                  appName,
+		Database:             databaseName,
+		ExpectedDirtyVersion: expectedDirtyVersion,
+		ForceVersion:         forceVersion,
+	}
+	if result, err := requireDestructiveApproval(decision, approveDestructive, approvalArtifact); err != nil {
+		printMigrationRepairResult(out, result)
+		_ = writeMigrationRepairSummary(result, envName, appName, nil)
+		return err
+	}
+
+	provider, closer, err := resolveIaCProvider(context.Background(), appProviderType, appProviderCfg)
+	if err != nil {
+		return fmt.Errorf("load provider %q: %w", appProviderType, err)
+	}
+	if closer != nil {
+		defer closer.Close() //nolint:errcheck // best-effort plugin shutdown
+	}
+	repairer, ok := provider.(interfaces.ProviderMigrationRepairer)
+	if !ok {
+		result := &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusUnsupported}
+		printMigrationRepairResult(out, result)
+		_ = writeMigrationRepairSummary(result, envName, appName, nil)
+		return fmt.Errorf("provider %q does not support migration repair", appProviderType)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	result, err := repairer.RepairDirtyMigration(ctx, req)
+	if result == nil {
+		if err != nil {
+			result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusFailed}
+		} else {
+			result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusSucceeded}
+		}
+	}
+	printMigrationRepairResult(out, result)
+	if summaryErr := writeMigrationRepairSummary(result, envName, appName, jobEnvMap); summaryErr != nil && err == nil {
+		err = summaryErr
+	}
+	if err != nil {
+		return err
+	}
+	if result.Status != "" && result.Status != interfaces.MigrationRepairStatusSucceeded {
+		return fmt.Errorf("migration repair finished with status %s", result.Status)
+	}
+	return nil
+}
+
+func findMigrateRepairInfraSpecByName(cfgFile, envName, name string) (interfaces.ResourceSpec, error) {
+	if strings.TrimSpace(name) == "" {
+		return interfaces.ResourceSpec{}, fmt.Errorf("infra resource name is required")
+	}
+	cfg, err := config.LoadFromFile(cfgFile)
+	if err != nil {
+		return interfaces.ResourceSpec{}, fmt.Errorf("load %s: %w", cfgFile, err)
+	}
+	for i := range cfg.Modules {
+		m := &cfg.Modules[i]
+		if !isInfraType(m.Type) {
+			continue
+		}
+		if envName == "" {
+			if m.Name == name {
+				r := &config.ResolvedModule{Name: m.Name, Type: m.Type, Config: config.ExpandEnvInMap(m.Config)}
+				return resourceSpecFromResolvedModule(r), nil
+			}
+			continue
+		}
+		resolved, ok := m.ResolveForEnv(envName)
+		if !ok {
+			continue
+		}
+		if m.Name == name || resolved.Name == name {
+			return resourceSpecFromResolvedModule(resolved), nil
+		}
+	}
+	if envName != "" {
+		return interfaces.ResourceSpec{}, fmt.Errorf("infra resource %q not found in %s for env %q", name, cfgFile, envName)
+	}
+	return interfaces.ResourceSpec{}, fmt.Errorf("infra resource %q not found in %s", name, cfgFile)
+}
+
+func collectMigrationRepairEnv(jobEnv, jobEnvFromEnv []string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, entry := range jobEnv {
+		key, value, ok := strings.Cut(entry, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("--job-env must be KEY=VALUE, got %q", entry)
+		}
+		out[key] = value
+	}
+	for _, key := range jobEnvFromEnv {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("--job-env-from-env requires a variable name")
+		}
+		value, ok := os.LookupEnv(key)
+		if !ok || value == "" {
+			return nil, fmt.Errorf("--job-env-from-env %s is not set", key)
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepairResult) {
+	if result == nil {
+		return
+	}
+	if result.ProviderJobID != "" {
+		fmt.Fprintf(out, "provider job %s: %s\n", result.ProviderJobID, result.Status)
+	} else if result.Status != "" {
+		fmt.Fprintf(out, "migration repair: %s\n", result.Status)
+	}
+	if strings.TrimSpace(result.Logs) != "" {
+		fmt.Fprintln(out, redactMigrationRepairSecrets(result.Logs, nil))
+	}
+}
+
+func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envName, appName string, secrets map[string]string) error {
+	if result == nil || os.Getenv("GITHUB_STEP_SUMMARY") == "" {
+		return nil
+	}
+	outcome := strings.ToUpper(result.Status)
+	if outcome == "" {
+		outcome = "UNKNOWN"
+	}
+	diagnostics := result.Diagnostics
+	if result.Logs != "" {
+		diagnostics = append(diagnostics, interfaces.Diagnostic{
+			ID:     result.ProviderJobID,
+			Phase:  result.Status,
+			Cause:  "migration repair logs",
+			Detail: redactMigrationRepairSecrets(result.Logs, secrets),
+		})
+	}
+	if len(diagnostics) == 0 && result.ProviderJobID != "" {
+		diagnostics = append(diagnostics, interfaces.Diagnostic{
+			ID:    result.ProviderJobID,
+			Phase: result.Status,
+			Cause: "provider job",
+		})
+	}
+	return WriteStepSummary(detectCIProvider(), SummaryInput{
+		Operation:   migrationRepairOperation,
+		Env:         envName,
+		Resource:    appName,
+		Outcome:     outcome,
+		Diagnostics: diagnostics,
+	})
+}
+
+func redactMigrationRepairSecrets(value string, secrets map[string]string) string {
+	for _, secret := range secrets {
+		if secret != "" {
+			value = strings.ReplaceAll(value, secret, "[REDACTED]")
+		}
+	}
+	return value
+}

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -172,10 +172,8 @@ Options:
 			result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusSucceeded}
 		}
 	}
-	if err == nil {
-		if statusErr := validateMigrationRepairResultStatus(result.Status); statusErr != nil {
-			return statusErr
-		}
+	if statusErr := validateMigrationRepairResultStatus(result.Status); statusErr != nil {
+		return redactMigrationRepairError(statusErr, jobEnvMap)
 	}
 	printMigrationRepairResult(out, result, jobEnvMap)
 	if summaryErr := writeMigrationRepairSummary(result, envName, appName, jobEnvMap); summaryErr != nil && err == nil {
@@ -286,10 +284,12 @@ func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepai
 	if result == nil {
 		return
 	}
+	providerJobID := redactMigrationRepairSecrets(result.ProviderJobID, secrets)
+	status := redactMigrationRepairSecrets(result.Status, secrets)
 	if result.ProviderJobID != "" {
-		fmt.Fprintf(out, "provider job %s: %s\n", result.ProviderJobID, result.Status)
+		fmt.Fprintf(out, "provider job %s: %s\n", providerJobID, status)
 	} else if result.Status != "" {
-		fmt.Fprintf(out, "migration repair: %s\n", result.Status)
+		fmt.Fprintf(out, "migration repair: %s\n", status)
 	}
 	if strings.TrimSpace(result.Logs) != "" {
 		fmt.Fprintln(out, redactMigrationRepairSecrets(result.Logs, secrets))

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+type migrationRepairProvider struct {
+	stateReturningProvider
+	called bool
+	req    interfaces.MigrationRepairRequest
+	result *interfaces.MigrationRepairResult
+	err    error
+}
+
+func (p *migrationRepairProvider) RepairDirtyMigration(_ context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
+	p.called = true
+	p.req = req
+	if p.result != nil || p.err != nil {
+		return p.result, p.err
+	}
+	return &interfaces.MigrationRepairResult{
+		ProviderJobID: "job-123",
+		Status:        interfaces.MigrationRepairStatusSucceeded,
+		Logs:          "repair complete",
+		Diagnostics: []interfaces.Diagnostic{{
+			ID:     "deploy-123",
+			Phase:  "ACTIVE",
+			Cause:  "job completed",
+			Detail: "repair complete",
+		}},
+	}, nil
+}
+
+func TestRunMigrateRepairDirtyResolvesEnvAndCallsProvider(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--then-up",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runMigrate repair-dirty: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("provider RepairDirtyMigration was not called")
+	}
+	if fake.req.AppResourceName != "bmw-staging" {
+		t.Fatalf("AppResourceName = %q, want env-resolved bmw-staging", fake.req.AppResourceName)
+	}
+	if fake.req.DatabaseResourceName != "bmw-staging-db" {
+		t.Fatalf("DatabaseResourceName = %q, want env-resolved bmw-staging-db", fake.req.DatabaseResourceName)
+	}
+	if !fake.req.ThenUp || fake.req.UpIfClean {
+		t.Fatalf("ThenUp/UpIfClean = %v/%v, want true/false", fake.req.ThenUp, fake.req.UpIfClean)
+	}
+	if !strings.Contains(out, "provider job job-123: succeeded") {
+		t.Fatalf("stdout = %q, want provider job status", out)
+	}
+}
+
+func TestRunMigrateRepairDirtyPropagatesJobEnv(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("DATABASE_URL", "postgres://secret")
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env", "PUBLIC_VALUE=visible",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runMigrate repair-dirty: %v", err)
+	}
+	if fake.req.Env["PUBLIC_VALUE"] != "visible" {
+		t.Fatalf("PUBLIC_VALUE env = %q", fake.req.Env["PUBLIC_VALUE"])
+	}
+	if fake.req.Env["DATABASE_URL"] != "postgres://secret" {
+		t.Fatalf("DATABASE_URL env was not propagated")
+	}
+}
+
+func TestRunMigrateRepairDirtyMissingEnvFromEnvFailsBeforeProvider(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("DATABASE_URL", "")
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected missing env error")
+	}
+	if fake.called {
+		t.Fatal("provider should not be called when --job-env-from-env is missing")
+	}
+	if !strings.Contains(err.Error(), "DATABASE_URL") {
+		t.Fatalf("error = %v, want missing env key", err)
+	}
+}
+
+func TestRunMigrateRepairDirtyRequiresApprovalForStaging(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeMigrateRepairInfraConfig(t, dir)
+	artifactPath := filepath.Join(dir, "approval.json")
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approval-artifact", artifactPath,
+		})
+	})
+	if err == nil {
+		t.Fatal("expected approval required error")
+	}
+	if fake.called {
+		t.Fatal("provider should not be called before approval")
+	}
+	if !strings.Contains(out, interfaces.MigrationRepairStatusApprovalRequired) {
+		t.Fatalf("stdout = %q, want approval_required status", out)
+	}
+	data, readErr := os.ReadFile(artifactPath)
+	if readErr != nil {
+		t.Fatalf("read artifact: %v", readErr)
+	}
+	for _, want := range []string{`"app":"bmw-app"`, `"database":"bmw-database"`, `"expected_dirty_version":"20260426000005"`, `"force_version":"20260422000001"`} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("artifact missing %s: %s", want, data)
+		}
+	}
+}
+
+func TestRunMigrateRepairDirtyReportsUnsupportedProvider(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	plain := &stateReturningProvider{}
+	restore := installMigrateRepairProvider(t, plain, "digitalocean")
+	defer restore()
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "dev",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+		})
+	})
+	if err == nil {
+		t.Fatal("expected unsupported provider error")
+	}
+	if !strings.Contains(out, interfaces.MigrationRepairStatusUnsupported) {
+		t.Fatalf("stdout = %q, want unsupported status", out)
+	}
+}
+
+func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeMigrateRepairInfraConfig(t, dir)
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--then-up",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runMigrate repair-dirty: %v", err)
+	}
+	summary, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read summary: %v", readErr)
+	}
+	for _, want := range []string{"migration_repair_dirty", "staging", "job-123", "succeeded", "repair complete"} {
+		if !strings.Contains(string(summary), want) {
+			t.Fatalf("summary missing %q:\n%s", want, summary)
+		}
+	}
+}
+
+func writeMigrateRepairInfraConfig(t *testing.T, dir string) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+environments:
+  staging:
+    provider: digitalocean
+    region: nyc3
+  dev:
+    provider: digitalocean
+    region: nyc3
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: test-token
+  - name: bmw-database
+    type: infra.database
+    config:
+      provider: do-provider
+      name: base-db
+    environments:
+      staging:
+        config:
+          name: bmw-staging-db
+      dev:
+        config:
+          name: bmw-dev-db
+  - name: bmw-app
+    type: infra.container_service
+    config:
+      provider: do-provider
+      name: base-app
+    environments:
+      staging:
+        config:
+          name: bmw-staging
+      dev:
+        config:
+          name: bmw-dev
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}
+
+func installMigrateRepairProvider(t *testing.T, provider interfaces.IaCProvider, wantProviderType string) func() {
+	t.Helper()
+	orig := resolveIaCProvider
+	resolveIaCProvider = func(_ context.Context, providerType string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+		if providerType != wantProviderType {
+			t.Fatalf("providerType = %q, want %q", providerType, wantProviderType)
+		}
+		return provider, nil, nil
+	}
+	return func() { resolveIaCProvider = orig }
+}
+
+func captureMigrateRepairStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+		_ = r.Close()
+	}()
+
+	runErr := fn()
+	_ = w.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String(), runErr
+}
+
+var _ interfaces.ProviderMigrationRepairer = (*migrationRepairProvider)(nil)
+
+func TestRunMigrateRepairDirtyHelp(t *testing.T) {
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{"repair-dirty", "--help"})
+	})
+	if err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	for _, want := range []string{"--expected-dirty-version", "--force-version", "--confirm-force", "--approve-destructive"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("help missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunMigrateRepairDirtyRejectsInvalidJobEnv(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "dev",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--job-env", "missing-equals",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected invalid --job-env error")
+	}
+	if !strings.Contains(fmt.Sprint(err), "KEY=VALUE") {
+		t.Fatalf("error = %v, want KEY=VALUE guidance", err)
+	}
+}

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -701,10 +701,13 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("read summary: %v", readErr)
 	}
-	for _, want := range []string{"migration_repair_dirty", "staging", "SUCCESS", "[REDACTED]", "succeeded", "repair complete"} {
+	for _, want := range []string{"migration_repair_dirty", "staging", "SUCCESS", "**Resource:** bmw-staging", "[REDACTED]", "succeeded", "repair complete"} {
 		if !strings.Contains(string(summary), want) {
 			t.Fatalf("summary missing %q:\n%s", want, summary)
 		}
+	}
+	if strings.Contains(string(summary), "**Resource:** bmw-app") {
+		t.Fatalf("summary used CLI app alias instead of resolved resource:\n%s", summary)
 	}
 	if strings.Contains(string(summary), secret) {
 		t.Fatalf("summary leaked secret:\n%s", summary)
@@ -825,8 +828,10 @@ func TestRunMigrateRepairDirtyHelp(t *testing.T) {
 			t.Fatalf("help missing %q:\n%s", want, out)
 		}
 	}
-	if !strings.Contains(out, "Required guard flags for non-dev environments") {
-		t.Fatalf("help missing non-dev approval guidance:\n%s", out)
+	for _, want := range []string{"Always required guard flags", "Additional approval required when destructive approval gating applies"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("help missing %q guidance:\n%s", want, out)
+		}
 	}
 }
 

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -562,6 +562,9 @@ func TestRunMigrateRepairDirtyHelp(t *testing.T) {
 			t.Fatalf("help missing %q:\n%s", want, out)
 		}
 	}
+	if !strings.Contains(out, "Required guard flags for non-dev environments") {
+		t.Fatalf("help missing non-dev approval guidance:\n%s", out)
+	}
 }
 
 func TestRunMigrateRepairDirtyRejectsInvalidJobEnv(t *testing.T) {

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -267,6 +267,46 @@ func TestRunMigrateRepairDirtyPropagatesJobEnv(t *testing.T) {
 	}
 }
 
+func TestRunMigrateRepairDirtyRedactsJobIDFromStdout(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	secret := "postgres://job-secret"
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-" + secret,
+			Status:        interfaces.MigrationRepairStatusSucceeded,
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("DATABASE_URL", secret)
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runMigrate repair-dirty: %v", err)
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("stdout leaked job ID secret: %q", out)
+	}
+	if !strings.Contains(out, "job-[REDACTED]") {
+		t.Fatalf("stdout = %q, want redacted job ID", out)
+	}
+}
+
 func TestRunMigrateRepairDirtyRedactsJobEnvFromProviderError(t *testing.T) {
 	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
 	secret := "postgres://error-secret"
@@ -388,6 +428,52 @@ func TestRunMigrateRepairDirtyRejectsSecretBearingProviderStatusBeforeSummary(t 
 			ProviderJobID: "job-123",
 			Status:        "failed-" + secret,
 		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected unknown provider status error")
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("stdout leaked secret status: %q", out)
+	}
+	if _, readErr := os.ReadFile(summaryPath); !os.IsNotExist(readErr) {
+		t.Fatalf("summary should not be written before status validation, read err = %v", readErr)
+	}
+}
+
+func TestRunMigrateRepairDirtyRejectsProviderErrorResultStatusBeforeOutput(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeMigrateRepairInfraConfig(t, dir)
+	summaryPath := filepath.Join(dir, "summary.md")
+	secret := "postgres://error-status-secret"
+	t.Setenv("DATABASE_URL", secret)
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        "failed-" + secret,
+		},
+		err: fmt.Errorf("provider failed"),
 	}
 	restore := installMigrateRepairProvider(t, fake, "digitalocean")
 	defer restore()

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -81,6 +81,138 @@ func TestRunMigrateRepairDirtyResolvesEnvAndCallsProvider(t *testing.T) {
 	}
 }
 
+func TestRunMigrateRepairDirtyUsesCanonicalEnvDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+environments:
+  staging:
+    provider: do-provider
+    region: nyc3
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: test-token
+  - name: bmw-database
+    type: infra.database
+    config:
+      name: base-db
+    environments:
+      staging:
+        config:
+          name: bmw-staging-db
+  - name: bmw-app
+    type: infra.container_service
+    config:
+      name: base-app
+    environments:
+      staging:
+        config:
+          name: bmw-staging
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--then-up",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runMigrate repair-dirty: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("provider RepairDirtyMigration was not called")
+	}
+	if fake.req.AppResourceName != "bmw-staging" || fake.req.DatabaseResourceName != "bmw-staging-db" {
+		t.Fatalf("request resources = %q/%q, want canonical env-resolved names", fake.req.AppResourceName, fake.req.DatabaseResourceName)
+	}
+}
+
+func TestRunMigrateRepairDirtyRejectsDifferentProviderRefsWithSameType(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+environments:
+  staging:
+    region: nyc3
+modules:
+  - name: do-provider-app
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: app-token
+  - name: do-provider-db
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: db-token
+  - name: bmw-database
+    type: infra.database
+    config:
+      provider: do-provider-db
+      name: base-db
+    environments:
+      staging:
+        config:
+          name: bmw-staging-db
+  - name: bmw-app
+    type: infra.container_service
+    config:
+      provider: do-provider-app
+      name: base-app
+    environments:
+      staging:
+        config:
+          name: bmw-staging
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--then-up",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected provider ref mismatch error")
+	}
+	if fake.called {
+		t.Fatal("provider should not be called for mismatched provider refs")
+	}
+	if !strings.Contains(err.Error(), "same provider module") {
+		t.Fatalf("error = %v, want provider module mismatch guidance", err)
+	}
+}
+
 func TestRunMigrateRepairDirtyPropagatesJobEnv(t *testing.T) {
 	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
 	secret := "postgres://secret"
@@ -457,5 +589,37 @@ func TestRunMigrateRepairDirtyRejectsInvalidJobEnv(t *testing.T) {
 	}
 	if !strings.Contains(fmt.Sprint(err), "KEY=VALUE") {
 		t.Fatalf("error = %v, want KEY=VALUE guidance", err)
+	}
+}
+
+func TestRunMigrateRepairDirtyRejectsInvalidJobEnvWithoutLeakingValue(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	secret := "postgres://parse-secret"
+	fake := &migrationRepairProvider{}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "dev",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--job-env", "=" + secret,
+		})
+	})
+	if err == nil {
+		t.Fatal("expected invalid --job-env error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked secret: %v", err)
+	}
+	if fake.called {
+		t.Fatal("provider should not be called for invalid --job-env")
 	}
 }

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -304,6 +304,73 @@ func TestRunMigrateRepairDirtyRedactsJobEnvFromProviderError(t *testing.T) {
 	}
 }
 
+func TestRunMigrateRepairDirtyRejectsEmptyProviderStatus(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected empty provider status error")
+	}
+	if !strings.Contains(err.Error(), "empty migration repair status") {
+		t.Fatalf("error = %v, want empty status guidance", err)
+	}
+}
+
+func TestRunMigrateRepairDirtyRejectsUnknownProviderStatus(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        "paused",
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected unknown provider status error")
+	}
+	if !strings.Contains(err.Error(), "unknown migration repair status") {
+		t.Fatalf("error = %v, want unknown status guidance", err)
+	}
+}
+
 func TestRunMigrateRepairDirtyMissingEnvFromEnvFailsBeforeProvider(t *testing.T) {
 	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
 	fake := &migrationRepairProvider{}
@@ -421,8 +488,8 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 			Status:        interfaces.MigrationRepairStatusSucceeded,
 			Logs:          "repair complete for postgres://summary-secret",
 			Diagnostics: []interfaces.Diagnostic{{
-				ID:     "deploy-123",
-				Phase:  "ACTIVE",
+				ID:     "deploy-postgres://summary-secret",
+				Phase:  "ACTIVE-postgres://summary-secret",
 				Cause:  "job used postgres://summary-secret",
 				Detail: "repair complete for postgres://summary-secret",
 			}},

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -348,7 +348,7 @@ func TestRunMigrateRepairDirtyRejectsUnknownProviderStatus(t *testing.T) {
 	restore := installMigrateRepairProvider(t, fake, "digitalocean")
 	defer restore()
 
-	_, err := captureMigrateRepairStdout(t, func() error {
+	out, err := captureMigrateRepairStdout(t, func() error {
 		return runMigrate([]string{
 			"repair-dirty",
 			"--config", cfgPath,
@@ -368,6 +368,54 @@ func TestRunMigrateRepairDirtyRejectsUnknownProviderStatus(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown migration repair status") {
 		t.Fatalf("error = %v, want unknown status guidance", err)
+	}
+	if strings.Contains(out, "paused") {
+		t.Fatalf("stdout emitted invalid status before validation: %q", out)
+	}
+}
+
+func TestRunMigrateRepairDirtyRejectsSecretBearingProviderStatusBeforeSummary(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeMigrateRepairInfraConfig(t, dir)
+	summaryPath := filepath.Join(dir, "summary.md")
+	secret := "postgres://status-secret"
+	t.Setenv("DATABASE_URL", secret)
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        "failed-" + secret,
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected unknown provider status error")
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("stdout leaked secret status: %q", out)
+	}
+	if _, readErr := os.ReadFile(summaryPath); !os.IsNotExist(readErr) {
+		t.Fatalf("summary should not be written before status validation, read err = %v", readErr)
 	}
 }
 
@@ -484,7 +532,7 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	t.Setenv("DATABASE_URL", secret)
 	fake := &migrationRepairProvider{
 		result: &interfaces.MigrationRepairResult{
-			ProviderJobID: "job-123",
+			ProviderJobID: "job-postgres://summary-secret",
 			Status:        interfaces.MigrationRepairStatusSucceeded,
 			Logs:          "repair complete for postgres://summary-secret",
 			Diagnostics: []interfaces.Diagnostic{{
@@ -521,7 +569,7 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("read summary: %v", readErr)
 	}
-	for _, want := range []string{"migration_repair_dirty", "staging", "job-123", "succeeded", "repair complete"} {
+	for _, want := range []string{"migration_repair_dirty", "staging", "[REDACTED]", "succeeded", "repair complete"} {
 		if !strings.Contains(string(summary), want) {
 			t.Fatalf("summary missing %q:\n%s", want, summary)
 		}

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -83,12 +83,25 @@ func TestRunMigrateRepairDirtyResolvesEnvAndCallsProvider(t *testing.T) {
 
 func TestRunMigrateRepairDirtyPropagatesJobEnv(t *testing.T) {
 	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
-	fake := &migrationRepairProvider{}
+	secret := "postgres://secret"
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        interfaces.MigrationRepairStatusSucceeded,
+			Logs:          "connected to postgres://secret and repaired",
+			Diagnostics: []interfaces.Diagnostic{{
+				ID:     "deploy-123",
+				Phase:  "ACTIVE",
+				Cause:  "job used postgres://secret",
+				Detail: "repair complete for postgres://secret",
+			}},
+		},
+	}
 	restore := installMigrateRepairProvider(t, fake, "digitalocean")
 	defer restore()
-	t.Setenv("DATABASE_URL", "postgres://secret")
+	t.Setenv("DATABASE_URL", secret)
 
-	_, err := captureMigrateRepairStdout(t, func() error {
+	out, err := captureMigrateRepairStdout(t, func() error {
 		return runMigrate([]string{
 			"repair-dirty",
 			"--config", cfgPath,
@@ -111,8 +124,51 @@ func TestRunMigrateRepairDirtyPropagatesJobEnv(t *testing.T) {
 	if fake.req.Env["PUBLIC_VALUE"] != "visible" {
 		t.Fatalf("PUBLIC_VALUE env = %q", fake.req.Env["PUBLIC_VALUE"])
 	}
-	if fake.req.Env["DATABASE_URL"] != "postgres://secret" {
+	if fake.req.Env["DATABASE_URL"] != secret {
 		t.Fatalf("DATABASE_URL env was not propagated")
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("stdout leaked secret: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("stdout = %q, want redacted secret marker", out)
+	}
+}
+
+func TestRunMigrateRepairDirtyRedactsJobEnvFromProviderError(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	secret := "postgres://error-secret"
+	fake := &migrationRepairProvider{
+		err: fmt.Errorf("migration failed while connecting to %s", secret),
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("DATABASE_URL", secret)
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected provider error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked secret: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error = %v, want redacted marker", err)
 	}
 }
 
@@ -225,7 +281,21 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
 	t.Setenv("GITHUB_ACTIONS", "true")
 	t.Setenv("WFCTL_ALLOW_TEST_STEP_SUMMARY", "true")
-	fake := &migrationRepairProvider{}
+	secret := "postgres://summary-secret"
+	t.Setenv("DATABASE_URL", secret)
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        interfaces.MigrationRepairStatusSucceeded,
+			Logs:          "repair complete for postgres://summary-secret",
+			Diagnostics: []interfaces.Diagnostic{{
+				ID:     "deploy-123",
+				Phase:  "ACTIVE",
+				Cause:  "job used postgres://summary-secret",
+				Detail: "repair complete for postgres://summary-secret",
+			}},
+		},
+	}
 	restore := installMigrateRepairProvider(t, fake, "digitalocean")
 	defer restore()
 
@@ -242,6 +312,7 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 			"--then-up",
 			"--confirm-force", interfaces.MigrationRepairConfirmation,
 			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
 		})
 	})
 	if err != nil {
@@ -255,6 +326,12 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 		if !strings.Contains(string(summary), want) {
 			t.Fatalf("summary missing %q:\n%s", want, summary)
 		}
+	}
+	if strings.Contains(string(summary), secret) {
+		t.Fatalf("summary leaked secret:\n%s", summary)
+	}
+	if !strings.Contains(string(summary), "[REDACTED]") {
+		t.Fatalf("summary missing redacted secret marker:\n%s", summary)
 	}
 }
 

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -307,6 +307,42 @@ func TestRunMigrateRepairDirtyRedactsJobIDFromStdout(t *testing.T) {
 	}
 }
 
+func TestRunMigrateRepairDirtyPropagatesEmptyJobEnvFromEnv(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        interfaces.MigrationRepairStatusSucceeded,
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("EMPTY_ALLOWED", "")
+
+	_, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--up-if-clean",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "EMPTY_ALLOWED",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runMigrate repair-dirty: %v", err)
+	}
+	if got, ok := fake.req.Env["EMPTY_ALLOWED"]; !ok || got != "" {
+		t.Fatalf("EMPTY_ALLOWED env = %q, present %v; want empty value propagated", got, ok)
+	}
+}
+
 func TestRunMigrateRepairDirtyRedactsJobEnvFromProviderError(t *testing.T) {
 	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
 	secret := "postgres://error-secret"
@@ -510,7 +546,17 @@ func TestRunMigrateRepairDirtyMissingEnvFromEnvFailsBeforeProvider(t *testing.T)
 	fake := &migrationRepairProvider{}
 	restore := installMigrateRepairProvider(t, fake, "digitalocean")
 	defer restore()
-	t.Setenv("DATABASE_URL", "")
+	original, hadOriginal := os.LookupEnv("DATABASE_URL")
+	if err := os.Unsetenv("DATABASE_URL"); err != nil {
+		t.Fatalf("unset DATABASE_URL: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadOriginal {
+			_ = os.Setenv("DATABASE_URL", original)
+		} else {
+			_ = os.Unsetenv("DATABASE_URL")
+		}
+	})
 
 	_, err := captureMigrateRepairStdout(t, func() error {
 		return runMigrate([]string{
@@ -655,7 +701,7 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("read summary: %v", readErr)
 	}
-	for _, want := range []string{"migration_repair_dirty", "staging", "[REDACTED]", "succeeded", "repair complete"} {
+	for _, want := range []string{"migration_repair_dirty", "staging", "SUCCESS", "[REDACTED]", "succeeded", "repair complete"} {
 		if !strings.Contains(string(summary), want) {
 			t.Fatalf("summary missing %q:\n%s", want, summary)
 		}
@@ -665,6 +711,22 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	}
 	if !strings.Contains(string(summary), "[REDACTED]") {
 		t.Fatalf("summary missing redacted secret marker:\n%s", summary)
+	}
+}
+
+func TestMigrationRepairSummaryOutcomeMapsNonSuccessToFailed(t *testing.T) {
+	for _, status := range []string{
+		interfaces.MigrationRepairStatusFailed,
+		interfaces.MigrationRepairStatusApprovalRequired,
+		interfaces.MigrationRepairStatusUnsupported,
+		"",
+	} {
+		if got := migrationRepairSummaryOutcome(status); got != "FAILED" {
+			t.Fatalf("migrationRepairSummaryOutcome(%q) = %q, want FAILED", status, got)
+		}
+	}
+	if got := migrationRepairSummaryOutcome(interfaces.MigrationRepairStatusSucceeded); got != "SUCCESS" {
+		t.Fatalf("migrationRepairSummaryOutcome(succeeded) = %q, want SUCCESS", got)
 	}
 }
 

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -822,6 +822,7 @@ wfctl migrate <subcommand> [options]
 | `status` | Show applied and pending migrations |
 | `diff` | Show pending migration SQL without applying |
 | `apply` | Apply all pending migrations |
+| `repair-dirty` | Repair a known dirty migration metadata state through an IaC provider job |
 
 **Examples:**
 
@@ -830,6 +831,43 @@ wfctl migrate status --db workflow.db
 wfctl migrate diff --db workflow.db
 wfctl migrate apply --db workflow.db
 ```
+
+#### `migrate repair-dirty`
+
+Run a guarded dirty migration repair inside a provider-managed runtime, such as
+an App Platform job or cloud task that already has database access. This avoids
+opening managed databases to CI runner IP ranges.
+
+```bash
+wfctl migrate repair-dirty --config infra.yaml --env staging \
+  --database app-db \
+  --app app-service \
+  --job-image registry.example.com/app-migrate:${IMAGE_SHA} \
+  --expected-dirty-version 20260426000005 \
+  --force-version 20260422000001 \
+  --then-up \
+  --confirm-force FORCE_MIGRATION_METADATA \
+  --approve-destructive
+```
+
+Required guard flags:
+
+| Flag | Description |
+|------|-------------|
+| `--expected-dirty-version` | Dirty version that must be present before repair |
+| `--force-version` | Version to force metadata to before replaying migrations |
+| `--confirm-force` | Must be `FORCE_MIGRATION_METADATA` |
+| `--approve-destructive` | Explicitly approves the metadata repair |
+
+For non-dev environments, omitting `--approve-destructive` writes an approval
+artifact and exits before provider invocation. The artifact defaults to
+`$RUNNER_TEMP/wfctl-destructive-approval.json` on GitHub Actions or
+`./wfctl-destructive-approval.json` elsewhere. Use `--approval-artifact` to set
+an explicit path.
+
+Pass provider job environment values with repeatable `--job-env KEY=VALUE` or
+`--job-env-from-env KEY`. Use `--job-env-from-env` for secrets; wfctl redacts
+those values from command output and GitHub step summaries.
 
 ---
 

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -857,7 +857,7 @@ Required guard flags:
 | `--expected-dirty-version` | Dirty version that must be present before repair |
 | `--force-version` | Version to force metadata to before replaying migrations |
 | `--confirm-force` | Must be `FORCE_MIGRATION_METADATA` |
-| `--approve-destructive` | Explicitly approves the metadata repair |
+| `--approve-destructive` | Explicitly approves the metadata repair; required for non-dev environments |
 
 For non-dev environments, omitting `--approve-destructive` writes an approval
 artifact and exits before provider invocation. The artifact defaults to

--- a/docs/manual/build-deploy/03-ci-deploy-environments.md
+++ b/docs/manual/build-deploy/03-ci-deploy-environments.md
@@ -84,6 +84,43 @@ For environments with `requireApproval: true`, an `environment: <name>` key is a
 
 ---
 
+## Conditional Human Gate for Destructive Operations
+
+Some operational commands are only destructive under specific conditions. For
+example, `wfctl migrate repair-dirty` changes migration metadata only when a
+known dirty version is present. Use GitHub environment protection on the repair
+job, not on every deploy job, when you only want human review for that repair.
+
+```yaml
+repair-staging-migrations:
+  environment: staging
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: GoCodeAlone/setup-wfctl@v1
+    - run: |
+        wfctl migrate repair-dirty --config infra.yaml --env staging \
+          --database app-db \
+          --app app-service \
+          --job-image "registry.example.com/app-migrate:${IMAGE_SHA}" \
+          --expected-dirty-version 20260426000005 \
+          --force-version 20260422000001 \
+          --then-up \
+          --confirm-force FORCE_MIGRATION_METADATA \
+          --approve-destructive \
+          --job-env-from-env DATABASE_URL
+      env:
+        DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+```
+
+Without `--approve-destructive`, wfctl writes a JSON approval artifact and exits
+with status `approval_required` before calling the provider. On GitHub Actions,
+the default artifact path is `$RUNNER_TEMP/wfctl-destructive-approval.json`.
+When `GITHUB_STEP_SUMMARY` is set, wfctl also writes the operation, environment,
+provider job status, diagnostics, and log tail to the run summary.
+
+---
+
 ## `environments.local` (dev overrides)
 
 The special `local` environment is used by `wfctl dev up` and applies build overrides for fast iteration:

--- a/docs/plans/2026-04-27-wfctl-provider-migration-repair-design.md
+++ b/docs/plans/2026-04-27-wfctl-provider-migration-repair-design.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: approved
 area: wfctl
 owner: workflow
 implementation_refs: []

--- a/docs/plans/2026-04-27-wfctl-provider-migration-repair-design.md
+++ b/docs/plans/2026-04-27-wfctl-provider-migration-repair-design.md
@@ -43,7 +43,7 @@ wfctl migrate repair-dirty --env staging --config infra.yaml \
   --app bmw-app \
   --job-image registry.digitalocean.com/bmw-registry/workflow-migrate:${IMAGE_SHA} \
   --expected-dirty-version 20260426000005 \
-  --force-version 20260426000004 \
+  --force-version <known-safe-version-before-replay> \
   --then-up \
   --confirm-force FORCE_MIGRATION_METADATA
 ```
@@ -82,7 +82,7 @@ type MigrationRepairRequest struct {
     ForceVersion          string            `json:"force_version"`
     ThenUp                bool              `json:"then_up"`
     UpIfClean             bool              `json:"up_if_clean"`
-    Confirmation          string            `json:"confirmation"`
+    ConfirmForce          string            `json:"confirm_force"`
     Env                   map[string]string `json:"env,omitempty"`
     TimeoutSeconds        int               `json:"timeout_seconds,omitempty"`
 }
@@ -122,7 +122,12 @@ The command:
 
 ### DigitalOcean Plugin
 
-DigitalOcean implements `ProviderMigrationRepairer` by using App Platform jobs:
+DigitalOcean implements `ProviderMigrationRepairer` by using App Platform jobs.
+The official App Platform docs describe jobs as app-spec components that can run
+before or after deployments, and describe adding a job through `doctl apps
+update` or the `PUT /v2/apps/{id}` API. They also expose job invocations and
+logs through App Platform job-invocation APIs. The plugin should use those
+provider-native surfaces rather than opening the database to the caller.
 
 1. Resolve the App Platform app by env-resolved resource name (`bmw-staging`).
 2. Resolve the database URI from provider output or caller-provided env secret.
@@ -143,6 +148,17 @@ DigitalOcean implements `ProviderMigrationRepairer` by using App Platform jobs:
 
 If DigitalOcean cannot run a true ad hoc job without changing app spec, the first implementation may apply a temporary `POST_DEPLOY` or `PRE_DEPLOY` job mutation with a generated job name, deploy it, collect the result, and restore the previous app spec. That path must be treated as a destructive provider operation because it mutates app spec, even if temporary.
 
+The provider result must distinguish:
+
+- `succeeded`: repair command exited zero.
+- `failed`: provider job reached a terminal failed state or exited non-zero.
+- `approval_required`: wfctl stopped before provider invocation.
+- `unsupported`: provider plugin does not implement the capability.
+
+The result diagnostics must include the provider app ID, deployment ID when
+available, job invocation ID when available, terminal phase, component name, and
+a log tail suitable for CI summaries.
+
 ## Human Gate
 
 For `staging`, the command may run with `--approve-destructive` from a GitHub environment-gated job. For `prod`, wfctl should default to requiring a CI approval artifact:
@@ -152,28 +168,59 @@ For `staging`, the command may run with `--approve-destructive` from a GitHub en
   "operation": "migration_repair_dirty",
   "env": "prod",
   "database": "bmw-database",
+  "app": "bmw-app",
   "expected_dirty_version": "20260426000005",
   "force_version": "20260426000004",
   "requires_approval": true
 }
 ```
 
-In GitHub Actions, BMW can bind that job to an environment with required reviewers. In other CI systems, wfctl still emits the same artifact and exits with a clear "approval required" status unless `--approve-destructive` is present.
+In GitHub Actions, BMW can bind that job to an environment with required reviewers. In other CI systems, wfctl still emits the same artifact and exits with a clear "approval required" status unless `--approve-destructive` is present. If the caller omits `--approval-artifact`, wfctl writes a default JSON artifact to `$RUNNER_TEMP/wfctl-destructive-approval.json` when running under GitHub Actions, otherwise `./wfctl-destructive-approval.json`.
+
+The CLI must also be able to pass provider runtime environment values into the
+job request without hardcoding a CI provider. It accepts repeatable
+`--job-env KEY=VALUE` flags and `--job-env-from-env KEY` flags. `--job-env` is
+for non-secret values that are safe in shell history; `--job-env-from-env`
+reads a local environment variable and stores only the key/value in the
+in-memory request. wfctl must redact these values in all logs and summaries.
+
+wfctl also writes a GitHub step summary when `GITHUB_STEP_SUMMARY` is set. The
+summary must be terse and operator-oriented: operation, environment, approval
+state, provider app/job/deployment IDs, terminal status, and the final log tail.
+
+If wfctl stops before provider execution, it should still produce a structured
+result/status for automation:
+
+- Missing human approval: status `approval_required`, exit non-zero, artifact written.
+- Provider does not implement repair capability: status `unsupported`, exit non-zero.
+- Provider runs and fails: status `failed`, exit non-zero with diagnostics.
+- Provider runs and succeeds: status `succeeded`, exit zero.
 
 ## BMW Adoption
 
-BMW keeps the current temporary pre-deploy repair until staging is clean. After the platform feature ships:
+BMW keeps the current temporary pre-deploy repair until staging is clean. The
+safe force target is the newest migration version before any missing prerequisite
+that must be replayed; for example, if the dirty migration alters a table that
+should have been created by an earlier idempotent migration, the force target
+must be before that table-creation migration. After the platform feature ships:
 
 1. Replace `.github/workflows/migration-repair.yml` runner-side `psql` with `wfctl migrate repair-dirty`.
 2. Gate the repair job with the `staging` environment.
 3. Remove the temporary staging `infra.yaml` repair `run_command` after one successful repair and deploy.
 4. Keep normal pre-deploy migrations as `workflow-migrate up --source-dir /migrations`.
 
+Shipping this through BMW requires a cross-repo release sequence:
+
+1. Merge Workflow core support and release a new Workflow/wfctl version.
+2. Update and release `workflow-plugin-digitalocean` against that Workflow interface.
+3. Update BMW setup-wfctl, workflow server image, plugin registry/lockfile, and any workflow-plugin-digitalocean pin to consume the releases.
+4. Merge BMW adoption and verify staging then prod deploy.
+
 ## Acceptance Criteria
 
 - Running `wfctl migrate repair-dirty --help` documents the required guard flags and provider execution behavior.
 - A fake provider test proves wfctl resolves app/database modules for an env and calls `RepairDirtyMigration` with the expected request.
-- A non-dev destructive run without approval emits an approval artifact and does not call the provider.
-- DigitalOcean unit tests prove the provider builds the expected repair command and returns job logs/diagnostics.
+- A non-dev destructive run without approval emits an approval artifact at the default path and does not call the provider.
+- wfctl writes a GitHub step summary when `GITHUB_STEP_SUMMARY` is set.
+- DigitalOcean unit tests prove the provider builds the expected repair command, mutates/restores app spec only when necessary, and returns job logs/diagnostics.
 - BMW staging can repair dirty version `20260426000005` without opening database ingress to GitHub-hosted runners.
-

--- a/docs/plans/2026-04-27-wfctl-provider-migration-repair-design.md
+++ b/docs/plans/2026-04-27-wfctl-provider-migration-repair-design.md
@@ -1,0 +1,179 @@
+---
+status: proposed
+area: wfctl
+owner: workflow
+implementation_refs: []
+external_refs:
+  - https://docs.digitalocean.com/products/app-platform/how-to/manage-jobs/
+  - https://docs.digitalocean.com/products/app-platform/reference/api/
+verification:
+  last_checked:
+  commands: []
+  result:
+supersedes: []
+superseded_by: []
+---
+
+# wfctl Provider-Executed Migration Repair — Design
+
+**Status:** Approved for autonomous design/plan pipeline, 2026-04-27
+
+**Goal:** Add a dogfooded `wfctl migrate repair-dirty` path that can repair a known dirty migration state from inside the provider trust boundary, without exposing managed databases to GitHub-hosted runners or ad hoc operator SQL.
+
+**Why:** BMW staging hit a dirty migration version (`20260426000005`). The existing GitHub Actions repair workflow had the correct guard logic, but it timed out connecting to the DigitalOcean managed database because the database correctly trusts only the App Platform app. Running repair from the CI runner would require opening database ingress to public runner IPs; running it as an App Platform job keeps database access in the same boundary as normal deploy-time migrations.
+
+---
+
+## Requirements
+
+1. **Provider-trusted execution:** migration repair commands run from a provider workload that already has database access, such as a DigitalOcean App Platform job trusted by managed-DB firewall rules.
+2. **Guarded destructive metadata changes:** dirty repair requires the expected dirty version, the force target version, and a typed confirmation. Non-dev environments must have a human-gate mode available before execution.
+3. **Portable wfctl surface:** users invoke a wfctl command, not provider-specific scripts. Provider-specific details live behind plugin interfaces.
+4. **Immediate BMW path:** BMW can repair staging dirty version `20260426000005`, continue migrations, and then return to normal `migrate up`.
+5. **No broad DB ingress workaround:** do not add GitHub runner IPs or `0.0.0.0/0` trusted database sources as the default answer.
+6. **Auditable output:** command output includes the provider job/deployment ID, status, log tail, and a GitHub step summary when running in CI.
+
+## Recommended Approach
+
+Introduce a provider-executed operation behind wfctl:
+
+```sh
+wfctl migrate repair-dirty --env staging --config infra.yaml \
+  --database bmw-database \
+  --app bmw-app \
+  --job-image registry.digitalocean.com/bmw-registry/workflow-migrate:${IMAGE_SHA} \
+  --expected-dirty-version 20260426000005 \
+  --force-version 20260426000004 \
+  --then-up \
+  --confirm-force FORCE_MIGRATION_METADATA
+```
+
+wfctl resolves the env-aware infra config and loads the relevant IaC provider. It asks the provider to run a one-shot migration job using the target app/container service as the network and secret boundary. On DigitalOcean, the plugin updates or creates a temporary App Platform job/deployment using the existing app spec shape and polls it to terminal status, returning logs and phase diagnostics.
+
+This keeps wfctl as the lifecycle orchestrator while letting the DigitalOcean plugin own App Platform mechanics. Other providers can later implement the same interface with ECS one-off tasks, Cloud Run jobs, Kubernetes jobs, or Azure Container Apps jobs.
+
+## Alternatives Considered
+
+### A. Open database access to GitHub Actions
+
+Fast for BMW, but weak security. GitHub-hosted runner IP ranges are large and change, and allowing public ingress undermines the current `trusted_sources: type: app` model. Reject as default.
+
+### B. Keep temporary pre-deploy repair in app config only
+
+This works immediately when a deploy succeeds far enough for the pre-deploy job to run. It is not ergonomic or auditable: operators must edit app config, merge, deploy, then remember to revert. Keep it as an emergency fallback, not the platform answer.
+
+### C. Provider-executed wfctl migration operation
+
+Recommended. It is secure by default, portable by interface, and dogfoods Workflow/wfctl. It also creates a reusable foundation for other guarded one-shot operational actions.
+
+## Architecture
+
+### Core Interfaces
+
+Add an optional provider capability in `interfaces`:
+
+```go
+type MigrationRepairRequest struct {
+    AppResourceName       string            `json:"app_resource_name"`
+    DatabaseResourceName  string            `json:"database_resource_name"`
+    JobImage              string            `json:"job_image"`
+    SourceDir             string            `json:"source_dir"`
+    ExpectedDirtyVersion  string            `json:"expected_dirty_version"`
+    ForceVersion          string            `json:"force_version"`
+    ThenUp                bool              `json:"then_up"`
+    UpIfClean             bool              `json:"up_if_clean"`
+    Confirmation          string            `json:"confirmation"`
+    Env                   map[string]string `json:"env,omitempty"`
+    TimeoutSeconds        int               `json:"timeout_seconds,omitempty"`
+}
+
+type MigrationRepairResult struct {
+    ProviderJobID string       `json:"provider_job_id,omitempty"`
+    Status        string       `json:"status"`
+    Applied       []string     `json:"applied,omitempty"`
+    Logs          string       `json:"logs,omitempty"`
+    Diagnostics   []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type ProviderMigrationRepairer interface {
+    RepairDirtyMigration(ctx context.Context, req MigrationRepairRequest) (*MigrationRepairResult, error)
+}
+```
+
+The interface is optional. wfctl probes for it over the same plugin service dispatch pattern used by other optional provider capabilities.
+
+### wfctl Command
+
+Extend `wfctl migrate` with a provider-aware branch:
+
+```text
+wfctl migrate repair-dirty --config infra.yaml --env staging --database bmw-database --app bmw-app ...
+```
+
+The command:
+
+1. Resolves `infra.yaml` for the selected env.
+2. Loads the `iac.provider` referenced by the app/database resources.
+3. Validates that the database and app use the same provider.
+4. Requires `--confirm-force FORCE_MIGRATION_METADATA` for metadata repair.
+5. For non-dev envs, emits a destructive-operation decision artifact and can require an explicit `--approve-destructive` flag or CI environment gate before execution.
+6. Calls `ProviderMigrationRepairer.RepairDirtyMigration`.
+7. Emits logs, diagnostics, and step summary.
+
+### DigitalOcean Plugin
+
+DigitalOcean implements `ProviderMigrationRepairer` by using App Platform jobs:
+
+1. Resolve the App Platform app by env-resolved resource name (`bmw-staging`).
+2. Resolve the database URI from provider output or caller-provided env secret.
+3. Build a job command:
+
+```sh
+/workflow-migrate repair-dirty \
+  --source-dir /migrations \
+  --expected-dirty-version <version> \
+  --force-version <version> \
+  --confirm-force FORCE_MIGRATION_METADATA \
+  --then-up
+```
+
+4. Create a temporary App Platform deployment/job using the app's existing network boundary and env vars.
+5. Poll until the job succeeds or fails.
+6. Return deployment/job ID, log tail, and diagnostics.
+
+If DigitalOcean cannot run a true ad hoc job without changing app spec, the first implementation may apply a temporary `POST_DEPLOY` or `PRE_DEPLOY` job mutation with a generated job name, deploy it, collect the result, and restore the previous app spec. That path must be treated as a destructive provider operation because it mutates app spec, even if temporary.
+
+## Human Gate
+
+For `staging`, the command may run with `--approve-destructive` from a GitHub environment-gated job. For `prod`, wfctl should default to requiring a CI approval artifact:
+
+```json
+{
+  "operation": "migration_repair_dirty",
+  "env": "prod",
+  "database": "bmw-database",
+  "expected_dirty_version": "20260426000005",
+  "force_version": "20260426000004",
+  "requires_approval": true
+}
+```
+
+In GitHub Actions, BMW can bind that job to an environment with required reviewers. In other CI systems, wfctl still emits the same artifact and exits with a clear "approval required" status unless `--approve-destructive` is present.
+
+## BMW Adoption
+
+BMW keeps the current temporary pre-deploy repair until staging is clean. After the platform feature ships:
+
+1. Replace `.github/workflows/migration-repair.yml` runner-side `psql` with `wfctl migrate repair-dirty`.
+2. Gate the repair job with the `staging` environment.
+3. Remove the temporary staging `infra.yaml` repair `run_command` after one successful repair and deploy.
+4. Keep normal pre-deploy migrations as `workflow-migrate up --source-dir /migrations`.
+
+## Acceptance Criteria
+
+- Running `wfctl migrate repair-dirty --help` documents the required guard flags and provider execution behavior.
+- A fake provider test proves wfctl resolves app/database modules for an env and calls `RepairDirtyMigration` with the expected request.
+- A non-dev destructive run without approval emits an approval artifact and does not call the provider.
+- DigitalOcean unit tests prove the provider builds the expected repair command and returns job logs/diagnostics.
+- BMW staging can repair dirty version `20260426000005` without opening database ingress to GitHub-hosted runners.
+

--- a/docs/plans/2026-04-27-wfctl-provider-migration-repair.md
+++ b/docs/plans/2026-04-27-wfctl-provider-migration-repair.md
@@ -1,6 +1,6 @@
 # wfctl Provider-Executed Migration Repair Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Implementation note:** Execute this plan task-by-task and validate each step before proceeding.
 
 **Goal:** Add `wfctl migrate repair-dirty` so guarded dirty migration repairs run inside provider-managed trusted runtime boundaries instead of from CI runners.
 

--- a/docs/plans/2026-04-27-wfctl-provider-migration-repair.md
+++ b/docs/plans/2026-04-27-wfctl-provider-migration-repair.md
@@ -1,0 +1,366 @@
+# wfctl Provider-Executed Migration Repair Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `wfctl migrate repair-dirty` so guarded dirty migration repairs run inside provider-managed trusted runtime boundaries instead of from CI runners.
+
+**Architecture:** wfctl resolves env-aware app/database infra modules, applies destructive-operation gating, and calls an optional provider interface. The first provider implementation target is DigitalOcean App Platform via `workflow-plugin-digitalocean`; Workflow core owns the CLI, request/result types, remote dispatch plumbing, and tests.
+
+**Tech Stack:** Go 1.26, wfctl, Workflow `interfaces`, external plugin gRPC service dispatch, DigitalOcean App Platform jobs/deployments, GitHub Actions step summaries.
+
+---
+
+### Task 1: Add Core Migration Repair Interface Types
+
+**Files:**
+- Create: `interfaces/migration_repair.go`
+- Test: `interfaces/migration_repair_test.go`
+
+**Step 1: Write the failing interface validation tests**
+
+Create tests for `MigrationRepairRequest.Validate()`:
+
+```go
+func TestMigrationRepairRequestValidateRequiresGuardFields(t *testing.T) {
+    req := interfaces.MigrationRepairRequest{
+        AppResourceName:      "bmw-app",
+        DatabaseResourceName: "bmw-database",
+        JobImage:             "registry.example/workflow-migrate:sha",
+        SourceDir:            "/migrations",
+    }
+    err := req.Validate()
+    if err == nil {
+        t.Fatal("expected validation error")
+    }
+    for _, want := range []string{"expected_dirty_version", "force_version", "confirm_force"} {
+        if !strings.Contains(err.Error(), want) {
+            t.Fatalf("error %q missing %q", err, want)
+        }
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `GOWORK=off go test ./interfaces -run TestMigrationRepairRequest -count=1`
+
+Expected: FAIL because `MigrationRepairRequest` is undefined.
+
+**Step 3: Add types and validation**
+
+Define:
+
+```go
+type MigrationRepairRequest struct {
+    AppResourceName      string            `json:"app_resource_name"`
+    DatabaseResourceName string            `json:"database_resource_name"`
+    JobImage             string            `json:"job_image"`
+    SourceDir            string            `json:"source_dir"`
+    ExpectedDirtyVersion string            `json:"expected_dirty_version"`
+    ForceVersion         string            `json:"force_version"`
+    ThenUp               bool              `json:"then_up"`
+    UpIfClean            bool              `json:"up_if_clean"`
+    ConfirmForce         string            `json:"confirm_force"`
+    Env                  map[string]string `json:"env,omitempty"`
+    TimeoutSeconds       int               `json:"timeout_seconds,omitempty"`
+}
+
+type MigrationRepairResult struct {
+    ProviderJobID string       `json:"provider_job_id,omitempty"`
+    Status        string       `json:"status"`
+    Applied       []string     `json:"applied,omitempty"`
+    Logs          string       `json:"logs,omitempty"`
+    Diagnostics   []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type ProviderMigrationRepairer interface {
+    RepairDirtyMigration(ctx context.Context, req MigrationRepairRequest) (*MigrationRepairResult, error)
+}
+```
+
+`Validate()` must require app, database, job image, source dir, expected dirty version, force version, and `ConfirmForce == "FORCE_MIGRATION_METADATA"`.
+
+**Step 4: Run tests**
+
+Run: `GOWORK=off go test ./interfaces -run TestMigrationRepairRequest -count=1`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add interfaces/migration_repair.go interfaces/migration_repair_test.go
+git commit -m "feat(interfaces): add migration repair request contract"
+```
+
+### Task 2: Add wfctl Destructive Operation Gate
+
+**Files:**
+- Create: `cmd/wfctl/destructive_gate.go`
+- Test: `cmd/wfctl/destructive_gate_test.go`
+
+**Step 1: Write failing gate tests**
+
+Add tests covering:
+
+- `staging` without `--approve-destructive` returns approval-required and writes JSON.
+- `prod` without approval returns approval-required.
+- `dev` executes without explicit approval.
+- `staging` with approval executes.
+
+Use a temp file path for the artifact and assert it contains `"operation":"migration_repair_dirty"`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestDestructiveGate -count=1`
+
+Expected: FAIL because helper is undefined.
+
+**Step 3: Implement gate helper**
+
+Add:
+
+```go
+type destructiveDecision struct {
+    Operation string `json:"operation"`
+    Env string `json:"env"`
+    Resource string `json:"resource,omitempty"`
+    RequiresApproval bool `json:"requires_approval"`
+}
+
+func requireDestructiveApproval(envName, operation, resource string, approved bool, artifactPath string) error
+```
+
+Rules:
+
+- `envName` in `dev`, `local`, `test` does not require approval.
+- Any other env requires approval unless `approved == true`.
+- If approval is missing and `artifactPath != ""`, write the JSON decision before returning an error that includes `approval required`.
+
+**Step 4: Run tests**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestDestructiveGate -count=1`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add cmd/wfctl/destructive_gate.go cmd/wfctl/destructive_gate_test.go
+git commit -m "feat(wfctl): add destructive operation approval gate"
+```
+
+### Task 3: Extend Provider Remote Dispatch
+
+**Files:**
+- Modify: `cmd/wfctl/deploy_providers.go`
+- Test: `cmd/wfctl/deploy_providers_remote_iac_test.go`
+- Modify: `plugin/grpc` files if strict proto service dispatch requires a method entry
+
+**Step 1: Write failing remote dispatch test**
+
+In the remote IaC provider tests, create a fake invoker that captures:
+
+```go
+method == "IaCProvider.RepairDirtyMigration"
+args["request"].(map[string]any)["expected_dirty_version"] == "20260426000005"
+```
+
+Call `remoteIaCProvider.RepairDirtyMigration(ctx, interfaces.MigrationRepairRequest{...})`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestRemoteIaCProvider_RepairDirtyMigration -count=1`
+
+Expected: FAIL because method is undefined.
+
+**Step 3: Implement remote method**
+
+Add method to `remoteIaCProvider`:
+
+```go
+func (r *remoteIaCProvider) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error)
+```
+
+Use `jsonToAny(req)`, invoke `"IaCProvider.RepairDirtyMigration"`, decode into `MigrationRepairResult`.
+
+If strict proto dispatch requires allowlisting, add it in the same task with a test that unregistered methods still fail.
+
+**Step 4: Run tests**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run 'TestRemoteIaCProvider_RepairDirtyMigration|TestRemoteIaCProvider' -count=1`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add cmd/wfctl/deploy_providers.go cmd/wfctl/deploy_providers_remote_iac_test.go plugin/grpc
+git commit -m "feat(wfctl): dispatch provider migration repair calls"
+```
+
+### Task 4: Implement `wfctl migrate repair-dirty`
+
+**Files:**
+- Modify: `cmd/wfctl/migrate.go`
+- Create: `cmd/wfctl/migrate_repair.go`
+- Test: `cmd/wfctl/migrate_repair_test.go`
+
+**Step 1: Write failing CLI tests**
+
+Use temp `infra.yaml` with:
+
+- `iac.provider` named `do-provider`
+- `infra.database` named `bmw-database`, env override `bmw-staging-db`
+- `infra.container_service` named `bmw-app`, env override `bmw-staging`
+
+Inject a fake provider through `resolveIaCProvider` that implements `ProviderMigrationRepairer`.
+
+Test:
+
+```go
+err := runMigrate([]string{
+  "repair-dirty",
+  "--config", cfgPath,
+  "--env", "staging",
+  "--database", "bmw-database",
+  "--app", "bmw-app",
+  "--job-image", "registry.example/workflow-migrate:sha",
+  "--expected-dirty-version", "20260426000005",
+  "--force-version", "20260426000004",
+  "--then-up",
+  "--confirm-force", "FORCE_MIGRATION_METADATA",
+  "--approve-destructive",
+})
+```
+
+Assert the fake provider received `AppResourceName == "bmw-staging"` and `DatabaseResourceName == "bmw-staging-db"`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestRunMigrateRepairDirty -count=1`
+
+Expected: FAIL because subcommand is unknown.
+
+**Step 3: Implement CLI**
+
+Add `repair-dirty` branch before SQLite DB opening, like `plugins`.
+
+Flags:
+
+- `--config`
+- `--env`
+- `--database`
+- `--app`
+- `--job-image`
+- `--source-dir` default `/migrations`
+- `--expected-dirty-version`
+- `--force-version`
+- `--then-up`
+- `--up-if-clean`
+- `--confirm-force`
+- `--approve-destructive`
+- `--approval-artifact`
+- `--timeout` default `10m`
+
+Implementation must:
+
+1. Parse env-resolved infra modules using existing helpers.
+2. Find app/database modules by base or env-resolved name.
+3. Validate both reference the same provider.
+4. Load that provider via `resolveIaCProvider`.
+5. Type-assert `interfaces.ProviderMigrationRepairer`.
+6. Run the destructive gate.
+7. Call provider and print `provider job <id>: <status>`.
+8. Print logs if returned.
+
+**Step 4: Run focused tests**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestRunMigrateRepairDirty -count=1`
+
+Expected: PASS.
+
+**Step 5: Run representative CLI help**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestRunMigrateRepairDirtyHelp -count=1`
+
+Expected: PASS and help output contains `--expected-dirty-version`, `--force-version`, and `--approve-destructive`.
+
+**Step 6: Commit**
+
+```bash
+git add cmd/wfctl/migrate.go cmd/wfctl/migrate_repair.go cmd/wfctl/migrate_repair_test.go
+git commit -m "feat(wfctl): add provider-executed migration repair command"
+```
+
+### Task 5: Document DigitalOcean Provider Contract
+
+**Files:**
+- Modify: `docs/WFCTL.md`
+- Modify: `docs/manual/build-deploy/03-ci-deploy-environments.md`
+- Create: `docs/plans/2026-04-27-wfctl-provider-migration-repair-bmw.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- why repair runs through provider-managed jobs
+- required guard flags
+- GitHub Actions environment gating example
+- BMW staging example command
+
+**Step 2: Verify docs render paths and command names**
+
+Run: `rg -n "migrate repair-dirty|approve-destructive|FORCE_MIGRATION_METADATA" docs cmd/wfctl`
+
+Expected: At least one match in `docs/WFCTL.md`, one in manual docs, one in CLI code/tests.
+
+**Step 3: Commit**
+
+```bash
+git add docs/WFCTL.md docs/manual/build-deploy/03-ci-deploy-environments.md docs/plans/2026-04-27-wfctl-provider-migration-repair-bmw.md
+git commit -m "docs(wfctl): document provider-executed migration repair"
+```
+
+### Task 6: Platform Integration Verification
+
+**Files:**
+- No source changes unless prior tasks reveal gaps.
+
+**Step 1: Run package tests**
+
+Run: `GOWORK=off go test ./interfaces ./cmd/wfctl -count=1`
+
+Expected: PASS.
+
+**Step 2: Run representative full wfctl test slice**
+
+Run: `GOWORK=off go test ./cmd/wfctl -run 'TestRunMigrateRepairDirty|TestRemoteIaCProvider_RepairDirtyMigration|TestDestructiveGate|TestInfraApply_EnvFlagResolvesOverrides' -count=1`
+
+Expected: PASS.
+
+**Step 3: Run CLI help manually**
+
+Run: `GOWORK=off go run ./cmd/wfctl migrate repair-dirty --help`
+
+Expected: exit 0 and help shows `--expected-dirty-version`, `--force-version`, `--confirm-force`, and `--approve-destructive`.
+
+**Step 4: Commit only if verification fixes were needed**
+
+If no fixes were needed, do not create an empty commit.
+
+### Task 7: Hand Off DigitalOcean Plugin Implementation
+
+**Files:**
+- No edits in this Workflow repo.
+
+**Step 1: Create follow-up implementation issue or plan in `workflow-plugin-digitalocean`**
+
+The DO plugin must implement `ProviderMigrationRepairer` after the Workflow interface lands. The implementation plan should cover App Platform job/deployment mechanics, log collection, and restoration if temporary app spec mutation is required.
+
+**Step 2: Verify issue/plan reference**
+
+Run: `rg -n "ProviderMigrationRepairer|RepairDirtyMigration|migration repair" docs/plans`
+
+Expected: the follow-up plan exists and references the Workflow PR/commit.
+

--- a/docs/plans/2026-04-27-wfctl-provider-migration-repair.md
+++ b/docs/plans/2026-04-27-wfctl-provider-migration-repair.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add `wfctl migrate repair-dirty` so guarded dirty migration repairs run inside provider-managed trusted runtime boundaries instead of from CI runners.
 
-**Architecture:** wfctl resolves env-aware app/database infra modules, applies destructive-operation gating, and calls an optional provider interface. The first provider implementation target is DigitalOcean App Platform via `workflow-plugin-digitalocean`; Workflow core owns the CLI, request/result types, remote dispatch plumbing, and tests.
+**Architecture:** wfctl resolves env-aware app/database infra modules, applies destructive-operation gating, and calls an optional provider interface. The first provider implementation target is DigitalOcean App Platform via `workflow-plugin-digitalocean`; Workflow core owns the CLI, request/result types, remote dispatch plumbing, CI summaries, and tests. The DigitalOcean plugin owns App Platform job/spec mechanics and diagnostics. BMW owns adoption/removal of temporary app-config repair once the platform path exists.
 
 **Tech Stack:** Go 1.26, wfctl, Workflow `interfaces`, external plugin gRPC service dispatch, DigitalOcean App Platform jobs/deployments, GitHub Actions step summaries.
 
@@ -103,8 +103,11 @@ git commit -m "feat(interfaces): add migration repair request contract"
 
 Add tests covering:
 
-- `staging` without `--approve-destructive` returns approval-required and writes JSON.
-- `prod` without approval returns approval-required.
+- `staging` without `--approve-destructive` returns approval-required and writes JSON to an explicit artifact path.
+- `staging` without `--approve-destructive` and without an explicit artifact writes the default local artifact `wfctl-destructive-approval.json`.
+- `prod` without approval returns approval-required and writes the default artifact.
+- `GITHUB_ACTIONS=true` + `RUNNER_TEMP=<tmp>` defaults the artifact to `<tmp>/wfctl-destructive-approval.json`.
+- approval artifact JSON includes `operation`, `env`, `app`, `database`, `expected_dirty_version`, `force_version`, and `requires_approval`.
 - `dev` executes without explicit approval.
 - `staging` with approval executes.
 
@@ -124,18 +127,23 @@ Add:
 type destructiveDecision struct {
     Operation string `json:"operation"`
     Env string `json:"env"`
-    Resource string `json:"resource,omitempty"`
+    App string `json:"app,omitempty"`
+    Database string `json:"database,omitempty"`
+    ExpectedDirtyVersion string `json:"expected_dirty_version,omitempty"`
+    ForceVersion string `json:"force_version,omitempty"`
     RequiresApproval bool `json:"requires_approval"`
 }
 
-func requireDestructiveApproval(envName, operation, resource string, approved bool, artifactPath string) error
+func requireDestructiveApproval(decision destructiveDecision, approved bool, artifactPath string) (*interfaces.MigrationRepairResult, error)
 ```
 
 Rules:
 
 - `envName` in `dev`, `local`, `test` does not require approval.
 - Any other env requires approval unless `approved == true`.
-- If approval is missing and `artifactPath != ""`, write the JSON decision before returning an error that includes `approval required`.
+- If approval is missing, write the JSON decision before returning `MigrationRepairResult{Status: "approval_required"}` and an error that includes `approval required`.
+- If `artifactPath == ""` and `GITHUB_ACTIONS=true` with `RUNNER_TEMP` set, use `$RUNNER_TEMP/wfctl-destructive-approval.json`.
+- Otherwise use `wfctl-destructive-approval.json` in the current working directory.
 
 **Step 4: Run tests**
 
@@ -272,7 +280,8 @@ Implementation must:
 5. Type-assert `interfaces.ProviderMigrationRepairer`.
 6. Run the destructive gate.
 7. Call provider and print `provider job <id>: <status>`.
-8. Print logs if returned.
+8. Print diagnostics and logs if returned.
+9. Write a GitHub step summary when `GITHUB_STEP_SUMMARY` is set. The summary must include operation, environment, approval status, provider job/deployment IDs, terminal status, and log tail.
 
 **Step 4: Run focused tests**
 
@@ -286,19 +295,55 @@ Run: `GOWORK=off go test ./cmd/wfctl -run TestRunMigrateRepairDirtyHelp -count=1
 
 Expected: PASS and help output contains `--expected-dirty-version`, `--force-version`, and `--approve-destructive`.
 
-**Step 6: Commit**
+**Step 6: Add step-summary tests**
+
+Add `TestRunMigrateRepairDirtyWritesGitHubStepSummary` with temp
+`GITHUB_STEP_SUMMARY`. Assert the summary includes:
+
+- `migration_repair_dirty`
+- selected environment
+- provider job/deployment ID
+- terminal status
+- log tail
+
+Run: `GOWORK=off go test ./cmd/wfctl -run TestRunMigrateRepairDirtyWritesGitHubStepSummary -count=1`
+
+Expected: PASS.
+
+**Step 7: Add env propagation and structured status tests**
+
+Add tests covering:
+
+- `--job-env FOO=bar` places `Env["FOO"] == "bar"` in `MigrationRepairRequest`.
+- `--job-env-from-env DATABASE_URL` reads the process env and places the value in `Env`.
+- missing env for `--job-env-from-env` fails before provider invocation.
+- provider missing `ProviderMigrationRepairer` returns/prints status `unsupported`.
+- missing approval returns/prints status `approval_required` and does not call provider.
+
+Implementation adds flags:
+
+- `--job-env KEY=VALUE`, repeatable.
+- `--job-env-from-env KEY`, repeatable.
+
+wfctl must redact request env values from stdout, stderr, errors, logs, and
+GitHub step summary.
+
+Run: `GOWORK=off go test ./cmd/wfctl -run 'TestRunMigrateRepairDirty.*(Env|Unsupported|Approval)' -count=1`
+
+Expected: PASS.
+
+**Step 8: Commit**
 
 ```bash
 git add cmd/wfctl/migrate.go cmd/wfctl/migrate_repair.go cmd/wfctl/migrate_repair_test.go
 git commit -m "feat(wfctl): add provider-executed migration repair command"
 ```
 
-### Task 5: Document DigitalOcean Provider Contract
+### Task 5: Document Workflow Provider Contract
 
 **Files:**
 - Modify: `docs/WFCTL.md`
 - Modify: `docs/manual/build-deploy/03-ci-deploy-environments.md`
-- Create: `docs/plans/2026-04-27-wfctl-provider-migration-repair-bmw.md`
 
 **Step 1: Update docs**
 
@@ -307,7 +352,8 @@ Document:
 - why repair runs through provider-managed jobs
 - required guard flags
 - GitHub Actions environment gating example
-- BMW staging example command
+- generic env-aware app/database example command
+- default approval artifact and GitHub step summary behavior
 
 **Step 2: Verify docs render paths and command names**
 
@@ -318,7 +364,7 @@ Expected: At least one match in `docs/WFCTL.md`, one in manual docs, one in CLI 
 **Step 3: Commit**
 
 ```bash
-git add docs/WFCTL.md docs/manual/build-deploy/03-ci-deploy-environments.md docs/plans/2026-04-27-wfctl-provider-migration-repair-bmw.md
+git add docs/WFCTL.md docs/manual/build-deploy/03-ci-deploy-environments.md
 git commit -m "docs(wfctl): document provider-executed migration repair"
 ```
 
@@ -349,18 +395,180 @@ Expected: exit 0 and help shows `--expected-dirty-version`, `--force-version`, `
 
 If no fixes were needed, do not create an empty commit.
 
-### Task 7: Hand Off DigitalOcean Plugin Implementation
+### Task 7: Implement DigitalOcean Provider Capability
+
+**Repository:** `/Users/jon/workspace/workflow-plugin-digitalocean`
 
 **Files:**
-- No edits in this Workflow repo.
+- Modify: `internal/module_instance.go`
+- Create: `internal/provider_migration_repair.go`
+- Test: `internal/provider_migration_repair_test.go`
+- Modify: `internal/grpc_dispatch_test.go`
+- Modify: `internal/drivers/app_platform.go` or create an app-job helper if the existing driver boundary is a better fit.
+- Test: `internal/drivers/app_platform_migration_repair_test.go`
 
-**Step 1: Create follow-up implementation issue or plan in `workflow-plugin-digitalocean`**
+**Step 1: Create an isolated plugin worktree after the Workflow interface lands**
 
-The DO plugin must implement `ProviderMigrationRepairer` after the Workflow interface lands. The implementation plan should cover App Platform job/deployment mechanics, log collection, and restoration if temporary app spec mutation is required.
+Use a branch like `feat/provider-migration-repair`. Do not edit the dirty root
+checkout. Update `go.mod` to the Workflow commit/release containing
+`ProviderMigrationRepairer` or use a temporary local `replace` only during
+development.
 
-**Step 2: Verify issue/plan reference**
+**Step 2: Write failing dispatch tests**
 
-Run: `rg -n "ProviderMigrationRepairer|RepairDirtyMigration|migration repair" docs/plans`
+Add a test proving `InvokeMethod("IaCProvider.RepairDirtyMigration", ...)`
+decodes `request`, calls a fake provider implementing the optional interface,
+and encodes `MigrationRepairResult`.
 
-Expected: the follow-up plan exists and references the Workflow PR/commit.
+Run: `GOWORK=off go test ./internal -run TestGRPCDispatch_IaCProvider_RepairDirtyMigration -count=1`
 
+Expected: FAIL before dispatch support exists.
+
+**Step 3: Implement `InvokeMethod` dispatch**
+
+Add `IaCProvider.RepairDirtyMigration` to the switch and return a clear
+unsupported error when the provider does not implement
+`interfaces.ProviderMigrationRepairer`.
+
+Run the focused dispatch test until PASS.
+
+**Step 4: Write failing App Platform command/spec tests**
+
+Tests must prove the provider:
+
+- resolves an App Platform app by resource/app name
+- builds `/workflow-migrate repair-dirty` with source dir, expected dirty version, force version, confirmation, and `--then-up`/`--up-if-clean`
+- injects caller env without logging secret values
+- adds a generated one-shot job name that cannot collide with declared jobs
+- uses official App Platform job/spec behavior: app spec update plus deployment/job invocation polling if a true ad hoc job endpoint is unavailable
+- restores the previous app spec after terminal success or failure when it mutated spec
+- returns app ID, deployment ID, job invocation ID when available, terminal status, diagnostics, and log tail
+
+Run: `GOWORK=off go test ./internal ./internal/drivers -run 'RepairDirtyMigration|MigrationRepair' -count=1`
+
+Expected: FAIL before implementation.
+
+**Step 5: Implement App Platform repair**
+
+Use existing App Platform client abstractions where possible. If godo exposes
+job invocations/log APIs, add them to the narrow client interface. If not, add a
+small HTTP client adapter for the documented endpoints while keeping it behind
+the driver interface for tests.
+
+Implementation rules:
+
+- Never open database trusted sources.
+- Never print env secret values.
+- Treat app-spec mutation as destructive and return diagnostics if restore fails.
+- Poll with context timeout and return the final known deployment/job state on timeout.
+- Prefer job invocation logs; fall back to deployment diagnostics/log tail when invocation logs are unavailable.
+
+**Step 6: Run plugin tests**
+
+Run: `GOWORK=off go test ./internal ./internal/drivers -count=1`
+
+Expected: PASS.
+
+**Step 7: Commit plugin changes**
+
+```bash
+git add internal go.mod go.sum
+git commit -m "feat(do): run migration repair via App Platform jobs"
+```
+
+### Task 8: Release Workflow Core
+
+**Repository:** `/Users/jon/workspace/workflow`
+
+**Files:**
+- Release metadata according to the existing Workflow release process.
+
+**Step 1: Merge Workflow implementation PR**
+
+After code review, Copilot comments, and CI are clean, admin squash merge the
+Workflow PR.
+
+**Step 2: Generate and verify release**
+
+Use the repository's existing release process to tag a new Workflow/wfctl
+version containing `ProviderMigrationRepairer` and `wfctl migrate repair-dirty`.
+
+Verify:
+
+- GitHub release workflow succeeds.
+- `setup-wfctl` can install the new version.
+- `wfctl migrate repair-dirty --help` works from the released binary.
+
+### Task 9: Release DigitalOcean Plugin
+
+**Repository:** `/Users/jon/workspace/workflow-plugin-digitalocean`
+
+**Step 1: Merge plugin implementation PR**
+
+After Workflow release is available, update the plugin dependency to that
+version, ensure CI is green, resolve comments, and admin squash merge.
+
+**Step 2: Generate plugin release**
+
+Use the plugin's existing release process to publish a version containing
+`IaCProvider.RepairDirtyMigration`.
+
+Verify the plugin registry metadata and platform lockfile checksums reference
+the released artifacts, not local or platform-specific top-level hashes.
+
+### Task 10: BMW Adoption Plan
+
+**Repository:** `/Users/jon/workspace/buymywishlist`
+
+**Files:**
+- Modify: `.github/workflows/migration-repair.yml`
+- Modify: `infra.yaml`
+- Modify: docs under `docs/ops/` if present
+- Test: existing config/migration tests
+
+**Step 1: Bump released dependencies**
+
+Update:
+
+- setup-wfctl/workflow version pins to the Workflow release from Task 8.
+- workflow-plugin-digitalocean registry/lockfile pins to the plugin release from Task 9.
+- Any app/deploy image base references that still point at older alpha labels.
+
+Run `wfctl plugin lock` or the repo's lockfile refresh command so BMW consumes
+release artifacts through lockfiles rather than explicit GitHub workflow plugin
+installs.
+
+**Step 2: Replace runner-side DB repair**
+
+After Workflow and DigitalOcean plugin releases are available, update the BMW
+migration repair workflow to call:
+
+```bash
+wfctl migrate repair-dirty --env staging --config infra.yaml \
+  --database bmw-database \
+  --app bmw-app \
+  --job-image "registry.digitalocean.com/bmw-registry/workflow-migrate:${IMAGE_SHA}" \
+  --expected-dirty-version 20260426000005 \
+  --force-version 20260422000001 \
+  --then-up \
+  --confirm-force FORCE_MIGRATION_METADATA \
+  --approve-destructive
+```
+
+Use GitHub environment gating for staging/prod approval. Keep force-version
+selection explicit; it must be before the earliest missing prerequisite that
+needs replay.
+
+**Step 3: Remove temporary pre-deploy repair after staging is clean**
+
+Once one provider-executed repair succeeds and normal deploy migration has run,
+remove the temporary staging `run_command` from `infra.yaml` so the image CMD
+returns to normal `workflow-migrate up --source-dir /migrations`.
+
+**Step 4: Verify BMW**
+
+Run:
+
+- `GOWORK=off go test ./bmwplugin/...`
+- `wfctl validate --skip-unknown-types app.yaml`
+- GitHub staging deploy, then prod deploy.

--- a/interfaces/migration_repair.go
+++ b/interfaces/migration_repair.go
@@ -1,0 +1,78 @@
+package interfaces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	MigrationRepairConfirmation = "FORCE_MIGRATION_METADATA"
+
+	MigrationRepairStatusSucceeded        = "succeeded"
+	MigrationRepairStatusFailed           = "failed"
+	MigrationRepairStatusApprovalRequired = "approval_required"
+	MigrationRepairStatusUnsupported      = "unsupported"
+)
+
+type MigrationRepairRequest struct {
+	AppResourceName      string            `json:"app_resource_name"`
+	DatabaseResourceName string            `json:"database_resource_name"`
+	JobImage             string            `json:"job_image"`
+	SourceDir            string            `json:"source_dir"`
+	ExpectedDirtyVersion string            `json:"expected_dirty_version"`
+	ForceVersion         string            `json:"force_version"`
+	ThenUp               bool              `json:"then_up"`
+	UpIfClean            bool              `json:"up_if_clean"`
+	ConfirmForce         string            `json:"confirm_force"`
+	Env                  map[string]string `json:"env,omitempty"`
+	TimeoutSeconds       int               `json:"timeout_seconds,omitempty"`
+}
+
+func (r MigrationRepairRequest) Validate() error {
+	var missing []string
+	if strings.TrimSpace(r.AppResourceName) == "" {
+		missing = append(missing, "app_resource_name")
+	}
+	if strings.TrimSpace(r.DatabaseResourceName) == "" {
+		missing = append(missing, "database_resource_name")
+	}
+	if strings.TrimSpace(r.JobImage) == "" {
+		missing = append(missing, "job_image")
+	}
+	if strings.TrimSpace(r.SourceDir) == "" {
+		missing = append(missing, "source_dir")
+	}
+	if strings.TrimSpace(r.ExpectedDirtyVersion) == "" {
+		missing = append(missing, "expected_dirty_version")
+	}
+	if strings.TrimSpace(r.ForceVersion) == "" {
+		missing = append(missing, "force_version")
+	}
+	if strings.TrimSpace(r.ConfirmForce) == "" {
+		missing = append(missing, "confirm_force")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("migration repair request missing required fields: %s", strings.Join(missing, ", "))
+	}
+	if r.ConfirmForce != MigrationRepairConfirmation {
+		return fmt.Errorf("confirm_force must equal %q", MigrationRepairConfirmation)
+	}
+	if r.ThenUp && r.UpIfClean {
+		return errors.New("then_up and up_if_clean are mutually exclusive")
+	}
+	return nil
+}
+
+type MigrationRepairResult struct {
+	ProviderJobID string       `json:"provider_job_id,omitempty"`
+	Status        string       `json:"status"`
+	Applied       []string     `json:"applied,omitempty"`
+	Logs          string       `json:"logs,omitempty"`
+	Diagnostics   []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type ProviderMigrationRepairer interface {
+	RepairDirtyMigration(ctx context.Context, req MigrationRepairRequest) (*MigrationRepairResult, error)
+}

--- a/interfaces/migration_repair_test.go
+++ b/interfaces/migration_repair_test.go
@@ -1,0 +1,65 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+func TestMigrationRepairRequestValidateRequiresGuardFields(t *testing.T) {
+	req := interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-app",
+		DatabaseResourceName: "bmw-database",
+		JobImage:             "registry.example/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+	}
+
+	err := req.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	for _, want := range []string{"expected_dirty_version", "force_version", "confirm_force"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestMigrationRepairRequestValidateRequiresConfirmationValue(t *testing.T) {
+	req := interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-app",
+		DatabaseResourceName: "bmw-database",
+		JobImage:             "registry.example/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ConfirmForce:         "yes",
+	}
+
+	err := req.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "FORCE_MIGRATION_METADATA") {
+		t.Fatalf("error %q missing required confirmation value", err)
+	}
+}
+
+func TestMigrationRepairRequestValidateAcceptsCompleteRequest(t *testing.T) {
+	req := interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-app",
+		DatabaseResourceName: "bmw-database",
+		JobImage:             "registry.example/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		Env:                  map[string]string{"DATABASE_URL": "postgres://example"},
+	}
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}

--- a/plugin/external/remote_module.go
+++ b/plugin/external/remote_module.go
@@ -123,6 +123,12 @@ func (m *RemoteModule) Destroy() error {
 
 // InvokeService calls a named method on the remote module's service interface.
 func (m *RemoteModule) InvokeService(method string, args map[string]any) (map[string]any, error) {
+	return m.InvokeServiceContext(context.Background(), method, args)
+}
+
+// InvokeServiceContext calls a named method on the remote module's service
+// interface using the caller's context.
+func (m *RemoteModule) InvokeServiceContext(ctx context.Context, method string, args map[string]any) (map[string]any, error) {
 	req := &pb.InvokeServiceRequest{
 		HandleId: m.handleID,
 		Method:   method,
@@ -142,7 +148,7 @@ func (m *RemoteModule) InvokeService(method string, args map[string]any) (map[st
 			}
 		}
 	}
-	resp, err := m.client.InvokeService(context.Background(), req)
+	resp, err := m.client.InvokeService(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("remote invoke %s: %w", method, err)
 	}

--- a/plugin/external/remote_step_test.go
+++ b/plugin/external/remote_step_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/GoCodeAlone/workflow/module"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -24,6 +26,7 @@ type stubPluginServiceClient struct {
 
 	lastInvokeRequest *pb.InvokeServiceRequest
 	invokeResponse    *pb.InvokeServiceResponse
+	invokeErr         error
 }
 
 // ExecuteStep records the request and returns the configured response.
@@ -77,6 +80,9 @@ func (c *stubPluginServiceClient) DestroyStep(_ context.Context, _ *pb.HandleReq
 }
 func (c *stubPluginServiceClient) InvokeService(_ context.Context, req *pb.InvokeServiceRequest, _ ...grpc.CallOption) (*pb.InvokeServiceResponse, error) {
 	c.lastInvokeRequest = req
+	if c.invokeErr != nil {
+		return nil, c.invokeErr
+	}
 	if c.invokeResponse != nil {
 		return c.invokeResponse, nil
 	}
@@ -397,6 +403,18 @@ func TestRemoteModule_InvokeService_StrictContractRequiresTypedOutput(t *testing
 	}
 	if !strings.Contains(err.Error(), "requires typed_output") {
 		t.Fatalf("expected missing typed output error, got %v", err)
+	}
+}
+
+func TestRemoteModule_InvokeService_PreservesStatusErrors(t *testing.T) {
+	stub := &stubPluginServiceClient{
+		invokeErr: status.Error(codes.Unimplemented, "provider does not implement ProviderMigrationRepairer"),
+	}
+	module := NewRemoteModule("test-module", "module-handle", stub)
+
+	_, err := module.InvokeService("IaCProvider.RepairDirtyMigration", map[string]any{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("InvokeService error code = %v, want Unimplemented (err=%v)", status.Code(err), err)
 	}
 }
 

--- a/plugin/external/sdk/grpc_server.go
+++ b/plugin/external/sdk/grpc_server.go
@@ -10,6 +10,7 @@ import (
 	goplugin "github.com/GoCodeAlone/go-plugin"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -475,8 +476,9 @@ func (s *grpcServer) GetConfigFragment(_ context.Context, _ *emptypb.Empty) (*pb
 // --- Service RPCs ---
 
 // InvokeService routes a service method call to the registered module identified
-// by handle_id. The module must implement ServiceInvoker; if it does not, an
-// error is returned to the host.
+// by handle_id. For untyped requests, ServiceContextInvoker is preferred when
+// implemented; otherwise the module must implement ServiceInvoker. If neither
+// interface is implemented, an error is returned to the host.
 func (s *grpcServer) InvokeService(ctx context.Context, req *pb.InvokeServiceRequest) (*pb.InvokeServiceResponse, error) {
 	s.mu.RLock()
 	inst, ok := s.modules[req.HandleId]
@@ -503,6 +505,9 @@ func (s *grpcServer) InvokeService(ctx context.Context, req *pb.InvokeServiceReq
 	if invoker, ok := inst.(ServiceContextInvoker); ok {
 		result, err := invoker.InvokeMethodContext(ctx, req.Method, args)
 		if err != nil {
+			if isGRPCStatusError(err) {
+				return nil, err
+			}
 			return &pb.InvokeServiceResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
 		}
 		return &pb.InvokeServiceResponse{Result: mapToStruct(result)}, nil
@@ -517,9 +522,21 @@ func (s *grpcServer) InvokeService(ctx context.Context, req *pb.InvokeServiceReq
 
 	result, err := invoker.InvokeMethod(req.Method, args)
 	if err != nil {
+		if isGRPCStatusError(err) {
+			return nil, err
+		}
 		return &pb.InvokeServiceResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
 	}
 	return &pb.InvokeServiceResponse{Result: mapToStruct(result)}, nil
+}
+
+type grpcStatusError interface {
+	GRPCStatus() *status.Status
+}
+
+func isGRPCStatusError(err error) bool {
+	var statusErr grpcStatusError
+	return errors.As(err, &statusErr) && statusErr.GRPCStatus() != nil
 }
 
 // --- Message delivery RPC ---

--- a/plugin/external/sdk/grpc_server.go
+++ b/plugin/external/sdk/grpc_server.go
@@ -477,7 +477,7 @@ func (s *grpcServer) GetConfigFragment(_ context.Context, _ *emptypb.Empty) (*pb
 // InvokeService routes a service method call to the registered module identified
 // by handle_id. The module must implement ServiceInvoker; if it does not, an
 // error is returned to the host.
-func (s *grpcServer) InvokeService(_ context.Context, req *pb.InvokeServiceRequest) (*pb.InvokeServiceResponse, error) {
+func (s *grpcServer) InvokeService(ctx context.Context, req *pb.InvokeServiceRequest) (*pb.InvokeServiceResponse, error) {
 	s.mu.RLock()
 	inst, ok := s.modules[req.HandleId]
 	s.mu.RUnlock()
@@ -499,6 +499,15 @@ func (s *grpcServer) InvokeService(_ context.Context, req *pb.InvokeServiceReque
 		return &pb.InvokeServiceResponse{TypedOutput: output}, nil
 	}
 
+	args := structToMap(req.Args)
+	if invoker, ok := inst.(ServiceContextInvoker); ok {
+		result, err := invoker.InvokeMethodContext(ctx, req.Method, args)
+		if err != nil {
+			return &pb.InvokeServiceResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
+		}
+		return &pb.InvokeServiceResponse{Result: mapToStruct(result)}, nil
+	}
+
 	invoker, ok := inst.(ServiceInvoker)
 	if !ok {
 		return &pb.InvokeServiceResponse{
@@ -506,7 +515,7 @@ func (s *grpcServer) InvokeService(_ context.Context, req *pb.InvokeServiceReque
 		}, nil
 	}
 
-	result, err := invoker.InvokeMethod(req.Method, structToMap(req.Args))
+	result, err := invoker.InvokeMethod(req.Method, args)
 	if err != nil {
 		return &pb.InvokeServiceResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
 	}

--- a/plugin/external/sdk/grpc_server_test.go
+++ b/plugin/external/sdk/grpc_server_test.go
@@ -8,7 +8,9 @@ import (
 
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -125,6 +127,7 @@ type contextServiceModule struct {
 	typedServiceModule
 	contextErr error
 	called     bool
+	err        error
 }
 
 func (m *contextServiceModule) InvokeMethodContext(ctx context.Context, method string, args map[string]any) (map[string]any, error) {
@@ -133,6 +136,9 @@ func (m *contextServiceModule) InvokeMethodContext(ctx context.Context, method s
 	m.contextErr = ctx.Err()
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	if m.err != nil {
+		return nil, m.err
 	}
 	return map[string]any{"value": args["value"]}, nil
 }
@@ -452,6 +458,28 @@ func TestInvokeService_ForwardsContextToLegacyInvoker(t *testing.T) {
 	}
 	if resp.Error == "" {
 		t.Fatal("expected response error from canceled context")
+	}
+}
+
+func TestInvokeService_PreservesStatusErrors(t *testing.T) {
+	module := &contextServiceModule{err: status.Error(codes.Unimplemented, "provider does not implement ProviderMigrationRepairer")}
+	srv := newGRPCServer(&typedServiceProvider{module: module})
+
+	createResp, err := srv.CreateModule(context.Background(), &pb.CreateModuleRequest{
+		Type: "typed.service",
+		Name: "typed",
+	})
+	if err != nil {
+		t.Fatalf("CreateModule returned rpc error: %v", err)
+	}
+
+	resp, err := srv.InvokeService(context.Background(), &pb.InvokeServiceRequest{
+		HandleId: createResp.HandleId,
+		Method:   "IaCProvider.RepairDirtyMigration",
+		Args:     mapToStruct(map[string]any{}),
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("InvokeService error code = %v, want Unimplemented (resp=%+v, err=%v)", status.Code(err), resp, err)
 	}
 }
 

--- a/plugin/external/sdk/grpc_server_test.go
+++ b/plugin/external/sdk/grpc_server_test.go
@@ -121,6 +121,22 @@ func (m *typedServiceModule) InvokeMethod(method string, args map[string]any) (m
 	return map[string]any{"value": args["value"]}, nil
 }
 
+type contextServiceModule struct {
+	typedServiceModule
+	contextErr error
+	called     bool
+}
+
+func (m *contextServiceModule) InvokeMethodContext(ctx context.Context, method string, args map[string]any) (map[string]any, error) {
+	m.called = true
+	m.lastMethod = method
+	m.contextErr = ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return map[string]any{"value": args["value"]}, nil
+}
+
 type typedServiceModuleWithoutTypedInvoker struct{}
 
 func (typedServiceModuleWithoutTypedInvoker) Init() error {
@@ -401,6 +417,41 @@ func TestInvokeService_WithTypedModuleFactoryForwardsLegacyInvoker(t *testing.T)
 	}
 	if got := resp.Result.AsMap()["value"]; got != "legacy-input" {
 		t.Fatalf("expected legacy result value, got %#v", got)
+	}
+}
+
+func TestInvokeService_ForwardsContextToLegacyInvoker(t *testing.T) {
+	module := &contextServiceModule{}
+	srv := newGRPCServer(&typedServiceProvider{module: module})
+
+	createResp, err := srv.CreateModule(context.Background(), &pb.CreateModuleRequest{
+		Type: "typed.service",
+		Name: "typed",
+	})
+	if err != nil {
+		t.Fatalf("CreateModule returned rpc error: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resp, err := srv.InvokeService(ctx, &pb.InvokeServiceRequest{
+		HandleId: createResp.HandleId,
+		Method:   "Echo",
+		Args: mapToStruct(map[string]any{
+			"value": "legacy-input",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("InvokeService returned rpc error: %v", err)
+	}
+	if !module.called {
+		t.Fatal("context-aware invoker was not called")
+	}
+	if module.contextErr == nil {
+		t.Fatal("expected canceled context to reach invoker")
+	}
+	if resp.Error == "" {
+		t.Fatal("expected response error from canceled context")
 	}
 }
 

--- a/plugin/external/sdk/interfaces.go
+++ b/plugin/external/sdk/interfaces.go
@@ -150,6 +150,12 @@ type ServiceInvoker interface {
 	InvokeMethod(method string, args map[string]any) (map[string]any, error)
 }
 
+// ServiceContextInvoker is optionally implemented by ModuleInstance to receive
+// the gRPC request context for long-running service invocations.
+type ServiceContextInvoker interface {
+	InvokeMethodContext(ctx context.Context, method string, args map[string]any) (map[string]any, error)
+}
+
 // TypedServiceInvoker is optionally implemented by ModuleInstance to handle
 // strict protobuf service method invocations from the host.
 type TypedServiceInvoker interface {


### PR DESCRIPTION
## Summary

Adds provider-executed dirty migration repair to wfctl so a known dirty migration state can be repaired inside the provider trust boundary instead of from CI runners.

## Changes

- Add `interfaces.ProviderMigrationRepairer`, guarded request/result types, statuses, and validation.
- Add `wfctl migrate repair-dirty` with env-resolved app/database lookup, same-provider-module validation, destructive approval gating, job env propagation, provider dispatch, GitHub step summaries, and secret redaction.
- Extend remote IaC provider dispatch and `RemoteModule` with context-aware service invocation for repair timeouts.
- Document the command, non-dev approval behavior, and GitHub environment-gated usage.

## Verification

- `GOWORK=off go test ./interfaces ./cmd/wfctl ./plugin/external -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestRunMigrateRepairDirty|TestRemoteIaCProvider_RepairDirtyMigration|TestDestructiveGate|TestDispatchMatrix_RemoteIaCProvider|TestInfraApply_EnvFlagResolvesOverrides' -count=1`
- `GOWORK=off go run ./cmd/wfctl migrate repair-dirty --help`

## TDD / Regression Proof

- Missing command path: `TestRunMigrateRepairDirty*` failed before `repair-dirty` routing and provider invocation existed, then passed after implementation.
- Secret redaction: reverting stdout/summary/error redaction caused focused tests to fail on leaked `postgres://...` values; restoring redaction passed.
- Review gap fixes: reverting malformed env handling, context-aware dispatch, provider-ref validation, result-status validation, or synthetic diagnostic/stdout redaction caused targeted tests to fail or build to fail; restoring fixes passed.

## Review

Internal antagonistic code review ran five rounds. Final verdict: SHIP-IT, no Critical or Important findings.
