### PR TITLE
feat(wfctl): export canonical editor bundle

### DIFF
--- a/cmd/wfctl/editor_bundle.go
+++ b/cmd/wfctl/editor_bundle.go
@@ -205,7 +205,8 @@ func editorBundleRegistrySources() ([]schema.EditorContractRegistrySource, error
 
 func contractRegistryFromPluginDescriptors(descriptors []pluginContractDescriptor) *pb.ContractRegistry {
 	registry := &pb.ContractRegistry{}
-	for _, descriptor := range descriptors {
+	for i := range descriptors {
+		descriptor := &descriptors[i]
 		contract := contractDescriptorFromPluginDescriptor(descriptor)
 		if contract != nil {
 			registry.Contracts = append(registry.Contracts, contract)
@@ -215,7 +216,8 @@ func contractRegistryFromPluginDescriptors(descriptors []pluginContractDescripto
 }
 
 func firstDescriptorSetRef(descriptors []pluginContractDescriptor) string {
-	for _, descriptor := range descriptors {
+	for i := range descriptors {
+		descriptor := &descriptors[i]
 		if descriptor.DescriptorSetRef != "" {
 			return descriptor.DescriptorSetRef
 		}
@@ -225,7 +227,8 @@ func firstDescriptorSetRef(descriptors []pluginContractDescriptor) string {
 
 func contractDescriptorSetRefsFromPluginDescriptors(descriptors []pluginContractDescriptor) map[string]string {
 	refs := map[string]string{}
-	for _, descriptor := range descriptors {
+	for i := range descriptors {
+		descriptor := &descriptors[i]
 		if descriptor.DescriptorSetRef == "" {
 			continue
 		}
@@ -241,7 +244,7 @@ func contractDescriptorSetRefsFromPluginDescriptors(descriptors []pluginContract
 	return refs
 }
 
-func editorBundleContractIDFromPluginDescriptor(descriptor pluginContractDescriptor) string {
+func editorBundleContractIDFromPluginDescriptor(descriptor *pluginContractDescriptor) string {
 	kind := normalizePluginContractKind(descriptor.Kind)
 	switch kind {
 	case "module":
@@ -279,7 +282,7 @@ func editorBundleContractIDFromPluginDescriptor(descriptor pluginContractDescrip
 	return ""
 }
 
-func contractDescriptorFromPluginDescriptor(descriptor pluginContractDescriptor) *pb.ContractDescriptor {
+func contractDescriptorFromPluginDescriptor(descriptor *pluginContractDescriptor) *pb.ContractDescriptor {
 	kind := normalizePluginContractKind(descriptor.Kind)
 	mode := normalizePluginContractMode(descriptor.Mode)
 	contract := &pb.ContractDescriptor{

--- a/cmd/wfctl/editor_bundle.go
+++ b/cmd/wfctl/editor_bundle.go
@@ -151,7 +151,7 @@ func editorBundlePluginRepoSource(path string) (schema.EditorContractRegistrySou
 		pluginName = filepath.Base(path)
 	}
 
-	descriptors, _, _, findings := loadPluginContractDescriptors(path, manifest, pluginAuditOptions{})
+	descriptors, _, _, findings := loadPluginContractDescriptors(path, manifest, pluginAuditOptions{StrictContracts: true})
 	for _, finding := range findings {
 		if finding.Level == "ERROR" {
 			return schema.EditorContractRegistrySource{}, fmt.Errorf("%s: %s", finding.Code, finding.Message)
@@ -186,7 +186,10 @@ func editorBundleRegistrySources() ([]schema.EditorContractRegistrySource, error
 	var sources []schema.EditorContractRegistrySource
 	for _, name := range names {
 		manifest, err := fetchEditorBundleRegistryManifest(name)
-		if err != nil || len(manifest.Contracts) == 0 {
+		if err != nil {
+			return nil, fmt.Errorf("fetch registry manifest %q: %w", name, err)
+		}
+		if len(manifest.Contracts) == 0 {
 			continue
 		}
 		sources = append(sources, schema.EditorContractRegistrySource{
@@ -254,6 +257,7 @@ func editorBundleContractIDFromPluginDescriptor(descriptor pluginContractDescrip
 			return "trigger:" + typ
 		}
 	case "service_method":
+		moduleType := descriptor.ModuleType
 		serviceName := descriptor.ServiceName
 		method := descriptor.Method
 		if serviceName == "" && method == "" {
@@ -261,6 +265,9 @@ func editorBundleContractIDFromPluginDescriptor(descriptor pluginContractDescrip
 				serviceName = parsedService
 				method = parsedMethod
 			}
+		}
+		if moduleType != "" && serviceName != "" {
+			return "service:" + moduleType + "/" + serviceName + "/" + method
 		}
 		if serviceName != "" {
 			return "service:" + serviceName + "/" + method

--- a/cmd/wfctl/editor_bundle.go
+++ b/cmd/wfctl/editor_bundle.go
@@ -12,12 +12,17 @@ import (
 	"github.com/GoCodeAlone/workflow/schema"
 )
 
+var (
+	listEditorBundleRegistryPluginNames = ListPluginNames
+	fetchEditorBundleRegistryManifest   = FetchManifest
+)
+
 func runEditorBundle(args []string) error {
 	fs := flag.NewFlagSet("editor-bundle", flag.ExitOnError)
 	output := fs.String("output", "", "Write bundle to file instead of stdout")
 	format := fs.String("format", "json", "Output format: json")
 	pluginDir := fs.String("plugin-dir", "", "Load plugin contract descriptors from a plugin repo or plugin root")
-	includeRegistry := fs.Bool("registry", false, "Include contract descriptors from the configured plugin registry")
+	includeRegistry := fs.Bool("registry", true, "Include contract descriptors from the configured plugin registry")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl editor-bundle [options]\n\nExport the canonical editor contract bundle.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -153,10 +158,11 @@ func editorBundlePluginRepoSource(path string) (schema.EditorContractRegistrySou
 		}
 	}
 	return schema.EditorContractRegistrySource{
-		Plugin:           pluginName,
-		Source:           schema.EditorContractSourcePluginContractsJSON,
-		DescriptorSetRef: firstDescriptorSetRef(descriptors),
-		Registry:         contractRegistryFromPluginDescriptors(descriptors),
+		Plugin:                    pluginName,
+		Source:                    schema.EditorContractSourcePluginContractsJSON,
+		DescriptorSetRef:          firstDescriptorSetRef(descriptors),
+		ContractDescriptorSetRefs: contractDescriptorSetRefsFromPluginDescriptors(descriptors),
+		Registry:                  contractRegistryFromPluginDescriptors(descriptors),
 	}, nil
 }
 
@@ -173,21 +179,22 @@ func readPluginManifestMap(path string) (map[string]any, error) {
 }
 
 func editorBundleRegistrySources() ([]schema.EditorContractRegistrySource, error) {
-	names, err := ListPluginNames()
+	names, err := listEditorBundleRegistryPluginNames()
 	if err != nil {
 		return nil, err
 	}
 	var sources []schema.EditorContractRegistrySource
 	for _, name := range names {
-		manifest, err := FetchManifest(name)
+		manifest, err := fetchEditorBundleRegistryManifest(name)
 		if err != nil || len(manifest.Contracts) == 0 {
 			continue
 		}
 		sources = append(sources, schema.EditorContractRegistrySource{
-			Plugin:           manifest.Name,
-			Source:           schema.EditorContractSourcePluginManifest,
-			DescriptorSetRef: firstDescriptorSetRef(manifest.Contracts),
-			Registry:         contractRegistryFromPluginDescriptors(manifest.Contracts),
+			Plugin:                    manifest.Name,
+			Source:                    schema.EditorContractSourcePluginManifest,
+			DescriptorSetRef:          firstDescriptorSetRef(manifest.Contracts),
+			ContractDescriptorSetRefs: contractDescriptorSetRefsFromPluginDescriptors(manifest.Contracts),
+			Registry:                  contractRegistryFromPluginDescriptors(manifest.Contracts),
 		})
 	}
 	return sources, nil
@@ -208,6 +215,58 @@ func firstDescriptorSetRef(descriptors []pluginContractDescriptor) string {
 	for _, descriptor := range descriptors {
 		if descriptor.DescriptorSetRef != "" {
 			return descriptor.DescriptorSetRef
+		}
+	}
+	return ""
+}
+
+func contractDescriptorSetRefsFromPluginDescriptors(descriptors []pluginContractDescriptor) map[string]string {
+	refs := map[string]string{}
+	for _, descriptor := range descriptors {
+		if descriptor.DescriptorSetRef == "" {
+			continue
+		}
+		id := editorBundleContractIDFromPluginDescriptor(descriptor)
+		if id == "" {
+			continue
+		}
+		refs[id] = descriptor.DescriptorSetRef
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+func editorBundleContractIDFromPluginDescriptor(descriptor pluginContractDescriptor) string {
+	kind := normalizePluginContractKind(descriptor.Kind)
+	switch kind {
+	case "module":
+		if typ := descriptor.contractType(kind); typ != "" {
+			return "module:" + typ
+		}
+	case "step":
+		if typ := descriptor.contractType(kind); typ != "" {
+			return "step:" + typ
+		}
+	case "trigger":
+		if typ := descriptor.contractType(kind); typ != "" {
+			return "trigger:" + typ
+		}
+	case "service_method":
+		serviceName := descriptor.ServiceName
+		method := descriptor.Method
+		if serviceName == "" && method == "" {
+			if parsedService, parsedMethod, ok := strings.Cut(descriptor.contractType(kind), "/"); ok {
+				serviceName = parsedService
+				method = parsedMethod
+			}
+		}
+		if serviceName != "" {
+			return "service:" + serviceName + "/" + method
+		}
+		if method != "" {
+			return "service:" + method
 		}
 	}
 	return ""

--- a/cmd/wfctl/editor_bundle.go
+++ b/cmd/wfctl/editor_bundle.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+func runEditorBundle(args []string) error {
+	fs := flag.NewFlagSet("editor-bundle", flag.ExitOnError)
+	output := fs.String("output", "", "Write bundle to file instead of stdout")
+	format := fs.String("format", "json", "Output format: json")
+	pluginDir := fs.String("plugin-dir", "", "Load plugin contract descriptors from a plugin repo or plugin root")
+	includeRegistry := fs.Bool("registry", false, "Include contract descriptors from the configured plugin registry")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: wfctl editor-bundle [options]\n\nExport the canonical editor contract bundle.\n\nOptions:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *format != "json" {
+		return fmt.Errorf("unsupported format %q", *format)
+	}
+
+	sources, err := editorBundleContractSources(*pluginDir, *includeRegistry)
+	if err != nil {
+		return err
+	}
+	bundle, err := schema.ExportEditorBundle(schema.EditorBundleOptions{
+		WorkflowVersion:    version,
+		ContractRegistries: sources,
+	})
+	if err != nil {
+		return err
+	}
+
+	if ref, refErr := loadEditorBundleDSLReference(); refErr == nil {
+		bundle.DSLReference = ref
+	}
+
+	w := os.Stdout
+	if *output != "" {
+		f, err := os.Create(*output)
+		if err != nil {
+			return fmt.Errorf("create output file: %w", err)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(bundle); err != nil {
+		return fmt.Errorf("encode editor bundle: %w", err)
+	}
+	if *output != "" {
+		fmt.Fprintf(os.Stderr, "Editor bundle written to %s\n", *output)
+	}
+	return nil
+}
+
+func loadEditorBundleDSLReference() (*DSLReferenceOutput, error) {
+	md, err := findDSLReferenceMarkdown()
+	if err != nil {
+		return nil, err
+	}
+	return parseDSLReference(string(md))
+}
+
+func editorBundleContractSources(pluginDir string, includeRegistry bool) ([]schema.EditorContractRegistrySource, error) {
+	var sources []schema.EditorContractRegistrySource
+	if pluginDir != "" {
+		pluginSources, err := editorBundlePluginDirSources(pluginDir)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, pluginSources...)
+	}
+	if includeRegistry {
+		registrySources, err := editorBundleRegistrySources()
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, registrySources...)
+	}
+	return sources, nil
+}
+
+func editorBundlePluginDirSources(path string) ([]schema.EditorContractRegistrySource, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat plugin dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("plugin-dir must be a directory")
+	}
+	if pluginAuditFileExists(filepath.Join(path, "plugin.json")) || pluginAuditFileExists(filepath.Join(path, "plugin.contracts.json")) {
+		source, err := editorBundlePluginRepoSource(path)
+		if err != nil {
+			return nil, err
+		}
+		if source.Registry == nil || len(source.Registry.Contracts) == 0 {
+			return nil, nil
+		}
+		return []schema.EditorContractRegistrySource{source}, nil
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin root: %w", err)
+	}
+	var sources []schema.EditorContractRegistrySource
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		repoPath := filepath.Join(path, entry.Name())
+		if !pluginAuditFileExists(filepath.Join(repoPath, "plugin.json")) && !pluginAuditFileExists(filepath.Join(repoPath, "plugin.contracts.json")) {
+			continue
+		}
+		source, err := editorBundlePluginRepoSource(repoPath)
+		if err != nil {
+			return nil, err
+		}
+		if source.Registry != nil && len(source.Registry.Contracts) > 0 {
+			sources = append(sources, source)
+		}
+	}
+	return sources, nil
+}
+
+func editorBundlePluginRepoSource(path string) (schema.EditorContractRegistrySource, error) {
+	manifest, err := readPluginManifestMap(filepath.Join(path, "plugin.json"))
+	if err != nil && !os.IsNotExist(err) {
+		return schema.EditorContractRegistrySource{}, err
+	}
+	pluginName := stringFromAny(manifest["name"])
+	if pluginName == "" {
+		pluginName = filepath.Base(path)
+	}
+
+	descriptors, _, _, findings := loadPluginContractDescriptors(path, manifest, pluginAuditOptions{})
+	for _, finding := range findings {
+		if finding.Level == "ERROR" {
+			return schema.EditorContractRegistrySource{}, fmt.Errorf("%s: %s", finding.Code, finding.Message)
+		}
+	}
+	return schema.EditorContractRegistrySource{
+		Plugin:           pluginName,
+		Source:           schema.EditorContractSourcePluginContractsJSON,
+		DescriptorSetRef: firstDescriptorSetRef(descriptors),
+		Registry:         contractRegistryFromPluginDescriptors(descriptors),
+	}, nil
+}
+
+func readPluginManifestMap(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]any{}, err
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parse plugin manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func editorBundleRegistrySources() ([]schema.EditorContractRegistrySource, error) {
+	names, err := ListPluginNames()
+	if err != nil {
+		return nil, err
+	}
+	var sources []schema.EditorContractRegistrySource
+	for _, name := range names {
+		manifest, err := FetchManifest(name)
+		if err != nil || len(manifest.Contracts) == 0 {
+			continue
+		}
+		sources = append(sources, schema.EditorContractRegistrySource{
+			Plugin:           manifest.Name,
+			Source:           schema.EditorContractSourcePluginManifest,
+			DescriptorSetRef: firstDescriptorSetRef(manifest.Contracts),
+			Registry:         contractRegistryFromPluginDescriptors(manifest.Contracts),
+		})
+	}
+	return sources, nil
+}
+
+func contractRegistryFromPluginDescriptors(descriptors []pluginContractDescriptor) *pb.ContractRegistry {
+	registry := &pb.ContractRegistry{}
+	for _, descriptor := range descriptors {
+		contract := contractDescriptorFromPluginDescriptor(descriptor)
+		if contract != nil {
+			registry.Contracts = append(registry.Contracts, contract)
+		}
+	}
+	return registry
+}
+
+func firstDescriptorSetRef(descriptors []pluginContractDescriptor) string {
+	for _, descriptor := range descriptors {
+		if descriptor.DescriptorSetRef != "" {
+			return descriptor.DescriptorSetRef
+		}
+	}
+	return ""
+}
+
+func contractDescriptorFromPluginDescriptor(descriptor pluginContractDescriptor) *pb.ContractDescriptor {
+	kind := normalizePluginContractKind(descriptor.Kind)
+	mode := normalizePluginContractMode(descriptor.Mode)
+	contract := &pb.ContractDescriptor{
+		Mode:          pbContractMode(mode),
+		ConfigMessage: descriptor.Config,
+		InputMessage:  descriptor.Input,
+		OutputMessage: descriptor.Output,
+	}
+	switch kind {
+	case "module":
+		contract.Kind = pb.ContractKind_CONTRACT_KIND_MODULE
+		contract.ModuleType = descriptor.contractType(kind)
+	case "step":
+		contract.Kind = pb.ContractKind_CONTRACT_KIND_STEP
+		contract.StepType = descriptor.contractType(kind)
+	case "trigger":
+		contract.Kind = pb.ContractKind_CONTRACT_KIND_TRIGGER
+		contract.TriggerType = descriptor.contractType(kind)
+	case "service_method":
+		contract.Kind = pb.ContractKind_CONTRACT_KIND_SERVICE
+		contract.ModuleType = descriptor.ModuleType
+		contract.ServiceName = descriptor.ServiceName
+		contract.Method = descriptor.Method
+		if contract.ServiceName == "" && contract.Method == "" {
+			serviceName, method, ok := strings.Cut(descriptor.contractType(kind), "/")
+			if ok {
+				contract.ServiceName = serviceName
+				contract.Method = method
+			}
+		}
+	default:
+		return nil
+	}
+	return contract
+}
+
+func pbContractMode(mode string) pb.ContractMode {
+	switch mode {
+	case "strict":
+		return pb.ContractMode_CONTRACT_MODE_STRICT_PROTO
+	case "proto_with_legacy", "proto_with_legacy_struct":
+		return pb.ContractMode_CONTRACT_MODE_PROTO_WITH_LEGACY_STRUCT
+	case "legacy", "legacy_struct":
+		return pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT
+	default:
+		return pb.ContractMode_CONTRACT_MODE_UNSPECIFIED
+	}
+}

--- a/cmd/wfctl/editor_bundle.go
+++ b/cmd/wfctl/editor_bundle.go
@@ -15,6 +15,7 @@ import (
 var (
 	listEditorBundleRegistryPluginNames = ListPluginNames
 	fetchEditorBundleRegistryManifest   = FetchManifest
+	loadEditorBundleDSLReferenceFunc    = loadEditorBundleDSLReference
 )
 
 func runEditorBundle(args []string) error {
@@ -46,9 +47,11 @@ func runEditorBundle(args []string) error {
 		return err
 	}
 
-	if ref, refErr := loadEditorBundleDSLReference(); refErr == nil {
-		bundle.DSLReference = ref
+	ref, err := loadEditorBundleDSLReferenceFunc()
+	if err != nil {
+		return fmt.Errorf("load DSL reference: %w", err)
 	}
+	bundle.DSLReference = ref
 
 	w := os.Stdout
 	if *output != "" {
@@ -157,13 +160,7 @@ func editorBundlePluginRepoSource(path string) (schema.EditorContractRegistrySou
 			return schema.EditorContractRegistrySource{}, fmt.Errorf("%s: %s", finding.Code, finding.Message)
 		}
 	}
-	return schema.EditorContractRegistrySource{
-		Plugin:                    pluginName,
-		Source:                    schema.EditorContractSourcePluginContractsJSON,
-		DescriptorSetRef:          firstDescriptorSetRef(descriptors),
-		ContractDescriptorSetRefs: contractDescriptorSetRefsFromPluginDescriptors(descriptors),
-		Registry:                  contractRegistryFromPluginDescriptors(descriptors),
-	}, nil
+	return editorBundleSourceFromPluginDescriptors(pluginName, schema.EditorContractSourcePluginContractsJSON, descriptors)
 }
 
 func readPluginManifestMap(path string) (map[string]any, error) {
@@ -192,27 +189,46 @@ func editorBundleRegistrySources() ([]schema.EditorContractRegistrySource, error
 		if len(manifest.Contracts) == 0 {
 			continue
 		}
-		sources = append(sources, schema.EditorContractRegistrySource{
-			Plugin:                    manifest.Name,
-			Source:                    schema.EditorContractSourcePluginManifest,
-			DescriptorSetRef:          firstDescriptorSetRef(manifest.Contracts),
-			ContractDescriptorSetRefs: contractDescriptorSetRefsFromPluginDescriptors(manifest.Contracts),
-			Registry:                  contractRegistryFromPluginDescriptors(manifest.Contracts),
-		})
+		source, err := editorBundleSourceFromPluginDescriptors(manifest.Name, schema.EditorContractSourcePluginManifest, manifest.Contracts)
+		if err != nil {
+			return nil, fmt.Errorf("plugin registry manifest %q: %w", manifest.Name, err)
+		}
+		sources = append(sources, source)
 	}
 	return sources, nil
 }
 
-func contractRegistryFromPluginDescriptors(descriptors []pluginContractDescriptor) *pb.ContractRegistry {
+func editorBundleSourceFromPluginDescriptors(pluginName, source string, descriptors []pluginContractDescriptor) (schema.EditorContractRegistrySource, error) {
+	registry, err := contractRegistryFromPluginDescriptors(descriptors)
+	if err != nil {
+		return schema.EditorContractRegistrySource{}, err
+	}
+	refs, err := contractDescriptorSetRefsFromPluginDescriptors(descriptors)
+	if err != nil {
+		return schema.EditorContractRegistrySource{}, err
+	}
+	return schema.EditorContractRegistrySource{
+		Plugin:                    pluginName,
+		Source:                    source,
+		DescriptorSetRef:          firstDescriptorSetRef(descriptors),
+		ContractDescriptorSetRefs: refs,
+		Registry:                  registry,
+	}, nil
+}
+
+func contractRegistryFromPluginDescriptors(descriptors []pluginContractDescriptor) (*pb.ContractRegistry, error) {
 	registry := &pb.ContractRegistry{}
 	for i := range descriptors {
 		descriptor := &descriptors[i]
-		contract := contractDescriptorFromPluginDescriptor(descriptor)
+		contract, err := contractDescriptorFromPluginDescriptor(descriptor)
+		if err != nil {
+			return nil, err
+		}
 		if contract != nil {
 			registry.Contracts = append(registry.Contracts, contract)
 		}
 	}
-	return registry
+	return registry, nil
 }
 
 func firstDescriptorSetRef(descriptors []pluginContractDescriptor) string {
@@ -225,39 +241,42 @@ func firstDescriptorSetRef(descriptors []pluginContractDescriptor) string {
 	return ""
 }
 
-func contractDescriptorSetRefsFromPluginDescriptors(descriptors []pluginContractDescriptor) map[string]string {
+func contractDescriptorSetRefsFromPluginDescriptors(descriptors []pluginContractDescriptor) (map[string]string, error) {
 	refs := map[string]string{}
 	for i := range descriptors {
 		descriptor := &descriptors[i]
 		if descriptor.DescriptorSetRef == "" {
 			continue
 		}
-		id := editorBundleContractIDFromPluginDescriptor(descriptor)
+		id, err := editorBundleContractIDFromPluginDescriptor(descriptor)
+		if err != nil {
+			return nil, err
+		}
 		if id == "" {
 			continue
 		}
 		refs[id] = descriptor.DescriptorSetRef
 	}
 	if len(refs) == 0 {
-		return nil
+		return nil, nil
 	}
-	return refs
+	return refs, nil
 }
 
-func editorBundleContractIDFromPluginDescriptor(descriptor *pluginContractDescriptor) string {
+func editorBundleContractIDFromPluginDescriptor(descriptor *pluginContractDescriptor) (string, error) {
 	kind := normalizePluginContractKind(descriptor.Kind)
 	switch kind {
 	case "module":
 		if typ := descriptor.contractType(kind); typ != "" {
-			return "module:" + typ
+			return "module:" + typ, nil
 		}
 	case "step":
 		if typ := descriptor.contractType(kind); typ != "" {
-			return "step:" + typ
+			return "step:" + typ, nil
 		}
 	case "trigger":
 		if typ := descriptor.contractType(kind); typ != "" {
-			return "trigger:" + typ
+			return "trigger:" + typ, nil
 		}
 	case "service_method":
 		moduleType := descriptor.ModuleType
@@ -269,20 +288,34 @@ func editorBundleContractIDFromPluginDescriptor(descriptor *pluginContractDescri
 				method = parsedMethod
 			}
 		}
-		if moduleType != "" && serviceName != "" {
-			return "service:" + moduleType + "/" + serviceName + "/" + method
+		if id, ok := editorBundleServiceContractID(moduleType, serviceName, method); ok {
+			return id, nil
 		}
-		if serviceName != "" {
-			return "service:" + serviceName + "/" + method
-		}
-		if method != "" {
-			return "service:" + method
-		}
+		return "", fmt.Errorf("malformed service_method contract descriptor: serviceName and method are required when moduleType or serviceName is set")
 	}
-	return ""
+	return "", nil
 }
 
-func contractDescriptorFromPluginDescriptor(descriptor *pluginContractDescriptor) *pb.ContractDescriptor {
+func editorBundleServiceContractID(moduleType, serviceName, method string) (string, bool) {
+	if moduleType != "" {
+		if serviceName == "" || method == "" {
+			return "", false
+		}
+		return "service:" + moduleType + "/" + serviceName + "/" + method, true
+	}
+	if serviceName != "" {
+		if method == "" {
+			return "", false
+		}
+		return "service:" + serviceName + "/" + method, true
+	}
+	if method != "" {
+		return "service:" + method, true
+	}
+	return "", false
+}
+
+func contractDescriptorFromPluginDescriptor(descriptor *pluginContractDescriptor) (*pb.ContractDescriptor, error) {
 	kind := normalizePluginContractKind(descriptor.Kind)
 	mode := normalizePluginContractMode(descriptor.Mode)
 	contract := &pb.ContractDescriptor{
@@ -313,10 +346,13 @@ func contractDescriptorFromPluginDescriptor(descriptor *pluginContractDescriptor
 				contract.Method = method
 			}
 		}
+		if _, ok := editorBundleServiceContractID(contract.ModuleType, contract.ServiceName, contract.Method); !ok {
+			return nil, fmt.Errorf("malformed service_method contract descriptor: serviceName and method are required when moduleType or serviceName is set")
+		}
 	default:
-		return nil
+		return nil, nil
 	}
-	return contract
+	return contract, nil
 }
 
 func pbContractMode(mode string) pb.ContractMode {

--- a/cmd/wfctl/editor_bundle_test.go
+++ b/cmd/wfctl/editor_bundle_test.go
@@ -11,7 +11,7 @@ func TestRunEditorBundleWritesCanonicalJSONBundle(t *testing.T) {
 	dir := t.TempDir()
 	outPath := filepath.Join(dir, "editor-bundle.json")
 
-	if err := runEditorBundle([]string{"--output", outPath}); err != nil {
+	if err := runEditorBundle([]string{"--registry=false", "--output", outPath}); err != nil {
 		t.Fatalf("editor-bundle failed: %v", err)
 	}
 
@@ -76,7 +76,7 @@ func TestRunEditorBundleLoadsPluginContractDescriptorSetReference(t *testing.T) 
 	}
 
 	outPath := filepath.Join(dir, "editor-bundle.json")
-	if err := runEditorBundle([]string{"--plugin-dir", pluginDir, "--output", outPath}); err != nil {
+	if err := runEditorBundle([]string{"--registry=false", "--plugin-dir", pluginDir, "--output", outPath}); err != nil {
 		t.Fatalf("editor-bundle failed: %v", err)
 	}
 
@@ -106,5 +106,146 @@ func TestRunEditorBundleLoadsPluginContractDescriptorSetReference(t *testing.T) 
 	}
 	if bundle.DescriptorSets["proto/strict.pb"].ExternalRef != "proto/strict.pb" {
 		t.Fatalf("descriptor set reference missing: %+v", bundle.DescriptorSets)
+	}
+}
+
+func TestRunEditorBundleIncludesRegistryContractsByDefault(t *testing.T) {
+	origList := listEditorBundleRegistryPluginNames
+	origFetch := fetchEditorBundleRegistryManifest
+	t.Cleanup(func() {
+		listEditorBundleRegistryPluginNames = origList
+		fetchEditorBundleRegistryManifest = origFetch
+	})
+	listEditorBundleRegistryPluginNames = func() ([]string, error) {
+		return []string{"workflow-plugin-registry-strict"}, nil
+	}
+	fetchEditorBundleRegistryManifest = func(name string) (*RegistryManifest, error) {
+		return &RegistryManifest{
+			Name: name,
+			Contracts: []pluginContractDescriptor{
+				{
+					Kind:             "step",
+					Type:             "step.registry_strict",
+					Mode:             "strict",
+					Input:            "workflow.registry.Input",
+					Output:           "workflow.registry.Output",
+					DescriptorSetRef: "proto/registry.pb",
+				},
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "editor-bundle.json")
+	if err := runEditorBundle([]string{"--output", outPath}); err != nil {
+		t.Fatalf("editor-bundle failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var bundle struct {
+		Contracts map[string]struct {
+			DescriptorSetRef string `json:"descriptorSetRef"`
+			RequestMessage   string `json:"requestMessage"`
+			ResponseMessage  string `json:"responseMessage"`
+		} `json:"contracts"`
+		Messages       map[string]any `json:"messages"`
+		DescriptorSets map[string]struct {
+			ExternalRef string `json:"externalRef"`
+		} `json:"descriptorSets"`
+	}
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		t.Fatalf("bundle is not valid JSON: %v", err)
+	}
+	contract := bundle.Contracts["step:step.registry_strict"]
+	if contract.DescriptorSetRef != "proto/registry.pb" {
+		t.Fatalf("descriptorSetRef = %q", contract.DescriptorSetRef)
+	}
+	if contract.RequestMessage != "workflow.registry.Input" || contract.ResponseMessage != "workflow.registry.Output" {
+		t.Fatalf("typed I/O metadata missing: %+v", contract)
+	}
+	if bundle.Messages["workflow.registry.Input"] == nil || bundle.Messages["workflow.registry.Output"] == nil {
+		t.Fatalf("expected registry message metadata placeholders, got %+v", bundle.Messages)
+	}
+	if bundle.DescriptorSets["proto/registry.pb"].ExternalRef != "proto/registry.pb" {
+		t.Fatalf("descriptor set reference missing: %+v", bundle.DescriptorSets)
+	}
+}
+
+func TestRunEditorBundlePreservesPerContractDescriptorSetReferences(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "workflow-plugin-multi-ref")
+	if err := os.Mkdir(pluginDir, 0755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"workflow-plugin-multi-ref"}`), 0644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.contracts.json"), []byte(`{
+  "version": "v1",
+  "contracts": [
+    {
+      "kind": "step",
+      "type": "step.one",
+      "mode": "strict",
+      "input": "workflow.one.Input",
+      "output": "workflow.one.Output",
+      "descriptorSetRef": "proto/one.pb"
+    },
+    {
+      "kind": "step",
+      "type": "step.two",
+      "mode": "strict",
+      "input": "workflow.two.Input",
+      "output": "workflow.two.Output",
+      "descriptorSetRef": "proto/two.pb"
+    }
+  ]
+}`), 0644); err != nil {
+		t.Fatalf("write plugin contracts: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "editor-bundle.json")
+	if err := runEditorBundle([]string{"--registry=false", "--plugin-dir", pluginDir, "--output", outPath}); err != nil {
+		t.Fatalf("editor-bundle failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var bundle struct {
+		Contracts map[string]struct {
+			DescriptorSetRef string `json:"descriptorSetRef"`
+		} `json:"contracts"`
+		Messages map[string]struct {
+			DescriptorSetRef string `json:"descriptorSetRef"`
+		} `json:"messages"`
+		DescriptorSets map[string]struct {
+			ExternalRef string `json:"externalRef"`
+		} `json:"descriptorSets"`
+	}
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		t.Fatalf("bundle is not valid JSON: %v", err)
+	}
+	if got := bundle.Contracts["step:step.one"].DescriptorSetRef; got != "proto/one.pb" {
+		t.Fatalf("step.one descriptorSetRef = %q", got)
+	}
+	if got := bundle.Contracts["step:step.two"].DescriptorSetRef; got != "proto/two.pb" {
+		t.Fatalf("step.two descriptorSetRef = %q", got)
+	}
+	if got := bundle.Messages["workflow.one.Input"].DescriptorSetRef; got != "proto/one.pb" {
+		t.Fatalf("workflow.one.Input descriptorSetRef = %q", got)
+	}
+	if got := bundle.Messages["workflow.two.Input"].DescriptorSetRef; got != "proto/two.pb" {
+		t.Fatalf("workflow.two.Input descriptorSetRef = %q", got)
+	}
+	if bundle.DescriptorSets["proto/one.pb"].ExternalRef != "proto/one.pb" {
+		t.Fatalf("descriptor set one reference missing: %+v", bundle.DescriptorSets)
+	}
+	if bundle.DescriptorSets["proto/two.pb"].ExternalRef != "proto/two.pb" {
+		t.Fatalf("descriptor set two reference missing: %+v", bundle.DescriptorSets)
 	}
 }

--- a/cmd/wfctl/editor_bundle_test.go
+++ b/cmd/wfctl/editor_bundle_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -109,6 +110,28 @@ func TestRunEditorBundleLoadsPluginContractDescriptorSetReference(t *testing.T) 
 	}
 }
 
+func TestRunEditorBundleRejectsMalformedPluginContractDescriptors(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "workflow-plugin-bad-contracts")
+	if err := os.Mkdir(pluginDir, 0755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"workflow-plugin-bad-contracts"}`), 0644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.contracts.json"), []byte(`{"contracts": [`), 0644); err != nil {
+		t.Fatalf("write plugin contracts: %v", err)
+	}
+
+	err := runEditorBundle([]string{"--registry=false", "--plugin-dir", pluginDir})
+	if err == nil {
+		t.Fatal("expected malformed plugin.contracts.json to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid_plugin_contract_descriptors") {
+		t.Fatalf("error = %v, want invalid_plugin_contract_descriptors", err)
+	}
+}
+
 func TestRunEditorBundleIncludesRegistryContractsByDefault(t *testing.T) {
 	origList := listEditorBundleRegistryPluginNames
 	origFetch := fetchEditorBundleRegistryManifest
@@ -171,6 +194,29 @@ func TestRunEditorBundleIncludesRegistryContractsByDefault(t *testing.T) {
 	}
 	if bundle.DescriptorSets["proto/registry.pb"].ExternalRef != "proto/registry.pb" {
 		t.Fatalf("descriptor set reference missing: %+v", bundle.DescriptorSets)
+	}
+}
+
+func TestRunEditorBundleFailsWhenRegistryManifestFetchFails(t *testing.T) {
+	origList := listEditorBundleRegistryPluginNames
+	origFetch := fetchEditorBundleRegistryManifest
+	t.Cleanup(func() {
+		listEditorBundleRegistryPluginNames = origList
+		fetchEditorBundleRegistryManifest = origFetch
+	})
+	listEditorBundleRegistryPluginNames = func() ([]string, error) {
+		return []string{"workflow-plugin-bad-registry"}, nil
+	}
+	fetchEditorBundleRegistryManifest = func(name string) (*RegistryManifest, error) {
+		return nil, os.ErrNotExist
+	}
+
+	err := runEditorBundle(nil)
+	if err == nil {
+		t.Fatal("expected registry fetch failure")
+	}
+	if !strings.Contains(err.Error(), "workflow-plugin-bad-registry") {
+		t.Fatalf("error = %v, want plugin name", err)
 	}
 }
 

--- a/cmd/wfctl/editor_bundle_test.go
+++ b/cmd/wfctl/editor_bundle_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunEditorBundleWritesCanonicalJSONBundle(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "editor-bundle.json")
+
+	if err := runEditorBundle([]string{"--output", outPath}); err != nil {
+		t.Fatalf("editor-bundle failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var bundle struct {
+		Version       string         `json:"version"`
+		ModuleSchemas map[string]any `json:"moduleSchemas"`
+		StepSchemas   map[string]any `json:"stepSchemas"`
+		CoercionRules map[string]any `json:"coercionRules"`
+		Schemas       struct {
+			App   map[string]any `json:"app"`
+			Infra map[string]any `json:"infra"`
+			Wfctl map[string]any `json:"wfctl"`
+		} `json:"schemas"`
+	}
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		t.Fatalf("bundle is not valid JSON: %v", err)
+	}
+	if bundle.Version == "" {
+		t.Fatal("expected bundle schema version")
+	}
+	if len(bundle.ModuleSchemas) == 0 {
+		t.Fatal("expected module schemas")
+	}
+	if len(bundle.StepSchemas) == 0 {
+		t.Fatal("expected step schemas")
+	}
+	if len(bundle.CoercionRules) == 0 {
+		t.Fatal("expected coercion rules")
+	}
+	if len(bundle.Schemas.App) == 0 || len(bundle.Schemas.Infra) == 0 || len(bundle.Schemas.Wfctl) == 0 {
+		t.Fatalf("expected app/infra/wfctl schemas, got %+v", bundle.Schemas)
+	}
+}
+
+func TestRunEditorBundleLoadsPluginContractDescriptorSetReference(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "workflow-plugin-strict")
+	if err := os.Mkdir(pluginDir, 0755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"workflow-plugin-strict"}`), 0644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.contracts.json"), []byte(`{
+  "version": "v1",
+  "descriptorSetRef": "proto/strict.pb",
+  "contracts": [
+    {
+      "kind": "step",
+      "type": "step.strict",
+      "mode": "strict",
+      "input": "workflow.strict.Input",
+      "output": "workflow.strict.Output"
+    }
+  ]
+}`), 0644); err != nil {
+		t.Fatalf("write plugin contracts: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "editor-bundle.json")
+	if err := runEditorBundle([]string{"--plugin-dir", pluginDir, "--output", outPath}); err != nil {
+		t.Fatalf("editor-bundle failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var bundle struct {
+		Contracts map[string]struct {
+			DescriptorSetRef string `json:"descriptorSetRef"`
+			RequestMessage   string `json:"requestMessage"`
+			ResponseMessage  string `json:"responseMessage"`
+		} `json:"contracts"`
+		DescriptorSets map[string]struct {
+			ExternalRef string `json:"externalRef"`
+		} `json:"descriptorSets"`
+	}
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		t.Fatalf("bundle is not valid JSON: %v", err)
+	}
+	contract := bundle.Contracts["step:step.strict"]
+	if contract.DescriptorSetRef != "proto/strict.pb" {
+		t.Fatalf("descriptorSetRef = %q", contract.DescriptorSetRef)
+	}
+	if contract.RequestMessage != "workflow.strict.Input" || contract.ResponseMessage != "workflow.strict.Output" {
+		t.Fatalf("typed I/O metadata missing: %+v", contract)
+	}
+	if bundle.DescriptorSets["proto/strict.pb"].ExternalRef != "proto/strict.pb" {
+		t.Fatalf("descriptor set reference missing: %+v", bundle.DescriptorSets)
+	}
+}

--- a/cmd/wfctl/editor_bundle_test.go
+++ b/cmd/wfctl/editor_bundle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,6 +130,56 @@ func TestRunEditorBundleRejectsMalformedPluginContractDescriptors(t *testing.T) 
 	}
 	if !strings.Contains(err.Error(), "invalid_plugin_contract_descriptors") {
 		t.Fatalf("error = %v, want invalid_plugin_contract_descriptors", err)
+	}
+}
+
+func TestRunEditorBundleRejectsMalformedServiceMethodContract(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "workflow-plugin-bad-service")
+	if err := os.Mkdir(pluginDir, 0755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"workflow-plugin-bad-service"}`), 0644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.contracts.json"), []byte(`{
+  "version": "v1",
+  "contracts": [
+    {
+      "kind": "service_method",
+      "moduleType": "module.bad",
+      "serviceName": "BadService",
+      "mode": "strict",
+      "input": "workflow.bad.Input",
+      "output": "workflow.bad.Output"
+    }
+  ]
+}`), 0644); err != nil {
+		t.Fatalf("write plugin contracts: %v", err)
+	}
+
+	err := runEditorBundle([]string{"--registry=false", "--plugin-dir", pluginDir})
+	if err == nil {
+		t.Fatal("expected malformed service_method descriptor to fail")
+	}
+	if !strings.Contains(err.Error(), "malformed service_method") {
+		t.Fatalf("error = %v, want malformed service_method", err)
+	}
+}
+
+func TestRunEditorBundleFailsWhenDSLReferenceCannotLoad(t *testing.T) {
+	orig := loadEditorBundleDSLReferenceFunc
+	t.Cleanup(func() { loadEditorBundleDSLReferenceFunc = orig })
+	loadEditorBundleDSLReferenceFunc = func() (*DSLReferenceOutput, error) {
+		return nil, errors.New("broken reference")
+	}
+
+	err := runEditorBundle([]string{"--registry=false"})
+	if err == nil {
+		t.Fatal("expected DSL reference load failure")
+	}
+	if !strings.Contains(err.Error(), "load DSL reference: broken reference") {
+		t.Fatalf("error = %v, want DSL reference context", err)
 	}
 }
 

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -84,6 +84,7 @@ var commands = map[string]func([]string) error{
 	"infra":           runInfra,
 	"docs":            runDocs,
 	"editor-schemas":  runEditorSchemas,
+	"editor-bundle":   runEditorBundle,
 	"dsl-reference":   runDSLReference,
 	"ci":              runCI,
 	"override":        runOverride,

--- a/cmd/wfctl/plugin_audit.go
+++ b/cmd/wfctl/plugin_audit.go
@@ -46,22 +46,24 @@ type pluginContractKindCoverage struct {
 }
 
 type pluginContractDescriptorFile struct {
-	Version   string                     `json:"version"`
-	Contracts []pluginContractDescriptor `json:"contracts"`
+	Version          string                     `json:"version"`
+	DescriptorSetRef string                     `json:"descriptorSetRef,omitempty"`
+	Contracts        []pluginContractDescriptor `json:"contracts"`
 }
 
 type pluginContractDescriptor struct {
-	Kind        string `json:"kind"`
-	Type        string `json:"type"`
-	Mode        string `json:"mode"`
-	Config      string `json:"config,omitempty"`
-	Input       string `json:"input,omitempty"`
-	Output      string `json:"output,omitempty"`
-	ModuleType  string `json:"moduleType,omitempty"`
-	StepType    string `json:"stepType,omitempty"`
-	TriggerType string `json:"triggerType,omitempty"`
-	ServiceName string `json:"serviceName,omitempty"`
-	Method      string `json:"method,omitempty"`
+	Kind             string `json:"kind"`
+	Type             string `json:"type"`
+	Mode             string `json:"mode"`
+	Config           string `json:"config,omitempty"`
+	Input            string `json:"input,omitempty"`
+	Output           string `json:"output,omitempty"`
+	ModuleType       string `json:"moduleType,omitempty"`
+	StepType         string `json:"stepType,omitempty"`
+	TriggerType      string `json:"triggerType,omitempty"`
+	ServiceName      string `json:"serviceName,omitempty"`
+	Method           string `json:"method,omitempty"`
+	DescriptorSetRef string `json:"descriptorSetRef,omitempty"`
 }
 
 func (d *pluginContractDescriptor) UnmarshalJSON(data []byte) error {
@@ -80,6 +82,7 @@ func (d *pluginContractDescriptor) UnmarshalJSON(data []byte) error {
 	d.TriggerType = firstStringField(raw, "triggerType", "trigger_type")
 	d.ServiceName = firstStringField(raw, "serviceName", "service_name")
 	d.Method = firstStringField(raw, "method")
+	d.DescriptorSetRef = firstStringField(raw, "descriptorSetRef", "descriptor_set_ref")
 	return nil
 }
 
@@ -278,6 +281,7 @@ func loadPluginContractDescriptors(repoPath string, manifest map[string]any, opt
 			})
 			return descriptors, contractPath, true, findings
 		}
+		applyDescriptorSetRef(file.Contracts, file.DescriptorSetRef)
 		descriptors = append(descriptors, file.Contracts...)
 		return descriptors, contractPath, true, findings
 	}
@@ -306,7 +310,19 @@ func parsePluginContractDescriptors(raw any) ([]pluginContractDescriptor, error)
 	if err := json.Unmarshal(data, &file); err != nil {
 		return nil, err
 	}
+	applyDescriptorSetRef(file.Contracts, file.DescriptorSetRef)
 	return file.Contracts, nil
+}
+
+func applyDescriptorSetRef(descriptors []pluginContractDescriptor, descriptorSetRef string) {
+	if descriptorSetRef == "" {
+		return
+	}
+	for i := range descriptors {
+		if descriptors[i].DescriptorSetRef == "" {
+			descriptors[i].DescriptorSetRef = descriptorSetRef
+		}
+	}
 }
 
 func addPluginContractKindFindings(result *pluginAuditResult, kind string, advertised []string, descriptors map[string]pluginContractDescriptor, opts pluginAuditOptions) pluginContractKindCoverage {

--- a/cmd/wfctl/wfctl.yaml
+++ b/cmd/wfctl/wfctl.yaml
@@ -67,6 +67,8 @@ workflows:
         description: Generate documentation from workflow configs
       - name: editor-schemas
         description: Export module schemas and type coercion rules
+      - name: editor-bundle
+        description: Export the canonical editor contract bundle
       - name: dsl-reference
         description: Parse DSL reference as structured JSON
       - name: ci
@@ -217,6 +219,10 @@ pipelines:
     trigger: {type: cli, config: {command: editor-schemas}}
     steps:
       - {name: run, type: step.cli_invoke, config: {command: editor-schemas}}
+  cmd-editor-bundle:
+    trigger: {type: cli, config: {command: editor-bundle}}
+    steps:
+      - {name: run, type: step.cli_invoke, config: {command: editor-bundle}}
   cmd-dsl-reference:
     trigger: {type: cli, config: {command: dsl-reference}}
     steps:

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -290,6 +290,32 @@ wfctl audit plugins --repo-root /path/to/workspace --strict
 wfctl audit plugins --repo-root /path/to/workspace --strict-contracts
 ```
 
+### `editor-bundle`
+
+Export the canonical editor contract bundle for Workflow-aware IDEs and visual editors.
+
+```
+wfctl editor-bundle [options]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output` | _(stdout)_ | Write the bundle JSON to a file |
+| `--format` | `json` | Output format; only `json` is supported |
+| `--plugin-dir` | _(none)_ | Load strict contract descriptors from one plugin repo or a directory of plugin repos |
+| `--registry` | `true` | Include strict contract descriptors from the configured plugin registry |
+
+The bundle includes core module and step schemas, YAML schemas, snippets, DSL reference data, and strict plugin contract metadata. Registry manifests are part of the canonical output by default; unavailable or malformed registry manifests fail the command. Use `--registry=false` for an explicit local-only export.
+
+When `--plugin-dir` is provided, `plugin.contracts.json` is parsed strictly. Invalid or unreadable descriptor files fail the command instead of producing a partial bundle. Service method contracts are keyed by module type when available, using `service:<module-type>/<service-name>/<method>`, so separate module-scoped services can expose the same service and method names without colliding.
+
+Examples:
+
+```bash
+wfctl editor-bundle --output editor-bundle.json
+wfctl editor-bundle --registry=false --plugin-dir ../workflow-plugin-example --output editor-bundle.json
+```
+
 ### `init`
 
 Scaffold a new workflow application project from a built-in template.

--- a/schema/editor_bundle.go
+++ b/schema/editor_bundle.go
@@ -207,10 +207,7 @@ func descriptorSetRefForContract(source EditorContractRegistrySource, descriptor
 	if ownerType == "" || ownerKey == "" {
 		return fallback
 	}
-	id := ownerType + ":" + ownerKey
-	if ownerType == "service" && descriptor.GetServiceName() != "" {
-		id = "service:" + descriptor.GetServiceName() + "/" + descriptor.GetMethod()
-	}
+	id := editorContractID(ownerType, ownerKey)
 	if ref := source.ContractDescriptorSetRefs[id]; ref != "" {
 		return ref
 	}
@@ -365,10 +362,7 @@ func normalizeContractDescriptor(source EditorContractRegistrySource, descriptor
 	if ownerType == "" || ownerKey == "" {
 		return nil
 	}
-	id := ownerType + ":" + ownerKey
-	if ownerType == "service" && descriptor.ServiceName != "" {
-		id = "service:" + descriptor.ServiceName + "/" + descriptor.Method
-	}
+	id := editorContractID(ownerType, ownerKey)
 	return &EditorContractDescriptor{
 		ID:               id,
 		Plugin:           source.Plugin,
@@ -392,6 +386,9 @@ func editorContractOwner(descriptor *pb.ContractDescriptor) (string, string) {
 	case pb.ContractKind_CONTRACT_KIND_TRIGGER:
 		return "trigger", descriptor.TriggerType
 	case pb.ContractKind_CONTRACT_KIND_SERVICE:
+		if descriptor.ModuleType != "" && descriptor.ServiceName != "" {
+			return "service", descriptor.ModuleType + "/" + descriptor.ServiceName + "/" + descriptor.Method
+		}
 		if descriptor.ServiceName == "" {
 			return "service", descriptor.Method
 		}
@@ -399,6 +396,13 @@ func editorContractOwner(descriptor *pb.ContractDescriptor) (string, string) {
 	default:
 		return "", ""
 	}
+}
+
+func editorContractID(ownerType, ownerKey string) string {
+	if ownerType == "" || ownerKey == "" {
+		return ""
+	}
+	return ownerType + ":" + ownerKey
 }
 
 func editorContractMode(mode pb.ContractMode) string {

--- a/schema/editor_bundle.go
+++ b/schema/editor_bundle.go
@@ -1,0 +1,457 @@
+package schema
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+const (
+	EditorBundleSchemaVersion = "editor-bundle/v1"
+
+	EditorContractSourceBuiltin             = "builtin"
+	EditorContractSourcePluginManifest      = "plugin-manifest"
+	EditorContractSourcePluginContractsJSON = "plugin-contracts-json"
+	EditorContractSourceLivePlugin          = "live-plugin"
+)
+
+type EditorBundleOptions struct {
+	WorkflowVersion    string
+	ContractRegistries []EditorContractRegistrySource
+}
+
+type EditorContractRegistrySource struct {
+	Plugin           string
+	Source           string
+	Registry         *pb.ContractRegistry
+	DescriptorSetRef string
+}
+
+type EditorContractBundle struct {
+	Version         string                               `json:"version"`
+	WorkflowVersion string                               `json:"workflowVersion"`
+	ModuleSchemas   map[string]*ModuleSchema             `json:"moduleSchemas"`
+	StepSchemas     map[string]*StepSchema               `json:"stepSchemas"`
+	CoercionRules   map[string][]string                  `json:"coercionRules"`
+	Contracts       map[string]*EditorContractDescriptor `json:"contracts"`
+	Messages        map[string]*EditorMessageDescriptor  `json:"messages"`
+	DescriptorSets  map[string]*EditorDescriptorSet      `json:"descriptorSets"`
+	DSLReference    any                                  `json:"dslReference,omitempty"`
+	Schemas         EditorYAMLSchemas                    `json:"schemas"`
+	Snippets        []EditorSnippet                      `json:"snippets"`
+}
+
+type EditorContractDescriptor struct {
+	ID               string `json:"id"`
+	Plugin           string `json:"plugin,omitempty"`
+	OwnerType        string `json:"ownerType"`
+	OwnerKey         string `json:"ownerKey"`
+	Mode             string `json:"mode"`
+	RequestMessage   string `json:"requestMessage,omitempty"`
+	ResponseMessage  string `json:"responseMessage,omitempty"`
+	ConfigMessage    string `json:"configMessage,omitempty"`
+	DescriptorSetRef string `json:"descriptorSetRef,omitempty"`
+	Source           string `json:"source"`
+}
+
+type EditorMessageDescriptor struct {
+	Name             string               `json:"name"`
+	FullName         string               `json:"fullName"`
+	Fields           []EditorMessageField `json:"fields"`
+	DescriptorSetRef string               `json:"descriptorSetRef,omitempty"`
+}
+
+type EditorMessageField struct {
+	Name        string `json:"name"`
+	JSONName    string `json:"jsonName,omitempty"`
+	Number      int32  `json:"number"`
+	Type        string `json:"type"`
+	MessageType string `json:"messageType,omitempty"`
+	EnumType    string `json:"enumType,omitempty"`
+	Repeated    bool   `json:"repeated,omitempty"`
+	Map         bool   `json:"map,omitempty"`
+}
+
+type EditorDescriptorSet struct {
+	ID              string   `json:"id"`
+	Plugin          string   `json:"plugin,omitempty"`
+	Encoding        string   `json:"encoding"`
+	SHA256          string   `json:"sha256,omitempty"`
+	EmbeddedBase64  string   `json:"embeddedBase64,omitempty"`
+	FileCount       int      `json:"fileCount"`
+	MessageCount    int      `json:"messageCount"`
+	MessageNames    []string `json:"messageNames"`
+	ExternalRef     string   `json:"externalRef,omitempty"`
+	ExternalRefType string   `json:"externalRefType,omitempty"`
+}
+
+type EditorYAMLSchemas struct {
+	App   *Schema `json:"app"`
+	Infra *Schema `json:"infra,omitempty"`
+	Wfctl *Schema `json:"wfctl,omitempty"`
+}
+
+type EditorSnippet struct {
+	Name        string   `json:"name"`
+	Prefix      string   `json:"prefix"`
+	Description string   `json:"description,omitempty"`
+	Body        []string `json:"body"`
+}
+
+func ExportEditorBundle(opts EditorBundleOptions) (*EditorContractBundle, error) {
+	moduleReg := NewModuleSchemaRegistry()
+	stepReg := NewStepSchemaRegistry()
+	coercionReg := NewTypeCoercionRegistry()
+
+	bundle := &EditorContractBundle{
+		Version:         EditorBundleSchemaVersion,
+		WorkflowVersion: opts.WorkflowVersion,
+		ModuleSchemas:   moduleReg.AllMap(),
+		StepSchemas:     stepReg.AllMap(),
+		CoercionRules:   coercionReg.Rules(),
+		Contracts:       map[string]*EditorContractDescriptor{},
+		Messages:        map[string]*EditorMessageDescriptor{},
+		DescriptorSets:  map[string]*EditorDescriptorSet{},
+		Schemas: EditorYAMLSchemas{
+			App:   GenerateWorkflowSchema(),
+			Infra: GenerateInfraSchema(),
+			Wfctl: GenerateWfctlSchema(),
+		},
+		Snippets: editorSnippets(),
+	}
+
+	for _, source := range opts.ContractRegistries {
+		if err := addContractRegistryToBundle(bundle, source); err != nil {
+			return nil, err
+		}
+	}
+	return bundle, nil
+}
+
+func editorSnippets() []EditorSnippet {
+	snippets := GetSnippets()
+	out := make([]EditorSnippet, 0, len(snippets))
+	for _, snippet := range snippets {
+		body := make([]string, len(snippet.Body))
+		copy(body, snippet.Body)
+		out = append(out, EditorSnippet{
+			Name:        snippet.Name,
+			Prefix:      snippet.Prefix,
+			Description: snippet.Description,
+			Body:        body,
+		})
+	}
+	return out
+}
+
+func addContractRegistryToBundle(bundle *EditorContractBundle, source EditorContractRegistrySource) error {
+	if source.Registry == nil {
+		return nil
+	}
+	descriptorSetRef := source.DescriptorSetRef
+	if source.Registry.FileDescriptorSet != nil && len(source.Registry.FileDescriptorSet.File) > 0 {
+		descriptorSet, err := normalizeDescriptorSet(source.Plugin, source.Registry.FileDescriptorSet)
+		if err != nil {
+			return err
+		}
+		bundle.DescriptorSets[descriptorSet.ID] = descriptorSet
+		descriptorSetRef = descriptorSet.ID
+		if err := addMessagesFromDescriptorSet(bundle.Messages, descriptorSetRef, source.Registry.FileDescriptorSet); err != nil {
+			return err
+		}
+	} else if descriptorSetRef != "" {
+		bundle.DescriptorSets[descriptorSetRef] = &EditorDescriptorSet{
+			ID:              descriptorSetRef,
+			Plugin:          source.Plugin,
+			Encoding:        "external",
+			ExternalRef:     descriptorSetRef,
+			ExternalRefType: "path",
+		}
+	}
+	for _, descriptor := range source.Registry.Contracts {
+		contract := normalizeContractDescriptor(source, descriptor, descriptorSetRef)
+		if contract == nil {
+			continue
+		}
+		bundle.Contracts[contract.ID] = contract
+		addReferencedMessagePlaceholders(bundle.Messages, contract, descriptorSetRef)
+	}
+	return nil
+}
+
+func normalizeDescriptorSet(plugin string, set *descriptorpb.FileDescriptorSet) (*EditorDescriptorSet, error) {
+	data, err := proto.Marshal(set)
+	if err != nil {
+		return nil, fmt.Errorf("marshal descriptor set: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	idParts := []string{"descriptor-set"}
+	if plugin != "" {
+		idParts = append(idParts, plugin)
+	}
+	idParts = append(idParts, hex.EncodeToString(sum[:8]))
+
+	names := descriptorSetMessageNames(set)
+	return &EditorDescriptorSet{
+		ID:             strings.Join(idParts, ":"),
+		Plugin:         plugin,
+		Encoding:       "protobuf.FileDescriptorSet+base64",
+		SHA256:         hex.EncodeToString(sum[:]),
+		EmbeddedBase64: base64.StdEncoding.EncodeToString(data),
+		FileCount:      len(set.File),
+		MessageCount:   len(names),
+		MessageNames:   names,
+	}, nil
+}
+
+func descriptorSetMessageNames(set *descriptorpb.FileDescriptorSet) []string {
+	var names []string
+	for _, file := range set.File {
+		pkg := file.GetPackage()
+		for _, msg := range file.MessageType {
+			collectDescriptorProtoNames(&names, pkg, "", msg)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func collectDescriptorProtoNames(names *[]string, pkg, parent string, msg *descriptorpb.DescriptorProto) {
+	if msg == nil {
+		return
+	}
+	name := msg.GetName()
+	if parent != "" {
+		name = parent + "." + name
+	}
+	fullName := name
+	if pkg != "" {
+		fullName = pkg + "." + name
+	}
+	*names = append(*names, fullName)
+	for _, nested := range msg.NestedType {
+		collectDescriptorProtoNames(names, pkg, name, nested)
+	}
+}
+
+func addMessagesFromDescriptorSet(messages map[string]*EditorMessageDescriptor, descriptorSetRef string, set *descriptorpb.FileDescriptorSet) error {
+	files, err := protodesc.NewFiles(set)
+	if err != nil {
+		return fmt.Errorf("parse descriptor set: %w", err)
+	}
+	var walkErr error
+	files.RangeFiles(func(file protoreflect.FileDescriptor) bool {
+		walkErr = addMessageDescriptors(messages, descriptorSetRef, file.Messages())
+		return walkErr == nil
+	})
+	return walkErr
+}
+
+func addMessageDescriptors(messages map[string]*EditorMessageDescriptor, descriptorSetRef string, descriptors protoreflect.MessageDescriptors) error {
+	for i := 0; i < descriptors.Len(); i++ {
+		descriptor := descriptors.Get(i)
+		fullName := string(descriptor.FullName())
+		messages[fullName] = &EditorMessageDescriptor{
+			Name:             string(descriptor.Name()),
+			FullName:         fullName,
+			Fields:           editorMessageFields(descriptor.Fields()),
+			DescriptorSetRef: descriptorSetRef,
+		}
+		if err := addMessageDescriptors(messages, descriptorSetRef, descriptor.Messages()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func editorMessageFields(fields protoreflect.FieldDescriptors) []EditorMessageField {
+	out := make([]EditorMessageField, 0, fields.Len())
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		editorField := EditorMessageField{
+			Name:     string(field.Name()),
+			JSONName: field.JSONName(),
+			Number:   int32(field.Number()),
+			Type:     editorFieldType(field),
+			Repeated: field.IsList(),
+			Map:      field.IsMap(),
+		}
+		if field.Message() != nil {
+			editorField.MessageType = string(field.Message().FullName())
+		}
+		if field.Enum() != nil {
+			editorField.EnumType = string(field.Enum().FullName())
+		}
+		out = append(out, editorField)
+	}
+	return out
+}
+
+func editorFieldType(field protoreflect.FieldDescriptor) string {
+	if field.IsMap() {
+		return "map"
+	}
+	switch field.Kind() {
+	case protoreflect.BoolKind:
+		return "bool"
+	case protoreflect.EnumKind:
+		return "enum"
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return "int32"
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return "uint32"
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return "int64"
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return "uint64"
+	case protoreflect.FloatKind:
+		return "float"
+	case protoreflect.DoubleKind:
+		return "double"
+	case protoreflect.StringKind:
+		return "string"
+	case protoreflect.BytesKind:
+		return "bytes"
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return "message"
+	default:
+		return string(field.Kind().String())
+	}
+}
+
+func normalizeContractDescriptor(source EditorContractRegistrySource, descriptor *pb.ContractDescriptor, descriptorSetRef string) *EditorContractDescriptor {
+	if descriptor == nil {
+		return nil
+	}
+	ownerType, ownerKey := editorContractOwner(descriptor)
+	if ownerType == "" || ownerKey == "" {
+		return nil
+	}
+	id := ownerType + ":" + ownerKey
+	if ownerType == "service" && descriptor.ServiceName != "" {
+		id = "service:" + descriptor.ServiceName + "/" + descriptor.Method
+	}
+	return &EditorContractDescriptor{
+		ID:               id,
+		Plugin:           source.Plugin,
+		OwnerType:        ownerType,
+		OwnerKey:         ownerKey,
+		Mode:             editorContractMode(descriptor.Mode),
+		RequestMessage:   descriptor.InputMessage,
+		ResponseMessage:  descriptor.OutputMessage,
+		ConfigMessage:    descriptor.ConfigMessage,
+		DescriptorSetRef: descriptorSetRef,
+		Source:           editorContractSource(source.Source),
+	}
+}
+
+func editorContractOwner(descriptor *pb.ContractDescriptor) (string, string) {
+	switch descriptor.Kind {
+	case pb.ContractKind_CONTRACT_KIND_MODULE:
+		return "module", descriptor.ModuleType
+	case pb.ContractKind_CONTRACT_KIND_STEP:
+		return "step", descriptor.StepType
+	case pb.ContractKind_CONTRACT_KIND_TRIGGER:
+		return "trigger", descriptor.TriggerType
+	case pb.ContractKind_CONTRACT_KIND_SERVICE:
+		if descriptor.ServiceName == "" {
+			return "service", descriptor.Method
+		}
+		return "service", descriptor.ServiceName + "/" + descriptor.Method
+	default:
+		return "", ""
+	}
+}
+
+func editorContractMode(mode pb.ContractMode) string {
+	switch mode {
+	case pb.ContractMode_CONTRACT_MODE_STRICT_PROTO:
+		return "strict"
+	case pb.ContractMode_CONTRACT_MODE_PROTO_WITH_LEGACY_STRUCT:
+		return "proto_with_legacy"
+	case pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT:
+		return "legacy"
+	default:
+		return "unspecified"
+	}
+}
+
+func editorContractSource(source string) string {
+	switch source {
+	case EditorContractSourceBuiltin,
+		EditorContractSourcePluginManifest,
+		EditorContractSourcePluginContractsJSON,
+		EditorContractSourceLivePlugin:
+		return source
+	default:
+		return EditorContractSourceBuiltin
+	}
+}
+
+func addReferencedMessagePlaceholders(messages map[string]*EditorMessageDescriptor, contract *EditorContractDescriptor, descriptorSetRef string) {
+	for _, name := range []string{contract.ConfigMessage, contract.RequestMessage, contract.ResponseMessage} {
+		if name == "" {
+			continue
+		}
+		if _, ok := messages[name]; ok {
+			continue
+		}
+		shortName := name
+		if idx := strings.LastIndex(shortName, "."); idx >= 0 {
+			shortName = shortName[idx+1:]
+		}
+		messages[name] = &EditorMessageDescriptor{
+			Name:             shortName,
+			FullName:         name,
+			DescriptorSetRef: descriptorSetRef,
+		}
+	}
+}
+
+func GenerateInfraSchema() *Schema {
+	s := &Schema{
+		Schema:      "https://json-schema.org/draft/2020-12/schema",
+		Title:       "Workflow infrastructure configuration",
+		Description: "Schema for infra.yaml files consumed by wfctl infrastructure workflows.",
+		Type:        "object",
+		Properties: map[string]*Schema{
+			"infrastructure": {Type: "object"},
+			"providers":      {Type: "object"},
+			"environments":   {Type: "object"},
+			"sidecars":       {Type: "array", Items: &Schema{Type: "object"}},
+			"state":          {Type: "object"},
+		},
+	}
+	s.setAdditionalPropertiesBool(true)
+	return s
+}
+
+func GenerateWfctlSchema() *Schema {
+	s := &Schema{
+		Schema:      "https://json-schema.org/draft/2020-12/schema",
+		Title:       "wfctl project configuration",
+		Description: "Schema for wfctl.yaml project metadata and tool policy.",
+		Type:        "object",
+		Properties: map[string]*Schema{
+			"project":      {Type: "object"},
+			"plugins":      {Type: "object"},
+			"registries":   {Type: "array", Items: &Schema{Type: "object"}},
+			"environments": {Type: "object"},
+			"validation":   {Type: "object"},
+			"deploy":       {Type: "object"},
+			"release":      {Type: "object"},
+			"secrets":      {Type: "object"},
+		},
+	}
+	s.setAdditionalPropertiesBool(true)
+	return s
+}

--- a/schema/editor_bundle.go
+++ b/schema/editor_bundle.go
@@ -30,10 +30,11 @@ type EditorBundleOptions struct {
 }
 
 type EditorContractRegistrySource struct {
-	Plugin           string
-	Source           string
-	Registry         *pb.ContractRegistry
-	DescriptorSetRef string
+	Plugin                    string
+	Source                    string
+	Registry                  *pb.ContractRegistry
+	DescriptorSetRef          string
+	ContractDescriptorSetRefs map[string]string
 }
 
 type EditorContractBundle struct {
@@ -178,14 +179,42 @@ func addContractRegistryToBundle(bundle *EditorContractBundle, source EditorCont
 		}
 	}
 	for _, descriptor := range source.Registry.Contracts {
-		contract := normalizeContractDescriptor(source, descriptor, descriptorSetRef)
+		contractDescriptorSetRef := descriptorSetRefForContract(source, descriptor, descriptorSetRef)
+		if contractDescriptorSetRef != "" && bundle.DescriptorSets[contractDescriptorSetRef] == nil {
+			bundle.DescriptorSets[contractDescriptorSetRef] = &EditorDescriptorSet{
+				ID:              contractDescriptorSetRef,
+				Plugin:          source.Plugin,
+				Encoding:        "external",
+				ExternalRef:     contractDescriptorSetRef,
+				ExternalRefType: "path",
+			}
+		}
+		contract := normalizeContractDescriptor(source, descriptor, contractDescriptorSetRef)
 		if contract == nil {
 			continue
 		}
 		bundle.Contracts[contract.ID] = contract
-		addReferencedMessagePlaceholders(bundle.Messages, contract, descriptorSetRef)
+		addReferencedMessagePlaceholders(bundle.Messages, contract, contractDescriptorSetRef)
 	}
 	return nil
+}
+
+func descriptorSetRefForContract(source EditorContractRegistrySource, descriptor *pb.ContractDescriptor, fallback string) string {
+	if len(source.ContractDescriptorSetRefs) == 0 {
+		return fallback
+	}
+	ownerType, ownerKey := editorContractOwner(descriptor)
+	if ownerType == "" || ownerKey == "" {
+		return fallback
+	}
+	id := ownerType + ":" + ownerKey
+	if ownerType == "service" && descriptor.GetServiceName() != "" {
+		id = "service:" + descriptor.GetServiceName() + "/" + descriptor.GetMethod()
+	}
+	if ref := source.ContractDescriptorSetRefs[id]; ref != "" {
+		return ref
+	}
+	return fallback
 }
 
 func normalizeDescriptorSet(plugin string, set *descriptorpb.FileDescriptorSet) (*EditorDescriptorSet, error) {

--- a/schema/editor_bundle.go
+++ b/schema/editor_bundle.go
@@ -441,7 +441,10 @@ func addReferencedMessagePlaceholders(messages map[string]*EditorMessageDescript
 		if name == "" {
 			continue
 		}
-		if _, ok := messages[name]; ok {
+		if existing, ok := messages[name]; ok {
+			if existing.DescriptorSetRef == "" && descriptorSetRef != "" {
+				existing.DescriptorSetRef = descriptorSetRef
+			}
 			continue
 		}
 		shortName := name

--- a/schema/editor_bundle.go
+++ b/schema/editor_bundle.go
@@ -386,13 +386,19 @@ func editorContractOwner(descriptor *pb.ContractDescriptor) (string, string) {
 	case pb.ContractKind_CONTRACT_KIND_TRIGGER:
 		return "trigger", descriptor.TriggerType
 	case pb.ContractKind_CONTRACT_KIND_SERVICE:
-		if descriptor.ModuleType != "" && descriptor.ServiceName != "" {
+		if descriptor.ModuleType != "" {
+			if descriptor.ServiceName == "" || descriptor.Method == "" {
+				return "", ""
+			}
 			return "service", descriptor.ModuleType + "/" + descriptor.ServiceName + "/" + descriptor.Method
 		}
-		if descriptor.ServiceName == "" {
-			return "service", descriptor.Method
+		if descriptor.ServiceName != "" {
+			if descriptor.Method == "" {
+				return "", ""
+			}
+			return "service", descriptor.ServiceName + "/" + descriptor.Method
 		}
-		return "service", descriptor.ServiceName + "/" + descriptor.Method
+		return "service", descriptor.Method
 	default:
 		return "", ""
 	}

--- a/schema/editor_bundle_test.go
+++ b/schema/editor_bundle_test.go
@@ -168,6 +168,57 @@ func TestExportEditorBundleIncludesExternalDescriptorSetReferences(t *testing.T)
 	}
 }
 
+func TestExportEditorBundlePreservesPerContractExternalDescriptorSetReferences(t *testing.T) {
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		ContractRegistries: []EditorContractRegistrySource{
+			{
+				Plugin:           "workflow-plugin-ref-test",
+				Source:           EditorContractSourcePluginContractsJSON,
+				DescriptorSetRef: "descriptors/default.pb",
+				ContractDescriptorSetRefs: map[string]string{
+					"step:step.one": "descriptors/one.pb",
+					"step:step.two": "descriptors/two.pb",
+				},
+				Registry: &pb.ContractRegistry{
+					Contracts: []*pb.ContractDescriptor{
+						{
+							Kind:         pb.ContractKind_CONTRACT_KIND_STEP,
+							StepType:     "step.one",
+							Mode:         pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage: "workflow.test.OneInput",
+						},
+						{
+							Kind:         pb.ContractKind_CONTRACT_KIND_STEP,
+							StepType:     "step.two",
+							Mode:         pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage: "workflow.test.TwoInput",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+
+	if got := bundle.Contracts["step:step.one"].DescriptorSetRef; got != "descriptors/one.pb" {
+		t.Fatalf("step.one descriptor set ref = %q", got)
+	}
+	if got := bundle.Contracts["step:step.two"].DescriptorSetRef; got != "descriptors/two.pb" {
+		t.Fatalf("step.two descriptor set ref = %q", got)
+	}
+	if got := bundle.Messages["workflow.test.OneInput"].DescriptorSetRef; got != "descriptors/one.pb" {
+		t.Fatalf("workflow.test.OneInput descriptor set ref = %q", got)
+	}
+	if got := bundle.Messages["workflow.test.TwoInput"].DescriptorSetRef; got != "descriptors/two.pb" {
+		t.Fatalf("workflow.test.TwoInput descriptor set ref = %q", got)
+	}
+	if bundle.DescriptorSets["descriptors/one.pb"] == nil || bundle.DescriptorSets["descriptors/two.pb"] == nil {
+		t.Fatalf("expected both descriptor set refs, got %+v", bundle.DescriptorSets)
+	}
+}
+
 func assertMessageField(t *testing.T, msg *EditorMessageDescriptor, name, typ string, repeated bool) {
 	t.Helper()
 	for _, field := range msg.Fields {

--- a/schema/editor_bundle_test.go
+++ b/schema/editor_bundle_test.go
@@ -219,6 +219,67 @@ func TestExportEditorBundlePreservesPerContractExternalDescriptorSetReferences(t
 	}
 }
 
+func TestExportEditorBundleKeysServiceContractsByModuleType(t *testing.T) {
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		ContractRegistries: []EditorContractRegistrySource{
+			{
+				Plugin: "workflow-plugin-service-test",
+				Source: EditorContractSourcePluginContractsJSON,
+				ContractDescriptorSetRefs: map[string]string{
+					"service:module.alpha/SharedService/Call": "descriptors/alpha.pb",
+					"service:module.beta/SharedService/Call":  "descriptors/beta.pb",
+				},
+				Registry: &pb.ContractRegistry{
+					Contracts: []*pb.ContractDescriptor{
+						{
+							Kind:          pb.ContractKind_CONTRACT_KIND_SERVICE,
+							ModuleType:    "module.alpha",
+							ServiceName:   "SharedService",
+							Method:        "Call",
+							Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage:  "workflow.test.AlphaRequest",
+							OutputMessage: "workflow.test.AlphaResponse",
+						},
+						{
+							Kind:          pb.ContractKind_CONTRACT_KIND_SERVICE,
+							ModuleType:    "module.beta",
+							ServiceName:   "SharedService",
+							Method:        "Call",
+							Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage:  "workflow.test.BetaRequest",
+							OutputMessage: "workflow.test.BetaResponse",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+
+	alpha := bundle.Contracts["service:module.alpha/SharedService/Call"]
+	beta := bundle.Contracts["service:module.beta/SharedService/Call"]
+	if alpha == nil || beta == nil {
+		t.Fatalf("expected module-scoped service contracts, got keys %+v", bundle.Contracts)
+	}
+	if alpha.OwnerKey != "module.alpha/SharedService/Call" {
+		t.Fatalf("alpha owner key = %q", alpha.OwnerKey)
+	}
+	if beta.OwnerKey != "module.beta/SharedService/Call" {
+		t.Fatalf("beta owner key = %q", beta.OwnerKey)
+	}
+	if alpha.DescriptorSetRef != "descriptors/alpha.pb" {
+		t.Fatalf("alpha descriptor set ref = %q", alpha.DescriptorSetRef)
+	}
+	if beta.DescriptorSetRef != "descriptors/beta.pb" {
+		t.Fatalf("beta descriptor set ref = %q", beta.DescriptorSetRef)
+	}
+	if alpha.RequestMessage != "workflow.test.AlphaRequest" || beta.RequestMessage != "workflow.test.BetaRequest" {
+		t.Fatalf("service contracts collided: alpha=%+v beta=%+v", alpha, beta)
+	}
+}
+
 func assertMessageField(t *testing.T, msg *EditorMessageDescriptor, name, typ string, repeated bool) {
 	t.Helper()
 	for _, field := range msg.Fields {

--- a/schema/editor_bundle_test.go
+++ b/schema/editor_bundle_test.go
@@ -1,0 +1,227 @@
+package schema
+
+import (
+	"testing"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func TestExportEditorBundleIncludesCoreAuthoringSections(t *testing.T) {
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		WorkflowVersion: "test-version",
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+
+	if bundle.Version == "" {
+		t.Fatal("expected explicit bundle schema version")
+	}
+	if bundle.WorkflowVersion != "test-version" {
+		t.Fatalf("workflow version = %q, want test-version", bundle.WorkflowVersion)
+	}
+	if len(bundle.ModuleSchemas) == 0 {
+		t.Fatal("expected module schemas")
+	}
+	if bundle.ModuleSchemas["http.server"] == nil {
+		t.Fatal("expected http.server module schema")
+	}
+	if len(bundle.StepSchemas) == 0 {
+		t.Fatal("expected step schemas")
+	}
+	if bundle.StepSchemas["step.validate"] == nil {
+		t.Fatal("expected step.validate schema")
+	}
+	if len(bundle.CoercionRules) == 0 {
+		t.Fatal("expected coercion rules")
+	}
+	if len(bundle.Snippets) == 0 {
+		t.Fatal("expected editor snippets")
+	}
+	if bundle.Schemas.App == nil {
+		t.Fatal("expected app.yaml schema")
+	}
+	if bundle.Schemas.Infra == nil {
+		t.Fatal("expected infra.yaml schema")
+	}
+	if bundle.Schemas.Wfctl == nil {
+		t.Fatal("expected wfctl.yaml schema")
+	}
+}
+
+func TestExportEditorBundleNormalizesStrictContractsAndMessageMetadata(t *testing.T) {
+	registry := &pb.ContractRegistry{
+		FileDescriptorSet: testEditorBundleDescriptorSet(),
+		Contracts: []*pb.ContractDescriptor{
+			{
+				Kind:          pb.ContractKind_CONTRACT_KIND_STEP,
+				StepType:      "step.strict_test",
+				Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+				ConfigMessage: "workflow.test.StrictConfig",
+				InputMessage:  "workflow.test.StrictInput",
+				OutputMessage: "workflow.test.StrictOutput",
+			},
+		},
+	}
+
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		ContractRegistries: []EditorContractRegistrySource{
+			{
+				Plugin:   "workflow-plugin-strict-test",
+				Source:   EditorContractSourceLivePlugin,
+				Registry: registry,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+
+	contract := bundle.Contracts["step:step.strict_test"]
+	if contract == nil {
+		t.Fatalf("expected strict step contract, got keys %v", bundle.Contracts)
+	}
+	if contract.Plugin != "workflow-plugin-strict-test" {
+		t.Fatalf("plugin = %q", contract.Plugin)
+	}
+	if contract.OwnerType != "step" || contract.OwnerKey != "step.strict_test" {
+		t.Fatalf("owner = %s/%s", contract.OwnerType, contract.OwnerKey)
+	}
+	if contract.Mode != "strict" {
+		t.Fatalf("mode = %q, want strict", contract.Mode)
+	}
+	if contract.ConfigMessage != "workflow.test.StrictConfig" {
+		t.Fatalf("config message = %q", contract.ConfigMessage)
+	}
+	if contract.RequestMessage != "workflow.test.StrictInput" {
+		t.Fatalf("request message = %q", contract.RequestMessage)
+	}
+	if contract.ResponseMessage != "workflow.test.StrictOutput" {
+		t.Fatalf("response message = %q", contract.ResponseMessage)
+	}
+	if contract.DescriptorSetRef == "" {
+		t.Fatal("expected descriptor set reference on contract")
+	}
+	if bundle.DescriptorSets[contract.DescriptorSetRef] == nil {
+		t.Fatalf("descriptor set ref %q not present in descriptorSets", contract.DescriptorSetRef)
+	}
+
+	input := bundle.Messages["workflow.test.StrictInput"]
+	if input == nil {
+		t.Fatalf("expected input message metadata, got keys %v", bundle.Messages)
+	}
+	if input.DescriptorSetRef != contract.DescriptorSetRef {
+		t.Fatalf("input descriptor set ref = %q, want %q", input.DescriptorSetRef, contract.DescriptorSetRef)
+	}
+	assertMessageField(t, input, "customer_id", "string", false)
+	assertMessageField(t, input, "quantity", "int32", false)
+
+	output := bundle.Messages["workflow.test.StrictOutput"]
+	if output == nil {
+		t.Fatal("expected output message metadata")
+	}
+	assertMessageField(t, output, "accepted", "bool", false)
+	assertMessageField(t, output, "warnings", "string", true)
+}
+
+func TestExportEditorBundleIncludesExternalDescriptorSetReferences(t *testing.T) {
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		ContractRegistries: []EditorContractRegistrySource{
+			{
+				Plugin:           "workflow-plugin-ref-test",
+				Source:           EditorContractSourcePluginContractsJSON,
+				DescriptorSetRef: "descriptors/workflow-plugin-ref-test.pb",
+				Registry: &pb.ContractRegistry{
+					Contracts: []*pb.ContractDescriptor{
+						{
+							Kind:         pb.ContractKind_CONTRACT_KIND_STEP,
+							StepType:     "step.ref_test",
+							Mode:         pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage: "workflow.test.RefInput",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+
+	contract := bundle.Contracts["step:step.ref_test"]
+	if contract == nil {
+		t.Fatal("expected step contract")
+	}
+	if contract.DescriptorSetRef != "descriptors/workflow-plugin-ref-test.pb" {
+		t.Fatalf("descriptor set ref = %q", contract.DescriptorSetRef)
+	}
+	ref := bundle.DescriptorSets["descriptors/workflow-plugin-ref-test.pb"]
+	if ref == nil {
+		t.Fatalf("expected descriptor set reference entry, got %+v", bundle.DescriptorSets)
+	}
+	if ref.ExternalRef != "descriptors/workflow-plugin-ref-test.pb" {
+		t.Fatalf("external ref = %q", ref.ExternalRef)
+	}
+	if ref.Plugin != "workflow-plugin-ref-test" {
+		t.Fatalf("plugin = %q", ref.Plugin)
+	}
+}
+
+func assertMessageField(t *testing.T, msg *EditorMessageDescriptor, name, typ string, repeated bool) {
+	t.Helper()
+	for _, field := range msg.Fields {
+		if field.Name == name {
+			if field.Type != typ {
+				t.Fatalf("%s field type = %q, want %q", name, field.Type, typ)
+			}
+			if field.Repeated != repeated {
+				t.Fatalf("%s repeated = %v, want %v", name, field.Repeated, repeated)
+			}
+			return
+		}
+	}
+	t.Fatalf("field %q not found in %+v", name, msg.Fields)
+}
+
+func testEditorBundleDescriptorSet() *descriptorpb.FileDescriptorSet {
+	labelOptional := descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+	labelRepeated := descriptorpb.FieldDescriptorProto_LABEL_REPEATED
+	typeString := descriptorpb.FieldDescriptorProto_TYPE_STRING
+	typeInt32 := descriptorpb.FieldDescriptorProto_TYPE_INT32
+	typeBool := descriptorpb.FieldDescriptorProto_TYPE_BOOL
+
+	return &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{
+		{
+			Name:    strPtr("workflow/test/strict.proto"),
+			Package: strPtr("workflow.test"),
+			Syntax:  strPtr("proto3"),
+			MessageType: []*descriptorpb.DescriptorProto{
+				{
+					Name: strPtr("StrictConfig"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{Name: strPtr("region"), Number: int32Ptr(1), Label: &labelOptional, Type: &typeString},
+					},
+				},
+				{
+					Name: strPtr("StrictInput"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{Name: strPtr("customer_id"), Number: int32Ptr(1), Label: &labelOptional, Type: &typeString},
+						{Name: strPtr("quantity"), Number: int32Ptr(2), Label: &labelOptional, Type: &typeInt32},
+					},
+				},
+				{
+					Name: strPtr("StrictOutput"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{Name: strPtr("accepted"), Number: int32Ptr(1), Label: &labelOptional, Type: &typeBool},
+						{Name: strPtr("warnings"), Number: int32Ptr(2), Label: &labelRepeated, Type: &typeString},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func strPtr(v string) *string { return &v }
+
+func int32Ptr(v int32) *int32 { return &v }

--- a/schema/editor_bundle_test.go
+++ b/schema/editor_bundle_test.go
@@ -280,6 +280,38 @@ func TestExportEditorBundleKeysServiceContractsByModuleType(t *testing.T) {
 	}
 }
 
+func TestExportEditorBundleSkipsMalformedServiceContracts(t *testing.T) {
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		ContractRegistries: []EditorContractRegistrySource{
+			{
+				Plugin: "workflow-plugin-service-test",
+				Source: EditorContractSourcePluginContractsJSON,
+				Registry: &pb.ContractRegistry{
+					Contracts: []*pb.ContractDescriptor{
+						{
+							Kind:          pb.ContractKind_CONTRACT_KIND_SERVICE,
+							ModuleType:    "module.bad",
+							ServiceName:   "BadService",
+							Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage:  "workflow.test.BadRequest",
+							OutputMessage: "workflow.test.BadResponse",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+	if len(bundle.Contracts) != 0 {
+		t.Fatalf("expected malformed service contract to be skipped, got %+v", bundle.Contracts)
+	}
+	if bundle.Contracts["service:module.bad/BadService/"] != nil {
+		t.Fatal("malformed service contract produced trailing-slash key")
+	}
+}
+
 func assertMessageField(t *testing.T, msg *EditorMessageDescriptor, name, typ string, repeated bool) {
 	t.Helper()
 	for _, field := range msg.Fields {

--- a/schema/editor_bundle_test.go
+++ b/schema/editor_bundle_test.go
@@ -219,6 +219,52 @@ func TestExportEditorBundlePreservesPerContractExternalDescriptorSetReferences(t
 	}
 }
 
+func TestExportEditorBundleUpgradesPlaceholderDescriptorSetReference(t *testing.T) {
+	bundle, err := ExportEditorBundle(EditorBundleOptions{
+		ContractRegistries: []EditorContractRegistrySource{
+			{
+				Plugin: "workflow-plugin-no-ref",
+				Source: EditorContractSourcePluginContractsJSON,
+				Registry: &pb.ContractRegistry{
+					Contracts: []*pb.ContractDescriptor{
+						{
+							Kind:         pb.ContractKind_CONTRACT_KIND_STEP,
+							StepType:     "step.no_ref",
+							Mode:         pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage: "workflow.test.SharedInput",
+						},
+					},
+				},
+			},
+			{
+				Plugin:           "workflow-plugin-ref-test",
+				Source:           EditorContractSourcePluginContractsJSON,
+				DescriptorSetRef: "descriptors/ref.pb",
+				Registry: &pb.ContractRegistry{
+					Contracts: []*pb.ContractDescriptor{
+						{
+							Kind:         pb.ContractKind_CONTRACT_KIND_STEP,
+							StepType:     "step.with_ref",
+							Mode:         pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+							InputMessage: "workflow.test.SharedInput",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("export editor bundle: %v", err)
+	}
+	msg := bundle.Messages["workflow.test.SharedInput"]
+	if msg == nil {
+		t.Fatalf("expected shared input placeholder, got %+v", bundle.Messages)
+	}
+	if msg.DescriptorSetRef != "descriptors/ref.pb" {
+		t.Fatalf("shared input descriptor set ref = %q", msg.DescriptorSetRef)
+	}
+}
+
 func TestExportEditorBundleKeysServiceContractsByModuleType(t *testing.T) {
 	bundle, err := ExportEditorBundle(EditorBundleOptions{
 		ContractRegistries: []EditorContractRegistrySource{


### PR DESCRIPTION
## Summary

- adds schema.ExportEditorBundle with explicit editor-bundle/v1 versioning
- adds `wfctl editor-bundle` JSON export
- includes module schemas, step schemas, coercion rules, snippets, YAML schemas, strict contracts, messages, and descriptor sets
- preserves per-contract descriptor refs and module-scoped service contract identity
- fails on malformed explicit plugin contract descriptors and registry contract fetch errors
- documents the command in docs/WFCTL.md

## Verification

- GOWORK=off go test ./cmd/wfctl ./schema
- GOWORK=off go test ./...

## Reviews

- spec review requested default registry contract inclusion and per-contract descriptor refs; fixed
- antagonistic code review requested strict plugin contract errors, registry error handling, module-scoped service identity, and docs; fixed
- final review approved
