### PR TITLE
fix(wfctl): hotfix 4 Critical/Important bugs in infra apply --plan

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -1003,36 +1003,41 @@ func runInfraApply(args []string) error {
 		if plan.DesiredHash != currentHash {
 			return fmt.Errorf("plan stale: config hash mismatch (run wfctl infra plan again)")
 		}
-		return applyFromPrecomputedPlan(ctx, plan, cfgFile, envName)
-	}
-
-	// Dispatch: infra.* modules use the direct IaCProvider path; legacy
-	// platform.* configs fall back to the pipeline runner (pipelines.apply).
-	// Mixing both types in the same config is not supported — fail fast with a
-	// descriptive error rather than silently skipping one class of modules.
-	if hasInfraModules(cfgFile) && hasPlatformModules(cfgFile) {
-		return fmt.Errorf(
-			"config %q mixes infra.* and platform.* module types — "+
-				"use one style per config file, or split into separate configs",
-			cfgFile,
-		)
-	}
-	if hasInfraModules(cfgFile) {
-		if err := applyInfraModules(ctx, cfgFile, envName); err != nil {
+		if err := applyFromPrecomputedPlan(ctx, plan, cfgFile, envName); err != nil {
 			return err
 		}
+		// Fall through to post-apply infra_output secrets sync below —
+		// same as the live-diff path so STAGING_DATABASE_URL and similar
+		// infra_output secrets are always refreshed after a successful apply.
 	} else {
-		pipelineCfg := cfgFile
-		if envName != "" {
-			tmp, resErr := writeEnvResolvedConfig(cfgFile, envName)
-			if resErr != nil {
-				return resErr
-			}
-			defer os.Remove(tmp)
-			pipelineCfg = tmp
+		// Dispatch: infra.* modules use the direct IaCProvider path; legacy
+		// platform.* configs fall back to the pipeline runner (pipelines.apply).
+		// Mixing both types in the same config is not supported — fail fast with a
+		// descriptive error rather than silently skipping one class of modules.
+		if hasInfraModules(cfgFile) && hasPlatformModules(cfgFile) {
+			return fmt.Errorf(
+				"config %q mixes infra.* and platform.* module types — "+
+					"use one style per config file, or split into separate configs",
+				cfgFile,
+			)
 		}
-		if err := runPipelineRun([]string{"-c", pipelineCfg, "-p", "apply"}); err != nil {
-			return err
+		if hasInfraModules(cfgFile) {
+			if err := applyInfraModules(ctx, cfgFile, envName); err != nil {
+				return err
+			}
+		} else {
+			pipelineCfg := cfgFile
+			if envName != "" {
+				tmp, resErr := writeEnvResolvedConfig(cfgFile, envName)
+				if resErr != nil {
+					return resErr
+				}
+				defer os.Remove(tmp)
+				pipelineCfg = tmp
+			}
+			if err := runPipelineRun([]string{"-c", pipelineCfg, "-p", "apply"}); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -630,9 +630,10 @@ func isAbstractSize(s interfaces.Size) bool {
 // embedded in plan.json by runInfraPlan and verified by runInfraApply
 // --plan to detect plans that are stale relative to the current config.
 func desiredStateHash(specs []interfaces.ResourceSpec) string {
-	if len(specs) == 0 {
-		return ""
-	}
+	// Do NOT short-circuit for empty specs: a plan that removes all resources
+	// ("delete all") has a valid, deterministic hash (sha256("[]")). Returning ""
+	// for empty specs would block such plans with a misleading "no hash" error.
+	// The "" sentinel is reserved exclusively for marshal failures below.
 	sorted := make([]interfaces.ResourceSpec, len(specs))
 	copy(sorted, specs)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -716,8 +717,16 @@ func applyFromPrecomputedPlan(ctx context.Context, plan interfaces.IaCPlan, cfgF
 	for i := range plan.Actions {
 		action := &plan.Actions[i]
 		moduleRef, _ := action.Resource.Config["provider"].(string)
+		// delete actions from ComputePlan carry an empty Resource.Config — the
+		// provider ref must be recovered from the recorded current state instead.
+		if moduleRef == "" && action.Current != nil {
+			moduleRef = action.Current.ProviderRef
+			if moduleRef == "" {
+				moduleRef, _ = action.Current.AppliedConfig["provider"].(string)
+			}
+		}
 		if moduleRef == "" {
-			return fmt.Errorf("plan action for %q: missing 'provider' field in resource config", action.Resource.Name)
+			return fmt.Errorf("plan action for %q: missing 'provider' field in resource config (delete actions require a current state record)", action.Resource.Name)
 		}
 		if _, exists := groups[moduleRef]; !exists {
 			def, ok := providerDefs[moduleRef]
@@ -781,6 +790,32 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 	for i := range plan.Actions {
 		if plan.Actions[i].Action == "delete" {
 			deleteNames[plan.Actions[i].Resource.Name] = struct{}{}
+		}
+	}
+
+	// Resolve abstract sizing tiers into concrete provider-specific values,
+	// mirroring the live-diff path in applyWithProviderAndStore. Without this,
+	// specs with Size:"m" would reach the provider unresolved.
+	for i := range plan.Actions {
+		if plan.Actions[i].Action == "delete" {
+			continue // deletes carry no spec to resolve
+		}
+		spec := &plan.Actions[i].Resource
+		if spec.Size == "" || !isAbstractSize(spec.Size) {
+			continue
+		}
+		sizing, sErr := provider.ResolveSizing(spec.Type, spec.Size, spec.Hints)
+		if sErr != nil {
+			return fmt.Errorf("%s/%s: resolve sizing: %w", spec.Type, spec.Name, sErr)
+		}
+		if sizing != nil {
+			if spec.Config == nil {
+				spec.Config = map[string]any{}
+			}
+			spec.Config["instance_type"] = sizing.InstanceType
+			for k, v := range sizing.Specs {
+				spec.Config[k] = v
+			}
 		}
 	}
 

--- a/cmd/wfctl/infra_apply_plan_test.go
+++ b/cmd/wfctl/infra_apply_plan_test.go
@@ -315,3 +315,104 @@ func TestInfraApplyPrecomputedPlan_PersistsState(t *testing.T) {
 		t.Error("ConfigHash: want non-empty, got empty")
 	}
 }
+
+// TestApplyFromPrecomputedPlan_DeleteActionResolvesProvider verifies that delete
+// actions (which carry no Resource.Config from ComputePlan) correctly resolve
+// their provider module from action.Current.ProviderRef.
+func TestApplyFromPrecomputedPlan_DeleteActionResolvesProvider(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+modules:
+  - name: test-provider
+    type: iac.provider
+    config:
+      provider: fake-cloud
+  - name: my-db
+    type: infra.database
+    config:
+      provider: test-provider
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Delete action has empty Resource.Config (as produced by ComputePlan).
+	deleteSpec := interfaces.ResourceSpec{
+		Name: "my-db",
+		Type: "infra.database",
+		// Config intentionally empty — mirrors ComputePlan's delete action.
+	}
+	currentState := &interfaces.ResourceState{
+		Name:        "my-db",
+		Type:        "infra.database",
+		ProviderRef: "test-provider", // provider ref lives in Current for deletes
+		AppliedConfig: map[string]any{
+			"provider": "test-provider",
+		},
+	}
+	specs := []interfaces.ResourceSpec{{
+		Name: "my-db", Type: "infra.database",
+		Config: map[string]any{"provider": "test-provider"},
+	}}
+	plan := interfaces.IaCPlan{
+		ID:          "delete-test",
+		DesiredHash: desiredStateHash(nil), // delete-all: empty desired
+		Actions:     []interfaces.PlanAction{{Action: "delete", Resource: deleteSpec, Current: currentState}},
+		CreatedAt:   time.Now().UTC(),
+	}
+	planData, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(planPath, planData, 0o600); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	// Also need the desiredHash to match (empty desired for delete-all).
+	// We reload the plan and fix the hash.
+	emptySpecs, _ := parseInfraResourceSpecs(cfgPath)
+	_ = emptySpecs // for delete-all, desired is empty after removing my-db from config.
+	plan.DesiredHash = desiredStateHash(nil)
+	planData, _ = json.Marshal(plan)
+	if err := os.WriteFile(planPath, planData, 0o600); err != nil {
+		t.Fatalf("rewrite plan: %v", err)
+	}
+
+	fake := &applyCapture{}
+	origResolve := resolveIaCProvider
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+		return fake, nil, nil
+	}
+	defer func() { resolveIaCProvider = origResolve }()
+
+	// With an empty config (delete-all scenario), hash matches because both
+	// sides hash nil/empty spec slices the same way.
+	// The key assertion: applyFromPrecomputedPlan must NOT error on the delete action.
+	_ = specs
+	err = applyFromPrecomputedPlan(context.Background(), plan, cfgPath, "")
+	// The apply itself won't error even if the config has my-db (hash mismatch
+	// would catch that) — we just want to confirm no "missing provider" error.
+	// With the delete action resolved via Current.ProviderRef, provider.Apply is called.
+	if err != nil && strings.Contains(err.Error(), "missing 'provider' field") {
+		t.Errorf("delete action should resolve provider from Current, got: %v", err)
+	}
+}
+
+// TestDesiredStateHash_EmptySpecsProducesStableHash verifies that an empty spec
+// slice hashes deterministically (not "") so delete-all plans are not blocked.
+func TestDesiredStateHash_EmptySpecsProducesStableHash(t *testing.T) {
+	h1 := desiredStateHash(nil)
+	h2 := desiredStateHash([]interfaces.ResourceSpec{})
+	if h1 == "" {
+		t.Error("desiredStateHash(nil) should return a stable hash, not empty string")
+	}
+	if h1 != h2 {
+		t.Errorf("desiredStateHash(nil) = %q, desiredStateHash([]) = %q; must be equal", h1, h2)
+	}
+	// Verify it differs from a non-empty spec hash.
+	nonEmpty := desiredStateHash([]interfaces.ResourceSpec{{Name: "db", Type: "infra.database"}})
+	if h1 == nonEmpty {
+		t.Error("hash of empty specs should differ from hash of non-empty specs")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes 4 Critical/Important bugs in F1 (#506) identified by code-reviewer that were merged before the review arrived.

### Finding 1 — Critical: delete actions fail with "missing provider field"

`platform.ComputePlan` generates delete actions with `Resource.Config = nil`. `applyFromPrecomputedPlan` errored immediately on any plan with deletes. Fix: fall back to `action.Current.ProviderRef` / `action.Current.AppliedConfig["provider"]` for delete actions.

### Finding 2 — Important: --plan skips post-apply infra_output secrets sync

`return applyFromPrecomputedPlan(...)` exited before `syncInfraOutputSecrets`. Fix: `if planFile != "" { ... } else { ... }` so both paths always run the post-apply secrets sync (refreshes STAGING_DATABASE_URL and similar infra_output secrets).

### Finding 3 — Important: abstract sizing unresolved in precomputed path

`applyPrecomputedPlanWithStore` called `provider.Apply` without resolving abstract sizing tiers. Fix: added the same `ResolveSizing` loop from `applyWithProviderAndStore`.

### Finding 4 — Important: desiredStateHash("") blocks delete-all plans

`desiredStateHash` returned `""` for empty specs, triggering "plan file has no hash" on legitimate delete-all plans. Fix: removed early return; empty specs hash deterministically (`sha256("[]")`). `""` is reserved for marshal failures only.

## Test plan
- [x] `TestApplyFromPrecomputedPlan_DeleteActionResolvesProvider`: delete action resolves provider from Current.ProviderRef
- [x] `TestDesiredStateHash_EmptySpecsProducesStableHash`: nil/[] hash equal and non-empty
- [x] All existing plan tests pass; full suite clean; 0 lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)