### PR TITLE
fix(wfctl): resolve golangci-lint issues in infra-align code

### DIFF
--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -74,7 +74,7 @@ func runInfraAlign(args []string) error {
 
 	// Write to GitHub Step Summary when running in CI
 	if summary := os.Getenv("GITHUB_STEP_SUMMARY"); summary != "" {
-		if f, err := os.OpenFile(summary, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
+		if f, err := os.OpenFile(summary, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600); err == nil {
 			fmt.Fprint(f, output)
 			f.Close()
 		}
@@ -178,8 +178,8 @@ func renderAlignMarkdown(findings []AlignFinding) string {
 		// Escape pipe characters to prevent breaking the markdown table.
 		resource := strings.ReplaceAll(f.Resource, "|", "\\|")
 		message := strings.ReplaceAll(f.Message, "|", "\\|")
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-			f.Rule, f.Severity, resource, message))
+		fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n",
+			f.Rule, f.Severity, resource, message)
 	}
 	sb.WriteString("\n")
 

--- a/cmd/wfctl/infra_align_rules.go
+++ b/cmd/wfctl/infra_align_rules.go
@@ -339,15 +339,18 @@ var sourceExtensions = map[string]struct{}{
 func pathExistsInSource(srcDir, path string) (bool, error) {
 	var found bool
 	err := filepath.Walk(srcDir, func(fp string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || found {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || found {
 			return nil
 		}
 		if _, ok := sourceExtensions[filepath.Ext(fp)]; !ok {
 			return nil
 		}
-		data, err := os.ReadFile(fp)
-		if err != nil {
-			return nil
+		data, readErr := os.ReadFile(fp)
+		if readErr != nil {
+			return nil // skip unreadable files
 		}
 		if strings.Contains(string(data), path) {
 			found = true
@@ -602,7 +605,8 @@ func checkRA7(plan *interfaces.IaCPlan, maxChanges int) []AlignFinding {
 	}
 	var findings []AlignFinding
 
-	for _, action := range plan.Actions {
+	for i := range plan.Actions {
+		action := &plan.Actions[i]
 		if action.Action == "delete" {
 			if protected, _ := action.Resource.Config["protected"].(bool); protected {
 				findings = append(findings, AlignFinding{

--- a/cmd/wfctl/infra_align_rules.go
+++ b/cmd/wfctl/infra_align_rules.go
@@ -350,7 +350,7 @@ func pathExistsInSource(srcDir, path string) (bool, error) {
 		}
 		data, readErr := os.ReadFile(fp)
 		if readErr != nil {
-			return nil // skip unreadable files
+			return readErr
 		}
 		if strings.Contains(string(data), path) {
 			found = true


### PR DESCRIPTION
## Summary

- Fix 5 golangci-lint violations surfaced in post-merge CI on `main` after #507 landed
- `gosec G302`: tighten `GITHUB_STEP_SUMMARY` file permissions from `0644` to `0600`
- `staticcheck QF1012`: replace `sb.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&sb, ...)`
- `nilerr` (x2): propagate `filepath.Walk` callback errors instead of returning `nil` when `err != nil`
- `gocritic rangeValCopy`: use index-based loop in `checkRA7` to avoid copying 136-byte struct per iteration

## Test plan

- [x] `GOWORK=off go build ./cmd/wfctl/` — passes
- [x] `GOWORK=off go test ./cmd/wfctl/ -run TestInfraAlign -race` — passes
- [ ] CI Lint job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)