### PR TITLE
fix(wfctl): print migration repair diagnostics

### DIFF
--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -175,6 +176,7 @@ Options:
 		}
 	}
 	if statusErr := validateMigrationRepairResultStatus(result.Status); statusErr != nil {
+		printMigrationRepairResultDetails(out, result, jobEnvMap)
 		return redactMigrationRepairError(statusErr, jobEnvMap)
 	}
 	printMigrationRepairResult(out, result, jobEnvMap)
@@ -293,8 +295,74 @@ func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepai
 	} else if result.Status != "" {
 		fmt.Fprintf(out, "migration repair: %s\n", status)
 	}
+	printMigrationRepairResultDetails(out, result, secrets)
+}
+
+func printMigrationRepairResultDetails(out io.Writer, result *interfaces.MigrationRepairResult, secrets map[string]string) {
+	if result == nil {
+		return
+	}
 	if strings.TrimSpace(result.Logs) != "" {
 		fmt.Fprintln(out, redactMigrationRepairSecrets(result.Logs, secrets))
+	}
+	printMigrationRepairDiagnostics(out, result.Diagnostics, secrets)
+}
+
+func printMigrationRepairDiagnostics(out io.Writer, diagnostics []interfaces.Diagnostic, secrets map[string]string) {
+	if len(diagnostics) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "Diagnostics:")
+	for _, diagnostic := range redactMigrationRepairDiagnostics(diagnostics, secrets) {
+		if strings.TrimSpace(diagnostic.ID) != "" {
+			printMigrationRepairDiagnosticField(out, "-", "id", diagnostic.ID)
+		} else {
+			fmt.Fprintln(out, "-")
+		}
+		if strings.TrimSpace(diagnostic.Phase) != "" {
+			printMigrationRepairDiagnosticField(out, " ", "phase", diagnostic.Phase)
+		}
+		if strings.TrimSpace(diagnostic.Cause) != "" {
+			printMigrationRepairDiagnosticField(out, " ", "cause", diagnostic.Cause)
+		}
+		if !diagnostic.At.IsZero() {
+			fmt.Fprintf(out, "  at: %s\n", diagnostic.At.Format(time.RFC3339))
+		}
+		if strings.TrimSpace(diagnostic.Detail) != "" {
+			printMigrationRepairDiagnosticBlockField(out, " ", "detail", diagnostic.Detail)
+		}
+	}
+}
+
+func printMigrationRepairDiagnosticField(out io.Writer, bullet, label, value string) {
+	trimmed := strings.TrimRight(value, "\n")
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) == 1 {
+		if bullet == "-" {
+			fmt.Fprintf(out, "- %s: %s\n", label, lines[0])
+		} else {
+			fmt.Fprintf(out, "  %s: %s\n", label, lines[0])
+		}
+		return
+	}
+	if bullet == "-" {
+		fmt.Fprintf(out, "- %s:\n", label)
+	} else {
+		fmt.Fprintf(out, "  %s:\n", label)
+	}
+	for _, line := range lines {
+		fmt.Fprintf(out, "    %s\n", line)
+	}
+}
+
+func printMigrationRepairDiagnosticBlockField(out io.Writer, bullet, label, value string) {
+	if bullet == "-" {
+		fmt.Fprintf(out, "- %s:\n", label)
+	} else {
+		fmt.Fprintf(out, "  %s:\n", label)
+	}
+	for _, line := range strings.Split(strings.TrimRight(value, "\n"), "\n") {
+		fmt.Fprintf(out, "    %s\n", line)
 	}
 }
 
@@ -351,12 +419,26 @@ func redactMigrationRepairDiagnostics(diagnostics []interfaces.Diagnostic, secre
 }
 
 func redactMigrationRepairSecrets(value string, secrets map[string]string) string {
-	for _, secret := range secrets {
-		if secret != "" {
-			value = strings.ReplaceAll(value, secret, "[REDACTED]")
-		}
+	for _, secret := range migrationRepairSecretValues(secrets) {
+		value = strings.ReplaceAll(value, secret, "[REDACTED]")
 	}
 	return value
+}
+
+func migrationRepairSecretValues(secrets map[string]string) []string {
+	if len(secrets) == 0 {
+		return nil
+	}
+	values := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		if secret != "" {
+			values = append(values, secret)
+		}
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return len(values[i]) > len(values[j])
+	})
+	return values
 }
 
 func redactMigrationRepairError(err error, secrets map[string]string) error {

--- a/cmd/wfctl/migrate_repair.go
+++ b/cmd/wfctl/migrate_repair.go
@@ -176,7 +176,7 @@ Options:
 		}
 	}
 	if statusErr := validateMigrationRepairResultStatus(result.Status); statusErr != nil {
-		printMigrationRepairResultDetails(out, result, jobEnvMap)
+		printMigrationRepairResultDetails(out, result, newMigrationRepairRedactor(jobEnvMap))
 		return redactMigrationRepairError(statusErr, jobEnvMap)
 	}
 	printMigrationRepairResult(out, result, jobEnvMap)
@@ -285,35 +285,39 @@ func collectMigrationRepairEnv(jobEnv, jobEnvFromEnv []string) (map[string]strin
 }
 
 func printMigrationRepairResult(out io.Writer, result *interfaces.MigrationRepairResult, secrets map[string]string) {
+	printMigrationRepairResultWithRedactor(out, result, newMigrationRepairRedactor(secrets))
+}
+
+func printMigrationRepairResultWithRedactor(out io.Writer, result *interfaces.MigrationRepairResult, redactor migrationRepairRedactor) {
 	if result == nil {
 		return
 	}
-	providerJobID := redactMigrationRepairSecrets(result.ProviderJobID, secrets)
-	status := redactMigrationRepairSecrets(result.Status, secrets)
+	providerJobID := redactor.redact(result.ProviderJobID)
+	status := redactor.redact(result.Status)
 	if result.ProviderJobID != "" {
 		fmt.Fprintf(out, "provider job %s: %s\n", providerJobID, status)
 	} else if result.Status != "" {
 		fmt.Fprintf(out, "migration repair: %s\n", status)
 	}
-	printMigrationRepairResultDetails(out, result, secrets)
+	printMigrationRepairResultDetails(out, result, redactor)
 }
 
-func printMigrationRepairResultDetails(out io.Writer, result *interfaces.MigrationRepairResult, secrets map[string]string) {
+func printMigrationRepairResultDetails(out io.Writer, result *interfaces.MigrationRepairResult, redactor migrationRepairRedactor) {
 	if result == nil {
 		return
 	}
 	if strings.TrimSpace(result.Logs) != "" {
-		fmt.Fprintln(out, redactMigrationRepairSecrets(result.Logs, secrets))
+		fmt.Fprintln(out, redactor.redact(result.Logs))
 	}
-	printMigrationRepairDiagnostics(out, result.Diagnostics, secrets)
+	printMigrationRepairDiagnostics(out, result.Diagnostics, redactor)
 }
 
-func printMigrationRepairDiagnostics(out io.Writer, diagnostics []interfaces.Diagnostic, secrets map[string]string) {
+func printMigrationRepairDiagnostics(out io.Writer, diagnostics []interfaces.Diagnostic, redactor migrationRepairRedactor) {
 	if len(diagnostics) == 0 {
 		return
 	}
 	fmt.Fprintln(out, "Diagnostics:")
-	for _, diagnostic := range redactMigrationRepairDiagnostics(diagnostics, secrets) {
+	for _, diagnostic := range redactMigrationRepairDiagnostics(diagnostics, redactor) {
 		if strings.TrimSpace(diagnostic.ID) != "" {
 			printMigrationRepairDiagnosticField(out, "-", "id", diagnostic.ID)
 		} else {
@@ -370,20 +374,21 @@ func writeMigrationRepairSummary(result *interfaces.MigrationRepairResult, envNa
 	if result == nil || os.Getenv("GITHUB_STEP_SUMMARY") == "" {
 		return nil
 	}
+	redactor := newMigrationRepairRedactor(secrets)
 	outcome := migrationRepairSummaryOutcome(result.Status)
-	diagnostics := redactMigrationRepairDiagnostics(result.Diagnostics, secrets)
+	diagnostics := redactMigrationRepairDiagnostics(result.Diagnostics, redactor)
 	if result.Logs != "" {
 		diagnostics = append(diagnostics, interfaces.Diagnostic{
-			ID:     redactMigrationRepairSecrets(result.ProviderJobID, secrets),
-			Phase:  redactMigrationRepairSecrets(result.Status, secrets),
+			ID:     redactor.redact(result.ProviderJobID),
+			Phase:  redactor.redact(result.Status),
 			Cause:  "migration repair logs",
-			Detail: redactMigrationRepairSecrets(result.Logs, secrets),
+			Detail: redactor.redact(result.Logs),
 		})
 	}
 	if len(diagnostics) == 0 && result.ProviderJobID != "" {
 		diagnostics = append(diagnostics, interfaces.Diagnostic{
-			ID:    redactMigrationRepairSecrets(result.ProviderJobID, secrets),
-			Phase: redactMigrationRepairSecrets(result.Status, secrets),
+			ID:    redactor.redact(result.ProviderJobID),
+			Phase: redactor.redact(result.Status),
 			Cause: "provider job",
 		})
 	}
@@ -403,23 +408,35 @@ func migrationRepairSummaryOutcome(status string) string {
 	return "FAILED"
 }
 
-func redactMigrationRepairDiagnostics(diagnostics []interfaces.Diagnostic, secrets map[string]string) []interfaces.Diagnostic {
+func redactMigrationRepairDiagnostics(diagnostics []interfaces.Diagnostic, redactor migrationRepairRedactor) []interfaces.Diagnostic {
 	if len(diagnostics) == 0 {
 		return nil
 	}
 	redacted := make([]interfaces.Diagnostic, 0, len(diagnostics))
 	for _, diagnostic := range diagnostics {
-		diagnostic.ID = redactMigrationRepairSecrets(diagnostic.ID, secrets)
-		diagnostic.Phase = redactMigrationRepairSecrets(diagnostic.Phase, secrets)
-		diagnostic.Cause = redactMigrationRepairSecrets(diagnostic.Cause, secrets)
-		diagnostic.Detail = redactMigrationRepairSecrets(diagnostic.Detail, secrets)
+		diagnostic.ID = redactor.redact(diagnostic.ID)
+		diagnostic.Phase = redactor.redact(diagnostic.Phase)
+		diagnostic.Cause = redactor.redact(diagnostic.Cause)
+		diagnostic.Detail = redactor.redact(diagnostic.Detail)
 		redacted = append(redacted, diagnostic)
 	}
 	return redacted
 }
 
 func redactMigrationRepairSecrets(value string, secrets map[string]string) string {
-	for _, secret := range migrationRepairSecretValues(secrets) {
+	return newMigrationRepairRedactor(secrets).redact(value)
+}
+
+type migrationRepairRedactor struct {
+	secrets []string
+}
+
+func newMigrationRepairRedactor(secrets map[string]string) migrationRepairRedactor {
+	return migrationRepairRedactor{secrets: migrationRepairSecretValues(secrets)}
+}
+
+func (r migrationRepairRedactor) redact(value string) string {
+	for _, secret := range r.secrets {
 		value = strings.ReplaceAll(value, secret, "[REDACTED]")
 	}
 	return value

--- a/cmd/wfctl/migrate_repair_test.go
+++ b/cmd/wfctl/migrate_repair_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 )
@@ -541,6 +542,50 @@ func TestRunMigrateRepairDirtyRejectsProviderErrorResultStatusBeforeOutput(t *te
 	}
 }
 
+func TestRunMigrateRepairDirtyPrintsDiagnosticsForInvalidStatus(t *testing.T) {
+	for _, status := range []string{"", "unknown"} {
+		t.Run(fmt.Sprintf("status_%q", status), func(t *testing.T) {
+			cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+			fake := &migrationRepairProvider{
+				result: &interfaces.MigrationRepairResult{
+					ProviderJobID: "job-123",
+					Status:        status,
+					Logs:          "repair log tail",
+					Diagnostics: []interfaces.Diagnostic{{
+						Phase: "decode",
+						Cause: "provider returned invalid status",
+					}},
+				},
+			}
+			restore := installMigrateRepairProvider(t, fake, "digitalocean")
+			defer restore()
+
+			out, err := captureMigrateRepairStdout(t, func() error {
+				return runMigrate([]string{
+					"repair-dirty",
+					"--config", cfgPath,
+					"--env", "staging",
+					"--database", "bmw-database",
+					"--app", "bmw-app",
+					"--job-image", "registry.example/workflow-migrate:sha",
+					"--expected-dirty-version", "20260426000005",
+					"--force-version", "20260422000001",
+					"--confirm-force", interfaces.MigrationRepairConfirmation,
+					"--approve-destructive",
+				})
+			})
+			if err == nil {
+				t.Fatal("expected invalid provider status error")
+			}
+			for _, want := range []string{"repair log tail", "Diagnostics:", "cause: provider returned invalid status"} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("stdout missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
 func TestRunMigrateRepairDirtyMissingEnvFromEnvFailsBeforeProvider(t *testing.T) {
 	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
 	fake := &migrationRepairProvider{}
@@ -714,6 +759,95 @@ func TestRunMigrateRepairDirtyWritesGitHubStepSummary(t *testing.T) {
 	}
 	if !strings.Contains(string(summary), "[REDACTED]") {
 		t.Fatalf("summary missing redacted secret marker:\n%s", summary)
+	}
+}
+
+func TestRunMigrateRepairDirtyPrintsDiagnosticsToStdout(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	secret := "postgres://diagnostic-secret"
+	at := time.Date(2026, 4, 27, 14, 17, 30, 0, time.UTC)
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			Status: interfaces.MigrationRepairStatusFailed,
+			Diagnostics: []interfaces.Diagnostic{{
+				Phase:  "update",
+				Cause:  "temporary repair job update failed\napp platform rejected spec",
+				At:     at,
+				Detail: "failed while using " + secret,
+			}},
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("DATABASE_URL", secret)
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env-from-env", "DATABASE_URL",
+		})
+	})
+	if err == nil {
+		t.Fatal("expected failed repair status error")
+	}
+	for _, want := range []string{"migration repair: failed", "Diagnostics:", "phase: update", "cause:", "    temporary repair job update failed", "    app platform rejected spec", "at: 2026-04-27T14:17:30Z", "detail:", "    failed while using [REDACTED]"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("stdout leaked secret:\n%s", out)
+	}
+}
+
+func TestRunMigrateRepairDirtyRedactsOverlappingSecrets(t *testing.T) {
+	cfgPath := writeMigrateRepairInfraConfig(t, t.TempDir())
+	shortSecret := "postgres://host"
+	longSecret := "postgres://host/db?token=secret"
+	fake := &migrationRepairProvider{
+		result: &interfaces.MigrationRepairResult{
+			Status: interfaces.MigrationRepairStatusFailed,
+			Diagnostics: []interfaces.Diagnostic{{
+				Phase:  "update",
+				Cause:  "temporary repair job update failed",
+				Detail: "failed while using " + longSecret,
+			}},
+		},
+	}
+	restore := installMigrateRepairProvider(t, fake, "digitalocean")
+	defer restore()
+	t.Setenv("DATABASE_URL", shortSecret)
+
+	out, err := captureMigrateRepairStdout(t, func() error {
+		return runMigrate([]string{
+			"repair-dirty",
+			"--config", cfgPath,
+			"--env", "staging",
+			"--database", "bmw-database",
+			"--app", "bmw-app",
+			"--job-image", "registry.example/workflow-migrate:sha",
+			"--expected-dirty-version", "20260426000005",
+			"--force-version", "20260422000001",
+			"--confirm-force", interfaces.MigrationRepairConfirmation,
+			"--approve-destructive",
+			"--job-env", "DATABASE_URL=" + shortSecret,
+			"--job-env", "DATABASE_URL_FULL=" + longSecret,
+		})
+	})
+	if err == nil {
+		t.Fatal("expected failed repair status error")
+	}
+	if strings.Contains(out, shortSecret) || strings.Contains(out, longSecret) || strings.Contains(out, "/db?token=secret") {
+		t.Fatalf("stdout leaked overlapping secret:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- print migration repair provider logs and diagnostics directly in the live command output
- preserve existing invalid-status safety while still surfacing logs/diagnostics from malformed provider results
- redact overlapping secrets longest-first and render timestamps/multiline diagnostic fields readably

## Root cause

BMW prod repair failed with only `migration repair: failed` because `wfctl migrate repair-dirty` only printed status and logs. Structured provider diagnostics were only written to the GitHub step summary, and invalid provider statuses could suppress details entirely.

## Verification

- `go test ./cmd/wfctl -run 'TestRunMigrateRepairDirtyPrintsDiagnosticsToStdout' -count=1` failed before the implementation with only `migration repair: failed` in stdout\n- `go test ./cmd/wfctl -run 'TestRunMigrateRepairDirty(PrintsDiagnosticsForInvalidStatus|PrintsDiagnosticsToStdout|RedactsOverlappingSecrets)' -count=1`\n- `go test ./cmd/wfctl -run 'TestRunMigrateRepairDirty|TestMigrationRepairSummaryOutcome' -count=1`\n- `go test ./cmd/wfctl -count=1`\n- `git diff --check`\n\n## Review\n\nAntagonistic code review requested changes twice; the final pass was SHIP-IT with no blocking findings. The minor multiline scalar coverage suggestion was addressed before opening this PR.