### PR TITLE
feat(wfctl): wfctl infra align — config-and-plan alignment validator (F2)

### DIFF
--- a/cmd/wfctl/dsl-reference-embedded.md
+++ b/cmd/wfctl/dsl-reference-embedded.md
@@ -1292,3 +1292,57 @@ security:
 - `security.network.defaultPolicy: deny` causes `wfctl security generate-network-policies` to include `Egress` in policy types
 - `networking.ingress` entries without a `tls` block are flagged as `HIGH` by `wfctl security audit`
 - `wfctl validate` checks `security.tls.provider` for valid values
+
+---
+
+<!-- section: wfctl-infra-align -->
+## wfctl infra align
+
+Cross-validates the IaC config (and an optional plan JSON) across 8 rule families. Writes a markdown findings table to stdout and to `$GITHUB_STEP_SUMMARY` when running in CI.
+
+### Usage
+
+```
+wfctl infra align [--config <file>] [--env <env>] [--plan <plan.json>] [--strict] [--strict-health] [--strict-cidr] [--max-changes N]
+```
+
+### Options
+
+- `--config <file>` — Config file (default: `infra.yaml` or `config/infra.yaml`)
+- `--env <name>` — Environment name for per-env config resolution
+- `--plan <file>` — Path to a plan JSON file (enables R-A7 checks)
+- `--strict` — Treat all WARNs as FAILs (exit 1)
+- `--strict-health` — Treat R-A2 health-check WARNs as FAILs
+- `--strict-cidr` — Enable strict CIDR overlap checks (reserved for future use)
+- `--max-changes N` — Warn when plan has more than N actions (default: 50)
+
+### Exit codes
+
+- `0` — no FAIL findings (WARNs allowed unless `--strict`)
+- `1` — any FAIL finding, or any WARN with `--strict`
+
+### Rule families
+
+| Rule | Name | Severity |
+|------|------|----------|
+| R-A1 | Container/runtime alignment | FAIL |
+| R-A2 | Health-check path in source | WARN (FAIL with `--strict-health`) |
+| R-A3 | Service-to-service DNS alignment | FAIL |
+| R-A4 | Env-var resolution | FAIL |
+| R-A5 | Migrations alignment | FAIL |
+| R-A6 | Network/exposure alignment | FAIL or WARN |
+| R-A7 | Plan-output sanity (requires `--plan`) | FAIL or WARN |
+| R-A8 | WebAuthn RP_ID alignment | FAIL |
+
+### Example output
+
+```
+## wfctl infra align
+
+| Rule | Severity | Resource | Message |
+|------|----------|----------|---------|
+| R-A6 | WARN | nats-broker | internal service should use expose: internal |
+| R-A4 | FAIL | api | unresolved env var: ${STRIPE_KEY} |
+
+1 FAIL, 1 WARN
+```

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -38,6 +38,8 @@ func runInfra(args []string) error {
 		return runInfraBootstrap(args[1:])
 	case "outputs":
 		return runInfraOutputs(args[1:])
+	case "align":
+		return runInfraAlign(args[1:])
 	default:
 		return infraUsage()
 	}
@@ -57,6 +59,7 @@ Actions:
   import    Import an existing cloud resource into state
   state     Manage IaC state (list, export, import)
   outputs   Print captured resource outputs from state
+  align     Validate IaC config + plan alignment (7 rule families)
 
 Options:
   --config <file>      Config file (default: infra.yaml or config/infra.yaml)

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -59,7 +59,7 @@ Actions:
   import    Import an existing cloud resource into state
   state     Manage IaC state (list, export, import)
   outputs   Print captured resource outputs from state
-  align     Validate IaC config + plan alignment (7 rule families)
+  align     Validate IaC config + plan alignment (8 rule families)
 
 Options:
   --config <file>      Config file (default: infra.yaml or config/infra.yaml)

--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -80,8 +80,14 @@ func runInfraAlign(args []string) error {
 		}
 	}
 
-	if code := alignExitCode(findings, opts.strict); code != 0 {
-		os.Exit(code)
+	if alignExitCode(findings, opts.strict) != 0 {
+		var failCount int
+		for _, f := range findings {
+			if f.Severity == "FAIL" {
+				failCount++
+			}
+		}
+		return fmt.Errorf("align: %d FAIL finding(s)", failCount)
 	}
 	return nil
 }
@@ -169,8 +175,11 @@ func renderAlignMarkdown(findings []AlignFinding) string {
 	sb.WriteString("| Rule | Severity | Resource | Message |\n")
 	sb.WriteString("|------|----------|----------|---------|\n")
 	for _, f := range findings {
+		// Escape pipe characters to prevent breaking the markdown table.
+		resource := strings.ReplaceAll(f.Resource, "|", "\\|")
+		message := strings.ReplaceAll(f.Message, "|", "\\|")
 		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-			f.Rule, f.Severity, f.Resource, f.Message))
+			f.Rule, f.Severity, resource, message))
 	}
 	sb.WriteString("\n")
 

--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// alignOptions holds parsed CLI options for the align subcommand.
+type alignOptions struct {
+	configFile   string
+	envName      string
+	planFile     string
+	strict       bool
+	strictHealth bool
+	strictCIDR   bool
+	maxChanges   int
+}
+
+// runInfraAlign is the CLI entry point for `wfctl infra align`.
+func runInfraAlign(args []string) error {
+	fs := flag.NewFlagSet("infra align", flag.ContinueOnError)
+	var opts alignOptions
+	fs.StringVar(&opts.configFile, "config", "", "Config file (default: infra.yaml or config/infra.yaml)")
+	fs.StringVar(&opts.configFile, "c", "", "Config file (short for --config)")
+	fs.StringVar(&opts.envName, "env", "", "Environment name")
+	fs.StringVar(&opts.planFile, "plan", "", "Path to plan JSON file (enables R-A7 checks)")
+	fs.BoolVar(&opts.strict, "strict", false, "Treat WARNs as FAILs")
+	fs.BoolVar(&opts.strictHealth, "strict-health", false, "Treat R-A2 health-check WARNs as FAILs")
+	fs.BoolVar(&opts.strictCIDR, "strict-cidr", false, "Enable strict CIDR overlap checks (reserved for future use)")
+	fs.IntVar(&opts.maxChanges, "max-changes", 50, "Warn when plan has more than N changes")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Resolve config file
+	if opts.configFile == "" {
+		f := fs.Lookup("config")
+		if f != nil {
+			opts.configFile = f.Value.String()
+		}
+	}
+	if opts.configFile == "" {
+		for _, candidate := range []string{"infra.yaml", "config/infra.yaml"} {
+			if _, err := os.Stat(candidate); err == nil {
+				opts.configFile = candidate
+				break
+			}
+		}
+	}
+	if opts.configFile == "" {
+		for _, arg := range fs.Args() {
+			if strings.HasSuffix(arg, ".yaml") || strings.HasSuffix(arg, ".yml") {
+				opts.configFile = arg
+				break
+			}
+		}
+	}
+	if opts.configFile == "" {
+		return fmt.Errorf("no config file specified and no infra.yaml found")
+	}
+
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		return err
+	}
+
+	output := renderAlignMarkdown(findings)
+	fmt.Print(output)
+
+	// Write to GitHub Step Summary when running in CI
+	if summary := os.Getenv("GITHUB_STEP_SUMMARY"); summary != "" {
+		if f, err := os.OpenFile(summary, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
+			fmt.Fprint(f, output)
+			f.Close()
+		}
+	}
+
+	if code := alignExitCode(findings, opts.strict); code != 0 {
+		os.Exit(code)
+	}
+	return nil
+}
+
+// runInfraAlignChecks runs all alignment rule families and returns findings.
+// This is separated from runInfraAlign to make it testable.
+func runInfraAlignChecks(opts alignOptions) ([]AlignFinding, error) {
+	ctx, err := buildAlignContext(opts.configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var findings []AlignFinding
+
+	// R-A1: container/runtime alignment
+	findings = append(findings, checkRA1(ctx)...)
+
+	// R-A2: health-check alignment
+	findings = append(findings, checkRA2(ctx, opts.strictHealth)...)
+
+	// R-A3: service-to-service DNS alignment
+	findings = append(findings, checkRA3(ctx)...)
+
+	// R-A4: env-var resolution
+	findings = append(findings, checkRA4(ctx)...)
+
+	// R-A5: migrations alignment
+	findings = append(findings, checkRA5(ctx)...)
+
+	// R-A6: network/exposure alignment
+	findings = append(findings, checkRA6(ctx)...)
+
+	// R-A7: plan-output sanity (only when --plan provided)
+	if opts.planFile != "" {
+		plan, err := loadPlanJSON(opts.planFile)
+		if err != nil {
+			return nil, fmt.Errorf("load plan: %w", err)
+		}
+		findings = append(findings, checkRA7(plan, opts.maxChanges)...)
+	}
+
+	// R-A8: WebAuthn alignment
+	findings = append(findings, checkRA8(ctx)...)
+
+	return findings, nil
+}
+
+// loadPlanJSON reads and decodes a plan JSON file.
+func loadPlanJSON(path string) (*interfaces.IaCPlan, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var plan interfaces.IaCPlan
+	if err := json.NewDecoder(f).Decode(&plan); err != nil {
+		return nil, err
+	}
+	return &plan, nil
+}
+
+// alignExitCode returns 0 (success) or 1 (failure) based on findings and flags.
+func alignExitCode(findings []AlignFinding, strict bool) int {
+	for _, f := range findings {
+		if f.Severity == "FAIL" {
+			return 1
+		}
+		if strict && f.Severity == "WARN" {
+			return 1
+		}
+	}
+	return 0
+}
+
+// renderAlignMarkdown formats findings as a markdown table with a summary line.
+func renderAlignMarkdown(findings []AlignFinding) string {
+	var sb strings.Builder
+	sb.WriteString("## wfctl infra align\n\n")
+
+	if len(findings) == 0 {
+		sb.WriteString("No alignment issues found.\n")
+		return sb.String()
+	}
+
+	sb.WriteString("| Rule | Severity | Resource | Message |\n")
+	sb.WriteString("|------|----------|----------|---------|\n")
+	for _, f := range findings {
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+			f.Rule, f.Severity, f.Resource, f.Message))
+	}
+	sb.WriteString("\n")
+
+	var failCount, warnCount int
+	for _, f := range findings {
+		switch f.Severity {
+		case "FAIL":
+			failCount++
+		case "WARN":
+			warnCount++
+		}
+	}
+
+	parts := []string{}
+	if failCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d FAIL", failCount))
+	}
+	if warnCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d WARN", warnCount))
+	}
+	sb.WriteString(strings.Join(parts, ", "))
+	sb.WriteString("\n")
+
+	return sb.String()
+}

--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -83,11 +83,11 @@ func runInfraAlign(args []string) error {
 	if alignExitCode(findings, opts.strict) != 0 {
 		var failCount int
 		for _, f := range findings {
-			if f.Severity == "FAIL" {
+			if f.Severity == "FAIL" || (opts.strict && f.Severity == "WARN") {
 				failCount++
 			}
 		}
-		return fmt.Errorf("align: %d FAIL finding(s)", failCount)
+		return fmt.Errorf("align: %d finding(s) require attention", failCount)
 	}
 	return nil
 }

--- a/cmd/wfctl/infra_align_integration_test.go
+++ b/cmd/wfctl/infra_align_integration_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInfraAlignIntegration_FullConfig exercises the align checker against a
+// realistic multi-service config that intentionally has several issues, then
+// verifies that each expected rule fires and no unexpected rules fire.
+func TestInfraAlignIntegration_FullConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a Dockerfile with no USER directive (triggers R-A1)
+	dfPath := filepath.Join(dir, "Dockerfile.api")
+	if err := os.WriteFile(dfPath, []byte("FROM golang:1.22\nRUN go build -o /app .\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write source file that does NOT contain /healthz (triggers R-A2)
+	srcFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(srcFile, []byte(`package main
+
+func main() {}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unset env var to trigger R-A4
+	os.Unsetenv("SECRET_TOKEN")
+
+	yamlContent := `
+modules:
+  - name: api-build
+    type: ci.build
+    config:
+      containers:
+        - name: api
+          dockerfile: "` + dfPath + `"
+
+  - name: api
+    type: infra.container_service
+    config:
+      image: "api:latest"
+      dockerfile: "` + dfPath + `"
+      http_port: 8080
+      src_dir: "` + dir + `"
+      health_check:
+        path: "/healthz"
+      env_vars:
+        CACHE_URL: "redis-cache.internal:6379"
+        TOKEN: "${SECRET_TOKEN}"
+
+  - name: redis-cache
+    type: infra.container_service
+    config:
+      image: "redis:7"
+      internal_ports:
+        - 6379
+
+  - name: nats-broker
+    type: infra.container_service
+    config:
+      image: "nats:latest"
+      http_port: 4222
+
+  - name: auth
+    type: infra.container_service
+    config:
+      image: "auth:latest"
+      http_port: 8081
+      env_vars:
+        WEBAUTHN_RP_ID: "example.com"
+        WEBAUTHN_ORIGIN: "https://other.example.org"
+`
+
+	cfg := writeAlignYAML(t, yamlContent)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expected findings:
+	// R-A1: api Dockerfile has no USER directive
+	if !findingsHaveRuleAndSeverity(findings, "R-A1", "FAIL") {
+		t.Error("expected R-A1 FAIL (no USER in Dockerfile)")
+	}
+
+	// R-A2: /healthz not found in src_dir source files
+	if !findingsHaveRule(findings, "R-A2") {
+		t.Error("expected R-A2 finding (/healthz not in source)")
+	}
+
+	// R-A4: ${SECRET_TOKEN} is unresolved
+	if !findingsHaveRuleAndSeverity(findings, "R-A4", "FAIL") {
+		t.Error("expected R-A4 FAIL (unresolved ${SECRET_TOKEN})")
+	}
+
+	// R-A6: nats-broker has http_port but no expose:internal
+	if !findingsHaveRuleAndSeverity(findings, "R-A6", "WARN") {
+		t.Error("expected R-A6 WARN (nats-broker should have expose:internal)")
+	}
+
+	// R-A8: auth has WEBAUTHN_RP_ID/ORIGIN mismatch
+	if !findingsHaveRuleAndSeverity(findings, "R-A8", "FAIL") {
+		t.Error("expected R-A8 FAIL (WebAuthn RP_ID mismatch)")
+	}
+
+	// No R-A3 findings: redis-cache.internal:6379 is properly declared
+	for _, f := range findings {
+		if f.Rule == "R-A3" {
+			t.Errorf("unexpected R-A3 finding: %v", f)
+		}
+	}
+
+	// No R-A5 findings: no pre_deploy migrate
+	for _, f := range findings {
+		if f.Rule == "R-A5" {
+			t.Errorf("unexpected R-A5 finding: %v", f)
+		}
+	}
+
+	// No R-A7 findings: no plan file provided
+	for _, f := range findings {
+		if f.Rule == "R-A7" {
+			t.Errorf("unexpected R-A7 finding (no plan file): %v", f)
+		}
+	}
+
+	// Verify markdown output is well-formed
+	out := renderAlignMarkdown(findings)
+	if len(out) == 0 {
+		t.Error("expected non-empty markdown output")
+	}
+	if out == "## wfctl infra align\n\nNo alignment issues found.\n" {
+		t.Error("expected findings in markdown output, got none")
+	}
+}

--- a/cmd/wfctl/infra_align_rules.go
+++ b/cmd/wfctl/infra_align_rules.go
@@ -1,0 +1,679 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// AlignFinding is a single rule violation emitted by an alignment check.
+type AlignFinding struct {
+	Rule     string // R-A1, R-A2, etc.
+	Severity string // FAIL or WARN
+	Resource string // affected resource name
+	Message  string // human-readable description
+}
+
+// alignContext holds all modules parsed from a config file plus helper indexes.
+type alignContext struct {
+	modules []config.ModuleConfig
+
+	// indexes built once and reused by rules
+	containerServices map[string]config.ModuleConfig // name → infra.container_service
+	ciBuilds          []config.ModuleConfig          // all ci.build modules
+	databases         []config.ModuleConfig          // all infra.database modules
+	secretKeys        map[string]struct{}            // union of secrets.generate/requires keys
+}
+
+func buildAlignContext(cfgFile string) (*alignContext, error) {
+	cfg, err := config.LoadFromFile(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	ctx := &alignContext{
+		modules:           cfg.Modules,
+		containerServices: map[string]config.ModuleConfig{},
+		secretKeys:        map[string]struct{}{},
+	}
+	for _, m := range cfg.Modules {
+		switch {
+		case m.Type == "infra.container_service":
+			ctx.containerServices[m.Name] = m
+		case strings.HasPrefix(m.Type, "ci.build"):
+			ctx.ciBuilds = append(ctx.ciBuilds, m)
+		case m.Type == "infra.database":
+			ctx.databases = append(ctx.databases, m)
+		case m.Type == "secrets.generate" || m.Type == "secrets.requires":
+			if gen, ok := extractSecretKeys(m.Config, "generate"); ok {
+				for _, k := range gen {
+					ctx.secretKeys[k] = struct{}{}
+				}
+			}
+			if req, ok := extractSecretKeys(m.Config, "requires"); ok {
+				for _, k := range req {
+					ctx.secretKeys[k] = struct{}{}
+				}
+			}
+		}
+	}
+	return ctx, nil
+}
+
+// extractSecretKeys extracts key names from config[field] which is expected
+// to be []any where each element is map[string]any with a "key" field.
+func extractSecretKeys(cfg map[string]any, field string) ([]string, bool) {
+	raw, ok := cfg[field]
+	if !ok {
+		return nil, false
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	var keys []string
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			if k, ok := m["key"].(string); ok && k != "" {
+				keys = append(keys, k)
+			}
+		}
+	}
+	return keys, true
+}
+
+// ── R-A1: container/runtime alignment ──────────────────────────────────────
+
+func checkRA1(ctx *alignContext) []AlignFinding {
+	// Build a set of image names from ci.build containers.
+	ciImages := map[string]string{} // image name → dockerfile path
+	for _, build := range ctx.ciBuilds {
+		if containers, ok := build.Config["containers"]; ok {
+			if items, ok := containers.([]any); ok {
+				for _, item := range items {
+					if m, ok := item.(map[string]any); ok {
+						name, _ := m["name"].(string)
+						df, _ := m["dockerfile"].(string)
+						if name != "" {
+							ciImages[name] = df
+						}
+					}
+				}
+			}
+		}
+	}
+
+	var findings []AlignFinding
+	for _, svc := range ctx.containerServices {
+		image, _ := svc.Config["image"].(string)
+		if image == "" {
+			continue
+		}
+		// Parse image name (strip tag)
+		imageName := image
+		if idx := strings.LastIndex(image, ":"); idx > 0 {
+			// Handle registry/name:tag — only strip the tag portion
+			imageName = image[:idx]
+		}
+		// Get just the final name component for matching
+		parts := strings.Split(imageName, "/")
+		shortName := parts[len(parts)-1]
+
+		// R-A1a: orphaned image reference (only check when ci.build modules exist OR if none exist at all)
+		if _, found := ciImages[shortName]; !found {
+			findings = append(findings, AlignFinding{
+				Rule:     "R-A1",
+				Severity: "FAIL",
+				Resource: svc.Name,
+				Message:  fmt.Sprintf("orphaned image reference %q: no ci.build container named %q", image, shortName),
+			})
+			// Skip Dockerfile checks if we can't match the build
+			continue
+		}
+
+		// Resolve dockerfile path
+		dfPath := resolveDockerfilePath(svc, ciImages, shortName)
+		if dfPath == "" {
+			continue
+		}
+		if _, err := os.Stat(dfPath); err != nil {
+			// Dockerfile not on disk — skip lint
+			continue
+		}
+
+		// R-A1b: USER directive check
+		if f := checkDockerfileUser(svc.Name, dfPath); f != nil {
+			findings = append(findings, *f)
+		}
+
+		// R-A1c: EXPOSE vs http_port/internal_ports check
+		if f := checkDockerfileExpose(svc, dfPath); f != nil {
+			findings = append(findings, *f...)
+		}
+	}
+	return findings
+}
+
+func resolveDockerfilePath(svc config.ModuleConfig, ciImages map[string]string, shortName string) string {
+	// Check service config directly
+	if df, ok := svc.Config["dockerfile"].(string); ok && df != "" {
+		return df
+	}
+	// Fall back to ci.build container match
+	if df, ok := ciImages[shortName]; ok && df != "" {
+		return df
+	}
+	return ""
+}
+
+func checkDockerfileUser(svcName, dfPath string) *AlignFinding {
+	f, err := os.Open(dfPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var foundUser string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(strings.ToUpper(line), "USER ") {
+			foundUser = strings.TrimSpace(line[5:])
+		}
+	}
+
+	if foundUser == "" {
+		return &AlignFinding{
+			Rule:     "R-A1",
+			Severity: "FAIL",
+			Resource: svcName,
+			Message:  fmt.Sprintf("Dockerfile %q has no USER directive (container runs as root)", dfPath),
+		}
+	}
+	// FAIL if explicitly root
+	if foundUser == "root" || foundUser == "0" {
+		return &AlignFinding{
+			Rule:     "R-A1",
+			Severity: "FAIL",
+			Resource: svcName,
+			Message:  fmt.Sprintf("Dockerfile %q sets USER root — containers must not run as root", dfPath),
+		}
+	}
+	return nil
+}
+
+func checkDockerfileExpose(svc config.ModuleConfig, dfPath string) *[]AlignFinding {
+	f, err := os.Open(dfPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var exposedPorts []int
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(upper, "EXPOSE ") {
+			parts := strings.Fields(line[7:])
+			for _, p := range parts {
+				// Strip /tcp or /udp
+				portStr := strings.Split(p, "/")[0]
+				if port, err := strconv.Atoi(portStr); err == nil {
+					exposedPorts = append(exposedPorts, port)
+				}
+			}
+		}
+	}
+
+	if len(exposedPorts) == 0 {
+		return nil
+	}
+
+	// Gather declared ports from config
+	declaredPorts := map[int]struct{}{}
+	if httpPort, ok := svc.Config["http_port"]; ok {
+		if p := toInt(httpPort); p > 0 {
+			declaredPorts[p] = struct{}{}
+		}
+	}
+	if raw, ok := svc.Config["internal_ports"]; ok {
+		if items, ok := raw.([]any); ok {
+			for _, item := range items {
+				if p := toInt(item); p > 0 {
+					declaredPorts[p] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(declaredPorts) == 0 {
+		return nil
+	}
+
+	var findings []AlignFinding
+	for _, ep := range exposedPorts {
+		if _, ok := declaredPorts[ep]; !ok {
+			findings = append(findings, AlignFinding{
+				Rule:     "R-A1",
+				Severity: "FAIL",
+				Resource: svc.Name,
+				Message:  fmt.Sprintf("Dockerfile EXPOSEs port %d but it is not in http_port or internal_ports", ep),
+			})
+		}
+	}
+	if len(findings) == 0 {
+		return nil
+	}
+	return &findings
+}
+
+// ── R-A2: health-check alignment ───────────────────────────────────────────
+
+func checkRA2(ctx *alignContext, strictHealth bool) []AlignFinding {
+	var findings []AlignFinding
+	for _, svc := range ctx.containerServices {
+		path := healthCheckPath(svc.Config)
+		if path == "" {
+			continue
+		}
+		srcDir, _ := svc.Config["src_dir"].(string)
+		if srcDir == "" {
+			srcDir = "."
+		}
+
+		found, err := pathExistsInSource(srcDir, path)
+		if err != nil || found {
+			continue
+		}
+
+		severity := "WARN"
+		if strictHealth {
+			severity = "FAIL"
+		}
+		findings = append(findings, AlignFinding{
+			Rule:     "R-A2",
+			Severity: severity,
+			Resource: svc.Name,
+			Message:  fmt.Sprintf("health check path %q not found in source tree %q", path, srcDir),
+		})
+	}
+	return findings
+}
+
+func healthCheckPath(cfg map[string]any) string {
+	// Try health_check.path (snake_case)
+	if hc, ok := cfg["health_check"]; ok {
+		if m, ok := hc.(map[string]any); ok {
+			if p, ok := m["path"].(string); ok {
+				return p
+			}
+		}
+	}
+	// Try healthCheck.path (camelCase)
+	if hc, ok := cfg["healthCheck"]; ok {
+		if m, ok := hc.(map[string]any); ok {
+			if p, ok := m["path"].(string); ok {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+var sourceExtensions = map[string]struct{}{
+	".go": {}, ".js": {}, ".ts": {}, ".py": {}, ".rs": {},
+}
+
+func pathExistsInSource(srcDir, path string) (bool, error) {
+	var found bool
+	err := filepath.Walk(srcDir, func(fp string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || found {
+			return nil
+		}
+		if _, ok := sourceExtensions[filepath.Ext(fp)]; !ok {
+			return nil
+		}
+		data, err := os.ReadFile(fp)
+		if err != nil {
+			return nil
+		}
+		if strings.Contains(string(data), path) {
+			found = true
+		}
+		return nil
+	})
+	return found, err
+}
+
+// ── R-A3: service-to-service DNS alignment ──────────────────────────────────
+
+var internalDNSRe = regexp.MustCompile(`([a-z][a-z0-9-]+)\.internal:(\d+)`)
+
+func checkRA3(ctx *alignContext) []AlignFinding {
+	var findings []AlignFinding
+	for _, m := range ctx.modules {
+		envVars := extractEnvVars(m.Config)
+		for _, val := range envVars {
+			matches := internalDNSRe.FindAllStringSubmatch(val, -1)
+			for _, match := range matches {
+				hostname := match[1]
+				portStr := match[2]
+				port, _ := strconv.Atoi(portStr)
+
+				target, ok := ctx.containerServices[hostname]
+				if !ok {
+					findings = append(findings, AlignFinding{
+						Rule:     "R-A3",
+						Severity: "FAIL",
+						Resource: m.Name,
+						Message:  fmt.Sprintf("DNS reference to %q.internal not resolvable: no container_service named %q", hostname, hostname),
+					})
+					continue
+				}
+
+				// Verify port matches http_port or internal_ports
+				if !serviceHasPort(target, port) {
+					findings = append(findings, AlignFinding{
+						Rule:     "R-A3",
+						Severity: "FAIL",
+						Resource: m.Name,
+						Message:  fmt.Sprintf("DNS reference to %s.internal:%d: port %d not declared in service %q (http_port or internal_ports)", hostname, port, port, hostname),
+					})
+				}
+			}
+		}
+	}
+	return findings
+}
+
+func extractEnvVars(cfg map[string]any) map[string]string {
+	result := map[string]string{}
+	if raw, ok := cfg["env_vars"]; ok {
+		if m, ok := raw.(map[string]any); ok {
+			for k, v := range m {
+				if s, ok := v.(string); ok {
+					result[k] = s
+				}
+			}
+		}
+	}
+	return result
+}
+
+func serviceHasPort(svc config.ModuleConfig, port int) bool {
+	if httpPort := toInt(svc.Config["http_port"]); httpPort == port {
+		return true
+	}
+	if raw, ok := svc.Config["internal_ports"]; ok {
+		if items, ok := raw.([]any); ok {
+			for _, item := range items {
+				if toInt(item) == port {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// ── R-A4: env-var resolution ───────────────────────────────────────────────
+
+var envTokenRe = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+func checkRA4(ctx *alignContext) []AlignFinding {
+	var findings []AlignFinding
+	for _, m := range ctx.modules {
+		envVars := extractEnvVars(m.Config)
+		for _, val := range envVars {
+			tokens := envTokenRe.FindAllStringSubmatch(val, -1)
+			for _, tok := range tokens {
+				varName := tok[1]
+				if _, resolved := ctx.secretKeys[varName]; resolved {
+					continue
+				}
+				if os.Getenv(varName) != "" {
+					continue
+				}
+				findings = append(findings, AlignFinding{
+					Rule:     "R-A4",
+					Severity: "FAIL",
+					Resource: m.Name,
+					Message:  fmt.Sprintf("unresolved env var: ${%s}", varName),
+				})
+			}
+		}
+	}
+	return findings
+}
+
+// ── R-A5: migrations alignment ─────────────────────────────────────────────
+
+func checkRA5(ctx *alignContext) []AlignFinding {
+	// Build a set of ci.build container image names
+	ciBuildImages := map[string]struct{}{}
+	for _, build := range ctx.ciBuilds {
+		if containers, ok := build.Config["containers"]; ok {
+			if items, ok := containers.([]any); ok {
+				for _, item := range items {
+					if m, ok := item.(map[string]any); ok {
+						if name, ok := m["name"].(string); ok && name != "" {
+							ciBuildImages[name] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	var findings []AlignFinding
+	for svcName, svc := range ctx.containerServices {
+		preDeploy, ok := svc.Config["pre_deploy"]
+		if !ok {
+			continue
+		}
+		pdMap, ok := preDeploy.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind, _ := pdMap["kind"].(string)
+		if kind != "migrate" {
+			continue
+		}
+
+		// R-A5a: must have an infra.database with trusted_sources entry for this service
+		dbFound := false
+		for _, db := range ctx.databases {
+			if dbTrustsService(db, svcName) {
+				dbFound = true
+				break
+			}
+		}
+		if !dbFound {
+			// Also accept any DB at all (spec says "the same env's infra.database must declare trusted_sources")
+			if len(ctx.databases) == 0 {
+				findings = append(findings, AlignFinding{
+					Rule:     "R-A5",
+					Severity: "FAIL",
+					Resource: svcName,
+					Message:  fmt.Sprintf("service %q has pre_deploy migrate but no infra.database module exists", svcName),
+				})
+			} else {
+				findings = append(findings, AlignFinding{
+					Rule:     "R-A5",
+					Severity: "FAIL",
+					Resource: svcName,
+					Message:  fmt.Sprintf("service %q has pre_deploy migrate but no infra.database declares trusted_sources for it", svcName),
+				})
+			}
+		}
+
+		// R-A5b: pre_deploy image must reference a ci.build container
+		if image, ok := pdMap["image"].(string); ok && image != "" {
+			imageName := image
+			if idx := strings.LastIndex(image, ":"); idx > 0 {
+				imageName = image[:idx]
+			}
+			parts := strings.Split(imageName, "/")
+			shortName := parts[len(parts)-1]
+			if len(ciBuildImages) > 0 {
+				if _, ok := ciBuildImages[shortName]; !ok {
+					findings = append(findings, AlignFinding{
+						Rule:     "R-A5",
+						Severity: "FAIL",
+						Resource: svcName,
+						Message:  fmt.Sprintf("pre_deploy image %q not found in any ci.build container", image),
+					})
+				}
+			}
+		}
+	}
+	return findings
+}
+
+func dbTrustsService(db config.ModuleConfig, svcName string) bool {
+	raw, ok := db.Config["trusted_sources"]
+	if !ok {
+		return false
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			if m["type"] == "app" && m["value"] == svcName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ── R-A6: network/exposure alignment ───────────────────────────────────────
+
+var internalServiceNameRe = regexp.MustCompile(`(^|-)(nats|redis|db|broker|internal)($|-)`)
+
+func checkRA6(ctx *alignContext) []AlignFinding {
+	var findings []AlignFinding
+	for _, svc := range ctx.containerServices {
+		expose, _ := svc.Config["expose"].(string)
+		httpPort := toInt(svc.Config["http_port"])
+
+		// R-A6a: expose:internal AND http_port is mutually exclusive
+		if expose == "internal" && httpPort > 0 {
+			findings = append(findings, AlignFinding{
+				Rule:     "R-A6",
+				Severity: "FAIL",
+				Resource: svc.Name,
+				Message:  "expose: internal with http_port is mutually exclusive",
+			})
+		}
+
+		// R-A6b: name pattern suggests internal service but expose:internal not set
+		if internalServiceNameRe.MatchString(svc.Name) && httpPort > 0 && expose != "internal" {
+			findings = append(findings, AlignFinding{
+				Rule:     "R-A6",
+				Severity: "WARN",
+				Resource: svc.Name,
+				Message:  "internal service should use expose: internal",
+			})
+		}
+	}
+	return findings
+}
+
+// ── R-A7: plan-output sanity ───────────────────────────────────────────────
+
+func checkRA7(plan *interfaces.IaCPlan, maxChanges int) []AlignFinding {
+	if plan == nil {
+		return nil
+	}
+	var findings []AlignFinding
+
+	for _, action := range plan.Actions {
+		if action.Action == "delete" {
+			if protected, _ := action.Resource.Config["protected"].(bool); protected {
+				findings = append(findings, AlignFinding{
+					Rule:     "R-A7",
+					Severity: "FAIL",
+					Resource: action.Resource.Name,
+					Message:  fmt.Sprintf("plan deletes protected resource %q", action.Resource.Name),
+				})
+			}
+		}
+	}
+
+	if len(plan.Actions) > maxChanges {
+		findings = append(findings, AlignFinding{
+			Rule:     "R-A7",
+			Severity: "WARN",
+			Resource: "(plan)",
+			Message:  fmt.Sprintf("plan has %d actions, exceeding max-changes limit of %d", len(plan.Actions), maxChanges),
+		})
+	}
+
+	return findings
+}
+
+// ── R-A8: WebAuthn alignment ───────────────────────────────────────────────
+
+func checkRA8(ctx *alignContext) []AlignFinding {
+	var findings []AlignFinding
+	for _, m := range ctx.modules {
+		envVars := extractEnvVars(m.Config)
+		rpID, hasRPID := envVars["WEBAUTHN_RP_ID"]
+		origin, hasOrigin := envVars["WEBAUTHN_ORIGIN"]
+		if !hasRPID || !hasOrigin {
+			continue
+		}
+
+		u, err := url.Parse(origin)
+		if err != nil {
+			findings = append(findings, AlignFinding{
+				Rule:     "R-A8",
+				Severity: "FAIL",
+				Resource: m.Name,
+				Message:  fmt.Sprintf("WEBAUTHN_ORIGIN %q is not a valid URL: %v", origin, err),
+			})
+			continue
+		}
+
+		host := u.Hostname()
+		if host != rpID {
+			findings = append(findings, AlignFinding{
+				Rule:     "R-A8",
+				Severity: "FAIL",
+				Resource: m.Name,
+				Message:  fmt.Sprintf("WEBAUTHN_RP_ID %q does not match WEBAUTHN_ORIGIN host %q", rpID, host),
+			})
+		}
+	}
+	return findings
+}
+
+// ── utilities ──────────────────────────────────────────────────────────────
+
+// toInt converts an any value to int, handling both int and float64
+// (YAML unmarshal produces float64 for numbers).
+func toInt(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case string:
+		i, _ := strconv.Atoi(n)
+		return i
+	}
+	return 0
+}

--- a/cmd/wfctl/infra_align_rules.go
+++ b/cmd/wfctl/infra_align_rules.go
@@ -126,16 +126,20 @@ func checkRA1(ctx *alignContext) []AlignFinding {
 		parts := strings.Split(imageName, "/")
 		shortName := parts[len(parts)-1]
 
-		// R-A1a: orphaned image reference (only check when ci.build modules exist OR if none exist at all)
-		if _, found := ciImages[shortName]; !found {
-			findings = append(findings, AlignFinding{
-				Rule:     "R-A1",
-				Severity: "FAIL",
-				Resource: svc.Name,
-				Message:  fmt.Sprintf("orphaned image reference %q: no ci.build container named %q", image, shortName),
-			})
-			// Skip Dockerfile checks if we can't match the build
-			continue
+		// R-A1a: orphaned image reference — only enforce when at least one
+		// ci.build module exists. Projects with no build phase use pre-built
+		// external images (redis:7, postgres:15, etc.) and should not be flagged.
+		if len(ctx.ciBuilds) > 0 {
+			if _, found := ciImages[shortName]; !found {
+				findings = append(findings, AlignFinding{
+					Rule:     "R-A1",
+					Severity: "FAIL",
+					Resource: svc.Name,
+					Message:  fmt.Sprintf("orphaned image reference %q: no ci.build container named %q", image, shortName),
+				})
+				// Skip Dockerfile checks if we can't match the build
+				continue
+			}
 		}
 
 		// Resolve dockerfile path
@@ -632,6 +636,13 @@ func checkRA8(ctx *alignContext) []AlignFinding {
 		rpID, hasRPID := envVars["WEBAUTHN_RP_ID"]
 		origin, hasOrigin := envVars["WEBAUTHN_ORIGIN"]
 		if !hasRPID || !hasOrigin {
+			continue
+		}
+
+		// Skip if either value is an unresolved ${...} reference — url.Parse
+		// accepts "${VAR}" without error but returns an empty hostname, causing
+		// a spurious FAIL when the value is runtime-injected via secrets.
+		if strings.Contains(origin, "${") || strings.Contains(rpID, "${") {
 			continue
 		}
 

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -1,0 +1,791 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func writeAlignYAML(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "align-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func writeAlignPlanJSON(t *testing.T, plan interfaces.IaCPlan) string {
+	t.Helper()
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "plan-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func findingsHaveRule(findings []AlignFinding, rule string) bool {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func findingsHaveRuleAndSeverity(findings []AlignFinding, rule, severity string) bool {
+	for _, f := range findings {
+		if f.Rule == rule && f.Severity == severity {
+			return true
+		}
+	}
+	return false
+}
+
+// ── R-A1: container/runtime alignment ─────────────────────────────────────
+
+func TestInfraAlign_RA1_OrphanedImageRef_Fires(t *testing.T) {
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+`
+	// No ci.build module — should FAIL with orphaned image reference
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A1", "FAIL") {
+		t.Errorf("expected R-A1 FAIL for orphaned image reference, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA1_OrphanedImageRef_DoesNotFire(t *testing.T) {
+	yaml := `
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: myapp
+          dockerfile: Dockerfile
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should not have R-A1 FAIL for orphaned image
+	for _, f := range findings {
+		if f.Rule == "R-A1" && f.Severity == "FAIL" && strings.Contains(f.Message, "orphaned") {
+			t.Errorf("unexpected R-A1 FAIL (orphan): %v", f)
+		}
+	}
+}
+
+func TestInfraAlign_RA1_DockerfileUser_Fires(t *testing.T) {
+	dir := t.TempDir()
+	dfPath := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(dfPath, []byte("FROM alpine\nRUN echo hi\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: myapp
+          dockerfile: "` + dfPath + `"
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      dockerfile: "` + dfPath + `"
+      http_port: 8080
+`
+	cfg := writeAlignYAML(t, yamlContent)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A1", "FAIL") {
+		t.Errorf("expected R-A1 FAIL for missing USER directive, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA1_DockerfileUser_DoesNotFire(t *testing.T) {
+	dir := t.TempDir()
+	dfPath := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(dfPath, []byte("FROM alpine\nUSER appuser\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: myapp
+          dockerfile: "` + dfPath + `"
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      dockerfile: "` + dfPath + `"
+      http_port: 8080
+`
+	cfg := writeAlignYAML(t, yamlContent)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range findings {
+		if f.Rule == "R-A1" && strings.Contains(f.Message, "USER") {
+			t.Errorf("unexpected R-A1 USER finding: %v", f)
+		}
+	}
+}
+
+func TestInfraAlign_RA1_RootUser_Fires(t *testing.T) {
+	dir := t.TempDir()
+	dfPath := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(dfPath, []byte("FROM alpine\nUSER root\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: myapp
+          dockerfile: "` + dfPath + `"
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      dockerfile: "` + dfPath + `"
+      http_port: 8080
+`
+	cfg := writeAlignYAML(t, yamlContent)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A1", "FAIL") {
+		t.Errorf("expected R-A1 FAIL for root USER, got: %v", findings)
+	}
+}
+
+// ── R-A2: health-check alignment ───────────────────────────────────────────
+
+func TestInfraAlign_RA2_HealthCheckPathMissing_Fires(t *testing.T) {
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(srcFile, []byte(`package main
+
+func main() {}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      src_dir: "` + dir + `"
+      health_check:
+        path: "/healthz"
+`
+	cfg := writeAlignYAML(t, yamlContent)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRule(findings, "R-A2") {
+		t.Errorf("expected R-A2 finding for missing health check path in source, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA2_HealthCheckPathFound_DoesNotFire(t *testing.T) {
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(srcFile, []byte(`package main
+
+func healthzHandler() { /* /healthz */ }
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      src_dir: "` + dir + `"
+      health_check:
+        path: "/healthz"
+`
+	cfg := writeAlignYAML(t, yamlContent)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A2") {
+		t.Errorf("unexpected R-A2 finding when path IS present in source: %v", findings)
+	}
+}
+
+// ── R-A3: service-to-service DNS alignment ─────────────────────────────────
+
+func TestInfraAlign_RA3_UnknownHostname_Fires(t *testing.T) {
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        CACHE_URL: "redis-cache.internal:6379"
+`
+	// No container_service named redis-cache
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A3", "FAIL") {
+		t.Errorf("expected R-A3 FAIL for unknown DNS hostname, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA3_KnownHostname_DoesNotFire(t *testing.T) {
+	yaml := `
+modules:
+  - name: redis-cache
+    type: infra.container_service
+    config:
+      image: "redis:7"
+      internal_ports:
+        - 6379
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        CACHE_URL: "redis-cache.internal:6379"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A3") {
+		t.Errorf("unexpected R-A3 finding for known service: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA3_PortMismatch_Fires(t *testing.T) {
+	yaml := `
+modules:
+  - name: redis-cache
+    type: infra.container_service
+    config:
+      image: "redis:7"
+      internal_ports:
+        - 6380
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        CACHE_URL: "redis-cache.internal:6379"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A3", "FAIL") {
+		t.Errorf("expected R-A3 FAIL for port mismatch, got: %v", findings)
+	}
+}
+
+// ── R-A4: env-var resolution ───────────────────────────────────────────────
+
+func TestInfraAlign_RA4_UnresolvedToken_Fires(t *testing.T) {
+	// Ensure STRIPE_KEY is NOT in env
+	os.Unsetenv("STRIPE_KEY")
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        PAYMENT_KEY: "${STRIPE_KEY}"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A4", "FAIL") {
+		t.Errorf("expected R-A4 FAIL for unresolved token, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA4_ResolvedToken_DoesNotFire(t *testing.T) {
+	t.Setenv("STRIPE_KEY", "sk_test_123")
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        PAYMENT_KEY: "${STRIPE_KEY}"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A4") {
+		t.Errorf("unexpected R-A4 finding when token IS set: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA4_SecretsGenerate_DoesNotFire(t *testing.T) {
+	os.Unsetenv("DB_PASSWORD")
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        DB_PASS: "${DB_PASSWORD}"
+  - name: secrets
+    type: secrets.generate
+    config:
+      generate:
+        - key: DB_PASSWORD
+          length: 32
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A4") {
+		t.Errorf("unexpected R-A4 finding for secrets.generate key: %v", findings)
+	}
+}
+
+// ── R-A5: migrations alignment ─────────────────────────────────────────────
+
+func TestInfraAlign_RA5_PreDeployMigrateNoDB_Fires(t *testing.T) {
+	yaml := `
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: migrator
+          dockerfile: Dockerfile.migrate
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      pre_deploy:
+        kind: migrate
+        image: "migrator:latest"
+`
+	// No infra.database module — FAIL
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A5", "FAIL") {
+		t.Errorf("expected R-A5 FAIL for pre_deploy migrate with no DB, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA5_PreDeployMigrate_WithDB_DoesNotFire(t *testing.T) {
+	yaml := `
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: migrator
+          dockerfile: Dockerfile.migrate
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      pre_deploy:
+        kind: migrate
+        image: "migrator:latest"
+  - name: db
+    type: infra.database
+    config:
+      engine: postgres
+      trusted_sources:
+        - type: app
+          value: api
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A5") {
+		t.Errorf("unexpected R-A5 finding when DB + trusted_sources present: %v", findings)
+	}
+}
+
+// ── R-A6: network/exposure alignment ──────────────────────────────────────
+
+func TestInfraAlign_RA6_InternalWithHTTPPort_Fires(t *testing.T) {
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      expose: internal
+      http_port: 8080
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A6", "FAIL") {
+		t.Errorf("expected R-A6 FAIL for expose:internal + http_port, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA6_InternalWithHTTPPort_DoesNotFire(t *testing.T) {
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRuleAndSeverity(findings, "R-A6", "FAIL") {
+		t.Errorf("unexpected R-A6 FAIL for normal http_port: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA6_InternalServiceWithoutExposeInternal_Warns(t *testing.T) {
+	yaml := `
+modules:
+  - name: nats-broker
+    type: infra.container_service
+    config:
+      image: "nats:latest"
+      http_port: 4222
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A6", "WARN") {
+		t.Errorf("expected R-A6 WARN for internal service name without expose:internal, got: %v", findings)
+	}
+}
+
+// ── R-A7: plan-output sanity ──────────────────────────────────────────────
+
+func TestInfraAlign_RA7_DeleteProtectedResource_Fires(t *testing.T) {
+	plan := interfaces.IaCPlan{
+		ID:        "plan-1",
+		CreatedAt: time.Now(),
+		Actions: []interfaces.PlanAction{
+			{
+				Action: "delete",
+				Resource: interfaces.ResourceSpec{
+					Name:   "prod-db",
+					Type:   "infra.database",
+					Config: map[string]any{"protected": true},
+				},
+			},
+		},
+	}
+
+	planFile := writeAlignPlanJSON(t, plan)
+	yaml := `
+modules:
+  - name: prod-db
+    type: infra.database
+    config:
+      engine: postgres
+      protected: true
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg, planFile: planFile}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A7", "FAIL") {
+		t.Errorf("expected R-A7 FAIL for delete of protected resource, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA7_DeleteProtectedResource_DoesNotFire(t *testing.T) {
+	plan := interfaces.IaCPlan{
+		ID:        "plan-2",
+		CreatedAt: time.Now(),
+		Actions: []interfaces.PlanAction{
+			{
+				Action: "update",
+				Resource: interfaces.ResourceSpec{
+					Name:   "prod-db",
+					Type:   "infra.database",
+					Config: map[string]any{"protected": true},
+				},
+			},
+		},
+	}
+
+	planFile := writeAlignPlanJSON(t, plan)
+	yaml := `
+modules:
+  - name: prod-db
+    type: infra.database
+    config:
+      engine: postgres
+      protected: true
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg, planFile: planFile}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRuleAndSeverity(findings, "R-A7", "FAIL") {
+		t.Errorf("unexpected R-A7 FAIL for non-delete action: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA7_TooManyChanges_Warns(t *testing.T) {
+	actions := make([]interfaces.PlanAction, 55)
+	for i := range actions {
+		actions[i] = interfaces.PlanAction{
+			Action: "create",
+			Resource: interfaces.ResourceSpec{
+				Name:   "resource-" + string(rune('a'+i%26)),
+				Type:   "infra.container_service",
+				Config: map[string]any{},
+			},
+		}
+	}
+	plan := interfaces.IaCPlan{
+		ID:        "plan-big",
+		CreatedAt: time.Now(),
+		Actions:   actions,
+	}
+
+	planFile := writeAlignPlanJSON(t, plan)
+	cfg := writeAlignYAML(t, `modules: []`)
+	opts := alignOptions{configFile: cfg, planFile: planFile, maxChanges: 50}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A7", "WARN") {
+		t.Errorf("expected R-A7 WARN for too many changes, got: %v", findings)
+	}
+}
+
+// ── R-A8: WebAuthn alignment ───────────────────────────────────────────────
+
+func TestInfraAlign_RA8_RPIDMismatch_Fires(t *testing.T) {
+	yaml := `
+modules:
+  - name: auth
+    type: infra.container_service
+    config:
+      image: "auth:latest"
+      http_port: 8080
+      env_vars:
+        WEBAUTHN_RP_ID: "example.com"
+        WEBAUTHN_ORIGIN: "https://app.other.com"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A8", "FAIL") {
+		t.Errorf("expected R-A8 FAIL for RP_ID/ORIGIN mismatch, got: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA8_RPIDMatch_DoesNotFire(t *testing.T) {
+	yaml := `
+modules:
+  - name: auth
+    type: infra.container_service
+    config:
+      image: "auth:latest"
+      http_port: 8080
+      env_vars:
+        WEBAUTHN_RP_ID: "example.com"
+        WEBAUTHN_ORIGIN: "https://example.com"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A8") {
+		t.Errorf("unexpected R-A8 finding when RP_ID matches ORIGIN host: %v", findings)
+	}
+}
+
+// ── exit-code and output tests ─────────────────────────────────────────────
+
+func TestInfraAlign_ExitCode_FailOnFail(t *testing.T) {
+	os.Unsetenv("STRIPE_KEY")
+	yaml := `
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        KEY: "${STRIPE_KEY}"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode := alignExitCode(findings, false); exitCode != 1 {
+		t.Errorf("expected exit code 1 on FAIL findings, got %d", exitCode)
+	}
+}
+
+func TestInfraAlign_ExitCode_WarnNoStrict(t *testing.T) {
+	findings := []AlignFinding{
+		{Rule: "R-A6", Severity: "WARN", Resource: "nats", Message: "test warn"},
+	}
+	if code := alignExitCode(findings, false); code != 0 {
+		t.Errorf("expected exit 0 for WARN without --strict, got %d", code)
+	}
+}
+
+func TestInfraAlign_ExitCode_WarnStrict(t *testing.T) {
+	findings := []AlignFinding{
+		{Rule: "R-A6", Severity: "WARN", Resource: "nats", Message: "test warn"},
+	}
+	if code := alignExitCode(findings, true); code != 1 {
+		t.Errorf("expected exit 1 for WARN with --strict, got %d", code)
+	}
+}
+
+func TestInfraAlign_RenderMarkdown(t *testing.T) {
+	findings := []AlignFinding{
+		{Rule: "R-A6", Severity: "WARN", Resource: "nats-broker", Message: "internal service should use expose: internal"},
+		{Rule: "R-A4", Severity: "FAIL", Resource: "api", Message: "unresolved env var: ${STRIPE_KEY}"},
+	}
+	out := renderAlignMarkdown(findings)
+	if !strings.Contains(out, "| Rule |") {
+		t.Error("expected markdown table header")
+	}
+	if !strings.Contains(out, "R-A6") {
+		t.Error("expected R-A6 in output")
+	}
+	if !strings.Contains(out, "R-A4") {
+		t.Error("expected R-A4 in output")
+	}
+	if !strings.Contains(out, "1 FAIL") {
+		t.Error("expected FAIL count in summary")
+	}
+	if !strings.Contains(out, "1 WARN") {
+		t.Error("expected WARN count in summary")
+	}
+}

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -68,13 +68,19 @@ func findingsHaveRuleAndSeverity(findings []AlignFinding, rule, severity string)
 func TestInfraAlign_RA1_OrphanedImageRef_Fires(t *testing.T) {
 	yaml := `
 modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: otherapp
+          dockerfile: Dockerfile
   - name: api
     type: infra.container_service
     config:
       image: "myapp:latest"
       http_port: 8080
 `
-	// No ci.build module — should FAIL with orphaned image reference
+	// ci.build exists but has no container named "myapp" → orphaned reference
 	cfg := writeAlignYAML(t, yaml)
 	opts := alignOptions{configFile: cfg}
 	findings, err := runInfraAlignChecks(opts)

--- a/cmd/wfctl/testdata/align/ra1-orphaned-image-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra1-orphaned-image-ok.yaml
@@ -1,0 +1,14 @@
+# R-A1 OK: ci.build declares "myapp" container matching the image name.
+# R-A1 does NOT fire.
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: myapp
+          dockerfile: Dockerfile
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080

--- a/cmd/wfctl/testdata/align/ra1-orphaned-image-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra1-orphaned-image-trip.yaml
@@ -1,0 +1,8 @@
+# R-A1 TRIP: container_service references image "myapp" but no ci.build
+# module declares a container named "myapp". R-A1 fires (FAIL).
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080

--- a/cmd/wfctl/testdata/align/ra1-orphaned-image-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra1-orphaned-image-trip.yaml
@@ -1,6 +1,12 @@
-# R-A1 TRIP: container_service references image "myapp" but no ci.build
-# module declares a container named "myapp". R-A1 fires (FAIL).
+# R-A1 TRIP: ci.build exists (so the check is active) but has no container
+# named "myapp" — the image reference is orphaned. R-A1 fires (FAIL).
 modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: otherapp
+          dockerfile: Dockerfile
   - name: api
     type: infra.container_service
     config:

--- a/cmd/wfctl/testdata/align/ra2-healthcheck-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra2-healthcheck-ok.yaml
@@ -1,0 +1,7 @@
+# R-A2 OK: no health_check.path declared, so R-A2 does not apply.
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080

--- a/cmd/wfctl/testdata/align/ra2-healthcheck-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra2-healthcheck-trip.yaml
@@ -1,0 +1,12 @@
+# R-A2 TRIP: container_service declares health_check.path "/healthz" but
+# src_dir contains no file referencing that path. R-A2 fires (WARN or FAIL
+# with --strict-health).
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      src_dir: "./src"
+      health_check:
+        path: "/healthz"

--- a/cmd/wfctl/testdata/align/ra3-dns-mismatch-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra3-dns-mismatch-ok.yaml
@@ -1,0 +1,16 @@
+# R-A3 OK: redis-cache is declared as a container_service and exposes port
+# 6379 via internal_ports. R-A3 does NOT fire.
+modules:
+  - name: redis-cache
+    type: infra.container_service
+    config:
+      image: "redis:7"
+      internal_ports:
+        - 6379
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        CACHE_URL: "redis-cache.internal:6379"

--- a/cmd/wfctl/testdata/align/ra3-dns-mismatch-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra3-dns-mismatch-trip.yaml
@@ -1,0 +1,10 @@
+# R-A3 TRIP: api references "redis-cache.internal:6379" but no
+# infra.container_service named "redis-cache" exists. R-A3 fires (FAIL).
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        CACHE_URL: "redis-cache.internal:6379"

--- a/cmd/wfctl/testdata/align/ra4-unresolved-var-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra4-unresolved-var-ok.yaml
@@ -1,0 +1,16 @@
+# R-A4 OK: ${DB_PASSWORD} is declared under secrets.generate, so it resolves
+# correctly. R-A4 does NOT fire.
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        DB_PASS: "${DB_PASSWORD}"
+  - name: secrets
+    type: secrets.generate
+    config:
+      generate:
+        - key: DB_PASSWORD
+          length: 32

--- a/cmd/wfctl/testdata/align/ra4-unresolved-var-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra4-unresolved-var-trip.yaml
@@ -1,0 +1,10 @@
+# R-A4 TRIP: env_var references ${STRIPE_KEY} which is not declared in
+# secrets.generate, secrets.requires, or the OS environment. R-A4 fires (FAIL).
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        PAYMENT_KEY: "${STRIPE_KEY}"

--- a/cmd/wfctl/testdata/align/ra5-migrate-no-db-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra5-migrate-no-db-trip.yaml
@@ -1,0 +1,17 @@
+# R-A5 TRIP: api has pre_deploy.kind=migrate but no infra.database module
+# exists. R-A5 fires (FAIL).
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: migrator
+          dockerfile: Dockerfile.migrate
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      pre_deploy:
+        kind: migrate
+        image: "migrator:latest"

--- a/cmd/wfctl/testdata/align/ra5-migrate-with-db-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra5-migrate-with-db-ok.yaml
@@ -1,0 +1,24 @@
+# R-A5 OK: api has pre_deploy.kind=migrate, infra.database exists, and
+# trusted_sources includes the service. R-A5 does NOT fire.
+modules:
+  - name: build
+    type: ci.build
+    config:
+      containers:
+        - name: migrator
+          dockerfile: Dockerfile.migrate
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      pre_deploy:
+        kind: migrate
+        image: "migrator:latest"
+  - name: db
+    type: infra.database
+    config:
+      engine: postgres
+      trusted_sources:
+        - type: app
+          value: api

--- a/cmd/wfctl/testdata/align/ra6-expose-internal-http-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra6-expose-internal-http-ok.yaml
@@ -1,0 +1,10 @@
+# R-A6 OK: expose:internal without http_port is valid (internal service).
+# R-A6 does NOT fire (FAIL).
+modules:
+  - name: internal-svc
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      expose: internal
+      internal_ports:
+        - 9000

--- a/cmd/wfctl/testdata/align/ra6-expose-internal-http-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra6-expose-internal-http-trip.yaml
@@ -1,0 +1,9 @@
+# R-A6 TRIP: expose:internal is mutually exclusive with http_port.
+# R-A6 fires (FAIL).
+modules:
+  - name: internal-svc
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      expose: internal
+      http_port: 8080

--- a/cmd/wfctl/testdata/align/ra7-delete-protected-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra7-delete-protected-ok.yaml
@@ -1,0 +1,8 @@
+# R-A7 OK: plan contains an update (not delete) on the protected resource,
+# and total actions are within --max-changes (default 50). R-A7 does NOT fire.
+modules:
+  - name: prod-db
+    type: infra.database
+    config:
+      engine: postgres
+      protected: true

--- a/cmd/wfctl/testdata/align/ra7-delete-protected-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra7-delete-protected-trip.yaml
@@ -1,0 +1,10 @@
+# R-A7 TRIP: plan.json (supplied via --plan) contains a delete action on a
+# resource with protected:true. Use with a plan JSON that has:
+#   {"actions":[{"action":"delete","resource":{"name":"prod-db","type":"infra.database","config":{"protected":true}}}]}
+# R-A7 fires (FAIL).
+modules:
+  - name: prod-db
+    type: infra.database
+    config:
+      engine: postgres
+      protected: true

--- a/cmd/wfctl/testdata/align/ra8-webauthn-mismatch-ok.yaml
+++ b/cmd/wfctl/testdata/align/ra8-webauthn-mismatch-ok.yaml
@@ -1,0 +1,11 @@
+# R-A8 OK: WEBAUTHN_ORIGIN host (example.com) matches WEBAUTHN_RP_ID.
+# R-A8 does NOT fire.
+modules:
+  - name: auth
+    type: infra.container_service
+    config:
+      image: "auth:latest"
+      http_port: 8080
+      env_vars:
+        WEBAUTHN_RP_ID: "example.com"
+        WEBAUTHN_ORIGIN: "https://example.com"

--- a/cmd/wfctl/testdata/align/ra8-webauthn-mismatch-trip.yaml
+++ b/cmd/wfctl/testdata/align/ra8-webauthn-mismatch-trip.yaml
@@ -1,0 +1,11 @@
+# R-A8 TRIP: WEBAUTHN_ORIGIN host (app.other.com) does not match
+# WEBAUTHN_RP_ID (example.com). R-A8 fires (FAIL).
+modules:
+  - name: auth
+    type: infra.container_service
+    config:
+      image: "auth:latest"
+      http_port: 8080
+      env_vars:
+        WEBAUTHN_RP_ID: "example.com"
+        WEBAUTHN_ORIGIN: "https://app.other.com"


### PR DESCRIPTION
## Summary
- New `wfctl infra align` subcommand validates IaC config + plan alignment across 8 rule families (R-A1 through R-A8).
- Rules cover container/runtime alignment, health-check paths, service DNS, env-var resolution, migrations, network exposure, plan sanity, and WebAuthn RP_ID.
- Exit 1 on any FAIL; --strict upgrades WARNs to failures.
- Outputs markdown findings to stdout; tees to \$GITHUB_STEP_SUMMARY in CI.

## Test plan
- [x] go test ./cmd/wfctl/ -run TestInfraAlign -v passes (28 rule unit tests + integration test)
- [x] go test ./cmd/wfctl/ -race passes (no data races)
- [x] go build ./cmd/wfctl/ succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)