### PR TITLE
fix(wfctl): make plugin lock checksums portable

### DIFF
--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -145,6 +145,58 @@ plugins:
 	}
 }
 
+func TestInstallFromWfctlLockfile_ScrubsExplicitEmptyTopLevelSHA256(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	lockWithEmptySHA := `version: 1
+generated_at: "2026-01-01T00:00:00Z"
+plugins:
+  workflow-plugin-auth:
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-auth
+    sha256:
+    platforms:
+      ` + currentPlatformKey() + `:
+        url: http://127.0.0.1:1/missing.tar.gz
+        sha256: ` + strings.Repeat("1", 64) + `
+`
+	if err := os.WriteFile(lockPath, []byte(lockWithEmptySHA), 0o600); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+	lf, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load lockfile: %v", err)
+	}
+
+	err = installFromWfctlLockfile(pluginDir, lockPath, lf)
+	if err == nil {
+		t.Fatal("expected install failure from unreachable URL")
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	authRaw := pluginRawMap(t, data, "workflow-plugin-auth")
+	if _, ok := authRaw["sha256"]; ok {
+		t.Fatalf("explicit empty top-level sha256 should be scrubbed:\n%s", data)
+	}
+}
+
 func TestInstallFromWfctlLockfile_MissingCurrentPlatformDoesNotFallbackToRegistry(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
@@ -265,7 +317,7 @@ func TestInstallFromWfctlLockfile_InitialScrubSaveFailureFails(t *testing.T) {
 
 func TestInstallFromWfctlLockfile_PostInstallSaveFailureFails(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "missing-dir", ".wfctl-lock.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
 	pluginDir := filepath.Join(dir, "plugins")
 	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -286,8 +338,12 @@ func TestInstallFromWfctlLockfile_PostInstallSaveFailureFails(t *testing.T) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(http.StatusOK)
 		w.Write(tarball) //nolint:errcheck
+		if err := os.Chmod(lockPath, 0o400); err != nil {
+			t.Errorf("chmod lockfile read-only: %v", err)
+		}
 	}))
 	defer srv.Close()
+	t.Cleanup(func() { _ = os.Chmod(lockPath, 0o600) })
 
 	lf := &config.WfctlLockfile{
 		Version:     1,

--- a/cmd/wfctl/plugin_install_lockfile_test.go
+++ b/cmd/wfctl/plugin_install_lockfile_test.go
@@ -15,47 +15,6 @@ import (
 	"github.com/GoCodeAlone/workflow/config"
 )
 
-func TestInstallFromWfctlLockfile_SHA256MismatchFails(t *testing.T) {
-	dir := t.TempDir()
-	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
-	pluginDir := filepath.Join(dir, "plugins")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Write a lockfile with a non-empty sha256.
-	lf := &config.WfctlLockfile{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Plugins: map[string]config.WfctlLockPluginEntry{
-			"workflow-plugin-foo": {
-				Version: "v1.0.0",
-				Source:  "github.com/GoCodeAlone/workflow-plugin-foo",
-				SHA256:  "expected-sha256-that-wont-match",
-			},
-		},
-	}
-	if err := config.SaveWfctlLockfile(lockPath, lf); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create a fake plugin binary at the NORMALIZED path.
-	// verifyWfctlLockfileChecksums calls normalizePluginName("workflow-plugin-foo") → "foo",
-	// so the binary must live at plugins/foo/foo, not plugins/workflow-plugin-foo/workflow-plugin-foo.
-	fooDir := filepath.Join(pluginDir, "foo")
-	if err := os.MkdirAll(fooDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(fooDir, "foo"), []byte("wrong content"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	err := verifyWfctlLockfileChecksums(pluginDir, lf)
-	if err == nil {
-		t.Fatal("expected sha256 mismatch error, got nil")
-	}
-}
-
 func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256AsArchiveChecksum(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
@@ -118,6 +77,71 @@ func TestInstallFromWfctlLockfile_UsesCurrentPlatformSHA256AsArchiveChecksum(t *
 	}
 	if got := entry.Platforms[currentPlatformKey()].SHA256; got != sha256Hex(tarball) {
 		t.Fatalf("current platform checksum = %q, want archive checksum %q", got, sha256Hex(tarball))
+	}
+}
+
+func TestInstallFromWfctlLockfile_PlatformSHA256MismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	const pluginName = "auth"
+	tarball := buildPluginTarGz(t, pluginName, []byte("#!/bin/sh\necho auth\n"), minimalPluginJSON(pluginName, "v1.2.3"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write(tarball) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	staleLock := `version: 1
+generated_at: "2026-01-01T00:00:00Z"
+plugins:
+  workflow-plugin-auth:
+    version: v1.2.3
+    source: github.com/GoCodeAlone/workflow-plugin-auth
+    sha256: ` + strings.Repeat("0", 64) + `
+    platforms:
+      ` + currentPlatformKey() + `:
+        url: ` + srv.URL + `/workflow-plugin-auth-` + currentPlatformKey() + `.tar.gz
+        sha256: ` + strings.Repeat("1", 64) + `
+`
+	if err := os.WriteFile(lockPath, []byte(staleLock), 0o600); err != nil {
+		t.Fatalf("write stale lockfile: %v", err)
+	}
+	lf, err := config.LoadWfctlLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("load stale lockfile: %v", err)
+	}
+
+	err = installFromWfctlLockfile(pluginDir, lockPath, lf)
+	if err == nil {
+		t.Fatal("expected platform archive checksum mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %q, want checksum mismatch detail", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(pluginDir, pluginName, pluginName)); !os.IsNotExist(statErr) {
+		t.Fatalf("plugin binary should not be installed after checksum mismatch, stat err: %v", statErr)
+	}
+	loaded, loadErr := config.LoadWfctlLockfile(lockPath)
+	if loadErr != nil {
+		t.Fatalf("load scrubbed lockfile: %v", loadErr)
+	}
+	if got := loaded.Plugins["workflow-plugin-auth"].SHA256; got != "" {
+		t.Fatalf("top-level checksum should be scrubbed even when install fails, got %q", got)
 	}
 }
 
@@ -186,17 +210,31 @@ func TestInstallFromWfctlLockfile_MissingCurrentPlatformDoesNotFallbackToRegistr
 	}
 }
 
-func TestVerifyWfctlLockfileChecksums_NoPlatformMetadataUsesLegacyTopLevelSHA256(t *testing.T) {
+func TestInstallFromWfctlLockfile_InitialScrubSaveFailureFails(t *testing.T) {
 	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "missing-dir", ".wfctl-lock.yaml")
 	pluginDir := filepath.Join(dir, "plugins")
-	authDir := filepath.Join(pluginDir, "auth")
-	if err := os.MkdirAll(authDir, 0o755); err != nil {
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	binaryContent := []byte("#!/bin/sh\necho auth\n")
-	if err := os.WriteFile(filepath.Join(authDir, "auth"), binaryContent, 0o755); err != nil {
-		t.Fatal(err)
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
 	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	const pluginName = "auth"
+	tarball := buildPluginTarGz(t, pluginName, []byte("#!/bin/sh\necho auth\n"), minimalPluginJSON(pluginName, "v1.2.3"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write(tarball) //nolint:errcheck
+	}))
+	defer srv.Close()
 
 	lf := &config.WfctlLockfile{
 		Version:     1,
@@ -205,13 +243,78 @@ func TestVerifyWfctlLockfileChecksums_NoPlatformMetadataUsesLegacyTopLevelSHA256
 			"workflow-plugin-auth": {
 				Version: "v1.2.3",
 				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
-				SHA256:  sha256Hex(binaryContent),
+				SHA256:  strings.Repeat("0", 64),
+				Platforms: map[string]config.WfctlLockPlatform{
+					currentPlatformKey(): {
+						URL:    srv.URL + "/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
+						SHA256: sha256Hex(tarball),
+					},
+				},
 			},
 		},
 	}
 
-	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
-		t.Fatalf("verifyWfctlLockfileChecksums should use legacy top-level checksum when platform metadata is absent: %v", err)
+	err = installFromWfctlLockfile(pluginDir, lockPath, lf)
+	if err == nil {
+		t.Fatal("expected lockfile save failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "persist scrubbed lockfile") {
+		t.Fatalf("error = %q, want persist scrubbed lockfile failure", err)
+	}
+}
+
+func TestInstallFromWfctlLockfile_PostInstallSaveFailureFails(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "missing-dir", ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	const pluginName = "auth"
+	tarball := buildPluginTarGz(t, pluginName, []byte("#!/bin/sh\necho auth\n"), minimalPluginJSON(pluginName, "v1.2.3"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write(tarball) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	lf := &config.WfctlLockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Plugins: map[string]config.WfctlLockPluginEntry{
+			"workflow-plugin-auth": {
+				Version: "v1.2.3",
+				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
+				Platforms: map[string]config.WfctlLockPlatform{
+					currentPlatformKey(): {
+						URL:    srv.URL + "/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
+						SHA256: sha256Hex(tarball),
+					},
+				},
+			},
+		},
+	}
+
+	err = installFromWfctlLockfile(pluginDir, lockPath, lf)
+	if err == nil {
+		t.Fatal("expected post-install lockfile save failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "persist scrubbed lockfile after installing workflow-plugin-auth") {
+		t.Fatalf("error = %q, want post-install scrubbed lockfile persistence failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(pluginDir, pluginName, pluginName)); statErr != nil {
+		t.Fatalf("plugin binary should be installed before post-install save failure, stat err: %v", statErr)
 	}
 }
 
@@ -280,7 +383,7 @@ func TestInstallFromWfctlLockfile_NoPlatformMetadataDoesNotPersistTopLevelSHA256
 			"workflow-plugin-auth": {
 				Version: "v1.2.3",
 				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
-				SHA256:  "",
+				SHA256:  strings.Repeat("0", 64),
 			},
 		},
 	}
@@ -401,75 +504,6 @@ func TestRunPluginInstall_DoesNotRewriteNewFormatLockfile(t *testing.T) {
 	}
 }
 
-func TestVerifyWfctlLockfileChecksums_IgnoresPlatformArchiveSHA256(t *testing.T) {
-	dir := t.TempDir()
-	pluginDir := filepath.Join(dir, "plugins")
-	authDir := filepath.Join(pluginDir, "auth")
-	if err := os.MkdirAll(authDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	binaryContent := []byte("#!/bin/sh\necho auth\n")
-	if err := os.WriteFile(filepath.Join(authDir, "auth"), binaryContent, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	lf := &config.WfctlLockfile{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Plugins: map[string]config.WfctlLockPluginEntry{
-			"workflow-plugin-auth": {
-				Version: "v1.2.3",
-				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
-				SHA256:  strings.Repeat("0", 64),
-				Platforms: map[string]config.WfctlLockPlatform{
-					currentPlatformKey(): {
-						URL:    "https://example.test/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
-						SHA256: strings.Repeat("1", 64),
-					},
-				},
-			},
-		},
-	}
-
-	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
-		t.Fatalf("verifyWfctlLockfileChecksums should not verify platform archive checksums against installed binaries: %v", err)
-	}
-}
-
-func TestVerifyWfctlLockfileChecksums_DoesNotFallbackToTopLevelSHA256WhenPlatformsExist(t *testing.T) {
-	dir := t.TempDir()
-	pluginDir := filepath.Join(dir, "plugins")
-	authDir := filepath.Join(pluginDir, "auth")
-	if err := os.MkdirAll(authDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	binaryContent := []byte("#!/bin/sh\necho auth\n")
-	if err := os.WriteFile(filepath.Join(authDir, "auth"), binaryContent, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	lf := &config.WfctlLockfile{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Plugins: map[string]config.WfctlLockPluginEntry{
-			"workflow-plugin-auth": {
-				Version: "v1.2.3",
-				Source:  "github.com/GoCodeAlone/workflow-plugin-auth",
-				SHA256:  strings.Repeat("0", 64),
-				Platforms: map[string]config.WfctlLockPlatform{
-					currentPlatformKey(): {
-						URL: "https://example.test/workflow-plugin-auth-" + currentPlatformKey() + ".tar.gz",
-					},
-				},
-			},
-		},
-	}
-
-	if err := verifyWfctlLockfileChecksums(pluginDir, lf); err != nil {
-		t.Fatalf("verifyWfctlLockfileChecksums should ignore top-level checksum when platform metadata exists without a platform checksum: %v", err)
-	}
-}
-
 func TestInstallFromWfctlLockfile_PlatformSHA256IsCaseInsensitive(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
@@ -519,57 +553,5 @@ func TestInstallFromWfctlLockfile_PlatformSHA256IsCaseInsensitive(t *testing.T) 
 
 	if err := installFromWfctlLockfile(pluginDir, lockPath, lf); err != nil {
 		t.Fatalf("installFromWfctlLockfile should accept uppercase platform checksum: %v", err)
-	}
-}
-
-func TestInstallFromWfctlLockfile_SHA256EmptySkipsVerification(t *testing.T) {
-	dir := t.TempDir()
-	pluginDir := filepath.Join(dir, "plugins")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	lf := &config.WfctlLockfile{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Plugins: map[string]config.WfctlLockPluginEntry{
-			"workflow-plugin-foo": {
-				Version: "v1.0.0",
-				Source:  "github.com/GoCodeAlone/workflow-plugin-foo",
-				SHA256:  "", // empty — skip verification
-			},
-		},
-	}
-
-	// No plugin binary present; should succeed because sha256 is empty.
-	err := verifyWfctlLockfileChecksums(pluginDir, lf)
-	if err != nil {
-		t.Fatalf("expected no error when sha256 is empty, got: %v", err)
-	}
-}
-
-// TestVerifyWfctlLockfileChecksums_EmptyEntryAlwaysPasses verifies that when a
-// plugin's top-level sha256 field is empty, the check is skipped entirely.
-// Alpha.1 lockfiles often have empty sha256 (no real download performed), so
-// this must be a no-op rather than a hard failure.
-func TestVerifyWfctlLockfileChecksums_EmptyEntryAlwaysPasses(t *testing.T) {
-	dir := t.TempDir()
-	pluginDir := filepath.Join(dir, "plugins")
-
-	lf := &config.WfctlLockfile{
-		Version:     1,
-		GeneratedAt: time.Now(),
-		Plugins: map[string]config.WfctlLockPluginEntry{
-			"workflow-plugin-foo": {
-				Version: "v1.0.0",
-				SHA256:  "", // empty — skip verification; no binary needed
-			},
-		},
-	}
-
-	// No plugin binary present; should succeed because sha256 is empty.
-	err := verifyWfctlLockfileChecksums(pluginDir, lf)
-	if err != nil {
-		t.Fatalf("expected no error when sha256 is empty, got: %v", err)
 	}
 }

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -29,13 +29,11 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 	}
 
 	if lockPath != "" {
-		scrubbed, changed := scrubbedWfctlLockfileTopLevelSHA256(lf)
-		if changed {
-			if err := config.SaveWfctlLockfile(lockPath, scrubbed); err != nil {
-				return fmt.Errorf("persist scrubbed lockfile: %w", err)
-			}
-			*lf = *scrubbed
+		scrubbed := scrubbedWfctlLockfileTopLevelSHA256(lf)
+		if err := config.SaveWfctlLockfile(lockPath, scrubbed); err != nil {
+			return fmt.Errorf("persist scrubbed lockfile: %w", err)
 		}
+		*lf = *scrubbed
 	}
 
 	// Sort plugin names for deterministic install order.
@@ -105,21 +103,17 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 	return nil
 }
 
-func scrubbedWfctlLockfileTopLevelSHA256(lf *config.WfctlLockfile) (*config.WfctlLockfile, bool) {
+func scrubbedWfctlLockfileTopLevelSHA256(lf *config.WfctlLockfile) *config.WfctlLockfile {
 	scrubbed := &config.WfctlLockfile{
 		Version:     lf.Version,
 		GeneratedAt: lf.GeneratedAt,
 		Plugins:     make(map[string]config.WfctlLockPluginEntry, len(lf.Plugins)),
 	}
-	changed := false
 	for name, entry := range lf.Plugins {
-		if entry.SHA256 != "" {
-			entry.SHA256 = ""
-			changed = true
-		}
+		entry.SHA256 = ""
 		scrubbed.Plugins[name] = entry
 	}
-	return scrubbed, changed
+	return scrubbed
 }
 
 // currentPlatformKey returns the GOOS-GOARCH key used in WfctlLockPlatform maps.

--- a/cmd/wfctl/plugin_install_wfctllock.go
+++ b/cmd/wfctl/plugin_install_wfctllock.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -14,7 +13,8 @@ import (
 // installFromWfctlLockfile installs all plugins recorded in a config.WfctlLockfile.
 // For each plugin:
 //   - If a platform URL is recorded, download from that URL and verify its archive SHA.
-//   - For legacy entries without platforms, verify top-level sha256 as a binary SHA.
+//   - Top-level sha256 is ignored in the new-format lockfile to avoid recording
+//     or enforcing host-specific binary hashes.
 //   - If no platform URL, fall back to registry lookup via the existing install path.
 //
 // lockPath is the on-disk path for .wfctl-lock.yaml. After each successful install
@@ -26,6 +26,16 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 	if len(lf.Plugins) == 0 {
 		fmt.Println("No plugins pinned in .wfctl-lock.yaml.")
 		return nil
+	}
+
+	if lockPath != "" {
+		scrubbed, changed := scrubbedWfctlLockfileTopLevelSHA256(lf)
+		if changed {
+			if err := config.SaveWfctlLockfile(lockPath, scrubbed); err != nil {
+				return fmt.Errorf("persist scrubbed lockfile: %w", err)
+			}
+			*lf = *scrubbed
+		}
 	}
 
 	// Sort plugin names for deterministic install order.
@@ -40,10 +50,6 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 		entry := lf.Plugins[name]
 		fmt.Fprintf(os.Stderr, "Installing %s@%s...\n", name, entry.Version)
 
-		// Normalize name for filesystem paths — the install layer uses short names
-		// (e.g. "digitalocean") while the manifest/lockfile stores full names
-		// (e.g. "workflow-plugin-digitalocean").
-		fsName := normalizePluginName(name)
 		installed := false
 
 		// If we have platform-specific URL, install from that URL.
@@ -64,7 +70,7 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 			}
 			if err := installFromURL(plat.URL, pluginDirVal, plat.SHA256, false); err != nil {
 				fmt.Fprintf(os.Stderr, "error installing %s from URL: %v\n", name, err)
-				failed = append(failed, name)
+				failed = append(failed, fmt.Sprintf("%s (%v)", name, err))
 				continue
 			}
 			installed = true
@@ -78,31 +84,17 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 			}
 			if err := runPluginInstall([]string{"--plugin-dir", pluginDirVal, spec}); err != nil {
 				fmt.Fprintf(os.Stderr, "error installing %s: %v\n", name, err)
-				failed = append(failed, name)
+				failed = append(failed, fmt.Sprintf("%s (%v)", name, err))
 				continue
 			}
 		}
 
-		// Verify the installed binary only for legacy lockfiles that have no
-		// platform metadata. Platform checksums are archive/artifact checksums.
-		if expectedSHA256 := legacyWfctlLockfileBinaryChecksum(entry); expectedSHA256 != "" {
-			destDir := filepath.Join(pluginDirVal, fsName)
-			if verifyErr := verifyInstalledChecksum(destDir, fsName, expectedSHA256); verifyErr != nil {
-				fmt.Fprintf(os.Stderr, "CHECKSUM MISMATCH for %s: %v\n", name, verifyErr)
-				_ = os.RemoveAll(destDir)
-				failed = append(failed, name)
-				continue
-			}
-		}
-
-		// Re-save the new-format lockfile after each successful install.
-		// installFromURL and runPluginInstall internally call updateLockfileWithChecksum,
-		// which serializes the OLD PluginLockfile format and can strip source/platforms
-		// fields from the on-disk .wfctl-lock.yaml. Overwrite it here with the
-		// original new-format data without recording host-specific binary hashes.
+		// Re-save the scrubbed new-format lockfile after each successful install
+		// so platform metadata remains authoritative even if lower-level install
+		// paths attempt lockfile maintenance.
 		if lockPath != "" {
 			if saveErr := config.SaveWfctlLockfile(lockPath, lf); saveErr != nil {
-				fmt.Fprintf(os.Stderr, "warning: could not persist lockfile after installing %s: %v\n", name, saveErr)
+				return fmt.Errorf("persist scrubbed lockfile after installing %s: %w", name, saveErr)
 			}
 		}
 	}
@@ -113,44 +105,21 @@ func installFromWfctlLockfile(pluginDirVal, lockPath string, lf *config.WfctlLoc
 	return nil
 }
 
-// verifyWfctlLockfileChecksums checks legacy top-level sha256 values against
-// already-installed plugin binaries. Platform checksums are archive/artifact
-// checksums and are verified during download, not against extracted binaries.
-// Returns an error if any mismatch is detected.
-func verifyWfctlLockfileChecksums(pluginDirVal string, lf *config.WfctlLockfile) error {
-	// Sort plugin names for deterministic verification order and predictable error messages.
-	names := make([]string, 0, len(lf.Plugins))
-	for name := range lf.Plugins {
-		names = append(names, name)
+func scrubbedWfctlLockfileTopLevelSHA256(lf *config.WfctlLockfile) (*config.WfctlLockfile, bool) {
+	scrubbed := &config.WfctlLockfile{
+		Version:     lf.Version,
+		GeneratedAt: lf.GeneratedAt,
+		Plugins:     make(map[string]config.WfctlLockPluginEntry, len(lf.Plugins)),
 	}
-	sort.Strings(names)
-
-	var mismatches []string
-	for _, name := range names {
-		entry := lf.Plugins[name]
-		expectedSHA256 := legacyWfctlLockfileBinaryChecksum(entry)
-		if expectedSHA256 == "" {
-			continue
+	changed := false
+	for name, entry := range lf.Plugins {
+		if entry.SHA256 != "" {
+			entry.SHA256 = ""
+			changed = true
 		}
-		// Normalize name for filesystem path — manifest stores full names,
-		// install layer uses short names (strips "workflow-plugin-" prefix).
-		fsName := normalizePluginName(name)
-		destDir := filepath.Join(pluginDirVal, fsName)
-		if err := verifyInstalledChecksum(destDir, fsName, expectedSHA256); err != nil {
-			mismatches = append(mismatches, fmt.Sprintf("%s: %v", name, err))
-		}
+		scrubbed.Plugins[name] = entry
 	}
-	if len(mismatches) > 0 {
-		return fmt.Errorf("checksum mismatches:\n  %s", strings.Join(mismatches, "\n  "))
-	}
-	return nil
-}
-
-func legacyWfctlLockfileBinaryChecksum(entry config.WfctlLockPluginEntry) string {
-	if len(entry.Platforms) > 0 {
-		return ""
-	}
-	return entry.SHA256
+	return scrubbed, changed
 }
 
 // currentPlatformKey returns the GOOS-GOARCH key used in WfctlLockPlatform maps.

--- a/cmd/wfctl/plugin_lock.go
+++ b/cmd/wfctl/plugin_lock.go
@@ -35,15 +35,16 @@ func runPluginLock(args []string) error {
 }
 
 // runPluginLockFromManifest regenerates .wfctl-lock.yaml from a wfctl.yaml manifest.
-// Existing sha256/platform data is preserved for plugins that are already locked
-// at the same version.
+// Existing platform data must be refreshed from a project-local registry so the
+// lockfile records portable archive checksums instead of host-specific binary hashes.
 func runPluginLockFromManifest(manifestPath, lockPath string) error {
 	m, err := config.LoadWfctlManifest(manifestPath)
 	if err != nil {
 		return fmt.Errorf("load manifest: %w", err)
 	}
 
-	// Load existing lockfile so we can preserve sha256 for unchanged versions.
+	// Load existing lockfile so unchanged versions with platform metadata can be
+	// forced through registry refresh instead of carrying stale archive entries.
 	var existing *config.WfctlLockfile
 	if lf, err := config.LoadWfctlLockfile(lockPath); err == nil {
 		existing = lf
@@ -96,13 +97,6 @@ func runPluginLockFromManifest(manifestPath, lockPath string) error {
 			return fmt.Errorf("refresh platform metadata for %s@%s: no project-local registry config available", p.Name, p.Version)
 		}
 
-		// Preserve existing top-level checksums only for legacy entries. Platform
-		// metadata must be refreshed from the registry instead of copied forward.
-		if len(entry.Platforms) == 0 && previous != nil {
-			if len(previous.Platforms) == 0 {
-				entry.SHA256 = previous.SHA256
-			}
-		}
 		newLF.Plugins[p.Name] = entry
 	}
 

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -35,6 +35,9 @@ plugins:
 	if err != nil {
 		t.Fatalf("read lockfile: %v", err)
 	}
+	if strings.Contains(string(data), "sha256:") {
+		t.Fatalf("regenerated new-format lockfile should not contain top-level sha256:\n%s", data)
+	}
 
 	var parsed struct {
 		Plugins map[string]struct {
@@ -57,12 +60,13 @@ plugins:
 	}
 }
 
-func TestPluginLock_FromManifest_PreservesExisting(t *testing.T) {
+func TestPluginLock_FromManifest_DropsExistingTopLevelSHA256(t *testing.T) {
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "wfctl.yaml")
 	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
 
-	// Pre-populate lockfile with sha256 for an existing plugin.
+	// Pre-populate lockfile with a host-specific binary sha256 from an older
+	// generated lockfile. Regenerating the new-format lockfile must not preserve it.
 	existingLock := `version: 1
 generated_at: "2026-01-01T00:00:00Z"
 plugins:
@@ -96,6 +100,15 @@ plugins:
 	if err != nil {
 		t.Fatalf("read lockfile: %v", err)
 	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse raw lockfile: %v", err)
+	}
+	pluginsRaw := raw["plugins"].(map[string]any)
+	fooRaw := pluginsRaw["workflow-plugin-foo"].(map[string]any)
+	if _, ok := fooRaw["sha256"]; ok {
+		t.Fatalf("workflow-plugin-foo should not contain top-level sha256:\n%s", data)
+	}
 
 	var parsed struct {
 		Plugins map[string]struct {
@@ -108,8 +121,8 @@ plugins:
 	}
 
 	foo := parsed.Plugins["workflow-plugin-foo"]
-	if foo.SHA256 != "existing-sha256" {
-		t.Errorf("existing sha256 not preserved: got %q, want existing-sha256", foo.SHA256)
+	if foo.SHA256 != "" {
+		t.Errorf("existing top-level sha256 should not be preserved: got %q", foo.SHA256)
 	}
 	if _, ok := parsed.Plugins["workflow-plugin-bar"]; !ok {
 		t.Error("new plugin workflow-plugin-bar not added")

--- a/cmd/wfctl/plugin_lock_test.go
+++ b/cmd/wfctl/plugin_lock_test.go
@@ -35,8 +35,9 @@ plugins:
 	if err != nil {
 		t.Fatalf("read lockfile: %v", err)
 	}
-	if strings.Contains(string(data), "sha256:") {
-		t.Fatalf("regenerated new-format lockfile should not contain top-level sha256:\n%s", data)
+	fooRaw := pluginRawMap(t, data, "workflow-plugin-foo")
+	if _, ok := fooRaw["sha256"]; ok {
+		t.Fatalf("workflow-plugin-foo should not contain top-level sha256:\n%s", data)
 	}
 
 	var parsed struct {
@@ -100,12 +101,7 @@ plugins:
 	if err != nil {
 		t.Fatalf("read lockfile: %v", err)
 	}
-	var raw map[string]any
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("parse raw lockfile: %v", err)
-	}
-	pluginsRaw := raw["plugins"].(map[string]any)
-	fooRaw := pluginsRaw["workflow-plugin-foo"].(map[string]any)
+	fooRaw := pluginRawMap(t, data, "workflow-plugin-foo")
 	if _, ok := fooRaw["sha256"]; ok {
 		t.Fatalf("workflow-plugin-foo should not contain top-level sha256:\n%s", data)
 	}
@@ -127,6 +123,24 @@ plugins:
 	if _, ok := parsed.Plugins["workflow-plugin-bar"]; !ok {
 		t.Error("new plugin workflow-plugin-bar not added")
 	}
+}
+
+func pluginRawMap(t *testing.T, data []byte, name string) map[string]any {
+	t.Helper()
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse raw lockfile: %v", err)
+	}
+	pluginsRaw, ok := raw["plugins"].(map[string]any)
+	if !ok {
+		t.Fatalf("plugins should be a map in lockfile:\n%s", data)
+	}
+	pluginRaw, ok := pluginsRaw[name].(map[string]any)
+	if !ok {
+		t.Fatalf("%s should be a plugin map in lockfile:\n%s", name, data)
+	}
+	return pluginRaw
 }
 
 func TestPluginLock_FromManifest_PopulatesPlatformURLsAndSHA256FromRegistry(t *testing.T) {

--- a/config/wfctl_lockfile.go
+++ b/config/wfctl_lockfile.go
@@ -20,9 +20,12 @@ type WfctlLockfile struct {
 
 // WfctlLockPluginEntry is the locked record for a single plugin.
 type WfctlLockPluginEntry struct {
-	Version   string                       `yaml:"version"`
-	Source    string                       `yaml:"source"`
-	SHA256    string                       `yaml:"sha256"`
+	Version string `yaml:"version"`
+	Source  string `yaml:"source"`
+	// SHA256 is deprecated top-level metadata from early new-format lockfiles.
+	// Platform archive checksums live under Platforms; old-format binary
+	// checksums are handled by cmd/wfctl/plugin_lockfile.go.
+	SHA256    string                       `yaml:"sha256,omitempty"`
 	Platforms map[string]WfctlLockPlatform `yaml:"platforms,omitempty"`
 }
 
@@ -91,9 +94,6 @@ func SaveWfctlLockfile(path string, lf *WfctlLockfile) error {
 		}
 		addField("version", entry.Version)
 		addField("source", entry.Source)
-		if len(entry.Platforms) == 0 {
-			addField("sha256", entry.SHA256)
-		}
 
 		if len(entry.Platforms) > 0 {
 			platKeys := make([]string, 0, len(entry.Platforms))


### PR DESCRIPTION
## Summary
- stop recording/enforcing host-specific top-level `sha256` in new-format `.wfctl-lock.yaml`
- keep platform `sha256` as archive/download checksum verified by `installFromURL`
- scrub stale top-level checksums before install attempts and fail if scrubbed lockfile persistence fails
- preserve legacy old-format plugin lock behavior outside the new-format path

## TDD / Regression Evidence
With old behavior restored, focused tests failed with binary checksum mismatch on new-format top-level SHA and preserved `existing-sha256` during plugin lock regeneration. With the fix restored, focused tests passed.

## Verification
- `GOWORK=off go test ./cmd/wfctl ./config -run 'Test(InstallFromWfctlLockfile|PluginLock|WfctlLockfile)' -count=1`\n- `GOWORK=off go test ./cmd/wfctl ./config -count=1`\n\n## Review\nAntagonistic reviewer loop reached SHIP-IT. Minor findings were cleaned up before PR: `sha256,omitempty`, precise top-level-key assertion, and clone-before-scrub persistence behavior.