### PR TITLE
feat(plugins): IaC cross-provider review discipline (Phase A)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,17 @@ Before submitting a plugin, ensure it passes the 8-point community validation:
 4. Document the plugin's purpose, inputs, outputs, and usage examples
 5. Reference the plugin in the PR description
 
+### Reviewing IaC plugin PRs
+
+When reviewing a PR in any `GoCodeAlone/workflow-plugin-*` repository that
+implements an IaC provider, apply the cross-provider review checklist:
+
+- [`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`](docs/IAC_PLUGIN_REVIEW_CHECKLIST.md)
+
+For executable enforcement, plugin authors should import the
+`workflow/plugin/sdk/iaclint/` test helpers in their CI test suite. The
+checklist's "Test pattern" sub-sections name the matcher for each bug class.
+
 ## Test Coverage Targets
 
 | Package | Target |

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -19,6 +19,12 @@ it.
   in your test suite and call the named matcher for every driver/field.
 - **As a maintainer auditing existing plugins:** apply each bug-class scan to
   the plugin's `main` HEAD and file one issue per finding.
+- **Grep portability note:** reviewer-scan greps that need word-boundary
+  matching use `grep -P` (PCRE), since POSIX ERE does NOT define `\b` and
+  some grep implementations silently drop or mis-match it. `-P` works on
+  GNU grep. **BSD/macOS reviewers:** stock `grep` does not support `-P` —
+  use [`rg`](https://github.com/BurntSushi/ripgrep) (ripgrep) as a
+  drop-in: e.g., `rg 'func.*\bDiff\b' internal/drivers/*.go`.
 
 ## BC-1: Plan/Diff cascade gap
 
@@ -42,7 +48,8 @@ no-change baseline + reorder/normalization cases).
 
 **Reviewer scan:**
 
-1. `grep -nE 'func.*\bDiff\b' internal/drivers/*.go provider/drivers/*.go`
+1. `grep -nP 'func.*\bDiff\b' internal/drivers/*.go provider/drivers/*.go`
+   (BSD/macOS: substitute `rg`.)
 2. For each Diff, read its body. Does it always return nil? Does it only
    compare one or two fields when the Create/Update accepts more?
 3. If the answer is "yes" to either, surface as **BC-1 BLOCKING**.
@@ -88,7 +95,7 @@ matching desired and asserts `NeedsUpdate=false`.
 
 1. Check `plugin.json` for `mode: strict`. If `strict`, BC-2 doesn't apply.
 2. Enumerate every Output-emitting helper:
-   `grep -nE 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
+   `grep -nP 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
    — read each body manually, since canonical Go uses BOTH map-literal and
    post-construction Outputs writes.
 3. Typed-slice writes (catch BOTH forms — every non-`[]any` hit is BLOCKING):
@@ -135,7 +142,7 @@ every declared key is present in `out.Outputs`.
    and post-construction forms — canonical Go drivers like `fwOutput` use
    the map-literal form, which the post-construction grep alone MISSES):
    - Enumerate Output builders so each can be read manually:
-     `grep -nE 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
+     `grep -nP 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
    - Map-literal writers (canonical):
      `grep -nE '"[a-zA-Z_]+": *[a-zA-Z]' internal/drivers/*.go` —
      restrict to hits inside `*Output(` bodies; the map-literal key is
@@ -178,11 +185,12 @@ kind and asserts the parser accepts/rejects per the documented contract.
 
 **Reviewer scan:**
 
-1. `grep -niE 'func .*\b(canonical|parse|validate)[a-z]*\b' \
+1. `grep -niP 'func .*\b(canonical|parse|validate)[a-z]*\b' \
    internal/drivers/*.go` — enumerate every field validator. The `-i`
    flag is REQUIRED so Go-convention Title Case exports
    (`ParseImageRef`, `ValidateConfig`, `CanonicalizeRule`) surface
-   alongside lowercase package-private helpers.
+   alongside lowercase package-private helpers; `-P` is REQUIRED for
+   `\b` word boundaries (POSIX ERE doesn't define `\b`).
 2. For each validator, identify which `KindX` it should match (port →
    TCPPort, count/replicas → NonNegativeInt, name/identifier →
    NonEmptyString, id/numeric → IntegerOnlyFloat, exposure/visibility →
@@ -256,11 +264,12 @@ validator and asserts both raise the same error class on bad input.
 
 **Reviewer scan:**
 
-1. `grep -niE 'func .*\b(canonical|normalize|equalize)[a-z]' \
+1. `grep -niP 'func .*\b(canonical|normalize|equalize)[a-z]' \
    internal/drivers/*.go` — every Diff-side canonicalizer. The `-i` flag
    is REQUIRED so Title Case exports (`CanonicalizeRule`,
    `NormalizeCIDR`, `EqualizeRules`) surface alongside the lowercase
-   package-private form.
+   package-private form; `-P` is REQUIRED for `\b` word boundaries
+   (POSIX ERE doesn't define `\b`).
 2. For each, find the matching Apply-side validator (`apply<Field>` /
    `validate<Field>` or inline check in `Create` / `Update`).
 3. Compare the input-acceptance contracts. Any silent acceptance on the

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -280,9 +280,11 @@ validator and asserts both raise the same error class on bad input.
 **Failure mode:** An Update path that swaps `inbound_rules.sources` (or
 the equivalent — AWS SG `IpRanges`, GCP firewall `sourceRanges`, Azure
 NSG `sourceAddressPrefixes`) silently widens CIDR ranges instead of
-erroring. Security regression: caller intends to narrow `10.0.0.0/24` to
-`10.0.0.0/28`, plugin accepts and applies a wider rule. No diff signal,
-no audit trail.
+erroring. Security regression: caller intends to narrow `10.0.0.0/24`
+(256 addresses) to `10.0.0.0/28` (16 addresses), but the plugin silently
+keeps the wider `/24` state OR widens further to a still-broader CIDR.
+No diff signal, no audit trail — the operator believes the narrow rule
+is in effect when in fact the wider rule is still allowing traffic.
 
 **Repro pattern:** identified in the v5.2.0 adversarial framing of
 `workflow-plugin-digitalocean` PR #36 (the v5.0.0 framing missed it on
@@ -291,11 +293,13 @@ reproduced by the v0.8.0 driver because DO firewall replaces all rules
 atomically — but every CIDR-widening Update path in any provider's
 firewall/SG/NSG driver is at risk.
 
-**Fix shape:** Fail Update when desired CIDR `sources` ⊊ current CIDR
-`sources` (i.e., the desired set is strictly broader than current) unless
-an explicit caller flag (`--strict-cidr=false` on `wfctl infra apply`, or
-plugin config `allow_cidr_widening: true`) opts out. The default is
-deny-on-widen; the opt-out makes the broadening intentional and auditable.
+**Fix shape:** Fail Update when `current` CIDR `sources` ⊊ `desired`
+CIDR `sources` (i.e., current's IP set is a strict subset of desired's
+IP set — desired allows IPs current didn't, which is widening) unless an
+explicit caller flag (`--strict-cidr=false` on `wfctl infra
+security-check`, or plugin config `allow_cidr_widening: true`) opts out.
+The default is deny-on-widen; the opt-out makes the broadening
+intentional and auditable.
 
 **Test pattern:** No `iaclint` matcher — verify by reviewer scan and
 manual test cases. Pattern: build a `current.Outputs` with narrow CIDRs,

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -87,10 +87,22 @@ matching desired and asserts `NeedsUpdate=false`.
 **Reviewer scan:**
 
 1. Check `plugin.json` for `mode: strict`. If `strict`, BC-2 doesn't apply.
-2. Otherwise: `grep -nE 'Outputs\["[^"]+"\] *= *\[\]' internal/drivers/*.go`
-   surfaces typed-slice writes. Each is a **BC-2 BLOCKING** instance.
-3. `grep -nE 'current\.Outputs\["[^"]+"\]\.\(\[\]' internal/drivers/*.go`
-   surfaces typed-slice reads in Diff. Each is a **BC-2 BLOCKING** instance.
+2. Enumerate every Output-emitting helper:
+   `grep -nE 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
+   — read each body manually, since canonical Go uses BOTH map-literal and
+   post-construction Outputs writes.
+3. Typed-slice writes (catch BOTH forms — fail-loud on ANY hit):
+   - Post-construction form:
+     `grep -nE 'Outputs\["[^"]+"\] *= *\[\][a-zA-Z]' internal/drivers/*.go`
+   - Map-literal form (canonical, used by `fwOutput` / `appOutput`):
+     `grep -nE '"[a-zA-Z_]+": *\[\][a-zA-Z]' internal/drivers/*.go`
+     — restrict attention to hits inside `*Output(` builder bodies and
+     test fixtures that round-trip through structpb.
+   Each non-`[]any` typed-slice hit is a **BC-2 BLOCKING** instance.
+4. Typed-slice reads in Diff:
+   `grep -nE 'current\.Outputs\["[^"]+"\]\.\(\[\][a-zA-Z]' internal/drivers/*.go`
+   surfaces type assertions to `[]string` / `[]int` / `[]godo.X`. Each is a
+   **BC-2 BLOCKING** instance.
 
 ## BC-3: Outputs-vs-Diff invariant
 
@@ -119,11 +131,21 @@ every declared key is present in `out.Outputs`.
 
 1. `grep -nE 'current\.Outputs\["[^"]+"\]' internal/drivers/*.go` —
    enumerate every Outputs key Diff reads.
-2. `grep -nE '\.Outputs\["[^"]+"\] *=' internal/drivers/*.go` — enumerate
-   every Outputs key the writers populate.
-3. Compute the set difference. Any key in (1) but not (2) is a **BC-3
-   BLOCKING** finding. Cross-link with BC-1 (Diff that reads phantom keys
-   often pairs with shallow Diff field coverage).
+2. Enumerate every Outputs key the writers populate (catch BOTH map-literal
+   and post-construction forms — canonical Go drivers like `fwOutput` use
+   the map-literal form, which the post-construction grep alone MISSES):
+   - Enumerate Output builders so each can be read manually:
+     `grep -nE 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
+   - Map-literal writers (canonical):
+     `grep -nE '"[a-zA-Z_]+": *[a-zA-Z]' internal/drivers/*.go` —
+     restrict to hits inside `*Output(` bodies; the map-literal key is
+     the Outputs[*] key.
+   - Post-construction writers:
+     `grep -nE '\.Outputs\["[^"]+"\] *=' internal/drivers/*.go`
+3. Compute the set difference between (1) and (2). Any key in (1) but not
+   in the union of (2) is a **BC-3 BLOCKING** finding. Cross-link with
+   BC-1 (Diff that reads phantom keys often pairs with shallow Diff field
+   coverage).
 
 ## BC-4: Validation matrix
 
@@ -156,8 +178,11 @@ kind and asserts the parser accepts/rejects per the documented contract.
 
 **Reviewer scan:**
 
-1. `grep -nE 'func .*\b(canonical|parse|validate)[A-Z][A-Za-z]*\b' \
-   internal/drivers/*.go` — enumerate every field validator.
+1. `grep -niE 'func .*\b(canonical|parse|validate)[a-z]*\b' \
+   internal/drivers/*.go` — enumerate every field validator. The `-i`
+   flag is REQUIRED so Go-convention Title Case exports
+   (`ParseImageRef`, `ValidateConfig`, `CanonicalizeRule`) surface
+   alongside lowercase package-private helpers.
 2. For each validator, identify which `KindX` it should match (port →
    TCPPort, count/replicas → NonNegativeInt, name/identifier →
    NonEmptyString, id/numeric → IntegerOnlyFloat, exposure/visibility →
@@ -231,8 +256,11 @@ validator and asserts both raise the same error class on bad input.
 
 **Reviewer scan:**
 
-1. `grep -nE 'func .*\b(canonical|normalize|equalize)[A-Z]' \
-   internal/drivers/*.go` — every Diff-side canonicalizer.
+1. `grep -niE 'func .*\b(canonical|normalize|equalize)[a-z]' \
+   internal/drivers/*.go` — every Diff-side canonicalizer. The `-i` flag
+   is REQUIRED so Title Case exports (`CanonicalizeRule`,
+   `NormalizeCIDR`, `EqualizeRules`) surface alongside the lowercase
+   package-private form.
 2. For each, find the matching Apply-side validator (`apply<Field>` /
    `validate<Field>` or inline check in `Create` / `Update`).
 3. Compare the input-acceptance contracts. Any silent acceptance on the

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -1,0 +1,95 @@
+# IaC Plugin Review Checklist
+
+This checklist captures the cross-provider bug-class taxonomy surfaced during
+plugin review cycles (initially `workflow-plugin-digitalocean v0.8.0`, P-2
+phase). Each bug class is reproducible across every IaC provider plugin (DO,
+AWS, GCP, Azure, Tofu, CI-generator). Apply this checklist when reviewing any
+plugin PR that touches ResourceDriver implementations, Outputs writers, or
+config-field validators.
+
+For executable enforcement, see the test-helper package
+`workflow/plugin/sdk/iaclint/`. Each bug class names the matcher that closes
+it.
+
+## How to use this checklist
+
+- **As a reviewer:** scan the diff for each bug class. The "Reviewer scan"
+  sub-section names the concrete grep / read steps.
+- **As a plugin author:** import `github.com/GoCodeAlone/workflow/plugin/sdk/iaclint`
+  in your test suite and call the named matcher for every driver/field.
+- **As a maintainer auditing existing plugins:** apply each bug-class scan to
+  the plugin's `main` HEAD and file one issue per finding.
+
+## BC-1: Plan/Diff cascade gap
+
+**Failure mode:** A driver's `Diff` implementation either always returns nil
+(stub) or only compares a subset of fields, so in-place updates silently
+no-op or emit spurious changes on every reconcile.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #35 round 1
+(`AppPlatformDriver.Diff` only compared `image`); PR #36 round 1
+(`FirewallDriver.Diff` always returned `NeedsUpdate=false`).
+
+**Fix shape:** `Diff` compares every canonical config field; the matching
+`appOutput` / `fwOutput` writer populates `Outputs[*]` for every field `Diff`
+reads (see also BC-3).
+
+**Test pattern:** combine `iaclint.AssertDiffPopulatesAllOutputFields` (BC-3
+matcher) with explicit `_DetectsXChange` test cases per field. See
+`workflow-plugin-digitalocean/internal/drivers/firewall_test.go` for the
+canonical structure (8 sub-cases per Diff: each field's positive case +
+no-change baseline + reorder/normalization cases).
+
+**Reviewer scan:**
+
+1. `grep -nE 'func.*\bDiff\b' internal/drivers/*.go provider/drivers/*.go`
+2. For each Diff, read its body. Does it always return nil? Does it only
+   compare one or two fields when the Create/Update accepts more?
+3. If the answer is "yes" to either, surface as **BC-1 BLOCKING**.
+
+## BC-2: structpb gRPC boundary (legacy compat plugins only)
+
+**Failure mode:** `Outputs["..."]` stores a typed slice (`[]int`, `[]string`,
+`[]godo.X` etc.) that is **rejected** by `structpb.NewStruct` at the
+wfctl→plugin gRPC boundary. After the boundary round-trip, reader-side type
+assertions fail (`current.Outputs["X"].([]godo.Y)` returns `ok=false`),
+treating current state as nil and emitting perpetual spurious changes from
+Diff. The whole Diff cascade fix becomes a no-op in production gRPC mode.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #36 round 2 (Diff cascade
+fix landed but typed-slice Outputs broke under realistic gRPC dispatch; round
+3 introduced canonical-shape Outputs to close the gap).
+
+**Constraint reference:** `internal/grpc_dispatch_test.go:30-32` in any
+external-dispatch plugin documents the structpb constraint:
+
+> "Slices must be `[]any`; native typed slices (`[]string`, `[]int`, etc.)
+> are rejected by `structpb.NewStruct` with 'proto: invalid type'."
+
+**Fix shape:**
+
+- `Outputs[<int-slice key>]` → `[]any` of `float64` (structpb collapses all
+  numerics to `float64`; storing as `float64` from the start makes the shape
+  symmetric with both pre- and post-roundtrip reads).
+- `Outputs[<string-slice key>]` → `[]any` of `string`.
+- `Outputs[<struct-slice key>]` → `[]any` of `map[string]any`, with a flatten
+  helper per godo struct type.
+- Reader-side helpers (`outputsAsIntSlice`, `outputsAsStringSlice`, etc.)
+  accept BOTH typed-slice (in-process pre-roundtrip path) AND `[]any` of
+  primitive/map (post-roundtrip path).
+
+**Test pattern:** import `iaclint` and call `iaclint.AssertOutputsRoundTripStructpb(t, out.Outputs)`
+in the driver's Create/Read/Update tests. For Diff, write a
+`_StructpbBoundary_DiffSurvivesRoundTrip` test that builds an Outputs map,
+round-trips through `structpb.NewStruct`/`AsMap()`, then calls Diff against a
+matching desired and asserts `NeedsUpdate=false`.
+
+**Reviewer scan:**
+
+1. Check `plugin.json` for `mode: strict`. If `strict`, BC-2 doesn't apply.
+2. Otherwise: `grep -nE 'Outputs\["[^"]+"\] *= *\[\]' internal/drivers/*.go`
+   surfaces typed-slice writes. Each is a **BC-2 BLOCKING** instance.
+3. `grep -nE 'current\.Outputs\["[^"]+"\]\.\(\[\]' internal/drivers/*.go`
+   surfaces typed-slice reads in Diff. Each is a **BC-2 BLOCKING** instance.
+
+## (Bug classes BC-3 through BC-8 to follow in Task 8)

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -91,7 +91,7 @@ matching desired and asserts `NeedsUpdate=false`.
    `grep -nE 'func .*Output\b' internal/drivers/*.go provider/drivers/*.go drivers/*.go`
    — read each body manually, since canonical Go uses BOTH map-literal and
    post-construction Outputs writes.
-3. Typed-slice writes (catch BOTH forms — fail-loud on ANY hit):
+3. Typed-slice writes (catch BOTH forms — every non-`[]any` hit is BLOCKING):
    - Post-construction form:
      `grep -nE 'Outputs\["[^"]+"\] *= *\[\][a-zA-Z]' internal/drivers/*.go`
    - Map-literal form (canonical, used by `fwOutput` / `appOutput`):

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -85,7 +85,7 @@ external-dispatch plugin documents the structpb constraint:
   accept BOTH typed-slice (in-process pre-roundtrip path) AND `[]any` of
   primitive/map (post-roundtrip path).
 
-**Test pattern:** import `iaclint` and call `iaclint.AssertOutputsRoundTripStructpb(t, out.Outputs)`
+**Test pattern:** import `iaclint` and call `iaclint.AssertOutputsStructpbCompatible(t, out.Outputs)`
 in the driver's Create/Read/Update tests. For Diff, write a
 `_StructpbBoundary_DiffSurvivesRoundTrip` test that builds an Outputs map,
 round-trips through `structpb.NewStruct`/`AsMap()`, then calls Diff against a

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -185,9 +185,9 @@ kind and asserts the parser accepts/rejects per the documented contract.
 
 **Reviewer scan:**
 
-1. `grep -niP 'func .*\b(canonical|parse|validate)[a-z]*\b' \
-   internal/drivers/*.go` — enumerate every field validator. The `-i`
-   flag is REQUIRED so Go-convention Title Case exports
+1. Enumerate every field validator:
+   `grep -niP 'func .*\b(canonical|parse|validate)[a-z]*\b' internal/drivers/*.go`.
+   The `-i` flag is REQUIRED so Go-convention Title Case exports
    (`ParseImageRef`, `ValidateConfig`, `CanonicalizeRule`) surface
    alongside lowercase package-private helpers; `-P` is REQUIRED for
    `\b` word boundaries (POSIX ERE doesn't define `\b`).
@@ -230,8 +230,8 @@ actual call sites; out of scope for v1.)
 
 **Reviewer scan:**
 
-1. `grep -niE 'plan[- ]?time' plugin.json CHANGELOG.md docs/*.md \
-   internal/drivers/*.go` — every claim of plan-time behavior.
+1. Every claim of plan-time behavior:
+   `grep -niE 'plan[- ]?time' plugin.json CHANGELOG.md docs/*.md internal/drivers/*.go`.
 2. For each hit, trace the named validator. Does it run from
    `Driver.Diff` (or `Driver.Validate` if the SDK supports it), or only
    from `Driver.Create` / `Driver.Update`?
@@ -264,9 +264,9 @@ validator and asserts both raise the same error class on bad input.
 
 **Reviewer scan:**
 
-1. `grep -niP 'func .*\b(canonical|normalize|equalize)[a-z]' \
-   internal/drivers/*.go` — every Diff-side canonicalizer. The `-i` flag
-   is REQUIRED so Title Case exports (`CanonicalizeRule`,
+1. Every Diff-side canonicalizer:
+   `grep -niP 'func .*\b(canonical|normalize|equalize)[a-z]' internal/drivers/*.go`.
+   The `-i` flag is REQUIRED so Title Case exports (`CanonicalizeRule`,
    `NormalizeCIDR`, `EqualizeRules`) surface alongside the lowercase
    package-private form; `-P` is REQUIRED for `\b` word boundaries
    (POSIX ERE doesn't define `\b`).
@@ -308,9 +308,12 @@ assert it returns an error citing the widened rule.
 
 **Reviewer scan:**
 
-1. `grep -nE \
-   'inbound_rules\.sources|outbound_rules\.destinations|IpRanges|sourceRanges|sourceAddressPrefixes' \
-   internal/drivers/*.go` — every CIDR-bearing rule field.
+1. Every CIDR-bearing rule field:
+
+   ```sh
+   grep -nE 'inbound_rules\.sources|outbound_rules\.destinations|IpRanges|sourceRanges|sourceAddressPrefixes' internal/drivers/*.go
+   ```
+
 2. For each Update path that mutates such a field, trace whether the path
    compares desired vs current CIDR set membership before applying.
 3. Any path that swaps without comparing is a **BC-7 BLOCKING** finding

--- a/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+++ b/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
@@ -92,4 +92,219 @@ matching desired and asserts `NeedsUpdate=false`.
 3. `grep -nE 'current\.Outputs\["[^"]+"\]\.\(\[\]' internal/drivers/*.go`
    surfaces typed-slice reads in Diff. Each is a **BC-2 BLOCKING** instance.
 
-## (Bug classes BC-3 through BC-8 to follow in Task 8)
+## BC-3: Outputs-vs-Diff invariant
+
+**Failure mode:** `Diff` reads `current.Outputs["X"]` for some field X but no
+writer (`Create` / `Update` / `Read`) ever populates X. Diff sees the
+zero-value (`""`, `0`, `nil`) and emits a spurious `FieldChange` every
+reconcile, even when the live resource matches the desired spec.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #35 round 4 (the
+`image` gap — `AppPlatformDriver.Diff` compared `image` but `appOutput`
+didn't write it, so every reconcile emitted a phantom image change).
+
+**Fix shape:** For every key Diff reads, verify a writer populates it. Add
+a `derive*FromAppSpec` (or `deriveOutputsFromCurrent`) helper if the value
+can be reconstructed from the live spec when the upstream API doesn't
+return it directly. The output writer (`appOutput`, `fwOutput`, etc.) is
+the single source of truth — Diff reads only what the writer commits.
+
+**Test pattern:** the driver implements `iaclint.DiffOutputKeyDeclarer`
+(returning the static slice of canonical output keys its Diff reads), then
+the test calls `iaclint.AssertDiffPopulatesAllOutputFields(t, driver,
+sampleSpec)`. The matcher invokes `Create` with `sampleSpec` and asserts
+every declared key is present in `out.Outputs`.
+
+**Reviewer scan:**
+
+1. `grep -nE 'current\.Outputs\["[^"]+"\]' internal/drivers/*.go` —
+   enumerate every Outputs key Diff reads.
+2. `grep -nE '\.Outputs\["[^"]+"\] *=' internal/drivers/*.go` — enumerate
+   every Outputs key the writers populate.
+3. Compute the set difference. Any key in (1) but not (2) is a **BC-3
+   BLOCKING** finding. Cross-link with BC-1 (Diff that reads phantom keys
+   often pairs with shallow Diff field coverage).
+
+## BC-4: Validation matrix
+
+**Failure mode:** Field validators check key presence but not value
+validity. Common variants observed in the v0.8.0 cycle:
+
+- TCP port: `0` or negative or `> 65535` accepted (PR #35 round 5).
+- Float-as-int: `123.9` silently truncated to `123` (PR #36 round 3) — gRPC
+  numeric coercion delivers JSON numbers as `float64`, so int-typed config
+  keys must reject fractional values explicitly.
+- Empty-string slice element: `["", "valid"]` not filtered (PR #36 round
+  2) — silently propagated downstream as an invalid CIDR or tag.
+- Non-string for string-typed enum: `expose: true` (Go bool) silently
+  treated as "omitted" → defaulted to `public` (PR #35 round 3).
+
+**Repro pattern:** PR #35 rounds 3 + 5 and PR #36 rounds 2 + 3 in
+`workflow-plugin-digitalocean`.
+
+**Fix shape:** Per-field TDD coverage for each {field, kind} pair —
+negative, zero, max, max+1, fractional, empty-string element, wrong-type,
+known-good. Validators that reject loudly with a context-bearing error
+beat validators that silently coerce or default.
+
+**Test pattern:** `iaclint.AssertValidationMatrix(t, parser, fieldName,
+kind)` for each {field, kind} pair the driver accepts. Available kinds:
+`KindTCPPort`, `KindNonNegativeInt`, `KindNonEmptyString`,
+`KindIntegerOnlyFloat`, and `iaclint.WithStringEnumOptions(allowed)` for
+string enums. The matcher exercises the standard probe battery for each
+kind and asserts the parser accepts/rejects per the documented contract.
+
+**Reviewer scan:**
+
+1. `grep -nE 'func .*\b(canonical|parse|validate)[A-Z][A-Za-z]*\b' \
+   internal/drivers/*.go` — enumerate every field validator.
+2. For each validator, identify which `KindX` it should match (port →
+   TCPPort, count/replicas → NonNegativeInt, name/identifier →
+   NonEmptyString, id/numeric → IntegerOnlyFloat, exposure/visibility →
+   StringEnum).
+3. Confirm the test suite has `AssertValidationMatrix` coverage for every
+   such validator. Missing coverage is a **BC-4** finding (severity scales
+   with blast radius — security-relevant validators promote to BLOCKING).
+
+## BC-5: Plan-time vs Apply-time documentation accuracy
+
+**Failure mode:** `plugin.json` description, `CHANGELOG.md` entry, or
+package doc-comment claims validation runs "at plan time", but the
+validator only fires from `Create` / `Update` (the Apply path) — the IaC
+provider's `Plan` doesn't dispatch to the driver for create actions. The
+operator reads the docs, expects a plan-time error before any provider
+API call, instead observes a partial apply with side effects.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #36 round 3 + PR #35
+round 5 — both shipped CHANGELOG entries claiming plan-time validation
+when the validator only ran inside `applyXxx` helpers on the Apply path.
+
+**Fix shape:** Two acceptable resolutions:
+
+- **Documentation rewording (cheap):** change "fail at plan time" to "fail
+  at apply time, before any DigitalOcean API call". Match doc-comments and
+  CHANGELOG language to the actual call site.
+- **Real plan-time validation (refactor):** call the validators from the
+  driver's `Diff` (or a dedicated `Validate` method) so plan output
+  surfaces the error before any apply state mutates. Larger surface area;
+  defer to v0.9.0 strict-contracts migration when the SDK gains a
+  first-class `Validate` hook.
+
+**Test pattern:** No `iaclint` matcher — verify by reviewer scan and
+manual test cases. (Future iaclint version may add an `AssertDocClaims`
+matcher that compares CHANGELOG/plugin.json claim strings against the
+actual call sites; out of scope for v1.)
+
+**Reviewer scan:**
+
+1. `grep -niE 'plan[- ]?time' plugin.json CHANGELOG.md docs/*.md \
+   internal/drivers/*.go` — every claim of plan-time behavior.
+2. For each hit, trace the named validator. Does it run from
+   `Driver.Diff` (or `Driver.Validate` if the SDK supports it), or only
+   from `Driver.Create` / `Driver.Update`?
+3. Mismatch is a **BC-5** finding. Default severity Minor unless the
+   misclaim hides a security validator (then promote to Important).
+
+## BC-6: Diff-side vs Apply-side parity
+
+**Failure mode:** Apply-side has tighter validation (e.g., non-string
+`expose` errors loudly via `applyExposeInternal`), but Diff-side accepts
+the bad value silently (e.g., `canonicalExpose` defaults to `"public"`).
+Plan output misleadingly suggests a successful update; Apply will actually
+error. Symmetric variants exist: Diff treats whitespace-only string as
+unset, Apply rejects it; Diff sorts a slice for stable comparison, Apply
+preserves caller order and rejects unsorted input.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #35 round 3
+(code-reviewer Observation B — `canonicalExpose` defaulted non-string
+input to public while `applyExposeInternal` rejected it).
+
+**Fix shape:** Mirror apply-side validation in Diff-side helpers, OR have
+Diff call apply-side validators directly and surface the error via the
+plan output. The Diff/Apply split should differ only in side effects, not
+in input acceptance.
+
+**Test pattern:** No `iaclint` matcher — verify by reviewer scan and
+manual test cases. Pattern: write a parametric test that feeds the same
+input through both the Diff-side canonicalizer and the Apply-side
+validator and asserts both raise the same error class on bad input.
+
+**Reviewer scan:**
+
+1. `grep -nE 'func .*\b(canonical|normalize|equalize)[A-Z]' \
+   internal/drivers/*.go` — every Diff-side canonicalizer.
+2. For each, find the matching Apply-side validator (`apply<Field>` /
+   `validate<Field>` or inline check in `Create` / `Update`).
+3. Compare the input-acceptance contracts. Any silent acceptance on the
+   Diff side that errors on the Apply side is a **BC-6** finding.
+
+## BC-7: CIDR widening regression scan (firewall / SG / NSG drivers)
+
+**Failure mode:** An Update path that swaps `inbound_rules.sources` (or
+the equivalent — AWS SG `IpRanges`, GCP firewall `sourceRanges`, Azure
+NSG `sourceAddressPrefixes`) silently widens CIDR ranges instead of
+erroring. Security regression: caller intends to narrow `10.0.0.0/24` to
+`10.0.0.0/28`, plugin accepts and applies a wider rule. No diff signal,
+no audit trail.
+
+**Repro pattern:** identified in the v5.2.0 adversarial framing of
+`workflow-plugin-digitalocean` PR #36 (the v5.0.0 framing missed it on
+the round-3 review; v5.2.0 caught it as a regression class). Not
+reproduced by the v0.8.0 driver because DO firewall replaces all rules
+atomically — but every CIDR-widening Update path in any provider's
+firewall/SG/NSG driver is at risk.
+
+**Fix shape:** Fail Update when desired CIDR `sources` ⊊ current CIDR
+`sources` (i.e., the desired set is strictly broader than current) unless
+an explicit caller flag (`--strict-cidr=false` on `wfctl infra apply`, or
+plugin config `allow_cidr_widening: true`) opts out. The default is
+deny-on-widen; the opt-out makes the broadening intentional and auditable.
+
+**Test pattern:** No `iaclint` matcher — verify by reviewer scan and
+manual test cases. Pattern: build a `current.Outputs` with narrow CIDRs,
+build a `desired.Config` with strictly broader CIDRs, call `Update`, and
+assert it returns an error citing the widened rule.
+
+**Reviewer scan:**
+
+1. `grep -nE \
+   'inbound_rules\.sources|outbound_rules\.destinations|IpRanges|sourceRanges|sourceAddressPrefixes' \
+   internal/drivers/*.go` — every CIDR-bearing rule field.
+2. For each Update path that mutates such a field, trace whether the path
+   compares desired vs current CIDR set membership before applying.
+3. Any path that swaps without comparing is a **BC-7 BLOCKING** finding
+   (security-class severity).
+
+## BC-8: Schema canonical-key registration
+
+**Failure mode:** Plugin adds a config key (e.g., `http_port_protocol`,
+`droplet_pool_strategy`) but doesn't propose adding it to the workflow
+framework's `interfaces.canonicalKeySet` or the matching enum in
+`schema/iac_canonical_schema.json`. Currently benign because the
+canonical-schema enforcement isn't wired into `wfctl validate` for IaC
+configs — but when it lands (v0.9.0+), configs using the unregistered
+key will be rejected by the validator with a confusing
+"unknown-canonical-key" error, even though the plugin accepts the key.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #35 round 1
+(code-reviewer Finding 2 — `http_port_protocol` added to the App Platform
+driver without a matching workflow-side canonical-key registration PR).
+
+**Fix shape:** Either land a small PR against the workflow framework
+adding the new key to `canonicalKeySet` + the JSON Schema enum, or
+document the plugin-scoped status in `CHANGELOG.md` ("Adds plugin-scoped
+config key X; will be promoted to canonical schema in workflow vY.Z."),
+so downstream readers know the validator gap is intentional.
+
+**Test pattern:** No `iaclint` matcher — verify by reviewer scan against
+`workflow/interfaces/iac_canonical_keys.go`'s `canonicalKeySet` (clone the
+workflow repo locally; the set is small enough to grep).
+
+**Reviewer scan:**
+
+1. `grep -nE '"[a-z][a-z0-9_]+":' internal/drivers/*.go internal/canonical*.go` —
+   enumerate every config key the plugin reads.
+2. For each, check whether the key appears in
+   `workflow/interfaces/iac_canonical_keys.go` `canonicalKeySet` or the
+   plugin's CHANGELOG documents the plugin-scoped status.
+3. Any new key not in either location is a **BC-8** finding.

--- a/docs/plans/2026-04-26-strict-grpc-plugin-contracts-design.md
+++ b/docs/plans/2026-04-26-strict-grpc-plugin-contracts-design.md
@@ -169,6 +169,25 @@ Batch plugin repos by contract shape:
 
 Each batch gets a branch, PR, spec review, adversarial code review, CI monitoring, Copilot review handling, and merge only after green checks and no meaningful unresolved review.
 
+### IaC Provider Plugins
+
+These plugins implement `interfaces.ResourceDriver` and consume the IaC
+canonical schema. They are tracked separately because their migration
+benefits from the cross-provider review discipline at
+[`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`](../IAC_PLUGIN_REVIEW_CHECKLIST.md).
+
+| Plugin | Strict-mode status (target v0.9.0) | Pre-migration audit findings |
+|---|---|---|
+| `workflow-plugin-aws` | active migration | (Phase C audit pending) |
+| `workflow-plugin-azure` | verified locally, awaiting PR | (Phase C audit pending) |
+| `workflow-plugin-ci-generator` | merged | n/a (already shipped strict) |
+| `workflow-plugin-digitalocean` | pending — v0.8.0 ships legacy compat | F4/F5/F7 cycle: BC-1, BC-2, BC-3, BC-4, BC-5, BC-6, BC-8 closed in v0.8.0; BC-7 not applicable. Issue #37 (Update naming consistency) deferred to v0.8.x |
+| `workflow-plugin-gcp` | pending | (Phase C audit pending) |
+| `workflow-plugin-tofu` | pending | (Phase C audit pending) |
+
+Each plugin's v0.9.0 strict-migration PR adds a "Pre-migration findings
+closed" sub-section to its CHANGELOG referencing the bug classes addressed.
+
 ## Testing
 
 Core tests must cover:

--- a/docs/plans/2026-04-26-strict-grpc-plugin-contracts.md
+++ b/docs/plans/2026-04-26-strict-grpc-plugin-contracts.md
@@ -136,6 +136,25 @@ Last updated: 2026-04-27 15:00 America/New_York.
 | Templates / samples | workflow-plugin-bento, workflow-plugin-messaging-core, workflow-plugin-migrations, workflow-plugin-template, workflow-plugin-template-private |
 | Application-owned plugins | workflow-dnd, workflow-cardgame, core-dump, buymywishlist |
 
+### IaC Provider Plugins
+
+These plugins implement `interfaces.ResourceDriver` and consume the IaC
+canonical schema. They are tracked separately because their migration
+benefits from the cross-provider review discipline at
+[`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`](../IAC_PLUGIN_REVIEW_CHECKLIST.md).
+
+| Plugin | Strict-mode status (target v0.9.0) | Pre-migration audit findings |
+|---|---|---|
+| `workflow-plugin-aws` | active migration | (Phase C audit pending) |
+| `workflow-plugin-azure` | verified locally, awaiting PR | (Phase C audit pending) |
+| `workflow-plugin-ci-generator` | merged | n/a (already shipped strict) |
+| `workflow-plugin-digitalocean` | pending — v0.8.0 ships legacy compat | F4/F5/F7 cycle: BC-1, BC-2, BC-3, BC-4, BC-5, BC-6, BC-8 closed in v0.8.0; BC-7 not applicable. Issue #37 (Update naming consistency) deferred to v0.8.x |
+| `workflow-plugin-gcp` | pending | (Phase C audit pending) |
+| `workflow-plugin-tofu` | pending | (Phase C audit pending) |
+
+Each plugin's v0.9.0 strict-migration PR adds a "Pre-migration findings
+closed" sub-section to its CHANGELOG referencing the bug classes addressed.
+
 ### Task 1: Core Proto Contract Descriptors
 
 **Files:**

--- a/docs/plans/2026-04-28-iac-plugin-review-design.md
+++ b/docs/plans/2026-04-28-iac-plugin-review-design.md
@@ -119,10 +119,13 @@ import (
     "github.com/GoCodeAlone/workflow/interfaces"
 )
 
-// AssertOutputsRoundTripStructpb verifies that every value in outputs survives
-// structpb.NewStruct → AsMap() round-trip without type degradation that breaks
-// downstream type assertions. Closes BC-2.
-func AssertOutputsRoundTripStructpb(t *testing.T, outputs map[string]any)
+// AssertOutputsStructpbCompatible verifies that every value in outputs is
+// structpb-compatible (structpb.NewStruct accepts them). Catches typed-slice
+// writes that would be rejected at the wfctl→plugin gRPC boundary. Closes
+// BC-2. Does NOT exercise the full NewStruct → AsMap round-trip — plugins
+// whose Diff reads typed values from current.Outputs should write a separate
+// post-roundtrip test.
+func AssertOutputsStructpbCompatible(t *testing.T, outputs map[string]any)
 
 // AssertDiffPopulatesAllOutputFields verifies that for every key the Diff
 // implementation reads from current.Outputs, the matching writer (Create/

--- a/docs/plans/2026-04-28-iac-plugin-review-design.md
+++ b/docs/plans/2026-04-28-iac-plugin-review-design.md
@@ -77,9 +77,9 @@ Distilled from the P-2 review cycle, every class shipped at least once in v0.8.0
 **Retroactive applicability:** every IaC plugin where Diff and Create/Update read the same config keys — high.
 
 ### BC-7: CIDR widening regression scan (firewall/SG/NSG drivers)
-**Failure mode:** An Update path that swaps `inbound_rules.sources` (or equivalent) silently widens CIDR ranges instead of erroring. Security regression: caller intends to narrow, plugin silently accepts a wider rule.
+**Failure mode:** An Update path that swaps `inbound_rules.sources` (or equivalent) silently widens CIDR ranges instead of erroring. Security regression: caller intends to narrow; plugin silently keeps the wider state OR widens further.
 **Repro pattern:** identified in P-2 F7 review prompt (the v5.0 framing missed this in workflow's earlier P-3 review; v5.2.0 framing caught it).
-**Fix shape:** Fail Update when desired CIDR sources ⊊ current CIDR sources unless explicit `--strict-cidr=false` flag.
+**Fix shape:** Fail Update when current CIDR sources ⊊ desired CIDR sources (desired allows IPs current didn't = widening) unless explicit `--strict-cidr=false` flag (on `wfctl infra security-check` / `wfctl infra align`).
 **Retroactive applicability:** AWS SG, GCP firewall, Azure NSG, DO firewall — high.
 
 ### BC-8: Schema canonical-key registration

--- a/docs/plans/2026-04-28-iac-plugin-review-design.md
+++ b/docs/plans/2026-04-28-iac-plugin-review-design.md
@@ -1,0 +1,255 @@
+---
+status: approved
+area: plugins
+owner: workflow
+external_refs: []
+verification:
+  last_checked: 2026-04-28
+  result: pending
+supersedes: []
+superseded_by: []
+---
+
+# IaC Plugin Cross-Provider Review Discipline & Audit
+
+**Date:** 2026-04-28
+**Author:** Jon Langevin
+**Status:** Approved (design)
+
+## Summary
+
+Extract the bug-class taxonomy surfaced by the workflow-plugin-digitalocean v0.8.0 (P-2 phase) review cycle into cross-provider discipline that benefits all IaC provider plugins (DO, AWS, GCP, Azure, Tofu, CI-generator) and prevents per-provider rediscovery. Four deliverables: a markdown checklist, an executable Go test-helper package, an extension to the existing strict-contracts migration tracker, and a generic plugin-pattern-reviewer skill.
+
+## Goals
+
+1. **Capture P-2 learnings as transferable discipline** so the same bug classes don't have to be rediscovered on every IaC provider plugin.
+2. **Make the discipline executable** — markdown for human reviewers + Go test helpers for CI so regressions surface automatically, not in production gRPC dispatch.
+3. **Auto-apply via reviewer skill** — code-reviewer agents reviewing any workflow plugin pick up the matching pattern checklist via plugin.json field detection, without per-prompt re-explanation.
+4. **Close the audit→migration loop** — fold pre-migration findings into the v0.9.0 strict-contracts migration so downstream readers see the bug-class fix lineage.
+
+## Non-Goals
+
+- Strict-contracts migration of IaC plugins themselves (that's tracked in [strict-grpc-plugin-contracts](2026-04-26-strict-grpc-plugin-contracts.md) and scheduled for v0.9.0+; this design feeds findings INTO that migration).
+- Reviewer-skill content for non-IaC patterns (auth/sso/payment/agent etc.) — pattern dispatch IS pre-allocated; only IaC content populated in v1.
+- Cross-cloud feature parity (e.g., bringing AWS to feature parity with DO) — out of scope.
+
+## Bug-class taxonomy (the deliverable's content)
+
+Distilled from the P-2 review cycle, every class shipped at least once in v0.8.0:
+
+### BC-1: Plan/Diff cascade gap
+**Failure mode:** A driver's `Diff` implementation either always returns nil (stub) or only compares a subset of fields, so in-place updates silently no-op or emit spurious changes.
+**Repro pattern:** P-3 round 1 of F4 (`AppPlatformDriver.Diff` only compared `image`); F7 round 1 (`FirewallDriver.Diff` always returned `NeedsUpdate=false`).
+**Fix shape:** Diff compares every canonical config field; the matching `appOutput` / `fwOutput` populates `Outputs[*]` for every field Diff reads.
+**Retroactive applicability:** every IaC plugin's resource drivers — high.
+
+### BC-2: structpb gRPC boundary (legacy compat plugins only)
+**Failure mode:** `Outputs["..."]` stores a typed slice (`[]int`/`[]string`/`[]godo.X`) that's rejected by `structpb.NewStruct` at the wfctl→plugin gRPC boundary. Reader-side type assertions fail post-roundtrip → assertions return nil → Diff emits perpetual spurious changes.
+**Repro pattern:** F7 round 2 (whole Diff cascade fix was a no-op in production gRPC mode until canonical-shape Outputs landed in round 3).
+**Fix shape:** Convert all typed slices to `[]any` of structpb-compatible primitives or `map[string]any` BEFORE storing; readers handle both pre- and post-roundtrip shapes via tolerant coercer helpers.
+**Retroactive applicability:** every IaC plugin still on legacy compat (DO/AWS/GCP/Azure/Tofu — strict-mode plugins are immune). Becomes obsolete after v0.9.0 strict-contracts migration of each plugin.
+
+### BC-3: Outputs-vs-Diff invariant
+**Failure mode:** Diff reads `current.Outputs["X"]` for some field X but no writer (Create/Update/Read) ever populates X. Diff sees `""` and emits a spurious FieldChange every reconcile.
+**Repro pattern:** F4 round 4 (image gap — Diff compared image but `appOutput` didn't write it).
+**Fix shape:** For every key Diff reads, verify a writer populates it. Add a `derive*FromAppSpec` helper if the value can be reconstructed from the live spec.
+**Retroactive applicability:** every IaC plugin — high.
+
+### BC-4: Validation matrix
+**Failure mode:** Field validators check key presence but not value validity. Common variants:
+- TCP port: `0` or negative or `> 65535` accepted (F4 round 5).
+- Float-as-int: `123.9` silently truncated to `123` (F7 round 3).
+- Empty-string slice element: `["", "valid"]` not filtered (F7 round 2).
+- Non-string for string-typed enum: `expose: true` (Go bool) silently treated as "omitted" → defaults to public (F4 round 3).
+**Fix shape:** TDD coverage for each {field, kind} pair: negative, zero, max, max+1, fractional, empty-string element, wrong-type.
+**Retroactive applicability:** every IaC plugin — high.
+
+### BC-5: Plan-time vs Apply-time documentation accuracy
+**Failure mode:** `plugin.json` description, CHANGELOG entry, or doc-comment claims validation runs "at plan time" but the validator only fires from `Create`/`Update` (the Apply path) — `DOProvider.Plan` doesn't call the driver for create actions. User reads the docs, expects a plan-time error, gets an apply-time error instead.
+**Repro pattern:** F7 round 3 + F4 round 5.
+**Fix shape:** Reword to "fail at apply time, before any [provider] API call" (or implement true plan-time validation by extending Diff/Validate paths — bigger refactor).
+**Retroactive applicability:** every IaC plugin's CHANGELOG/doc-comments — moderate.
+
+### BC-6: Diff-side vs Apply-side parity
+**Failure mode:** Apply-side has tighter validation (e.g., non-string `expose` errors loudly via `applyExposeInternal`), but Diff-side accepts the bad value silently (e.g., `canonicalExpose` defaults to `"public"`). Plan output misleadingly suggests a successful update when Apply will actually error.
+**Repro pattern:** F4 round 3 (code-reviewer Observation B).
+**Fix shape:** Mirror apply-side validation in Diff-side helpers, OR have Diff call apply-side validators and surface the error in Plan output.
+**Retroactive applicability:** every IaC plugin where Diff and Create/Update read the same config keys — high.
+
+### BC-7: CIDR widening regression scan (firewall/SG/NSG drivers)
+**Failure mode:** An Update path that swaps `inbound_rules.sources` (or equivalent) silently widens CIDR ranges instead of erroring. Security regression: caller intends to narrow, plugin silently accepts a wider rule.
+**Repro pattern:** identified in P-2 F7 review prompt (the v5.0 framing missed this in workflow's earlier P-3 review; v5.2.0 framing caught it).
+**Fix shape:** Fail Update when desired CIDR sources ⊊ current CIDR sources unless explicit `--strict-cidr=false` flag.
+**Retroactive applicability:** AWS SG, GCP firewall, Azure NSG, DO firewall — high.
+
+### BC-8: Schema canonical-key registration
+**Failure mode:** Plugin adds a config key (e.g., `http_port_protocol`) but doesn't propose adding it to workflow's `interfaces.canonicalKeySet`. Currently benign because the canonical-schema enforcement isn't wired into `wfctl validate`, but when it is, configs using the key will be rejected by the validator.
+**Repro pattern:** F5 round 1 (code-reviewer Finding 2).
+**Fix shape:** PR against workflow framework to add the key to `canonicalKeySet` + `iac_canonical_schema.json` enum, or document plugin-scoped status in CHANGELOG.
+**Retroactive applicability:** every IaC plugin that has added schema keys post-canonical-schema landing — moderate.
+
+## Architecture (4 deliverables)
+
+### D-1: Cross-provider review checklist (markdown)
+
+**Path:** `workflow/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+
+Single document, ~400-600 lines. Each bug class above gets a section with:
+- Failure mode
+- Repro pattern (cite the v0.8.0 review round + commit if applicable)
+- Fix shape
+- Test pattern (link to D-2 helper)
+- Reviewer scan procedure (concrete grep / code-read steps)
+
+References from:
+- `workflow/CONTRIBUTING.md` (top-level link)
+- Each IaC plugin's `CONTRIBUTING.md` (added in retroactive Phase C, one PR per plugin)
+
+### D-2: Executable Go test-helper package
+
+**Path:** `workflow/plugin/sdk/iaclint/`
+
+Public API (initial):
+
+```go
+package iaclint
+
+import (
+    "testing"
+    "github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// AssertOutputsRoundTripStructpb verifies that every value in outputs survives
+// structpb.NewStruct → AsMap() round-trip without type degradation that breaks
+// downstream type assertions. Closes BC-2.
+func AssertOutputsRoundTripStructpb(t *testing.T, outputs map[string]any)
+
+// AssertDiffPopulatesAllOutputFields verifies that for every key the Diff
+// implementation reads from current.Outputs, the matching writer (Create/
+// Update/Read) populates it. Closes BC-3.
+func AssertDiffPopulatesAllOutputFields(
+    t *testing.T,
+    driver interfaces.ResourceDriver,
+    sampleSpec interfaces.ResourceSpec,
+)
+
+// ValidationKind enumerates the standard {field, value-class} probes.
+type ValidationKind int
+const (
+    KindTCPPort ValidationKind = iota  // probes: 0, -1, 1, 65535, 65536
+    KindNonNegativeInt                  // probes: 0, -1, max
+    KindNonEmptyString                  // probes: "", "  ", "x"
+    KindStringEnum                      // probes: each value, "" (absent), random string, non-string
+    KindIntegerOnlyFloat                // probes: 1.0, 1.9, max int float, NaN, Inf
+)
+
+// AssertValidationMatrix runs the standard battery for the named field
+// against the parser. Closes BC-4. Caller passes a parser closure that
+// extracts and validates one config field.
+func AssertValidationMatrix(
+    t *testing.T,
+    parser func(cfg map[string]any) (any, error),
+    fieldName string,
+    kind ValidationKind,
+)
+```
+
+Each IaC plugin imports this in its test suite and calls the matchers for every driver/field. CI catches regressions per-PR.
+
+### D-3: Strict-contracts tracker extension
+
+**Modify:** `workflow/docs/plans/2026-04-26-strict-grpc-plugin-contracts.md` and its companion design doc.
+
+Add to the `implementation_refs` and the per-plugin migration table:
+
+| Plugin | Strict migration status (target v0.9.0) | Pre-migration audit findings |
+|---|---|---|
+| workflow-plugin-aws | active | (Phase C audit fills this in) |
+| workflow-plugin-azure | verified locally, awaiting PR | (Phase C audit fills this in) |
+| workflow-plugin-ci-generator | merged | n/a (already shipped) |
+| **workflow-plugin-digitalocean** | **pending (v0.8.0 ships legacy compat)** | **F4/F5/F7 cycle: BC-1, BC-2, BC-3, BC-4, BC-5, BC-6, BC-8 closed in v0.8.0; BC-7 not applicable. Issue #37 (BC-5 Update naming consistency) deferred to v0.8.x** |
+| **workflow-plugin-gcp** | **pending** | (Phase C audit fills this in) |
+| **workflow-plugin-tofu** | **pending** | (Phase C audit fills this in) |
+
+Each IaC plugin's v0.9.0 strict-migration PR adds a "Pre-migration findings closed" CHANGELOG sub-section that references the Phase C audit issues and the bug classes addressed in the migration.
+
+### D-4: Generic plugin-pattern-reviewer skill
+
+**Path:** `~/.claude/skills/workflow-plugin-reviewer/SKILL.md` (workspace-local; not pushed upstream to superpowers as a contribution unless cross-team adoption emerges).
+
+**Skill content shape:**
+
+```markdown
+---
+name: workflow-plugin-reviewer
+description: Use when reviewing a PR in any GoCodeAlone/workflow-plugin-* repository — auto-detects the provider pattern from plugin.json and applies the matching cross-provider bug-class checklist.
+---
+
+# Workflow Plugin Review Discipline
+
+When reviewing a PR in a workflow plugin repo:
+
+1. Read `plugin.json` to identify which provider pattern the plugin implements.
+2. Load the matching checklist from the workflow framework docs:
+   - `iacProvider` → `workflow/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+   - `authProvider` → (TBD — checklist pending)
+   - `paymentProvider` → (TBD — checklist pending)
+   - `agentProvider` → (TBD — checklist pending)
+   - `auditProvider` → (TBD — checklist pending)
+   - `module-step` → (TBD — generic step-driver checklist pending)
+3. Apply the matched checklist as part of the bug-class scan, in addition to the standard adversarial-review framing.
+4. If the plugin is on legacy compat dispatch (no `internal/contracts/` package, plugin.json `mode` ≠ `strict`), include the structpb-boundary scan from BC-2.
+
+(Pattern dispatch table is pre-allocated. Only IaC has populated content as of 2026-04-28.)
+```
+
+The skill auto-loads when the code-reviewer (or any reviewer agent) is invoked on a plugin repo. Future provider-pattern checklists slot into the dispatch table without rewriting the skill.
+
+## Sequencing
+
+### Phase A — Author the discipline (this cycle)
+
+- D-1 (markdown checklist): 1 implementer, ~4 hours.
+- D-2 (Go test-helper package): 1 implementer, ~6 hours including matcher API design + tests for the helpers themselves.
+- D-3 (tracker extension): doc-only edit, ~30 min.
+- D-4 (generic skill): ~1 hour.
+
+Single team, 2 implementers split D-1+D-3+D-4 vs D-2.
+
+### Phase B — P-1 BMW cleanup (existing plan)
+
+Per `core-dump/_worktrees/docs-iac-design/docs/plans/2026-04-27-iac-do-staging-implementation.md` Task P-1.BMW. The Phase A checklist is reviewer input — when BMW runs `wfctl infra plan/align/security-check` against real config, any new findings feed back into the checklist via Phase A revision.
+
+### Phase C — Retroactive fix-forward across IaC plugins
+
+For each IaC plugin (DO/AWS/GCP/Azure/Tofu/CI-generator):
+1. Run the checklist against the current main HEAD.
+2. File one issue per bug-class instance found.
+3. Open per-plugin per-finding PRs (matches `feedback_per_agent_worktree_per_task_pr.md`).
+4. Each PR's CHANGELOG entry references the bug class it closes.
+5. After all plugin audit PRs land, the strict-migration tracker rows for that plugin show "Pre-migration findings closed" — feeds into v0.9.0 strict migration cleanly.
+
+Estimated 4-5 findings per plugin × 6 plugins = 25-30 small PRs. Multi-team execution; can split across multiple cycles.
+
+## System Impact
+
+Per `core-dump/CLAUDE.md` matrix (this design doc dated 2026-04-28+ requires the section):
+
+- **auth, authorization, anti-cheat, malware/ecology, sandbox/code execution, network/hacking, filesystem, process/OS, email/social/comms, NPC sim, factions/orgs, economy/stocks/crypto, infrastructure/IoT/ICS, media/gossip, legal/heat/agency, forensics/IR/defense, assistant/VERA, achievements/Steam, client desktop apps, shell/terminal, world history, content/narrative, telemetry:** None — this design touches only the workflow framework + IaC plugin repos. Core-dump game systems are unaffected.
+- **tests:** Phase A D-2 ships a public `workflow/plugin/sdk/iaclint/` test-helper package with its own unit tests. Phase C audit PRs add per-plugin tests via the helpers. Tests run via each plugin's existing CI.
+
+## Risks & Mitigations
+
+- **D-2 helper API churn during Phase C** — if Phase C audit findings reveal the helpers don't cover a class, helper API expands. Mitigation: ship D-2 as `v0.x.x` with explicit "API may evolve until cross-plugin adoption is complete" CHANGELOG note; tag stable when all 6 IaC plugins have adopted.
+- **D-4 skill adoption depends on reviewer agents auto-loading it** — if the skill isn't picked up, the discipline lives in docs only. Mitigation: include explicit "if reviewing a workflow plugin, invoke `workflow-plugin-reviewer`" line in the team-conventions reviewer prompts (P-2 used `agents/team-conventions.md`; we update that to chain).
+- **Phase C surge on AWS/GCP/Azure** — these plugins are larger than DO; per-plugin audit could surface 8-12 findings each (vs DO's 4-5). Mitigation: prioritize highest-severity bug class (BC-2 structpb boundary) first across all plugins, then BC-1/BC-3 as the next pass; defer cosmetic classes to a later cycle.
+- **v0.9.0 strict migration may obsolete some bug classes mid-Phase-C** — if strict migration lands first for a plugin, the BC-2 audit becomes moot. Mitigation: each Phase-C audit PR is small enough to land or close cleanly regardless of migration timing.
+
+## Acceptance
+
+- D-1: `workflow/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md` committed to `main`. CONTRIBUTING.md links to it. Each bug class has the four sub-sections (failure / repro / fix / scan).
+- D-2: `workflow/plugin/sdk/iaclint/` package committed; matchers covered by unit tests; usage example in package godoc. Demonstrate by importing in workflow-plugin-digitalocean's test suite as a smoke check (no audit PR yet, just import + run).
+- D-3: Strict-contracts tracker shows DO/GCP/Tofu rows; DO row's "Pre-migration audit findings" cell populated with the v0.8.0 closures.
+- D-4: Skill file at `~/.claude/skills/workflow-plugin-reviewer/SKILL.md` with pattern-dispatch table; reviewer agents on a workflow-plugin-* PR successfully load + reference the IaC checklist.
+
+After Phase A merges to main, Phase B (P-1 BMW) auto-dispatches per the autonomous mandate.

--- a/docs/plans/2026-04-28-iac-plugin-review.md
+++ b/docs/plans/2026-04-28-iac-plugin-review.md
@@ -1,0 +1,1372 @@
+# IaC Plugin Cross-Provider Review Discipline & Audit — Phase A Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Phase A of the IaC review discipline rollout — author the markdown checklist, build the executable test-helper package, extend the strict-contracts tracker for IaC plugins, and ship the generic plugin-pattern-reviewer skill. Phase B (P-1 BMW) auto-chains after Phase A merges.
+
+**Architecture:** Four parallel deliverables in the workflow framework repo. D-1 + D-3 + D-4 are doc-shape (markdown). D-2 is a small Go package (`workflow/plugin/sdk/iaclint/`) with three matcher functions backed by unit tests. All four ship in a single PR off `design/iac-plugin-review` since they're cohesive and the design doc + plan are already on that branch.
+
+**Tech Stack:** Go 1.26+ stdlib + `google.golang.org/protobuf/types/known/structpb` (already a workflow dep) for D-2; markdown for D-1/D-3/D-4.
+
+**Working dir:** `/Users/jon/workspace/workflow/_worktrees/iac-plugin-review/` (branch `design/iac-plugin-review`, already exists at `6e159ee` with the design doc committed).
+
+**Design reference:** `docs/plans/2026-04-28-iac-plugin-review-design.md` (committed at `6e159ee`).
+
+---
+
+## Task 1: D-2 package skeleton + ValidationKind enum
+
+**Files:**
+- Create: `plugin/sdk/iaclint/iaclint.go`
+- Create: `plugin/sdk/iaclint/iaclint_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+package iaclint_test
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
+)
+
+func TestValidationKind_String(t *testing.T) {
+	cases := map[iaclint.ValidationKind]string{
+		iaclint.KindTCPPort:          "TCPPort",
+		iaclint.KindNonNegativeInt:   "NonNegativeInt",
+		iaclint.KindNonEmptyString:   "NonEmptyString",
+		iaclint.KindStringEnum:       "StringEnum",
+		iaclint.KindIntegerOnlyFloat: "IntegerOnlyFloat",
+	}
+	for kind, want := range cases {
+		if got := kind.String(); got != want {
+			t.Errorf("kind %d: got %q, want %q", kind, got, want)
+		}
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/...`
+Expected: FAIL with `package github.com/GoCodeAlone/workflow/plugin/sdk/iaclint is not in std`.
+
+**Step 3: Write minimal implementation**
+
+```go
+// Package iaclint provides cross-provider review discipline as executable
+// test helpers for IaC plugin authors. The bug-class taxonomy and rationale
+// for each helper live in the project review checklist:
+//
+//	docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+//
+// IaC plugins import this package in their test suites so the bug classes
+// surfaced during the workflow-plugin-digitalocean v0.8.0 review cycle are
+// caught at CI time rather than during production gRPC dispatch or in code
+// review.
+package iaclint
+
+// ValidationKind enumerates the standard {field, value-class} probes used by
+// AssertValidationMatrix. Each kind exercises a battery of edge values that
+// match the bug-class definitions in the project review checklist.
+type ValidationKind int
+
+const (
+	// KindTCPPort probes 0, -1, 1, 65535, 65536. Closes BC-4 port-range gap.
+	KindTCPPort ValidationKind = iota
+	// KindNonNegativeInt probes 0, -1, 1.
+	KindNonNegativeInt
+	// KindNonEmptyString probes "", "  ", "valid".
+	KindNonEmptyString
+	// KindStringEnum probes each known value, "" (absent), random string, non-string Go types.
+	KindStringEnum
+	// KindIntegerOnlyFloat probes 1.0, 1.9, NaN, Inf. Closes BC-4 fractional-float gap.
+	KindIntegerOnlyFloat
+)
+
+// String returns the human-readable name of the kind, suitable for test output.
+func (k ValidationKind) String() string {
+	switch k {
+	case KindTCPPort:
+		return "TCPPort"
+	case KindNonNegativeInt:
+		return "NonNegativeInt"
+	case KindNonEmptyString:
+		return "NonEmptyString"
+	case KindStringEnum:
+		return "StringEnum"
+	case KindIntegerOnlyFloat:
+		return "IntegerOnlyFloat"
+	}
+	return "Unknown"
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/...`
+Expected: PASS, output `ok  github.com/GoCodeAlone/workflow/plugin/sdk/iaclint`.
+
+**Step 5: Commit**
+
+```bash
+git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/iaclint_test.go
+git commit -m "feat(iaclint): add ValidationKind enum + package skeleton (D-2)"
+```
+
+---
+
+## Task 2: D-2 AssertOutputsRoundTripStructpb (BC-2 helper)
+
+**Files:**
+- Modify: `plugin/sdk/iaclint/iaclint.go`
+- Test: `plugin/sdk/iaclint/iaclint_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestAssertOutputsRoundTripStructpb_RejectsTypedSlice(t *testing.T) {
+	// Typed slices ([]int, []string, []GoStruct) are rejected by structpb.
+	// AssertOutputsRoundTripStructpb must surface the rejection as a test failure.
+	tt := &mockT{}
+	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+		"droplet_ids": []int{123, 456}, // BC-2: typed slice rejected by structpb
+	})
+	if !tt.failed {
+		t.Fatal("AssertOutputsRoundTripStructpb accepted typed []int slice; expected failure")
+	}
+	if !strings.Contains(tt.fatalMsg, "droplet_ids") {
+		t.Errorf("fatal msg %q missing field name 'droplet_ids'", tt.fatalMsg)
+	}
+}
+
+func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
+	tt := &mockT{}
+	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+		"droplet_ids":   []any{float64(123), float64(456)},
+		"tags":          []any{"a", "b"},
+		"inbound_rules": []any{map[string]any{"protocol": "tcp"}},
+		"name":          "fw-1",
+	})
+	if tt.failed {
+		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.fatalMsg)
+	}
+}
+
+// mockT captures testing.TB calls without actually failing the outer test.
+type mockT struct {
+	failed   bool
+	fatalMsg string
+}
+
+func (m *mockT) Helper()                                {}
+func (m *mockT) Fatalf(format string, args ...any)      { m.failed = true; m.fatalMsg = fmt.Sprintf(format, args...) }
+func (m *mockT) Errorf(format string, args ...any)      { m.failed = true; m.fatalMsg = fmt.Sprintf(format, args...) }
+```
+
+(Add `"fmt"`, `"strings"` to test imports.)
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertOutputsRoundTripStructpb`
+Expected: FAIL with `undefined: iaclint.AssertOutputsRoundTripStructpb`.
+
+**Step 3: Write minimal implementation**
+
+```go
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TB is the subset of testing.TB the iaclint matchers use. Accepting an
+// interface (rather than *testing.T) lets the matchers be unit-tested with a
+// mock that captures failures.
+type TB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
+
+// AssertOutputsRoundTripStructpb verifies that every value in outputs survives
+// a structpb.NewStruct → AsMap() round-trip without breaking downstream type
+// assertions. Closes BC-2 (structpb gRPC boundary): typed slices ([]int,
+// []string, []godo.X) are rejected by structpb.NewStruct outright; godo
+// structs round-trip as map[string]any so reader-side type assertions to the
+// original struct type fail silently.
+//
+// Plugins on legacy compat dispatch (no internal/contracts/ proto package,
+// plugin.json mode != "strict") MUST call this matcher in their test suite for
+// every Outputs map written by Create/Update/Read, so the canonical-shape
+// invariant is enforced at CI time.
+//
+// Strict-mode plugins (plugin.json mode == "strict") are immune to BC-2 and do
+// not need this matcher.
+func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
+	t.Helper()
+	if outputs == nil {
+		return
+	}
+	if _, err := structpb.NewStruct(outputs); err != nil {
+		// Identify the offending key to give the test author a direct pointer.
+		for k, v := range outputs {
+			if _, single := structpb.NewStruct(map[string]any{k: v}); single != nil {
+				t.Fatalf("Outputs[%q] (%T) is not structpb-compatible: %v — see BC-2 in IAC_PLUGIN_REVIEW_CHECKLIST.md", k, v, single)
+				return
+			}
+		}
+		t.Fatalf("Outputs not structpb-compatible: %v", err)
+	}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertOutputsRoundTripStructpb`
+Expected: PASS, both sub-tests green.
+
+**Step 5: Commit**
+
+```bash
+git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/iaclint_test.go
+git commit -m "feat(iaclint): AssertOutputsRoundTripStructpb (D-2 BC-2 matcher)"
+```
+
+---
+
+## Task 3: D-2 AssertValidationMatrix — KindTCPPort + KindIntegerOnlyFloat
+
+**Files:**
+- Modify: `plugin/sdk/iaclint/iaclint.go`
+- Test: `plugin/sdk/iaclint/iaclint_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestAssertValidationMatrix_TCPPort_StrictParserPasses(t *testing.T) {
+	// A parser that rejects 0, negative, and >65535 should pass the TCPPort matrix.
+	parser := func(cfg map[string]any) (any, error) {
+		v, ok := cfg["port"].(int)
+		if !ok {
+			if f, fok := cfg["port"].(float64); fok && f == float64(int(f)) {
+				v = int(f)
+			} else {
+				return nil, fmt.Errorf("port: must be an integer")
+			}
+		}
+		if v < 1 || v > 65535 {
+			return nil, fmt.Errorf("port: %d invalid (must be 1..65535)", v)
+		}
+		return v, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
+	if tt.failed {
+		t.Fatalf("strict TCPPort parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_TCPPort_LooseParserFails(t *testing.T) {
+	// A parser that accepts 0 (loose) should fail the TCPPort matrix.
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["port"].(int)
+		if v < 0 || v > 65535 {
+			return nil, fmt.Errorf("port: %d invalid", v)
+		}
+		return v, nil // accepts 0 — BC-4 violation
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
+	if !tt.failed {
+		t.Fatal("loose TCPPort parser passed matrix; expected failure for value 0")
+	}
+}
+
+func TestAssertValidationMatrix_IntegerOnlyFloat_StrictParserPasses(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		v, ok := cfg["id"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("id: must be a number")
+		}
+		if v != float64(int64(v)) {
+			return nil, fmt.Errorf("id: %v is not an integer", v)
+		}
+		return int64(v), nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "id", iaclint.KindIntegerOnlyFloat)
+	if tt.failed {
+		t.Fatalf("strict IntegerOnlyFloat parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertValidationMatrix`
+Expected: FAIL with `undefined: iaclint.AssertValidationMatrix`.
+
+**Step 3: Write minimal implementation**
+
+```go
+import "math"
+
+// ConfigParser is a closure that extracts and validates one config field. The
+// parser receives a config map (mirroring the cfg map[string]any shape used
+// across IaC drivers) and returns the parsed value or an error.
+//
+// AssertValidationMatrix calls the parser repeatedly with edge-case inputs and
+// asserts the parser correctly accepts/rejects each.
+type ConfigParser func(cfg map[string]any) (any, error)
+
+// AssertValidationMatrix runs the standard {field, value-class} battery
+// against parser. Closes BC-4 (validation matrix) by exercising the edge
+// values that have historically been silently accepted by IaC plugin parsers.
+//
+// fieldName is the cfg key the parser reads (e.g., "port", "droplet_ids").
+// kind selects which battery to run.
+func AssertValidationMatrix(t TB, parser ConfigParser, fieldName string, kind ValidationKind) {
+	t.Helper()
+	switch kind {
+	case KindTCPPort:
+		// Each entry: (value, expectAccept)
+		probes := []struct {
+			value        any
+			expectAccept bool
+			label        string
+		}{
+			{0, false, "zero"},
+			{-1, false, "negative"},
+			{1, true, "min valid"},
+			{65535, true, "max valid"},
+			{65536, false, "above max"},
+		}
+		runProbes(t, parser, fieldName, kind, probes)
+	case KindIntegerOnlyFloat:
+		probes := []struct {
+			value        any
+			expectAccept bool
+			label        string
+		}{
+			{1.0, true, "integer-valued float"},
+			{1.9, false, "fractional"},
+			{math.NaN(), false, "NaN"},
+			{math.Inf(1), false, "Inf"},
+		}
+		runProbes(t, parser, fieldName, kind, probes)
+	default:
+		t.Fatalf("AssertValidationMatrix: unhandled kind %s", kind)
+	}
+}
+
+// runProbes is the shared driver for each kind's probe table.
+func runProbes(t TB, parser ConfigParser, fieldName string, kind ValidationKind, probes []struct {
+	value        any
+	expectAccept bool
+	label        string
+},
+) {
+	t.Helper()
+	for _, p := range probes {
+		_, err := parser(map[string]any{fieldName: p.value})
+		got := err == nil
+		if got != p.expectAccept {
+			verb := "rejected"
+			if got {
+				verb = "accepted"
+			}
+			t.Errorf("%s probe %q (value=%v): parser %s; expected %s — see BC-4 in IAC_PLUGIN_REVIEW_CHECKLIST.md",
+				kind, p.label, p.value, verb, acceptStr(p.expectAccept))
+		}
+	}
+}
+
+func acceptStr(b bool) string {
+	if b {
+		return "accept"
+	}
+	return "reject"
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test -race ./plugin/sdk/iaclint/...`
+Expected: PASS, all 5 tests green (3 from this task + 2 from prior tasks).
+
+**Step 5: Commit**
+
+```bash
+git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/iaclint_test.go
+git commit -m "feat(iaclint): AssertValidationMatrix — TCPPort + IntegerOnlyFloat (D-2 BC-4)"
+```
+
+---
+
+## Task 4: D-2 AssertValidationMatrix — KindNonNegativeInt + KindNonEmptyString + KindStringEnum
+
+**Files:**
+- Modify: `plugin/sdk/iaclint/iaclint.go`
+- Test: `plugin/sdk/iaclint/iaclint_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `iaclint_test.go`:
+
+```go
+func TestAssertValidationMatrix_NonNegativeInt_Strict(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["count"].(int)
+		if v < 0 {
+			return nil, fmt.Errorf("count: %d invalid", v)
+		}
+		return v, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "count", iaclint.KindNonNegativeInt)
+	if tt.failed {
+		t.Fatalf("strict NonNegativeInt parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_NonEmptyString_Strict(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["name"].(string)
+		if strings.TrimSpace(v) == "" {
+			return nil, fmt.Errorf("name: must be non-empty")
+		}
+		return v, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "name", iaclint.KindNonEmptyString)
+	if tt.failed {
+		t.Fatalf("strict NonEmptyString parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_StringEnum_Strict(t *testing.T) {
+	allowed := []string{"public", "internal"}
+	parser := func(cfg map[string]any) (any, error) {
+		v, exists := cfg["expose"]
+		if !exists {
+			return "", nil // absent is fine
+		}
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("expose: must be a string, got %T", v)
+		}
+		s = strings.ToLower(strings.TrimSpace(s))
+		if s == "" {
+			return s, nil
+		}
+		for _, a := range allowed {
+			if s == a {
+				return s, nil
+			}
+		}
+		return nil, fmt.Errorf("expose: %q invalid; must be one of %v", s, allowed)
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
+	if tt.failed {
+		t.Fatalf("strict StringEnum parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_StringEnum_LooseFailsOnNonString(t *testing.T) {
+	allowed := []string{"public", "internal"}
+	parser := func(cfg map[string]any) (any, error) {
+		// BC-4 violation: silently treats non-string as omitted.
+		s, _ := cfg["expose"].(string)
+		return s, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
+	if !tt.failed {
+		t.Fatal("loose StringEnum parser passed matrix; expected failure on non-string probe")
+	}
+}
+```
+
+(Add `"strings"` if not already in test imports.)
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertValidationMatrix_(NonNegativeInt|NonEmptyString|StringEnum)`
+Expected: FAIL with `undefined: iaclint.WithStringEnumOptions`.
+
+**Step 3: Write minimal implementation**
+
+```go
+// stringEnumKind is StringEnum with attached allowed values. Returned by
+// WithStringEnumOptions so the matrix knows which strings are valid for the
+// non-string and unknown-string probes.
+type stringEnumKind struct {
+	ValidationKind
+	allowed []string
+}
+
+// WithStringEnumOptions returns a StringEnum kind bound to the given allowed
+// values. Use this instead of the bare KindStringEnum constant when calling
+// AssertValidationMatrix:
+//
+//	iaclint.AssertValidationMatrix(t, parser, "expose",
+//	    iaclint.WithStringEnumOptions([]string{"public", "internal"}))
+func WithStringEnumOptions(allowed []string) ValidationKind {
+	// Encode allowed in a package-level registry keyed by the returned kind.
+	// We can't extend the ValidationKind enum at call sites, so use a
+	// thread-safe lookup keyed by a unique kind id.
+	id := nextEnumID()
+	enumOptions[id] = append([]string(nil), allowed...)
+	return id
+}
+
+var (
+	enumOptionsMu sync.Mutex
+	enumOptions   = map[ValidationKind][]string{}
+	nextEnumIDVal = ValidationKind(1000) // reserve [0..999] for static kinds
+)
+
+func nextEnumID() ValidationKind {
+	enumOptionsMu.Lock()
+	defer enumOptionsMu.Unlock()
+	id := nextEnumIDVal
+	nextEnumIDVal++
+	return id
+}
+```
+
+Then extend `AssertValidationMatrix` switch with:
+
+```go
+	case KindNonNegativeInt:
+		probes := []struct {
+			value        any
+			expectAccept bool
+			label        string
+		}{
+			{-1, false, "negative"},
+			{0, true, "zero"},
+			{1, true, "positive"},
+		}
+		runProbes(t, parser, fieldName, kind, probes)
+	case KindNonEmptyString:
+		probes := []struct {
+			value        any
+			expectAccept bool
+			label        string
+		}{
+			{"", false, "empty"},
+			{"   ", false, "whitespace"},
+			{"valid", true, "non-empty"},
+		}
+		runProbes(t, parser, fieldName, kind, probes)
+	default:
+		// StringEnum kinds (returned by WithStringEnumOptions) carry IDs >= 1000.
+		enumOptionsMu.Lock()
+		allowed, isEnum := enumOptions[kind]
+		enumOptionsMu.Unlock()
+		if isEnum {
+			runStringEnumProbes(t, parser, fieldName, allowed)
+			return
+		}
+		t.Fatalf("AssertValidationMatrix: unhandled kind %s", kind)
+	}
+```
+
+And add `runStringEnumProbes`:
+
+```go
+func runStringEnumProbes(t TB, parser ConfigParser, fieldName string, allowed []string) {
+	t.Helper()
+	type probe struct {
+		value        any
+		expectAccept bool
+		label        string
+	}
+	var probes []probe
+	for _, a := range allowed {
+		probes = append(probes, probe{a, true, "allowed " + a})
+	}
+	probes = append(probes,
+		probe{"", true, "absent (empty string)"},
+		probe{"definitely-not-a-real-value", false, "unknown string"},
+		probe{true, false, "non-string bool"},
+		probe{123, false, "non-string int"},
+		probe{[]string{}, false, "non-string slice"},
+	)
+	for _, p := range probes {
+		var cfg map[string]any
+		if p.value == "" && p.label == "absent (empty string)" {
+			cfg = map[string]any{} // genuinely absent — no key
+		} else {
+			cfg = map[string]any{fieldName: p.value}
+		}
+		_, err := parser(cfg)
+		got := err == nil
+		if got != p.expectAccept {
+			verb := "rejected"
+			if got {
+				verb = "accepted"
+			}
+			t.Errorf("StringEnum probe %q (value=%v): parser %s; expected %s — see BC-4 in IAC_PLUGIN_REVIEW_CHECKLIST.md",
+				p.label, p.value, verb, acceptStr(p.expectAccept))
+		}
+	}
+}
+```
+
+(Add `"sync"` to imports.)
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test -race ./plugin/sdk/iaclint/...`
+Expected: PASS, all 9 tests green.
+
+**Step 5: Commit**
+
+```bash
+git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/iaclint_test.go
+git commit -m "feat(iaclint): AssertValidationMatrix — NonNegativeInt + NonEmptyString + StringEnum (D-2 BC-4)"
+```
+
+---
+
+## Task 5: D-2 AssertDiffPopulatesAllOutputFields (BC-3 helper)
+
+**Files:**
+- Modify: `plugin/sdk/iaclint/iaclint.go`
+- Test: `plugin/sdk/iaclint/iaclint_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// fakeDriver is a minimal interfaces.ResourceDriver impl used to exercise
+// AssertDiffPopulatesAllOutputFields. The contract: every key Diff reads from
+// current.Outputs MUST be populated by Create/Read/Update on the writer side.
+type fakeDriver struct {
+	createOutputs map[string]any
+	diffReadsKeys []string // keys this fake's Diff would read
+}
+
+func (f *fakeDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:    spec.Name,
+		Type:    spec.Type,
+		Outputs: f.createOutputs,
+		Status:  "running",
+	}, nil
+}
+
+// (Implement other ResourceDriver methods as no-ops.)
+
+// Diff records that it read the expected keys but doesn't actually compare.
+func (f *fakeDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	for _, k := range f.diffReadsKeys {
+		_ = current.Outputs[k] // simulate reading the field
+	}
+	return &interfaces.DiffResult{NeedsUpdate: false}, nil
+}
+
+func TestAssertDiffPopulatesAllOutputFields_OK(t *testing.T) {
+	d := &fakeDriver{
+		createOutputs: map[string]any{"image": "x:v1", "expose": "internal"},
+		diffReadsKeys: []string{"image", "expose"},
+	}
+	tt := &mockT{}
+	iaclint.AssertDiffPopulatesAllOutputFields(tt, d,
+		interfaces.ResourceSpec{Name: "fake", Type: "fake.thing", Config: map[string]any{}})
+	if tt.failed {
+		t.Fatalf("driver with matching writer/reader keys failed assertion: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertDiffPopulatesAllOutputFields_MissingKey(t *testing.T) {
+	// Writer doesn't populate "expose" but Diff reads it.
+	d := &fakeDriver{
+		createOutputs: map[string]any{"image": "x:v1"}, // no "expose"
+		diffReadsKeys: []string{"image", "expose"},
+	}
+	tt := &mockT{}
+	iaclint.AssertDiffPopulatesAllOutputFields(tt, d,
+		interfaces.ResourceSpec{Name: "fake", Type: "fake.thing", Config: map[string]any{}})
+	if !tt.failed {
+		t.Fatal("driver with missing writer key passed assertion; expected failure")
+	}
+	if !strings.Contains(tt.fatalMsg, "expose") {
+		t.Errorf("fatal msg missing key name 'expose': %q", tt.fatalMsg)
+	}
+}
+```
+
+(Add the rest of the no-op methods on fakeDriver. Add `context`, `interfaces` to test imports.)
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertDiffPopulatesAllOutputFields`
+Expected: FAIL with `undefined: iaclint.AssertDiffPopulatesAllOutputFields`.
+
+**Step 3: Write minimal implementation**
+
+This matcher requires the driver to declare which keys its Diff reads — Go's reflection can't introspect runtime field reads safely. So the API takes the keys explicitly via a small interface plugins implement on their drivers (or the test calls a sibling function that exposes the read set):
+
+```go
+// DiffOutputKeyDeclarer is an optional interface a ResourceDriver may
+// implement to declare which Outputs[*] keys its Diff implementation reads.
+// AssertDiffPopulatesAllOutputFields uses this to verify the writer side
+// (Create/Read/Update) populates all declared keys.
+//
+// Plugins typically implement this as a sibling method that returns a static
+// slice of canonical key names — small surface, easy to keep in sync.
+type DiffOutputKeyDeclarer interface {
+	DiffReadsOutputKeys() []string
+}
+
+// AssertDiffPopulatesAllOutputFields verifies that for every key the driver's
+// Diff implementation reads from current.Outputs, the matching Create call
+// populates that key. Closes BC-3 (Outputs-vs-Diff invariant).
+//
+// The driver must implement DiffOutputKeyDeclarer to declare its read set.
+// The matcher invokes Create with the provided sample spec and inspects the
+// returned ResourceOutput.Outputs map for the declared keys.
+//
+// Sample spec must be a representative input that exercises the writer's
+// happy path. Use the spec the plugin's own tests use.
+func AssertDiffPopulatesAllOutputFields(t TB, driver interfaces.ResourceDriver, sampleSpec interfaces.ResourceSpec) {
+	t.Helper()
+	declarer, ok := driver.(DiffOutputKeyDeclarer)
+	if !ok {
+		t.Fatalf("driver %T does not implement DiffOutputKeyDeclarer; cannot verify BC-3 invariant", driver)
+		return
+	}
+	out, err := driver.Create(context.Background(), sampleSpec)
+	if err != nil {
+		t.Fatalf("driver.Create failed: %v", err)
+		return
+	}
+	if out == nil || out.Outputs == nil {
+		t.Fatalf("driver.Create returned nil Outputs")
+		return
+	}
+	for _, key := range declarer.DiffReadsOutputKeys() {
+		if _, present := out.Outputs[key]; !present {
+			t.Errorf("Outputs[%q] not populated by Create, but Diff reads it — see BC-3 in IAC_PLUGIN_REVIEW_CHECKLIST.md", key)
+		}
+	}
+}
+```
+
+Update fakeDriver in test to implement DiffOutputKeyDeclarer:
+
+```go
+func (f *fakeDriver) DiffReadsOutputKeys() []string { return f.diffReadsKeys }
+```
+
+(Add `"context"` to package imports if not already.)
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test -race ./plugin/sdk/iaclint/...`
+Expected: PASS, all 11 tests green.
+
+**Step 5: Commit**
+
+```bash
+git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/iaclint_test.go
+git commit -m "feat(iaclint): AssertDiffPopulatesAllOutputFields (D-2 BC-3 matcher)"
+```
+
+---
+
+## Task 6: D-2 package godoc + usage example (Example test)
+
+**Files:**
+- Modify: `plugin/sdk/iaclint/iaclint.go` (expand top-level package doc)
+- Create: `plugin/sdk/iaclint/example_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+package iaclint_test
+
+import (
+	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
+)
+
+// Example shows a typical IaC plugin test importing iaclint to assert all
+// three bug-class invariants on a single driver.
+func Example() {
+	// In a real plugin test:
+	//
+	//   driver := &MyFirewallDriver{client: mockClient}
+	//   iaclint.AssertOutputsRoundTripStructpb(t, mustCreate(t, driver).Outputs)
+	//   iaclint.AssertDiffPopulatesAllOutputFields(t, driver, sampleSpec)
+	//   iaclint.AssertValidationMatrix(t, parsePort, "port", iaclint.KindTCPPort)
+	//
+	// See docs/IAC_PLUGIN_REVIEW_CHECKLIST.md for the bug-class taxonomy.
+	_ = iaclint.KindTCPPort
+	// Output:
+}
+```
+
+**Step 2: Run test to verify it fails (or passes — Example tests don't have a "fail-first" mode)**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test -race ./plugin/sdk/iaclint/...`
+Expected: PASS (Example test always runs; just verifies it compiles).
+
+**Step 3: Update package doc**
+
+Expand the existing package doc-comment in `iaclint.go` (the one starting with `// Package iaclint provides...`) to mention all three matchers and their bug-class mapping:
+
+```go
+// Package iaclint provides cross-provider review discipline as executable
+// test helpers for IaC plugin authors.
+//
+// The bug-class taxonomy and rationale for each helper live in the project
+// review checklist:
+//
+//	docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+//
+// Three matchers are exposed:
+//
+//   - AssertOutputsRoundTripStructpb (BC-2): verifies Outputs map values
+//     survive structpb.NewStruct round-trip without breaking type assertions.
+//     Use for plugins on legacy compat dispatch.
+//
+//   - AssertDiffPopulatesAllOutputFields (BC-3): verifies every Outputs[*]
+//     key the driver's Diff reads is populated by the matching Create writer.
+//     Use for every ResourceDriver in the plugin.
+//
+//   - AssertValidationMatrix (BC-4): exercises edge values for a config-field
+//     parser (TCP port, integer-only float, non-empty string, string enum,
+//     non-negative int). Use for every field-level config validator.
+//
+// IaC plugins import this package in their test suites so the bug classes
+// surfaced during the workflow-plugin-digitalocean v0.8.0 review cycle are
+// caught at CI time rather than during production gRPC dispatch or in code
+// review.
+```
+
+**Step 4: Run tests to verify all green**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test -race ./plugin/sdk/iaclint/... && GOWORK=off go vet ./plugin/sdk/iaclint/...`
+Expected: PASS, vet clean, godoc renders (verify with `go doc github.com/GoCodeAlone/workflow/plugin/sdk/iaclint`).
+
+**Step 5: Commit**
+
+```bash
+git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/example_test.go
+git commit -m "docs(iaclint): expand package godoc + add Example (D-2 polish)"
+```
+
+---
+
+## Task 7: D-1 markdown checklist — skeleton + BC-1 + BC-2
+
+**Files:**
+- Create: `docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+
+**Step 1: Write the file**
+
+```markdown
+# IaC Plugin Review Checklist
+
+This checklist captures the cross-provider bug-class taxonomy surfaced during
+plugin review cycles (initially `workflow-plugin-digitalocean v0.8.0`, P-2
+phase). Each bug class is reproducible across every IaC provider plugin (DO,
+AWS, GCP, Azure, Tofu, CI-generator). Apply this checklist when reviewing any
+plugin PR that touches ResourceDriver implementations, Outputs writers, or
+config-field validators.
+
+For executable enforcement, see the test-helper package
+`workflow/plugin/sdk/iaclint/`. Each bug class names the matcher that closes
+it.
+
+## How to use this checklist
+
+- **As a reviewer:** scan the diff for each bug class. The "Reviewer scan"
+  sub-section names the concrete grep / read steps.
+- **As a plugin author:** import `github.com/GoCodeAlone/workflow/plugin/sdk/iaclint`
+  in your test suite and call the named matcher for every driver/field.
+- **As a maintainer auditing existing plugins:** apply each bug-class scan to
+  the plugin's `main` HEAD and file one issue per finding.
+
+## BC-1: Plan/Diff cascade gap
+
+**Failure mode:** A driver's `Diff` implementation either always returns nil
+(stub) or only compares a subset of fields, so in-place updates silently
+no-op or emit spurious changes on every reconcile.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #35 round 1
+(`AppPlatformDriver.Diff` only compared `image`); PR #36 round 1
+(`FirewallDriver.Diff` always returned `NeedsUpdate=false`).
+
+**Fix shape:** `Diff` compares every canonical config field; the matching
+`appOutput` / `fwOutput` writer populates `Outputs[*]` for every field `Diff`
+reads (see also BC-3).
+
+**Test pattern:** combine `iaclint.AssertDiffPopulatesAllOutputFields` (BC-3
+matcher) with explicit `_DetectsXChange` test cases per field. See
+`workflow-plugin-digitalocean/internal/drivers/firewall_test.go` for the
+canonical structure (8 sub-cases per Diff: each field's positive case +
+no-change baseline + reorder/normalization cases).
+
+**Reviewer scan:**
+
+1. `grep -nE 'func.*\bDiff\b' internal/drivers/*.go provider/drivers/*.go`
+2. For each Diff, read its body. Does it always return nil? Does it only
+   compare one or two fields when the Create/Update accepts more?
+3. If the answer is "yes" to either, surface as **BC-1 BLOCKING**.
+
+## BC-2: structpb gRPC boundary (legacy compat plugins only)
+
+**Failure mode:** `Outputs["..."]` stores a typed slice (`[]int`, `[]string`,
+`[]godo.X` etc.) that is **rejected** by `structpb.NewStruct` at the
+wfctl→plugin gRPC boundary. After the boundary round-trip, reader-side type
+assertions fail (`current.Outputs["X"].([]godo.Y)` returns `ok=false`),
+treating current state as nil and emitting perpetual spurious changes from
+Diff. The whole Diff cascade fix becomes a no-op in production gRPC mode.
+
+**Repro pattern:** `workflow-plugin-digitalocean` PR #36 round 2 (Diff cascade
+fix landed but typed-slice Outputs broke under realistic gRPC dispatch; round
+3 introduced canonical-shape Outputs to close the gap).
+
+**Constraint reference:** `internal/grpc_dispatch_test.go:30-32` in any
+external-dispatch plugin documents the structpb constraint:
+
+> "Slices must be `[]any`; native typed slices (`[]string`, `[]int`, etc.)
+> are rejected by `structpb.NewStruct` with 'proto: invalid type'."
+
+**Fix shape:**
+
+- `Outputs[<int-slice key>]` → `[]any` of `float64` (structpb collapses all
+  numerics to `float64`; storing as `float64` from the start makes the shape
+  symmetric with both pre- and post-roundtrip reads).
+- `Outputs[<string-slice key>]` → `[]any` of `string`.
+- `Outputs[<struct-slice key>]` → `[]any` of `map[string]any`, with a flatten
+  helper per godo struct type.
+- Reader-side helpers (`outputsAsIntSlice`, `outputsAsStringSlice`, etc.)
+  accept BOTH typed-slice (in-process pre-roundtrip path) AND `[]any` of
+  primitive/map (post-roundtrip path).
+
+**Test pattern:** import `iaclint` and call `iaclint.AssertOutputsRoundTripStructpb(t, out.Outputs)`
+in the driver's Create/Read/Update tests. For Diff, write a
+`_StructpbBoundary_DiffSurvivesRoundTrip` test that builds an Outputs map,
+round-trips through `structpb.NewStruct`/`AsMap()`, then calls Diff against a
+matching desired and asserts `NeedsUpdate=false`.
+
+**Reviewer scan:**
+
+1. Check `plugin.json` for `mode: strict`. If `strict`, BC-2 doesn't apply.
+2. Otherwise: `grep -nE 'Outputs\["[^"]+"\] *= *\[\]' internal/drivers/*.go`
+   surfaces typed-slice writes. Each is a **BC-2 BLOCKING** instance.
+3. `grep -nE 'current\.Outputs\["[^"]+"\]\.\(\[\]' internal/drivers/*.go`
+   surfaces typed-slice reads in Diff. Each is a **BC-2 BLOCKING** instance.
+
+## (Bug classes BC-3 through BC-8 to follow in Task 8)
+```
+
+**Step 2: Run any verification**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && grep -c "## BC-" docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+Expected: `2` (BC-1 + BC-2 sections present).
+
+**Step 3: Commit**
+
+```bash
+git add docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+git commit -m "docs(iac): D-1 review checklist skeleton + BC-1 + BC-2"
+```
+
+---
+
+## Task 8: D-1 markdown checklist — BC-3 through BC-8
+
+**Files:**
+- Modify: `docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+
+**Step 1: Append the remaining bug classes**
+
+Append BC-3, BC-4, BC-5, BC-6, BC-7, BC-8 sections following the same
+four-sub-section structure (Failure mode / Repro pattern / Fix shape / Test
+pattern + Reviewer scan). Pull the content directly from the design doc
+(`docs/plans/2026-04-28-iac-plugin-review-design.md` "Bug-class taxonomy"
+section), expanding each into the same shape as BC-1/BC-2.
+
+For BC-3 (Outputs-vs-Diff invariant), the test pattern is
+`iaclint.AssertDiffPopulatesAllOutputFields` and the driver must implement
+`iaclint.DiffOutputKeyDeclarer`.
+
+For BC-4 (validation matrix), the test pattern is
+`iaclint.AssertValidationMatrix(t, parser, fieldName, kind)` for each
+{field, kind} pair the driver accepts.
+
+BC-5/BC-6/BC-7/BC-8 don't have iaclint matchers (they're discipline-shape
+patterns reviewers apply manually); call this out in the test pattern
+section: "No iaclint matcher; verify by reviewer scan and manual test cases."
+
+**Step 2: Run verification**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && grep -c "## BC-" docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+Expected: `8` (all 8 bug classes documented).
+
+Also run: `grep -nE 'BC-[1-8]' docs/IAC_PLUGIN_REVIEW_CHECKLIST.md | wc -l`
+Expected: at least 16 (each bug class referenced multiple times in cross-links).
+
+**Step 3: Commit**
+
+```bash
+git add docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+git commit -m "docs(iac): D-1 review checklist BC-3..BC-8 (full taxonomy)"
+```
+
+---
+
+## Task 9: D-1 link from CONTRIBUTING.md
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+**Step 1: Add a section pointing to the checklist**
+
+Open `CONTRIBUTING.md`. Find the "Plugin Development" section (or a similar
+plugin-related heading). Add a sub-section:
+
+```markdown
+### Reviewing IaC plugin PRs
+
+When reviewing a PR in any `GoCodeAlone/workflow-plugin-*` repository that
+implements an IaC provider, apply the cross-provider review checklist:
+
+- [`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`](docs/IAC_PLUGIN_REVIEW_CHECKLIST.md)
+
+For executable enforcement, plugin authors should import the
+`workflow/plugin/sdk/iaclint/` test helpers in their CI test suite. The
+checklist's "Test pattern" sub-sections name the matcher for each bug class.
+```
+
+If `CONTRIBUTING.md` has no plugin-related section, add the sub-section under
+"Code Review" or after "Project Structure".
+
+**Step 2: Run verification**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && grep -c 'IAC_PLUGIN_REVIEW_CHECKLIST' CONTRIBUTING.md`
+Expected: `1` (single link reference).
+
+**Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(contributing): link IAC_PLUGIN_REVIEW_CHECKLIST from CONTRIBUTING (D-1)"
+```
+
+---
+
+## Task 10: D-3 strict-contracts tracker extension
+
+**Files:**
+- Modify: `docs/plans/2026-04-26-strict-grpc-plugin-contracts.md`
+- Modify: `docs/plans/2026-04-26-strict-grpc-plugin-contracts-design.md`
+
+**Step 1: Add IaC plugin migration table**
+
+In both documents, locate the per-plugin migration tracking section. Add (or
+extend) a sub-section:
+
+```markdown
+### IaC Provider Plugins
+
+These plugins implement `interfaces.ResourceDriver` and consume the IaC
+canonical schema. They are tracked separately because their migration
+benefits from the cross-provider review discipline at
+[`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`](../IAC_PLUGIN_REVIEW_CHECKLIST.md).
+
+| Plugin | Strict-mode status (target v0.9.0) | Pre-migration audit findings |
+|---|---|---|
+| `workflow-plugin-aws` | active migration | (Phase C audit pending) |
+| `workflow-plugin-azure` | verified locally, awaiting PR | (Phase C audit pending) |
+| `workflow-plugin-ci-generator` | merged | n/a (already shipped strict) |
+| `workflow-plugin-digitalocean` | pending — v0.8.0 ships legacy compat | F4/F5/F7 cycle: BC-1, BC-2, BC-3, BC-4, BC-5, BC-6, BC-8 closed in v0.8.0; BC-7 not applicable. Issue #37 (Update naming consistency) deferred to v0.8.x |
+| `workflow-plugin-gcp` | pending | (Phase C audit pending) |
+| `workflow-plugin-tofu` | pending | (Phase C audit pending) |
+
+Each plugin's v0.9.0 strict-migration PR adds a "Pre-migration findings
+closed" sub-section to its CHANGELOG referencing the bug classes addressed.
+```
+
+**Step 2: Run verification**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && grep -c 'workflow-plugin-digitalocean' docs/plans/2026-04-26-strict-grpc-plugin-contracts.md`
+Expected: at least `1` (DO row added to migration table).
+
+Also: `grep -c 'IAC_PLUGIN_REVIEW_CHECKLIST' docs/plans/2026-04-26-strict-grpc-plugin-contracts.md`
+Expected: at least `1`.
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-04-26-strict-grpc-plugin-contracts.md docs/plans/2026-04-26-strict-grpc-plugin-contracts-design.md
+git commit -m "docs(plans): D-3 extend strict-contracts tracker with IaC plugins"
+```
+
+---
+
+## Task 11: D-4 plugin-pattern-reviewer skill
+
+**Files:**
+- Create: `~/.claude/skills/workflow-plugin-reviewer/SKILL.md`
+
+(Note: this file lives in the user's home dir, not the workflow repo. The
+skill is workspace-local.)
+
+**Step 1: Write the skill file**
+
+```markdown
+---
+name: workflow-plugin-reviewer
+description: Use when reviewing a PR in any GoCodeAlone/workflow-plugin-* repository — auto-detects the provider pattern from plugin.json and applies the matching cross-provider bug-class checklist. v1 ships with IaC pattern populated; other patterns added as they emerge.
+---
+
+# Workflow Plugin Review Discipline
+
+When reviewing a PR in a workflow plugin repo, follow this dispatch:
+
+## 1. Identify the provider pattern
+
+Read `plugin.json` from the PR's working directory. Look for one of these
+top-level keys:
+
+| Key in plugin.json | Pattern | Checklist source |
+|---|---|---|
+| `iacProvider` | IaC provider | `workflow/docs/IAC_PLUGIN_REVIEW_CHECKLIST.md` |
+| `authProvider` | Auth provider | (TBD — checklist pending) |
+| `paymentProvider` | Payment provider | (TBD — checklist pending) |
+| `agentProvider` | Agent provider | (TBD — checklist pending) |
+| `auditProvider` | Audit provider | (TBD — checklist pending) |
+| (none of the above) | Module/step plugin | (TBD — generic step-driver checklist pending) |
+
+If multiple keys are present, apply all matching checklists.
+
+## 2. Load the matched checklist
+
+Read the named checklist file from a local clone of `GoCodeAlone/workflow`.
+The checklist defines bug classes (e.g., BC-1 through BC-8 for IaC) with
+four sub-sections each: failure mode, repro pattern, fix shape, reviewer
+scan. The reviewer scan is the concrete steps to apply to the diff.
+
+## 3. Apply the checklist as part of the bug-class scan
+
+In addition to the standard adversarial-review framing from
+`agents/team-conventions.md` and `skills/requesting-code-review/SKILL.md`:
+
+- For each bug class in the loaded checklist, run its "Reviewer scan"
+  sub-section against the diff.
+- Report findings inline at file:line, tagging the bug class identifier
+  (e.g., "BC-2 BLOCKING: typed `[]int` slice in firewall.go:407 won't
+  survive structpb roundtrip").
+- Promote BC-1, BC-2, BC-3, BC-7 findings to **Important** by default
+  (these are correctness or security gaps).
+- BC-4, BC-5, BC-6, BC-8 default to **Minor** unless they exhibit a clear
+  blast radius (e.g., security-relevant validation gap).
+
+## 4. Legacy compat dispatch detection
+
+If the plugin is on legacy compat dispatch (no `internal/contracts/` package
+in the repo, plugin.json `mode` ≠ `"strict"`), include the BC-2 structpb
+boundary scan even if not in the checklist's default order — legacy plugins
+have this gap as a recurring risk class.
+
+## Pattern dispatch table is pre-allocated; only IaC has populated content as of 2026-04-28
+
+Future provider-pattern checklists slot into the dispatch table without
+rewriting this skill. When a new pattern's checklist lands in
+`workflow/docs/`, add a row to the table above.
+```
+
+**Step 2: Run verification**
+
+Run: `ls -la ~/.claude/skills/workflow-plugin-reviewer/SKILL.md`
+Expected: file exists, non-empty.
+
+Also: `grep -c 'iacProvider\|authProvider\|paymentProvider' ~/.claude/skills/workflow-plugin-reviewer/SKILL.md`
+Expected: at least `3`.
+
+**Step 3: Commit (this file is outside the workflow repo, so no commit needed inside the worktree)**
+
+The skill file is a workspace-local artifact, not part of the workflow repo
+itself. Note its existence in the PR description when opening the PR for
+this branch — reviewers should be aware the skill exists for the auto-load
+behavior to take effect.
+
+---
+
+## Task 12: Smoke check — import iaclint in workflow-plugin-digitalocean test suite
+
+**Files:**
+- (Read-only — no commit in this PR. Just verify the helpers can be imported and called.)
+
+**Step 1: Add a temporary smoke test**
+
+In a separate scratch worktree of `workflow-plugin-digitalocean`:
+
+```bash
+cd /Users/jon/workspace/workflow-plugin-digitalocean
+git fetch origin
+git checkout main && git pull
+```
+
+Then create a temporary file `internal/drivers/iaclint_smoke_scratch.go` (do
+NOT commit) that imports the helpers:
+
+```go
+//go:build ignore
+
+package drivers_test
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
+)
+
+func TestIaclintSmokeImport(t *testing.T) {
+	// Verify the package imports and matchers exist with the expected signatures.
+	_ = iaclint.KindTCPPort
+	_ = iaclint.AssertOutputsRoundTripStructpb
+	_ = iaclint.AssertDiffPopulatesAllOutputFields
+	_ = iaclint.AssertValidationMatrix
+}
+```
+
+**Step 2: Run smoke check**
+
+Run: `cd /Users/jon/workspace/workflow-plugin-digitalocean && GOWORK=off go vet -tags=ignore ./...`
+Expected: no errors related to the iaclint package import. (If errors emerge
+because workflow-plugin-digitalocean go.mod doesn't yet pin a workflow
+version that includes the new package, that's expected and is closed in
+Phase C — for this smoke check, the goal is verifying the helpers compile in
+the workflow worktree itself.)
+
+A safer smoke check: in the workflow worktree, add a temporary
+`plugin/sdk/iaclint/_examples/firewall_smoke_test.go.example` (named with
+`.example` to keep it out of the build) that mimics how a plugin would call
+the matchers, and verify it parses with `go vet`:
+
+```go
+// Save as plugin/sdk/iaclint/_examples/firewall_smoke_test.go.example
+// (renamed in Phase C when consumed by an actual plugin).
+//
+// Demonstrates the calling pattern; not a runnable test in this repo.
+package _examples
+
+// (calling-pattern code as comments)
+```
+
+**Step 3: Clean up**
+
+Remove the scratch file. The smoke check is informational only.
+
+**Step 4: No commit**
+
+This task produces no committed artifacts. It exists to verify the helpers
+have a sensible API before the plan-end review.
+
+---
+
+## Task 13: Phase A wrap-up — push branch + open PR
+
+**Files:**
+- (No file changes — this task pushes commits and opens the PR.)
+
+**Step 1: Verify all tasks done**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && git log --oneline origin/main..HEAD | wc -l`
+Expected: at least 8 commits (Tasks 1-6 + 7-10; Task 11 is outside the repo, Task 12 is no-commit).
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test -race ./plugin/sdk/iaclint/... && GOWORK=off go vet ./plugin/sdk/iaclint/...`
+Expected: PASS, vet clean.
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && grep -c '## BC-' docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`
+Expected: `8`.
+
+**Step 2: Push branch**
+
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && git push origin design/iac-plugin-review`
+Expected: branch updated.
+
+**Step 3: Open PR**
+
+```bash
+gh pr create --repo GoCodeAlone/workflow \
+  --base main \
+  --head design/iac-plugin-review \
+  --title "feat(plugins): IaC cross-provider review discipline (Phase A)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase A of the IaC plugin review discipline rollout. Captures the bug-class
+taxonomy from workflow-plugin-digitalocean v0.8.0 (P-2) review cycle as
+cross-provider discipline that benefits all IaC provider plugins.
+
+## Deliverables
+
+- **D-1** \`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md\` — markdown taxonomy of 8 bug
+  classes (Plan/Diff cascade, structpb boundary, Outputs-vs-Diff invariant,
+  validation matrix, plan-time vs apply-time docs, Diff-side vs Apply-side
+  parity, CIDR widening, canonical-key registration). Linked from
+  CONTRIBUTING.md.
+- **D-2** \`plugin/sdk/iaclint/\` — Go test-helper package with three
+  matchers: \`AssertOutputsRoundTripStructpb\`, \`AssertDiffPopulatesAllOutputFields\`,
+  \`AssertValidationMatrix\`. Each IaC plugin imports for CI enforcement.
+- **D-3** \`docs/plans/2026-04-26-strict-grpc-plugin-contracts.md\` —
+  extended with IaC plugin migration table (DO/GCP/Tofu rows added; v0.8.0
+  closures recorded for DO).
+- **D-4** \`~/.claude/skills/workflow-plugin-reviewer/SKILL.md\` (workspace-
+  local; not in this repo) — generic plugin-pattern-reviewer skill that
+  auto-detects provider pattern from plugin.json and loads the matching
+  checklist.
+
+## Design reference
+
+\`docs/plans/2026-04-28-iac-plugin-review-design.md\` (committed in this
+branch).
+
+## Phase B / Phase C
+
+After this lands, Phase B (P-1 BMW cleanup) auto-dispatches per the existing
+\`docs/plans/2026-04-27-iac-do-staging-implementation.md\` plan. Phase C
+(retroactive plugin audit fix-forward) auto-chains after P-1.
+
+## Test plan
+
+- [x] \`GOWORK=off go test -race ./plugin/sdk/iaclint/...\` — all matcher tests pass
+- [x] \`GOWORK=off go vet ./plugin/sdk/iaclint/...\` — clean
+- [x] Checklist contains all 8 bug classes
+- [x] Strict-contracts tracker references checklist + adds IaC plugin rows
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 4: DM team-lead with PR URL**
+
+DM the orchestrator with the PR number + branch + head commit. The PR moves
+to gate-clearing (CI + Copilot + spec/code reviewers per the standard
+pipeline). After SHIP-IT + Copilot OK + admin-merge, Phase B auto-dispatches.
+
+---
+
+## Acceptance (full Phase A)
+
+- [ ] All 13 tasks complete; 11+ commits on `design/iac-plugin-review`.
+- [ ] \`GOWORK=off go test -race ./plugin/sdk/iaclint/...\` passes (all matcher tests green).
+- [ ] \`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md\` contains all 8 bug classes.
+- [ ] CONTRIBUTING.md links to checklist.
+- [ ] Strict-contracts tracker has IaC plugin migration table.
+- [ ] `~/.claude/skills/workflow-plugin-reviewer/SKILL.md` exists.
+- [ ] PR open against `main`, CI green, Copilot OK.
+
+After PR merges to main: Phase B (P-1 BMW) auto-chains via the orchestrator.

--- a/docs/plans/2026-04-28-iac-plugin-review.md
+++ b/docs/plans/2026-04-28-iac-plugin-review.md
@@ -927,7 +927,8 @@ no-change baseline + reorder/normalization cases).
 
 **Reviewer scan:**
 
-1. `grep -nE 'func.*\bDiff\b' internal/drivers/*.go provider/drivers/*.go`
+1. `grep -nP 'func.*\bDiff\b' internal/drivers/*.go provider/drivers/*.go`
+   (BSD/macOS: substitute `rg` — POSIX ERE doesn't define `\b`.)
 2. For each Diff, read its body. Does it always return nil? Does it only
    compare one or two fields when the Create/Update accepts more?
 3. If the answer is "yes" to either, surface as **BC-1 BLOCKING**.

--- a/docs/plans/2026-04-28-iac-plugin-review.md
+++ b/docs/plans/2026-04-28-iac-plugin-review.md
@@ -129,7 +129,7 @@ git commit -m "feat(iaclint): add ValidationKind enum + package skeleton (D-2)"
 
 ---
 
-## Task 2: D-2 AssertOutputsRoundTripStructpb (BC-2 helper)
+## Task 2: D-2 AssertOutputsStructpbCompatible (BC-2 helper)
 
 **Files:**
 - Modify: `plugin/sdk/iaclint/iaclint.go`
@@ -138,31 +138,31 @@ git commit -m "feat(iaclint): add ValidationKind enum + package skeleton (D-2)"
 **Step 1: Write the failing test**
 
 ```go
-func TestAssertOutputsRoundTripStructpb_RejectsTypedSlice(t *testing.T) {
+func TestAssertOutputsStructpbCompatible_RejectsTypedSlice(t *testing.T) {
 	// Typed slices ([]int, []string, []GoStruct) are rejected by structpb.
-	// AssertOutputsRoundTripStructpb must surface the rejection as a test failure.
+	// AssertOutputsStructpbCompatible must surface the rejection as a test failure.
 	tt := &mockT{}
-	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+	iaclint.AssertOutputsStructpbCompatible(tt, map[string]any{
 		"droplet_ids": []int{123, 456}, // BC-2: typed slice rejected by structpb
 	})
 	if !tt.failed {
-		t.Fatal("AssertOutputsRoundTripStructpb accepted typed []int slice; expected failure")
+		t.Fatal("AssertOutputsStructpbCompatible accepted typed []int slice; expected failure")
 	}
 	if !strings.Contains(tt.fatalMsg, "droplet_ids") {
 		t.Errorf("fatal msg %q missing field name 'droplet_ids'", tt.fatalMsg)
 	}
 }
 
-func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
+func TestAssertOutputsStructpbCompatible_AcceptsCanonicalShape(t *testing.T) {
 	tt := &mockT{}
-	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+	iaclint.AssertOutputsStructpbCompatible(tt, map[string]any{
 		"droplet_ids":   []any{float64(123), float64(456)},
 		"tags":          []any{"a", "b"},
 		"inbound_rules": []any{map[string]any{"protocol": "tcp"}},
 		"name":          "fw-1",
 	})
 	if tt.failed {
-		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.fatalMsg)
+		t.Fatalf("AssertOutputsStructpbCompatible rejected canonical shape: %s", tt.fatalMsg)
 	}
 }
 
@@ -181,8 +181,8 @@ func (m *mockT) Errorf(format string, args ...any)      { m.failed = true; m.fat
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertOutputsRoundTripStructpb`
-Expected: FAIL with `undefined: iaclint.AssertOutputsRoundTripStructpb`.
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertOutputsStructpbCompatible`
+Expected: FAIL with `undefined: iaclint.AssertOutputsStructpbCompatible`.
 
 **Step 3: Write minimal implementation**
 
@@ -202,12 +202,16 @@ type TB interface {
 	Errorf(format string, args ...any)
 }
 
-// AssertOutputsRoundTripStructpb verifies that every value in outputs survives
-// a structpb.NewStruct → AsMap() round-trip without breaking downstream type
-// assertions. Closes BC-2 (structpb gRPC boundary): typed slices ([]int,
-// []string, []godo.X) are rejected by structpb.NewStruct outright; godo
-// structs round-trip as map[string]any so reader-side type assertions to the
-// original struct type fail silently.
+// AssertOutputsStructpbCompatible verifies that every value in outputs is
+// structpb-compatible (structpb.NewStruct accepts the outputs map without
+// error). Closes BC-2 (structpb gRPC boundary): typed slices ([]int,
+// []string, []godo.X) are rejected by structpb.NewStruct outright. The
+// matcher catches the most common BC-2 failure mode — typed-slice writes
+// that would degrade at the wfctl→plugin gRPC boundary.
+//
+// Scope note: this matcher does NOT exercise the full NewStruct → AsMap
+// round-trip. If your plugin's Diff reads typed values from current.Outputs,
+// also write a post-roundtrip test in your plugin's test suite.
 //
 // Plugins on legacy compat dispatch (no internal/contracts/ proto package,
 // plugin.json mode != "strict") MUST call this matcher in their test suite for
@@ -216,7 +220,7 @@ type TB interface {
 //
 // Strict-mode plugins (plugin.json mode == "strict") are immune to BC-2 and do
 // not need this matcher.
-func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
+func AssertOutputsStructpbCompatible(t TB, outputs map[string]any) {
 	t.Helper()
 	if outputs == nil {
 		return
@@ -236,14 +240,14 @@ func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertOutputsRoundTripStructpb`
+Run: `cd /Users/jon/workspace/workflow/_worktrees/iac-plugin-review && GOWORK=off go test ./plugin/sdk/iaclint/... -run TestAssertOutputsStructpbCompatible`
 Expected: PASS, both sub-tests green.
 
 **Step 5: Commit**
 
 ```bash
 git add plugin/sdk/iaclint/iaclint.go plugin/sdk/iaclint/iaclint_test.go
-git commit -m "feat(iaclint): AssertOutputsRoundTripStructpb (D-2 BC-2 matcher)"
+git commit -m "feat(iaclint): AssertOutputsStructpbCompatible (D-2 BC-2 matcher)"
 ```
 
 ---
@@ -813,7 +817,7 @@ func Example() {
 	// In a real plugin test:
 	//
 	//   driver := &MyFirewallDriver{client: mockClient}
-	//   iaclint.AssertOutputsRoundTripStructpb(t, mustCreate(t, driver).Outputs)
+	//   iaclint.AssertOutputsStructpbCompatible(t, mustCreate(t, driver).Outputs)
 	//   iaclint.AssertDiffPopulatesAllOutputFields(t, driver, sampleSpec)
 	//   iaclint.AssertValidationMatrix(t, parsePort, "port", iaclint.KindTCPPort)
 	//
@@ -843,9 +847,12 @@ Expand the existing package doc-comment in `iaclint.go` (the one starting with `
 //
 // Three matchers are exposed:
 //
-//   - AssertOutputsRoundTripStructpb (BC-2): verifies Outputs map values
-//     survive structpb.NewStruct round-trip without breaking type assertions.
-//     Use for plugins on legacy compat dispatch.
+//   - AssertOutputsStructpbCompatible (BC-2): verifies Outputs map values
+//     are structpb-compatible (NewStruct accepts them). Catches typed-slice
+//     writes that would degrade at the wfctl→plugin gRPC boundary. Does NOT
+//     exercise the full NewStruct → AsMap round-trip; if your plugin's Diff
+//     reads typed values from current.Outputs, write a post-roundtrip test
+//     in your plugin's test suite. Use for plugins on legacy compat dispatch.
 //
 //   - AssertDiffPopulatesAllOutputFields (BC-3): verifies every Outputs[*]
 //     key the driver's Diff reads is populated by the matching Create writer.
@@ -964,7 +971,7 @@ external-dispatch plugin documents the structpb constraint:
   accept BOTH typed-slice (in-process pre-roundtrip path) AND `[]any` of
   primitive/map (post-roundtrip path).
 
-**Test pattern:** import `iaclint` and call `iaclint.AssertOutputsRoundTripStructpb(t, out.Outputs)`
+**Test pattern:** import `iaclint` and call `iaclint.AssertOutputsStructpbCompatible(t, out.Outputs)`
 in the driver's Create/Read/Update tests. For Diff, write a
 `_StructpbBoundary_DiffSurvivesRoundTrip` test that builds an Outputs map,
 round-trips through `structpb.NewStruct`/`AsMap()`, then calls Diff against a
@@ -1247,7 +1254,7 @@ import (
 func TestIaclintSmokeImport(t *testing.T) {
 	// Verify the package imports and matchers exist with the expected signatures.
 	_ = iaclint.KindTCPPort
-	_ = iaclint.AssertOutputsRoundTripStructpb
+	_ = iaclint.AssertOutputsStructpbCompatible
 	_ = iaclint.AssertDiffPopulatesAllOutputFields
 	_ = iaclint.AssertValidationMatrix
 }
@@ -1331,7 +1338,7 @@ cross-provider discipline that benefits all IaC provider plugins.
   parity, CIDR widening, canonical-key registration). Linked from
   CONTRIBUTING.md.
 - **D-2** \`plugin/sdk/iaclint/\` — Go test-helper package with three
-  matchers: \`AssertOutputsRoundTripStructpb\`, \`AssertDiffPopulatesAllOutputFields\`,
+  matchers: \`AssertOutputsStructpbCompatible\`, \`AssertDiffPopulatesAllOutputFields\`,
   \`AssertValidationMatrix\`. Each IaC plugin imports for CI enforcement.
 - **D-3** \`docs/plans/2026-04-26-strict-grpc-plugin-contracts.md\` —
   extended with IaC plugin migration table (DO/GCP/Tofu rows added; v0.8.0

--- a/docs/plans/2026-04-28-iac-plugin-review.md
+++ b/docs/plans/2026-04-28-iac-plugin-review.md
@@ -1,3 +1,15 @@
+---
+status: in_progress
+area: plugins
+owner: workflow
+external_refs: []
+verification:
+  last_checked: 2026-04-28
+  result: pending
+supersedes: []
+superseded_by: []
+---
+
 # IaC Plugin Cross-Provider Review Discipline & Audit — Phase A Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.

--- a/plugin/sdk/iaclint/example_test.go
+++ b/plugin/sdk/iaclint/example_test.go
@@ -1,0 +1,20 @@
+package iaclint_test
+
+import (
+	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
+)
+
+// Example shows a typical IaC plugin test importing iaclint to assert all
+// three bug-class invariants on a single driver.
+func Example() {
+	// In a real plugin test:
+	//
+	//   driver := &MyFirewallDriver{client: mockClient}
+	//   iaclint.AssertOutputsRoundTripStructpb(t, mustCreate(t, driver).Outputs)
+	//   iaclint.AssertDiffPopulatesAllOutputFields(t, driver, sampleSpec)
+	//   iaclint.AssertValidationMatrix(t, parsePort, "port", iaclint.KindTCPPort)
+	//
+	// See docs/IAC_PLUGIN_REVIEW_CHECKLIST.md for the bug-class taxonomy.
+	_ = iaclint.KindTCPPort
+	// Output:
+}

--- a/plugin/sdk/iaclint/example_test.go
+++ b/plugin/sdk/iaclint/example_test.go
@@ -10,7 +10,7 @@ func Example() {
 	// In a real plugin test:
 	//
 	//   driver := &MyFirewallDriver{client: mockClient}
-	//   iaclint.AssertOutputsRoundTripStructpb(t, mustCreate(t, driver).Outputs)
+	//   iaclint.AssertOutputsStructpbCompatible(t, mustCreate(t, driver).Outputs)
 	//   iaclint.AssertDiffPopulatesAllOutputFields(t, driver, sampleSpec)
 	//   iaclint.AssertValidationMatrix(t, parsePort, "port", iaclint.KindTCPPort)
 	//

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -8,7 +8,7 @@
 //
 // Three matchers are exposed:
 //
-//   - AssertOutputsRoundTripStructpb (BC-2): verifies Outputs map values
+//   - AssertOutputsStructpbCompatible (BC-2): verifies Outputs map values
 //     are structpb-compatible (NewStruct accepts them). Catches typed-slice
 //     writes that would degrade at the wfctl→plugin gRPC boundary. Does NOT
 //     exercise the full NewStruct → AsMap round-trip; see BC-3 for
@@ -27,7 +27,7 @@
 // surfaced during the workflow-plugin-digitalocean v0.8.0 review cycle are
 // caught at CI time rather than during production gRPC dispatch or in code
 // review. Plugins on legacy compat dispatch (no internal/contracts/ proto
-// package, plugin.json mode != "strict") MUST call AssertOutputsRoundTripStructpb
+// package, plugin.json mode != "strict") MUST call AssertOutputsStructpbCompatible
 // for every Outputs map written by Create/Update/Read. Strict-mode plugins
 // (plugin.json mode == "strict") are immune to BC-2 and may skip that matcher.
 package iaclint
@@ -94,7 +94,7 @@ func (k ValidationKind) String() string {
 	return "Unknown"
 }
 
-// AssertOutputsRoundTripStructpb verifies that every value in outputs is
+// AssertOutputsStructpbCompatible verifies that every value in outputs is
 // structpb-compatible — that is, that structpb.NewStruct accepts the outputs
 // map without error. structpb's encoding rejects typed slices ([]int,
 // []string, []godo.X) outright, so this matcher catches the most common BC-2
@@ -120,7 +120,7 @@ func (k ValidationKind) String() string {
 // compatible. Detecting whether Outputs is populated at all (the writer-side
 // invariant) is BC-3's job — pair this matcher with
 // AssertDiffPopulatesAllOutputFields for full coverage.
-func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
+func AssertOutputsStructpbCompatible(t TB, outputs map[string]any) {
 	t.Helper()
 	if outputs == nil {
 		return

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -90,12 +90,19 @@ func (k ValidationKind) String() string {
 	return "Unknown"
 }
 
-// AssertOutputsRoundTripStructpb verifies that every value in outputs survives
-// a structpb.NewStruct → AsMap() round-trip without breaking downstream type
-// assertions. Closes BC-2 (structpb gRPC boundary): typed slices ([]int,
-// []string, []godo.X) are rejected by structpb.NewStruct outright; godo
-// structs round-trip as map[string]any so reader-side type assertions to the
-// original struct type fail silently.
+// AssertOutputsRoundTripStructpb verifies that every value in outputs is
+// structpb-compatible — that is, that structpb.NewStruct accepts the outputs
+// map without error. structpb's encoding rejects typed slices ([]int,
+// []string, []godo.X) outright, so this matcher catches the most common BC-2
+// failure mode: typed-slice writes that would silently degrade at the
+// wfctl→plugin gRPC boundary.
+//
+// Scope note: this matcher does NOT exercise the full NewStruct → AsMap
+// round-trip. Values that NewStruct accepts but degrade structurally on
+// AsMap (e.g., godo structs becoming map[string]any so reader-side type
+// assertions to the original struct type fail silently) are not caught. If
+// your plugin's Diff reads typed values from current.Outputs, also test the
+// post-roundtrip path explicitly — see BC-3 in IAC_PLUGIN_REVIEW_CHECKLIST.md.
 //
 // Plugins on legacy compat dispatch (no internal/contracts/ proto package,
 // plugin.json mode != "strict") MUST call this matcher in their test suite for

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -11,9 +11,11 @@
 package iaclint
 
 import (
+	"context"
 	"math"
 	"sync"
 
+	"github.com/GoCodeAlone/workflow/interfaces"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -185,6 +187,50 @@ func WithStringEnumOptions(allowed []string) ValidationKind {
 	enumOptions[id] = append([]string(nil), allowed...)
 	enumOptionsMu.Unlock()
 	return id
+}
+
+// DiffOutputKeyDeclarer is an optional interface a ResourceDriver may
+// implement to declare which Outputs[*] keys its Diff implementation reads.
+// AssertDiffPopulatesAllOutputFields uses this to verify the writer side
+// (Create/Read/Update) populates all declared keys.
+//
+// Plugins typically implement this as a sibling method that returns a static
+// slice of canonical key names — small surface, easy to keep in sync.
+type DiffOutputKeyDeclarer interface {
+	DiffReadsOutputKeys() []string
+}
+
+// AssertDiffPopulatesAllOutputFields verifies that for every key the driver's
+// Diff implementation reads from current.Outputs, the matching Create call
+// populates that key. Closes BC-3 (Outputs-vs-Diff invariant).
+//
+// The driver must implement DiffOutputKeyDeclarer to declare its read set.
+// The matcher invokes Create with the provided sample spec and inspects the
+// returned ResourceOutput.Outputs map for the declared keys.
+//
+// sampleSpec must be a representative input that exercises the writer's
+// happy path. Use the spec the plugin's own tests use.
+func AssertDiffPopulatesAllOutputFields(t TB, driver interfaces.ResourceDriver, sampleSpec interfaces.ResourceSpec) {
+	t.Helper()
+	declarer, ok := driver.(DiffOutputKeyDeclarer)
+	if !ok {
+		t.Fatalf("driver %T does not implement DiffOutputKeyDeclarer; cannot verify BC-3 invariant", driver)
+		return
+	}
+	out, err := driver.Create(context.Background(), sampleSpec)
+	if err != nil {
+		t.Fatalf("driver.Create failed: %v", err)
+		return
+	}
+	if out == nil || out.Outputs == nil {
+		t.Fatalf("driver.Create returned nil Outputs")
+		return
+	}
+	for _, key := range declarer.DiffReadsOutputKeys() {
+		if _, present := out.Outputs[key]; !present {
+			t.Errorf("Outputs[%q] not populated by Create, but Diff reads it — see BC-3 in IAC_PLUGIN_REVIEW_CHECKLIST.md", key)
+		}
+	}
 }
 
 func runStringEnumProbes(t TB, parser ConfigParser, fieldName string, allowed []string) {

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -11,6 +11,8 @@
 package iaclint
 
 import (
+	"math"
+
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -87,4 +89,72 @@ func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
 		}
 		t.Fatalf("Outputs not structpb-compatible: %v", err)
 	}
+}
+
+// ConfigParser is a closure that extracts and validates one config field. The
+// parser receives a config map (mirroring the cfg map[string]any shape used
+// across IaC drivers) and returns the parsed value or an error.
+//
+// AssertValidationMatrix calls the parser repeatedly with edge-case inputs and
+// asserts the parser correctly accepts/rejects each.
+type ConfigParser func(cfg map[string]any) (any, error)
+
+// validationProbe is one row of the {value, expectAccept, label} battery.
+type validationProbe struct {
+	value        any
+	expectAccept bool
+	label        string
+}
+
+// AssertValidationMatrix runs the standard {field, value-class} battery
+// against parser. Closes BC-4 (validation matrix) by exercising the edge
+// values that have historically been silently accepted by IaC plugin parsers.
+//
+// fieldName is the cfg key the parser reads (e.g., "port", "droplet_ids").
+// kind selects which battery to run.
+func AssertValidationMatrix(t TB, parser ConfigParser, fieldName string, kind ValidationKind) {
+	t.Helper()
+	switch kind {
+	case KindTCPPort:
+		runProbes(t, parser, fieldName, kind, []validationProbe{
+			{0, false, "zero"},
+			{-1, false, "negative"},
+			{1, true, "min valid"},
+			{65535, true, "max valid"},
+			{65536, false, "above max"},
+		})
+	case KindIntegerOnlyFloat:
+		runProbes(t, parser, fieldName, kind, []validationProbe{
+			{1.0, true, "integer-valued float"},
+			{1.9, false, "fractional"},
+			{math.NaN(), false, "NaN"},
+			{math.Inf(1), false, "Inf"},
+		})
+	default:
+		t.Fatalf("AssertValidationMatrix: unhandled kind %s", kind)
+	}
+}
+
+// runProbes is the shared driver for each kind's probe table.
+func runProbes(t TB, parser ConfigParser, fieldName string, kind ValidationKind, probes []validationProbe) {
+	t.Helper()
+	for _, p := range probes {
+		_, err := parser(map[string]any{fieldName: p.value})
+		got := err == nil
+		if got != p.expectAccept {
+			verb := "rejected"
+			if got {
+				verb = "accepted"
+			}
+			t.Errorf("%s probe %q (value=%v): parser %s; expected %s — see BC-4 in IAC_PLUGIN_REVIEW_CHECKLIST.md",
+				kind, p.label, p.value, verb, acceptStr(p.expectAccept))
+		}
+	}
+}
+
+func acceptStr(b bool) string {
+	if b {
+		return "accept"
+	}
+	return "reject"
 }

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -63,7 +63,11 @@ const (
 	KindNonNegativeInt
 	// KindNonEmptyString probes "", "  ", "valid".
 	KindNonEmptyString
-	// KindStringEnum probes each known value, "" (absent), random string, non-string Go types.
+	// KindStringEnum probes each known value, "" (absent), random string,
+	// non-string Go types. The bare constant carries no allowed-values set,
+	// so it is NOT directly usable with AssertValidationMatrix — pass
+	// WithStringEnumOptions([]string{...}) instead. AssertValidationMatrix
+	// fails loudly with that guidance if called with the bare constant.
 	KindStringEnum
 	// KindIntegerOnlyFloat probes 1.0, 1.9, NaN, Inf. Closes BC-4 fractional-float gap.
 	KindIntegerOnlyFloat
@@ -158,6 +162,8 @@ func AssertValidationMatrix(t TB, parser ConfigParser, fieldName string, kind Va
 			{65535, true, "max valid (int)"},
 			{65536, false, "above max (int)"},
 			{float64(0), false, "zero (float64 — gRPC coercion)"},
+			{float64(-1), false, "negative (float64 — gRPC coercion)"},
+			{float64(1), true, "min valid (float64 — gRPC coercion)"},
 			{float64(65535), true, "max valid (float64 — gRPC coercion)"},
 			{float64(65536), false, "above max (float64 — gRPC coercion)"},
 		})
@@ -180,6 +186,13 @@ func AssertValidationMatrix(t TB, parser ConfigParser, fieldName string, kind Va
 			{"   ", false, "whitespace"},
 			{"valid", true, "non-empty"},
 		})
+	case KindStringEnum:
+		// Bare KindStringEnum has no allowed-values set, so it cannot run a
+		// matrix on its own. Fail loudly with actionable guidance instead of
+		// the generic "unhandled kind" path. Callers must construct a kind
+		// via WithStringEnumOptions to bind allowed values.
+		t.Fatalf("AssertValidationMatrix: KindStringEnum requires allowed values — call iaclint.WithStringEnumOptions([]string{...}) instead of using the bare KindStringEnum constant")
+		return
 	default:
 		// StringEnum kinds (returned by WithStringEnumOptions) carry IDs >= 1000.
 		enumOptionsMu.Lock()
@@ -251,8 +264,9 @@ type DiffOutputKeyDeclarer interface {
 }
 
 // AssertDiffPopulatesAllOutputFields verifies that for every key the driver's
-// Diff implementation reads from current.Outputs, the matching Create call
-// populates that key. Closes BC-3 (Outputs-vs-Diff invariant).
+// Diff implementation reads from current.Outputs, the driver's Create call
+// populates that key. Closes BC-3 (Outputs-vs-Diff invariant) for the Create
+// path.
 //
 // The driver must implement DiffOutputKeyDeclarer to declare its read set.
 // The matcher invokes Create with the provided sample spec and inspects the
@@ -260,6 +274,13 @@ type DiffOutputKeyDeclarer interface {
 //
 // sampleSpec must be a representative input that exercises the writer's
 // happy path. Use the spec the plugin's own tests use.
+//
+// Scope note: this matcher only verifies the Create writer. Read and Update
+// population are NOT exercised here — if your driver only populates a key on
+// the Read or Update path (e.g., post-deployment status, in-place rotation),
+// add a separate test that calls Read/Update against a representative ref
+// and asserts the same key set. Drift between writer paths is a recurring
+// BC-3 sub-class.
 func AssertDiffPopulatesAllOutputFields(t TB, driver interfaces.ResourceDriver, sampleSpec interfaces.ResourceSpec) {
 	t.Helper()
 	declarer, ok := driver.(DiffOutputKeyDeclarer)

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -9,8 +9,11 @@
 // Three matchers are exposed:
 //
 //   - AssertOutputsRoundTripStructpb (BC-2): verifies Outputs map values
-//     survive structpb.NewStruct round-trip without breaking type assertions.
-//     Use for plugins on legacy compat dispatch.
+//     are structpb-compatible (NewStruct accepts them). Catches typed-slice
+//     writes that would degrade at the wfctl→plugin gRPC boundary. Does NOT
+//     exercise the full NewStruct → AsMap round-trip; see BC-3 for
+//     post-roundtrip type-assertion coverage. Use for plugins on legacy
+//     compat dispatch.
 //
 //   - AssertDiffPopulatesAllOutputFields (BC-3): verifies every Outputs[*]
 //     key the driver's Diff reads is populated by the matching Create writer.
@@ -32,6 +35,7 @@ package iaclint
 import (
 	"context"
 	"math"
+	"sort"
 	"sync"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -123,9 +127,17 @@ func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
 	}
 	if _, err := structpb.NewStruct(outputs); err != nil {
 		// Identify the offending key to give the test author a direct pointer.
-		for k, v := range outputs {
-			if _, single := structpb.NewStruct(map[string]any{k: v}); single != nil {
-				t.Fatalf("Outputs[%q] (%T) is not structpb-compatible: %v — see BC-2 in IAC_PLUGIN_REVIEW_CHECKLIST.md", k, v, single)
+		// Sort the keys first so the reported key is deterministic when
+		// multiple keys are bad — Go map iteration is randomized, which
+		// would otherwise produce flaky failure messages across test runs.
+		keys := make([]string, 0, len(outputs))
+		for k := range outputs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if _, single := structpb.NewStruct(map[string]any{k: outputs[k]}); single != nil {
+				t.Fatalf("Outputs[%q] (%T) is not structpb-compatible: %v — see BC-2 in IAC_PLUGIN_REVIEW_CHECKLIST.md", k, outputs[k], single)
 				return
 			}
 		}

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -100,6 +100,11 @@ func (k ValidationKind) String() string {
 //
 // Strict-mode plugins (plugin.json mode == "strict") are immune to BC-2 and do
 // not need this matcher.
+//
+// Returns silently for nil or empty outputs; both are trivially structpb-
+// compatible. Detecting whether Outputs is populated at all (the writer-side
+// invariant) is BC-3's job — pair this matcher with
+// AssertDiffPopulatesAllOutputFields for full coverage.
 func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
 	t.Helper()
 	if outputs == nil {
@@ -211,6 +216,13 @@ func nextEnumID() ValidationKind {
 //
 //	iaclint.AssertValidationMatrix(t, parser, "expose",
 //	    iaclint.WithStringEnumOptions([]string{"public", "internal"}))
+//
+// Note on internal state: each call registers the allowed-values slice in a
+// package-level map keyed by a unique ValidationKind ID. Map entries are not
+// reclaimed after a test exits — practically harmless for `go test` (process
+// exits, OS reclaims memory). If iaclint is ever embedded in a long-running
+// review server, consider threading a *RegistryHandle through the matcher
+// signature instead (deferred to v2).
 func WithStringEnumOptions(allowed []string) ValidationKind {
 	id := nextEnumID()
 	enumOptionsMu.Lock()
@@ -226,6 +238,14 @@ func WithStringEnumOptions(allowed []string) ValidationKind {
 //
 // Plugins typically implement this as a sibling method that returns a static
 // slice of canonical key names — small surface, easy to keep in sync.
+//
+// WARNING: the returned slice is the source of truth for
+// AssertDiffPopulatesAllOutputFields — drift between this slice and the
+// actual Diff implementation makes the matcher silently vacuous (it'll
+// happily verify a stale, shrinking key set while real Diff reads grow
+// uncovered). Treat additions or removals to the Diff body and this slice
+// as paired commits, ideally enforced by code review per BC-3 in
+// docs/IAC_PLUGIN_REVIEW_CHECKLIST.md.
 type DiffOutputKeyDeclarer interface {
 	DiffReadsOutputKeys() []string
 }

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -53,7 +53,11 @@ type TB interface {
 type ValidationKind int
 
 const (
-	// KindTCPPort probes 0, -1, 1, 65535, 65536. Closes BC-4 port-range gap.
+	// KindTCPPort probes 0, -1, 1, 65535, 65536 in BOTH int and float64
+	// shapes. The float64 probes cover the gRPC-dispatch coercion path
+	// (structpb collapses every numeric to float64), so a single call to
+	// AssertValidationMatrix is sufficient for plugins on either dispatch
+	// path. Closes BC-4 port-range gap.
 	KindTCPPort ValidationKind = iota
 	// KindNonNegativeInt probes 0, -1, 1.
 	KindNonNegativeInt
@@ -138,12 +142,19 @@ func AssertValidationMatrix(t TB, parser ConfigParser, fieldName string, kind Va
 	t.Helper()
 	switch kind {
 	case KindTCPPort:
+		// Probe both int and float64 shapes — gRPC dispatch coerces every
+		// numeric to float64 via structpb, so parsers strict on int but lax
+		// on float64 ship green-CI yet fail in production. Covering both
+		// shapes in a single call closes that BC-4 gap.
 		runProbes(t, parser, fieldName, kind, []validationProbe{
-			{0, false, "zero"},
-			{-1, false, "negative"},
-			{1, true, "min valid"},
-			{65535, true, "max valid"},
-			{65536, false, "above max"},
+			{0, false, "zero (int)"},
+			{-1, false, "negative (int)"},
+			{1, true, "min valid (int)"},
+			{65535, true, "max valid (int)"},
+			{65536, false, "above max (int)"},
+			{float64(0), false, "zero (float64 — gRPC coercion)"},
+			{float64(65535), true, "max valid (float64 — gRPC coercion)"},
+			{float64(65536), false, "above max (float64 — gRPC coercion)"},
 		})
 	case KindIntegerOnlyFloat:
 		runProbes(t, parser, fieldName, kind, []validationProbe{

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -12,6 +12,7 @@ package iaclint
 
 import (
 	"math"
+	"sync"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -130,8 +131,97 @@ func AssertValidationMatrix(t TB, parser ConfigParser, fieldName string, kind Va
 			{math.NaN(), false, "NaN"},
 			{math.Inf(1), false, "Inf"},
 		})
+	case KindNonNegativeInt:
+		runProbes(t, parser, fieldName, kind, []validationProbe{
+			{-1, false, "negative"},
+			{0, true, "zero"},
+			{1, true, "positive"},
+		})
+	case KindNonEmptyString:
+		runProbes(t, parser, fieldName, kind, []validationProbe{
+			{"", false, "empty"},
+			{"   ", false, "whitespace"},
+			{"valid", true, "non-empty"},
+		})
 	default:
+		// StringEnum kinds (returned by WithStringEnumOptions) carry IDs >= 1000.
+		enumOptionsMu.Lock()
+		allowed, isEnum := enumOptions[kind]
+		enumOptionsMu.Unlock()
+		if isEnum {
+			runStringEnumProbes(t, parser, fieldName, allowed)
+			return
+		}
 		t.Fatalf("AssertValidationMatrix: unhandled kind %s", kind)
+	}
+}
+
+// stringEnum allowed-values registry. Each call to WithStringEnumOptions
+// reserves a fresh ValidationKind id (>= 1000) so callers can pass distinct
+// allowed sets without mutating the package-wide enum constants.
+var (
+	enumOptionsMu sync.Mutex
+	enumOptions   = map[ValidationKind][]string{}
+	nextEnumIDVal = ValidationKind(1000) // reserve [0..999] for static kinds
+)
+
+func nextEnumID() ValidationKind {
+	enumOptionsMu.Lock()
+	defer enumOptionsMu.Unlock()
+	id := nextEnumIDVal
+	nextEnumIDVal++
+	return id
+}
+
+// WithStringEnumOptions returns a StringEnum kind bound to the given allowed
+// values. Use this instead of the bare KindStringEnum constant when calling
+// AssertValidationMatrix:
+//
+//	iaclint.AssertValidationMatrix(t, parser, "expose",
+//	    iaclint.WithStringEnumOptions([]string{"public", "internal"}))
+func WithStringEnumOptions(allowed []string) ValidationKind {
+	id := nextEnumID()
+	enumOptionsMu.Lock()
+	enumOptions[id] = append([]string(nil), allowed...)
+	enumOptionsMu.Unlock()
+	return id
+}
+
+func runStringEnumProbes(t TB, parser ConfigParser, fieldName string, allowed []string) {
+	t.Helper()
+	type probe struct {
+		value        any
+		expectAccept bool
+		label        string
+	}
+	var probes []probe
+	for _, a := range allowed {
+		probes = append(probes, probe{a, true, "allowed " + a})
+	}
+	probes = append(probes,
+		probe{nil, true, "absent (no key)"},
+		probe{"definitely-not-a-real-value", false, "unknown string"},
+		probe{true, false, "non-string bool"},
+		probe{123, false, "non-string int"},
+		probe{[]string{}, false, "non-string slice"},
+	)
+	for _, p := range probes {
+		var cfg map[string]any
+		if p.label == "absent (no key)" {
+			cfg = map[string]any{} // genuinely absent — no key
+		} else {
+			cfg = map[string]any{fieldName: p.value}
+		}
+		_, err := parser(cfg)
+		got := err == nil
+		if got != p.expectAccept {
+			verb := "rejected"
+			if got {
+				verb = "accepted"
+			}
+			t.Errorf("StringEnum probe %q (value=%v): parser %s; expected %s — see BC-4 in IAC_PLUGIN_REVIEW_CHECKLIST.md",
+				p.label, p.value, verb, acceptStr(p.expectAccept))
+		}
 	}
 }
 

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -1,13 +1,32 @@
 // Package iaclint provides cross-provider review discipline as executable
-// test helpers for IaC plugin authors. The bug-class taxonomy and rationale
-// for each helper live in the project review checklist:
+// test helpers for IaC plugin authors.
+//
+// The bug-class taxonomy and rationale for each helper live in the project
+// review checklist:
 //
 //	docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+//
+// Three matchers are exposed:
+//
+//   - AssertOutputsRoundTripStructpb (BC-2): verifies Outputs map values
+//     survive structpb.NewStruct round-trip without breaking type assertions.
+//     Use for plugins on legacy compat dispatch.
+//
+//   - AssertDiffPopulatesAllOutputFields (BC-3): verifies every Outputs[*]
+//     key the driver's Diff reads is populated by the matching Create writer.
+//     Use for every ResourceDriver in the plugin.
+//
+//   - AssertValidationMatrix (BC-4): exercises edge values for a config-field
+//     parser (TCP port, integer-only float, non-empty string, string enum,
+//     non-negative int). Use for every field-level config validator.
 //
 // IaC plugins import this package in their test suites so the bug classes
 // surfaced during the workflow-plugin-digitalocean v0.8.0 review cycle are
 // caught at CI time rather than during production gRPC dispatch or in code
-// review.
+// review. Plugins on legacy compat dispatch (no internal/contracts/ proto
+// package, plugin.json mode != "strict") MUST call AssertOutputsRoundTripStructpb
+// for every Outputs map written by Create/Update/Read. Strict-mode plugins
+// (plugin.json mode == "strict") are immune to BC-2 and may skip that matcher.
 package iaclint
 
 import (

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -1,0 +1,46 @@
+// Package iaclint provides cross-provider review discipline as executable
+// test helpers for IaC plugin authors. The bug-class taxonomy and rationale
+// for each helper live in the project review checklist:
+//
+//	docs/IAC_PLUGIN_REVIEW_CHECKLIST.md
+//
+// IaC plugins import this package in their test suites so the bug classes
+// surfaced during the workflow-plugin-digitalocean v0.8.0 review cycle are
+// caught at CI time rather than during production gRPC dispatch or in code
+// review.
+package iaclint
+
+// ValidationKind enumerates the standard {field, value-class} probes used by
+// AssertValidationMatrix. Each kind exercises a battery of edge values that
+// match the bug-class definitions in the project review checklist.
+type ValidationKind int
+
+const (
+	// KindTCPPort probes 0, -1, 1, 65535, 65536. Closes BC-4 port-range gap.
+	KindTCPPort ValidationKind = iota
+	// KindNonNegativeInt probes 0, -1, 1.
+	KindNonNegativeInt
+	// KindNonEmptyString probes "", "  ", "valid".
+	KindNonEmptyString
+	// KindStringEnum probes each known value, "" (absent), random string, non-string Go types.
+	KindStringEnum
+	// KindIntegerOnlyFloat probes 1.0, 1.9, NaN, Inf. Closes BC-4 fractional-float gap.
+	KindIntegerOnlyFloat
+)
+
+// String returns the human-readable name of the kind, suitable for test output.
+func (k ValidationKind) String() string {
+	switch k {
+	case KindTCPPort:
+		return "TCPPort"
+	case KindNonNegativeInt:
+		return "NonNegativeInt"
+	case KindNonEmptyString:
+		return "NonEmptyString"
+	case KindStringEnum:
+		return "StringEnum"
+	case KindIntegerOnlyFloat:
+		return "IntegerOnlyFloat"
+	}
+	return "Unknown"
+}

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -10,6 +10,19 @@
 // review.
 package iaclint
 
+import (
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TB is the subset of testing.TB the iaclint matchers use. Accepting an
+// interface (rather than *testing.T) lets the matchers be unit-tested with a
+// mock that captures failures.
+type TB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
+
 // ValidationKind enumerates the standard {field, value-class} probes used by
 // AssertValidationMatrix. Each kind exercises a battery of edge values that
 // match the bug-class definitions in the project review checklist.
@@ -43,4 +56,35 @@ func (k ValidationKind) String() string {
 		return "IntegerOnlyFloat"
 	}
 	return "Unknown"
+}
+
+// AssertOutputsRoundTripStructpb verifies that every value in outputs survives
+// a structpb.NewStruct → AsMap() round-trip without breaking downstream type
+// assertions. Closes BC-2 (structpb gRPC boundary): typed slices ([]int,
+// []string, []godo.X) are rejected by structpb.NewStruct outright; godo
+// structs round-trip as map[string]any so reader-side type assertions to the
+// original struct type fail silently.
+//
+// Plugins on legacy compat dispatch (no internal/contracts/ proto package,
+// plugin.json mode != "strict") MUST call this matcher in their test suite for
+// every Outputs map written by Create/Update/Read, so the canonical-shape
+// invariant is enforced at CI time.
+//
+// Strict-mode plugins (plugin.json mode == "strict") are immune to BC-2 and do
+// not need this matcher.
+func AssertOutputsRoundTripStructpb(t TB, outputs map[string]any) {
+	t.Helper()
+	if outputs == nil {
+		return
+	}
+	if _, err := structpb.NewStruct(outputs); err != nil {
+		// Identify the offending key to give the test author a direct pointer.
+		for k, v := range outputs {
+			if _, single := structpb.NewStruct(map[string]any{k: v}); single != nil {
+				t.Fatalf("Outputs[%q] (%T) is not structpb-compatible: %v — see BC-2 in IAC_PLUGIN_REVIEW_CHECKLIST.md", k, v, single)
+				return
+			}
+		}
+		t.Fatalf("Outputs not structpb-compatible: %v", err)
+	}
 }

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -11,9 +11,10 @@
 //   - AssertOutputsStructpbCompatible (BC-2): verifies Outputs map values
 //     are structpb-compatible (NewStruct accepts them). Catches typed-slice
 //     writes that would degrade at the wfctl→plugin gRPC boundary. Does NOT
-//     exercise the full NewStruct → AsMap round-trip; see BC-3 for
-//     post-roundtrip type-assertion coverage. Use for plugins on legacy
-//     compat dispatch.
+//     exercise the full NewStruct → AsMap round-trip; if your plugin's Diff
+//     reads typed values from current.Outputs, write a post-roundtrip test
+//     in your plugin's test suite. Use for plugins on legacy compat
+//     dispatch.
 //
 //   - AssertDiffPopulatesAllOutputFields (BC-3): verifies every Outputs[*]
 //     key the driver's Diff reads is populated by the matching Create writer.
@@ -105,8 +106,10 @@ func (k ValidationKind) String() string {
 // round-trip. Values that NewStruct accepts but degrade structurally on
 // AsMap (e.g., godo structs becoming map[string]any so reader-side type
 // assertions to the original struct type fail silently) are not caught. If
-// your plugin's Diff reads typed values from current.Outputs, also test the
-// post-roundtrip path explicitly — see BC-3 in IAC_PLUGIN_REVIEW_CHECKLIST.md.
+// your plugin's Diff reads typed values from current.Outputs, also write
+// a post-roundtrip test in your plugin's test suite that builds an Outputs
+// map, round-trips through structpb.NewStruct/AsMap(), then asserts your
+// reader-side helpers still extract the values correctly.
 //
 // Plugins on legacy compat dispatch (no internal/contracts/ proto package,
 // plugin.json mode != "strict") MUST call this matcher in their test suite for

--- a/plugin/sdk/iaclint/iaclint.go
+++ b/plugin/sdk/iaclint/iaclint.go
@@ -265,25 +265,29 @@ func AssertDiffPopulatesAllOutputFields(t TB, driver interfaces.ResourceDriver, 
 
 func runStringEnumProbes(t TB, parser ConfigParser, fieldName string, allowed []string) {
 	t.Helper()
-	type probe struct {
-		value        any
-		expectAccept bool
-		label        string
+	// stringEnumProbe carries an explicit genuineAbsent flag so the loop
+	// dispatches on a bool rather than on label-string equality, which would
+	// be brittle to label edits.
+	type stringEnumProbe struct {
+		value         any
+		expectAccept  bool
+		label         string
+		genuineAbsent bool // when true, omit the field key from cfg entirely
 	}
-	var probes []probe
+	var probes []stringEnumProbe
 	for _, a := range allowed {
-		probes = append(probes, probe{a, true, "allowed " + a})
+		probes = append(probes, stringEnumProbe{value: a, expectAccept: true, label: "allowed " + a})
 	}
 	probes = append(probes,
-		probe{nil, true, "absent (no key)"},
-		probe{"definitely-not-a-real-value", false, "unknown string"},
-		probe{true, false, "non-string bool"},
-		probe{123, false, "non-string int"},
-		probe{[]string{}, false, "non-string slice"},
+		stringEnumProbe{value: nil, expectAccept: true, label: "absent (no key)", genuineAbsent: true},
+		stringEnumProbe{value: "definitely-not-a-real-value", expectAccept: false, label: "unknown string"},
+		stringEnumProbe{value: true, expectAccept: false, label: "non-string bool"},
+		stringEnumProbe{value: 123, expectAccept: false, label: "non-string int"},
+		stringEnumProbe{value: []string{}, expectAccept: false, label: "non-string slice"},
 	)
 	for _, p := range probes {
 		var cfg map[string]any
-		if p.label == "absent (no key)" {
+		if p.genuineAbsent {
 			cfg = map[string]any{} // genuinely absent — no key
 		} else {
 			cfg = map[string]any{fieldName: p.value}

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -64,30 +64,30 @@ func TestValidationKind_String(t *testing.T) {
 	}
 }
 
-func TestAssertOutputsRoundTripStructpb_RejectsTypedSlice(t *testing.T) {
+func TestAssertOutputsStructpbCompatible_RejectsTypedSlice(t *testing.T) {
 	// Typed slices ([]int, []string, []GoStruct) are rejected by structpb.
-	// AssertOutputsRoundTripStructpb must surface the rejection as a test failure.
+	// AssertOutputsStructpbCompatible must surface the rejection as a test failure.
 	tt := &mockT{}
-	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+	iaclint.AssertOutputsStructpbCompatible(tt, map[string]any{
 		"droplet_ids": []int{123, 456}, // BC-2: typed slice rejected by structpb
 	})
 	if !tt.failed {
-		t.Fatal("AssertOutputsRoundTripStructpb accepted typed []int slice; expected failure")
+		t.Fatal("AssertOutputsStructpbCompatible accepted typed []int slice; expected failure")
 	}
 	if !tt.hasMessageContaining("droplet_ids") {
 		t.Errorf("captured messages %q missing field name 'droplet_ids'", tt.messages)
 	}
 }
 
-// TestAssertOutputsRoundTripStructpb_DeterministicOffendingKey guards
+// TestAssertOutputsStructpbCompatible_DeterministicOffendingKey guards
 // against a flaky-test failure mode: when multiple Outputs keys are bad,
 // the matcher's offending-key search MUST report a deterministic key
 // (lexicographically first) rather than whatever Go's randomized map
 // iteration happens to surface first. Without sort, this test is flaky
 // across runs; with sort, it's stable.
-func TestAssertOutputsRoundTripStructpb_DeterministicOffendingKey(t *testing.T) {
+func TestAssertOutputsStructpbCompatible_DeterministicOffendingKey(t *testing.T) {
 	tt := &mockT{}
-	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+	iaclint.AssertOutputsStructpbCompatible(tt, map[string]any{
 		"z_bad": []int{1, 2, 3}, // lexicographically later — should NOT be reported
 		"a_bad": []int{4, 5, 6}, // lexicographically first — should be reported
 	})
@@ -99,16 +99,16 @@ func TestAssertOutputsRoundTripStructpb_DeterministicOffendingKey(t *testing.T) 
 	}
 }
 
-func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
+func TestAssertOutputsStructpbCompatible_AcceptsCanonicalShape(t *testing.T) {
 	tt := &mockT{}
-	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+	iaclint.AssertOutputsStructpbCompatible(tt, map[string]any{
 		"droplet_ids":   []any{float64(123), float64(456)},
 		"tags":          []any{"a", "b"},
 		"inbound_rules": []any{map[string]any{"protocol": "tcp"}},
 		"name":          "fw-1",
 	})
 	if tt.failed {
-		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.lastMessage())
+		t.Fatalf("AssertOutputsStructpbCompatible rejected canonical shape: %s", tt.lastMessage())
 	}
 }
 

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -1,10 +1,28 @@
 package iaclint_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
 )
+
+// mockT captures testing.TB calls without actually failing the outer test.
+type mockT struct {
+	failed   bool
+	fatalMsg string
+}
+
+func (m *mockT) Helper() {}
+func (m *mockT) Fatalf(format string, args ...any) {
+	m.failed = true
+	m.fatalMsg = fmt.Sprintf(format, args...)
+}
+func (m *mockT) Errorf(format string, args ...any) {
+	m.failed = true
+	m.fatalMsg = fmt.Sprintf(format, args...)
+}
 
 func TestValidationKind_String(t *testing.T) {
 	cases := map[iaclint.ValidationKind]string{
@@ -18,5 +36,33 @@ func TestValidationKind_String(t *testing.T) {
 		if got := kind.String(); got != want {
 			t.Errorf("kind %d: got %q, want %q", kind, got, want)
 		}
+	}
+}
+
+func TestAssertOutputsRoundTripStructpb_RejectsTypedSlice(t *testing.T) {
+	// Typed slices ([]int, []string, []GoStruct) are rejected by structpb.
+	// AssertOutputsRoundTripStructpb must surface the rejection as a test failure.
+	tt := &mockT{}
+	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+		"droplet_ids": []int{123, 456}, // BC-2: typed slice rejected by structpb
+	})
+	if !tt.failed {
+		t.Fatal("AssertOutputsRoundTripStructpb accepted typed []int slice; expected failure")
+	}
+	if !strings.Contains(tt.fatalMsg, "droplet_ids") {
+		t.Errorf("fatal msg %q missing field name 'droplet_ids'", tt.fatalMsg)
+	}
+}
+
+func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
+	tt := &mockT{}
+	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+		"droplet_ids":   []any{float64(123), float64(456)},
+		"tags":          []any{"a", "b"},
+		"inbound_rules": []any{map[string]any{"protocol": "tcp"}},
+		"name":          "fw-1",
+	})
+	if tt.failed {
+		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.fatalMsg)
 	}
 }

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -108,6 +108,33 @@ func TestAssertValidationMatrix_TCPPort_LooseParserFails(t *testing.T) {
 	}
 }
 
+// TestAssertValidationMatrix_TCPPort_FloatLooseParserFails exercises the
+// gRPC-coercion gap: a parser that's strict on int but silently accepts
+// float64 ships green-CI but fails in production gRPC dispatch (where the
+// structpb boundary collapses every numeric to float64). The TCPPort matrix
+// MUST probe both int and float64 shapes for a single call to be sufficient.
+func TestAssertValidationMatrix_TCPPort_FloatLooseParserFails(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		// Strict on int — passes all int probes.
+		if v, ok := cfg["port"].(int); ok {
+			if v < 1 || v > 65535 {
+				return nil, fmt.Errorf("port: %d invalid", v)
+			}
+			return v, nil
+		}
+		// Loose on float64 — accepts everything (BC-4 violation under gRPC coercion).
+		if f, ok := cfg["port"].(float64); ok {
+			return int(f), nil
+		}
+		return nil, fmt.Errorf("port: must be a number")
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
+	if !tt.failed {
+		t.Fatal("float-loose TCPPort parser passed matrix; expected failure on float64 probes (gRPC coercion path uncovered)")
+	}
+}
+
 func TestAssertValidationMatrix_IntegerOnlyFloat_StrictParserPasses(t *testing.T) {
 	parser := func(cfg map[string]any) (any, error) {
 		v, ok := cfg["id"].(float64)

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -11,19 +11,42 @@ import (
 )
 
 // mockT captures testing.TB calls without actually failing the outer test.
+// All messages are captured (not just the last) so tests can assert on a
+// specific probe's failure even when multiple probes fail in one matrix run.
 type mockT struct {
 	failed   bool
-	fatalMsg string
+	messages []string
 }
 
 func (m *mockT) Helper() {}
 func (m *mockT) Fatalf(format string, args ...any) {
 	m.failed = true
-	m.fatalMsg = fmt.Sprintf(format, args...)
+	m.messages = append(m.messages, fmt.Sprintf(format, args...))
 }
 func (m *mockT) Errorf(format string, args ...any) {
 	m.failed = true
-	m.fatalMsg = fmt.Sprintf(format, args...)
+	m.messages = append(m.messages, fmt.Sprintf(format, args...))
+}
+
+// lastMessage returns the most-recent captured message, or "" if none.
+// Convenience for tests that only care about the latest failure.
+func (m *mockT) lastMessage() string {
+	if len(m.messages) == 0 {
+		return ""
+	}
+	return m.messages[len(m.messages)-1]
+}
+
+// hasMessageContaining reports whether any captured message contains substr.
+// Use when multiple probes may fail and the test needs to assert a specific
+// probe's message was emitted.
+func (m *mockT) hasMessageContaining(substr string) bool {
+	for _, msg := range m.messages {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestValidationKind_String(t *testing.T) {
@@ -51,8 +74,8 @@ func TestAssertOutputsRoundTripStructpb_RejectsTypedSlice(t *testing.T) {
 	if !tt.failed {
 		t.Fatal("AssertOutputsRoundTripStructpb accepted typed []int slice; expected failure")
 	}
-	if !strings.Contains(tt.fatalMsg, "droplet_ids") {
-		t.Errorf("fatal msg %q missing field name 'droplet_ids'", tt.fatalMsg)
+	if !tt.hasMessageContaining("droplet_ids") {
+		t.Errorf("captured messages %q missing field name 'droplet_ids'", tt.messages)
 	}
 }
 
@@ -65,7 +88,7 @@ func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
 		"name":          "fw-1",
 	})
 	if tt.failed {
-		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.fatalMsg)
+		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.lastMessage())
 	}
 }
 
@@ -88,7 +111,7 @@ func TestAssertValidationMatrix_TCPPort_StrictParserPasses(t *testing.T) {
 	tt := &mockT{}
 	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
 	if tt.failed {
-		t.Fatalf("strict TCPPort parser failed matrix: %s", tt.fatalMsg)
+		t.Fatalf("strict TCPPort parser failed matrix: %s", tt.lastMessage())
 	}
 }
 
@@ -149,7 +172,7 @@ func TestAssertValidationMatrix_IntegerOnlyFloat_StrictParserPasses(t *testing.T
 	tt := &mockT{}
 	iaclint.AssertValidationMatrix(tt, parser, "id", iaclint.KindIntegerOnlyFloat)
 	if tt.failed {
-		t.Fatalf("strict IntegerOnlyFloat parser failed matrix: %s", tt.fatalMsg)
+		t.Fatalf("strict IntegerOnlyFloat parser failed matrix: %s", tt.lastMessage())
 	}
 }
 
@@ -164,7 +187,7 @@ func TestAssertValidationMatrix_NonNegativeInt_Strict(t *testing.T) {
 	tt := &mockT{}
 	iaclint.AssertValidationMatrix(tt, parser, "count", iaclint.KindNonNegativeInt)
 	if tt.failed {
-		t.Fatalf("strict NonNegativeInt parser failed matrix: %s", tt.fatalMsg)
+		t.Fatalf("strict NonNegativeInt parser failed matrix: %s", tt.lastMessage())
 	}
 }
 
@@ -179,7 +202,7 @@ func TestAssertValidationMatrix_NonEmptyString_Strict(t *testing.T) {
 	tt := &mockT{}
 	iaclint.AssertValidationMatrix(tt, parser, "name", iaclint.KindNonEmptyString)
 	if tt.failed {
-		t.Fatalf("strict NonEmptyString parser failed matrix: %s", tt.fatalMsg)
+		t.Fatalf("strict NonEmptyString parser failed matrix: %s", tt.lastMessage())
 	}
 }
 
@@ -208,7 +231,7 @@ func TestAssertValidationMatrix_StringEnum_Strict(t *testing.T) {
 	tt := &mockT{}
 	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
 	if tt.failed {
-		t.Fatalf("strict StringEnum parser failed matrix: %s", tt.fatalMsg)
+		t.Fatalf("strict StringEnum parser failed matrix: %s", tt.lastMessage())
 	}
 }
 
@@ -223,6 +246,54 @@ func TestAssertValidationMatrix_StringEnum_LooseFailsOnNonString(t *testing.T) {
 	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
 	if !tt.failed {
 		t.Fatal("loose StringEnum parser passed matrix; expected failure on non-string probe")
+	}
+	// Assert specifically that the non-string probes were the ones that
+	// triggered failures — guards against regressions where a different
+	// probe class (e.g., unknown-string) starts failing while non-string
+	// rejection silently regresses.
+	for _, label := range []string{"non-string bool", "non-string int", "non-string slice"} {
+		if !tt.hasMessageContaining(label) {
+			t.Errorf("expected failure message for probe %q; captured messages: %v", label, tt.messages)
+		}
+	}
+}
+
+func TestAssertValidationMatrix_IntegerOnlyFloat_LooseAcceptsFractional(t *testing.T) {
+	// A parser that silently truncates 1.9 → 1 should fail the matrix.
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["id"].(float64)
+		return int64(v), nil // BC-4 violation: silently truncates fractional values
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "id", iaclint.KindIntegerOnlyFloat)
+	if !tt.failed {
+		t.Fatal("loose IntegerOnlyFloat parser passed matrix; expected failure on 1.9 / NaN / Inf probes")
+	}
+}
+
+func TestAssertValidationMatrix_NonNegativeInt_LooseAcceptsNegative(t *testing.T) {
+	// A parser that doesn't range-check should fail the matrix on -1.
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["count"].(int)
+		return v, nil // BC-4 violation: accepts -1
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "count", iaclint.KindNonNegativeInt)
+	if !tt.failed {
+		t.Fatal("loose NonNegativeInt parser passed matrix; expected failure on -1 probe")
+	}
+}
+
+func TestAssertValidationMatrix_NonEmptyString_LooseAcceptsEmpty(t *testing.T) {
+	// A parser that doesn't trim/check should fail the matrix on "" and "   ".
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["name"].(string)
+		return v, nil // BC-4 violation: accepts empty / whitespace-only
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "name", iaclint.KindNonEmptyString)
+	if !tt.failed {
+		t.Fatal("loose NonEmptyString parser passed matrix; expected failure on empty / whitespace probes")
 	}
 }
 
@@ -282,7 +353,7 @@ func TestAssertDiffPopulatesAllOutputFields_OK(t *testing.T) {
 	iaclint.AssertDiffPopulatesAllOutputFields(tt, d,
 		interfaces.ResourceSpec{Name: "fake", Type: "fake.thing", Config: map[string]any{}})
 	if tt.failed {
-		t.Fatalf("driver with matching writer/reader keys failed assertion: %s", tt.fatalMsg)
+		t.Fatalf("driver with matching writer/reader keys failed assertion: %s", tt.lastMessage())
 	}
 }
 
@@ -298,7 +369,7 @@ func TestAssertDiffPopulatesAllOutputFields_MissingKey(t *testing.T) {
 	if !tt.failed {
 		t.Fatal("driver with missing writer key passed assertion; expected failure")
 	}
-	if !strings.Contains(tt.fatalMsg, "expose") {
-		t.Errorf("fatal msg missing key name 'expose': %q", tt.fatalMsg)
+	if !strings.Contains(tt.lastMessage(), "expose") {
+		t.Errorf("fatal msg missing key name 'expose': %q", tt.lastMessage())
 	}
 }

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -66,3 +66,60 @@ func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
 		t.Fatalf("AssertOutputsRoundTripStructpb rejected canonical shape: %s", tt.fatalMsg)
 	}
 }
+
+func TestAssertValidationMatrix_TCPPort_StrictParserPasses(t *testing.T) {
+	// A parser that rejects 0, negative, and >65535 should pass the TCPPort matrix.
+	parser := func(cfg map[string]any) (any, error) {
+		v, ok := cfg["port"].(int)
+		if !ok {
+			if f, fok := cfg["port"].(float64); fok && f == float64(int(f)) {
+				v = int(f)
+			} else {
+				return nil, fmt.Errorf("port: must be an integer")
+			}
+		}
+		if v < 1 || v > 65535 {
+			return nil, fmt.Errorf("port: %d invalid (must be 1..65535)", v)
+		}
+		return v, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
+	if tt.failed {
+		t.Fatalf("strict TCPPort parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_TCPPort_LooseParserFails(t *testing.T) {
+	// A parser that accepts 0 (loose) should fail the TCPPort matrix.
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["port"].(int)
+		if v < 0 || v > 65535 {
+			return nil, fmt.Errorf("port: %d invalid", v)
+		}
+		return v, nil // accepts 0 — BC-4 violation
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
+	if !tt.failed {
+		t.Fatal("loose TCPPort parser passed matrix; expected failure for value 0")
+	}
+}
+
+func TestAssertValidationMatrix_IntegerOnlyFloat_StrictParserPasses(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		v, ok := cfg["id"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("id: must be a number")
+		}
+		if v != float64(int64(v)) {
+			return nil, fmt.Errorf("id: %v is not an integer", v)
+		}
+		return int64(v), nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "id", iaclint.KindIntegerOnlyFloat)
+	if tt.failed {
+		t.Fatalf("strict IntegerOnlyFloat parser failed matrix: %s", tt.fatalMsg)
+	}
+}

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -1,0 +1,22 @@
+package iaclint_test
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
+)
+
+func TestValidationKind_String(t *testing.T) {
+	cases := map[iaclint.ValidationKind]string{
+		iaclint.KindTCPPort:          "TCPPort",
+		iaclint.KindNonNegativeInt:   "NonNegativeInt",
+		iaclint.KindNonEmptyString:   "NonEmptyString",
+		iaclint.KindStringEnum:       "StringEnum",
+		iaclint.KindIntegerOnlyFloat: "IntegerOnlyFloat",
+	}
+	for kind, want := range cases {
+		if got := kind.String(); got != want {
+			t.Errorf("kind %d: got %q, want %q", kind, got, want)
+		}
+	}
+}

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -258,6 +258,64 @@ func TestAssertValidationMatrix_StringEnum_LooseFailsOnNonString(t *testing.T) {
 	}
 }
 
+// TestAssertValidationMatrix_TCPPort_FloatBoundaryMisbehaviorCaught proves
+// that the float64 probe table covers the negative (-1) and min-valid (1)
+// boundary values claimed by the KindTCPPort docstring. The parser inverts
+// boundary handling (accepts float64(-1), rejects float64(1)) so the matrix
+// MUST flag both probes by name. Without those two probes in the table this
+// test would not see "negative (float64" or "min valid (float64" in the
+// captured failure messages.
+func TestAssertValidationMatrix_TCPPort_FloatBoundaryMisbehaviorCaught(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		// Strict on int — passes all int probes.
+		if v, ok := cfg["port"].(int); ok {
+			if v < 1 || v > 65535 {
+				return nil, fmt.Errorf("port: %d invalid", v)
+			}
+			return v, nil
+		}
+		// Inverted boundary on float64: accepts the values we expect to be
+		// rejected (-1, 0, 65536) and rejects the values we expect to be
+		// accepted (1, 65535) — exercises the full float64 boundary.
+		if f, ok := cfg["port"].(float64); ok {
+			if f == -1 || f == 0 || f == 65536 {
+				return int(f), nil // BUG: silently accepts
+			}
+			return nil, fmt.Errorf("port: %v invalid", f) // BUG: rejects 1, 65535
+		}
+		return nil, fmt.Errorf("port: must be a number")
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "port", iaclint.KindTCPPort)
+	if !tt.failed {
+		t.Fatal("expected matrix failure on inverted-boundary float64 parser")
+	}
+	if !tt.hasMessageContaining("negative (float64") {
+		t.Errorf("expected float64(-1) probe to be exercised; messages: %v", tt.messages)
+	}
+	if !tt.hasMessageContaining("min valid (float64") {
+		t.Errorf("expected float64(1) probe to be exercised; messages: %v", tt.messages)
+	}
+}
+
+// TestAssertValidationMatrix_StringEnum_BareKindFailsLoudly verifies that
+// passing the bare KindStringEnum constant (without WithStringEnumOptions)
+// surfaces a targeted error directing the caller to WithStringEnumOptions —
+// the bare exported constant looks usable but isn't, so the matcher must
+// fail loudly with actionable guidance rather than the generic "unhandled
+// kind" message.
+func TestAssertValidationMatrix_StringEnum_BareKindFailsLoudly(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) { return cfg["x"], nil }
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "x", iaclint.KindStringEnum)
+	if !tt.failed {
+		t.Fatal("expected loud failure for bare KindStringEnum constant")
+	}
+	if !tt.hasMessageContaining("WithStringEnumOptions") {
+		t.Errorf("expected fatal message to point caller to WithStringEnumOptions; messages: %v", tt.messages)
+	}
+}
+
 func TestAssertValidationMatrix_IntegerOnlyFloat_LooseAcceptsFractional(t *testing.T) {
 	// A parser that silently truncates 1.9 → 1 should fail the matrix.
 	parser := func(cfg map[string]any) (any, error) {

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -79,6 +79,26 @@ func TestAssertOutputsRoundTripStructpb_RejectsTypedSlice(t *testing.T) {
 	}
 }
 
+// TestAssertOutputsRoundTripStructpb_DeterministicOffendingKey guards
+// against a flaky-test failure mode: when multiple Outputs keys are bad,
+// the matcher's offending-key search MUST report a deterministic key
+// (lexicographically first) rather than whatever Go's randomized map
+// iteration happens to surface first. Without sort, this test is flaky
+// across runs; with sort, it's stable.
+func TestAssertOutputsRoundTripStructpb_DeterministicOffendingKey(t *testing.T) {
+	tt := &mockT{}
+	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{
+		"z_bad": []int{1, 2, 3}, // lexicographically later — should NOT be reported
+		"a_bad": []int{4, 5, 6}, // lexicographically first — should be reported
+	})
+	if !tt.failed {
+		t.Fatal("expected failure on multi-bad-key Outputs")
+	}
+	if !strings.Contains(tt.lastMessage(), "a_bad") {
+		t.Errorf("expected 'a_bad' (lex-first) in fatal msg; got %q", tt.lastMessage())
+	}
+}
+
 func TestAssertOutputsRoundTripStructpb_AcceptsCanonicalShape(t *testing.T) {
 	tt := &mockT{}
 	iaclint.AssertOutputsRoundTripStructpb(tt, map[string]any{

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -123,3 +123,76 @@ func TestAssertValidationMatrix_IntegerOnlyFloat_StrictParserPasses(t *testing.T
 		t.Fatalf("strict IntegerOnlyFloat parser failed matrix: %s", tt.fatalMsg)
 	}
 }
+
+func TestAssertValidationMatrix_NonNegativeInt_Strict(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["count"].(int)
+		if v < 0 {
+			return nil, fmt.Errorf("count: %d invalid", v)
+		}
+		return v, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "count", iaclint.KindNonNegativeInt)
+	if tt.failed {
+		t.Fatalf("strict NonNegativeInt parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_NonEmptyString_Strict(t *testing.T) {
+	parser := func(cfg map[string]any) (any, error) {
+		v, _ := cfg["name"].(string)
+		if strings.TrimSpace(v) == "" {
+			return nil, fmt.Errorf("name: must be non-empty")
+		}
+		return v, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "name", iaclint.KindNonEmptyString)
+	if tt.failed {
+		t.Fatalf("strict NonEmptyString parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_StringEnum_Strict(t *testing.T) {
+	allowed := []string{"public", "internal"}
+	parser := func(cfg map[string]any) (any, error) {
+		v, exists := cfg["expose"]
+		if !exists {
+			return "", nil // absent is fine
+		}
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("expose: must be a string, got %T", v)
+		}
+		s = strings.ToLower(strings.TrimSpace(s))
+		if s == "" {
+			return s, nil
+		}
+		for _, a := range allowed {
+			if s == a {
+				return s, nil
+			}
+		}
+		return nil, fmt.Errorf("expose: %q invalid; must be one of %v", s, allowed)
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
+	if tt.failed {
+		t.Fatalf("strict StringEnum parser failed matrix: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertValidationMatrix_StringEnum_LooseFailsOnNonString(t *testing.T) {
+	allowed := []string{"public", "internal"}
+	parser := func(cfg map[string]any) (any, error) {
+		// BC-4 violation: silently treats non-string as omitted.
+		s, _ := cfg["expose"].(string)
+		return s, nil
+	}
+	tt := &mockT{}
+	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
+	if !tt.failed {
+		t.Fatal("loose StringEnum parser passed matrix; expected failure on non-string probe")
+	}
+}

--- a/plugin/sdk/iaclint/iaclint_test.go
+++ b/plugin/sdk/iaclint/iaclint_test.go
@@ -1,10 +1,12 @@
 package iaclint_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/GoCodeAlone/workflow/plugin/sdk/iaclint"
 )
 
@@ -194,5 +196,82 @@ func TestAssertValidationMatrix_StringEnum_LooseFailsOnNonString(t *testing.T) {
 	iaclint.AssertValidationMatrix(tt, parser, "expose", iaclint.WithStringEnumOptions(allowed))
 	if !tt.failed {
 		t.Fatal("loose StringEnum parser passed matrix; expected failure on non-string probe")
+	}
+}
+
+// fakeDriver is a minimal interfaces.ResourceDriver impl used to exercise
+// AssertDiffPopulatesAllOutputFields. The contract: every key Diff reads from
+// current.Outputs MUST be populated by Create/Read/Update on the writer side.
+type fakeDriver struct {
+	createOutputs map[string]any
+	diffReadsKeys []string // keys this fake's Diff would read
+}
+
+func (f *fakeDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:    spec.Name,
+		Type:    spec.Type,
+		Outputs: f.createOutputs,
+		Status:  "running",
+	}, nil
+}
+
+func (f *fakeDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+
+func (f *fakeDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+
+func (f *fakeDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error { return nil }
+
+// Diff records that it read the expected keys but doesn't actually compare.
+func (f *fakeDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	for _, k := range f.diffReadsKeys {
+		_ = current.Outputs[k] // simulate reading the field
+	}
+	return &interfaces.DiffResult{NeedsUpdate: false}, nil
+}
+
+func (f *fakeDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return nil, nil
+}
+
+func (f *fakeDriver) Scale(ctx context.Context, ref interfaces.ResourceRef, replicas int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+
+func (f *fakeDriver) SensitiveKeys() []string { return nil }
+
+func (f *fakeDriver) DiffReadsOutputKeys() []string { return f.diffReadsKeys }
+
+func TestAssertDiffPopulatesAllOutputFields_OK(t *testing.T) {
+	d := &fakeDriver{
+		createOutputs: map[string]any{"image": "x:v1", "expose": "internal"},
+		diffReadsKeys: []string{"image", "expose"},
+	}
+	tt := &mockT{}
+	iaclint.AssertDiffPopulatesAllOutputFields(tt, d,
+		interfaces.ResourceSpec{Name: "fake", Type: "fake.thing", Config: map[string]any{}})
+	if tt.failed {
+		t.Fatalf("driver with matching writer/reader keys failed assertion: %s", tt.fatalMsg)
+	}
+}
+
+func TestAssertDiffPopulatesAllOutputFields_MissingKey(t *testing.T) {
+	// Writer doesn't populate "expose" but Diff reads it.
+	d := &fakeDriver{
+		createOutputs: map[string]any{"image": "x:v1"}, // no "expose"
+		diffReadsKeys: []string{"image", "expose"},
+	}
+	tt := &mockT{}
+	iaclint.AssertDiffPopulatesAllOutputFields(tt, d,
+		interfaces.ResourceSpec{Name: "fake", Type: "fake.thing", Config: map[string]any{}})
+	if !tt.failed {
+		t.Fatal("driver with missing writer key passed assertion; expected failure")
+	}
+	if !strings.Contains(tt.fatalMsg, "expose") {
+		t.Errorf("fatal msg missing key name 'expose': %q", tt.fatalMsg)
 	}
 }


### PR DESCRIPTION
## Summary

Phase A of the IaC plugin review discipline rollout. Captures the bug-class
taxonomy from the workflow-plugin-digitalocean v0.8.0 (P-2) review cycle as
cross-provider discipline that benefits every IaC provider plugin.

## Deliverables

- **D-1** [`docs/IAC_PLUGIN_REVIEW_CHECKLIST.md`](docs/IAC_PLUGIN_REVIEW_CHECKLIST.md) — markdown taxonomy of 8 bug classes (Plan/Diff cascade, structpb gRPC boundary, Outputs-vs-Diff invariant, validation matrix, plan-time vs apply-time docs, Diff-side vs Apply-side parity, CIDR widening, canonical-key registration). Each class documents failure mode, repro pattern, fix shape, test pattern, and concrete reviewer-scan steps. Linked from `CONTRIBUTING.md`.
- **D-2** [`plugin/sdk/iaclint/`](plugin/sdk/iaclint/) — Go test-helper package with three matchers IaC plugins import for CI enforcement:
  - `AssertOutputsRoundTripStructpb` (BC-2): verifies `Outputs` map values survive `structpb.NewStruct` round-trip without breaking type assertions. Required for plugins on legacy compat dispatch.
  - `AssertDiffPopulatesAllOutputFields` (BC-3): verifies every `Outputs[*]` key the driver's `Diff` reads is populated by the matching `Create` writer. Driver opts in via `DiffOutputKeyDeclarer.DiffReadsOutputKeys()`.
  - `AssertValidationMatrix` (BC-4): exercises edge values for a config-field parser. Five `ValidationKind`s ship: `KindTCPPort` (probes int + float64 to cover gRPC coercion), `KindIntegerOnlyFloat`, `KindNonNegativeInt`, `KindNonEmptyString`, plus dynamic `WithStringEnumOptions` for enum allow-lists.
  - 17 unit tests; strict + loose-parser inverse-fail coverage for every kind; race-clean.
- **D-3** [`docs/plans/2026-04-26-strict-grpc-plugin-contracts.md`](docs/plans/2026-04-26-strict-grpc-plugin-contracts.md) + companion design doc — extended with an IaC provider migration table (DO/AWS/Azure/GCP/Tofu/CI-generator rows added; v0.8.0 closures recorded for DO).
- **D-4** `~/.claude/skills/workflow-plugin-reviewer/SKILL.md` — workspace-local plugin-pattern-reviewer skill (not in this repo). Auto-detects provider pattern from `plugin.json` and dispatches to the matching checklist; v1 ships with the IaC pattern populated and dispatch slots reserved for auth/payment/agent/audit/module patterns as their checklists land.

## Design + Plan reference

- Design: [`docs/plans/2026-04-28-iac-plugin-review-design.md`](docs/plans/2026-04-28-iac-plugin-review-design.md)
- Implementation plan: [`docs/plans/2026-04-28-iac-plugin-review.md`](docs/plans/2026-04-28-iac-plugin-review.md)

Both committed in this branch.

## Review history

Round 1 verdict: REQUEST-CHANGES (2 Important regex false-negatives in checklist + 9 Minors in iaclint Go code). Round 2 closed all 2 Importants + 8 Minors (Findings 3-5, 7-9, 11) + 1 round-2 prose follow-up (Finding 12). Findings 6 (Example vacuous) and 10 (probe-driver dedup) accepted out-of-scope per code-reviewer's recommendation.

## Phase B / Phase C

After this lands, **Phase B** (P-1 BMW cleanup) auto-dispatches per the existing [`docs/plans/2026-04-27-iac-do-staging-implementation.md`](docs/plans/2026-04-27-iac-do-staging-implementation.md) plan. **Phase C** (retroactive plugin audit fix-forward across DO/AWS/GCP/Tofu) auto-chains after P-1.

## Test plan

- [x] `GOWORK=off go test -race ./plugin/sdk/iaclint/...` — 17 tests pass
- [x] `GOWORK=off go vet ./plugin/sdk/iaclint/...` — clean
- [x] `gofmt -d plugin/sdk/iaclint/` — clean
- [x] `docs/IAC_PLUGIN_REVIEW_CHECKLIST.md` contains all 8 BC sections
- [x] `CONTRIBUTING.md` links the checklist
- [x] Strict-contracts tracker references checklist + adds IaC plugin rows
- [x] D-4 skill file exists at `~/.claude/skills/workflow-plugin-reviewer/SKILL.md` (workspace-local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)