### PR TITLE
feat(wfctl): add R-A9 align rule for suspicious provider_credential key suffix

### DIFF
--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -132,6 +132,9 @@ func runInfraAlignChecks(opts alignOptions) ([]AlignFinding, error) {
 	// R-A8: WebAuthn alignment
 	findings = append(findings, checkRA8(ctx)...)
 
+	// R-A9: suspicious provider_credential key suffix
+	findings = append(findings, checkRA9(ctx)...)
+
 	return findings, nil
 }
 

--- a/cmd/wfctl/infra_align_rules.go
+++ b/cmd/wfctl/infra_align_rules.go
@@ -31,6 +31,7 @@ type alignContext struct {
 	ciBuilds          []config.ModuleConfig          // all ci.build modules
 	databases         []config.ModuleConfig          // all infra.database modules
 	secretKeys        map[string]struct{}            // union of secrets.generate/requires keys
+	secretGens        []SecretGen                    // secrets.generate entries from top-level secrets block
 }
 
 func buildAlignContext(cfgFile string) (*alignContext, error) {
@@ -42,6 +43,9 @@ func buildAlignContext(cfgFile string) (*alignContext, error) {
 		modules:           cfg.Modules,
 		containerServices: map[string]config.ModuleConfig{},
 		secretKeys:        map[string]struct{}{},
+	}
+	if cfg.Secrets != nil {
+		ctx.secretGens = cfg.Secrets.Generate
 	}
 	for _, m := range cfg.Modules {
 		switch {
@@ -669,6 +673,46 @@ func checkRA8(ctx *alignContext) []AlignFinding {
 				Resource: m.Name,
 				Message:  fmt.Sprintf("WEBAUTHN_RP_ID %q does not match WEBAUTHN_ORIGIN host %q", rpID, host),
 			})
+		}
+	}
+	return findings
+}
+
+// ── R-A9: suspicious provider_credential key suffix ────────────────────────
+
+// checkRA9 warns when a secrets.generate entry with type "provider_credential"
+// uses a key that already ends with a known sub-key suffix (e.g. "_access_key",
+// "_secret_key"). This pattern means the caller pre-appended the sub-key name
+// that bootstrapSecrets will append again, producing double-suffixed storage
+// keys such as SPACES_access_key_access_key. The canonical form is to use the
+// root key (e.g. "SPACES") and let bootstrapSecrets derive the sub-key names.
+//
+// The rule only fires for sources registered in providerCredentialSubKeys.
+// Unknown sources are skipped — we cannot predict their sub-key names.
+func checkRA9(ctx *alignContext) []AlignFinding {
+	var findings []AlignFinding
+	for _, gen := range ctx.secretGens {
+		if gen.Type != "provider_credential" {
+			continue
+		}
+		subs, known := subKeysForSource(gen.Source)
+		if !known {
+			continue
+		}
+		for _, sub := range subs {
+			suffix := "_" + sub
+			if strings.HasSuffix(gen.Key, suffix) {
+				findings = append(findings, AlignFinding{
+					Rule:     "R-A9",
+					Severity: "WARN",
+					Resource: gen.Key,
+					Message: fmt.Sprintf(
+						"provider_credential key %q ends with auto-generated suffix %q — use root key (e.g. %q) and let bootstrapSecrets derive sub-keys",
+						gen.Key, suffix, strings.TrimSuffix(gen.Key, suffix),
+					),
+				})
+				break // one finding per gen entry is enough
+			}
 		}
 	}
 	return findings

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -773,6 +773,127 @@ func TestInfraAlign_ExitCode_WarnStrict(t *testing.T) {
 	}
 }
 
+// ── R-A9: suspicious provider_credential key ──────────────────────────────────
+
+// TestCheckRA9_SuspiciousProviderCredentialKey is a table-driven unit test
+// for checkRA9. Each case provides secretGens directly to alignContext so the
+// rule logic is tested without file I/O.
+func TestCheckRA9_SuspiciousProviderCredentialKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		gens        []SecretGen
+		wantFinding bool
+		wantMsgSub  string // substring expected in finding.Message
+	}{
+		{
+			name:        "clean — key SPACES with digitalocean.spaces source",
+			gens:        []SecretGen{{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"}},
+			wantFinding: false,
+		},
+		{
+			name:        "suspicious — key ends with _access_key for digitalocean.spaces",
+			gens:        []SecretGen{{Key: "SPACES_access_key", Type: "provider_credential", Source: "digitalocean.spaces"}},
+			wantFinding: true,
+			wantMsgSub:  "_access_key",
+		},
+		{
+			name:        "suspicious — key ends with _secret_key",
+			gens:        []SecretGen{{Key: "MY_THING_secret_key", Type: "provider_credential", Source: "digitalocean.spaces"}},
+			wantFinding: true,
+			wantMsgSub:  "_secret_key",
+		},
+		{
+			name:        "not provider_credential — random_hex with _access_key suffix is fine",
+			gens:        []SecretGen{{Key: "FOO_access_key", Type: "random_hex", Length: 32}},
+			wantFinding: false,
+		},
+		{
+			name:        "unknown source — no rule applies until source is in providerCredentialSubKeys",
+			gens:        []SecretGen{{Key: "FOO_access_key", Type: "provider_credential", Source: "aws.s3"}},
+			wantFinding: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &alignContext{secretGens: tc.gens}
+			findings := checkRA9(ctx)
+			if tc.wantFinding && len(findings) == 0 {
+				t.Fatal("expected R-A9 finding, got none")
+			}
+			if !tc.wantFinding && len(findings) != 0 {
+				t.Fatalf("expected no findings, got: %+v", findings)
+			}
+			if tc.wantFinding && tc.wantMsgSub != "" && !strings.Contains(findings[0].Message, tc.wantMsgSub) {
+				t.Errorf("expected message to contain %q, got: %s", tc.wantMsgSub, findings[0].Message)
+			}
+			if tc.wantFinding && findings[0].Rule != "R-A9" {
+				t.Errorf("expected Rule=R-A9, got %q", findings[0].Rule)
+			}
+			if tc.wantFinding && findings[0].Severity != "WARN" {
+				t.Errorf("expected Severity=WARN, got %q", findings[0].Severity)
+			}
+		})
+	}
+}
+
+// TestInfraAlign_RA9_SuspiciousKey_Fires verifies R-A9 fires end-to-end
+// through runInfraAlignChecks with a YAML that uses the bad pattern.
+func TestInfraAlign_RA9_SuspiciousKey_Fires(t *testing.T) {
+	yaml := `
+secrets:
+  provider: github
+  config:
+    repo: example/test
+    token_env: GH_TOKEN
+  generate:
+    - key: SPACES_access_key
+      type: provider_credential
+      source: digitalocean.spaces
+      name: example-deploy-key
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !findingsHaveRuleAndSeverity(findings, "R-A9", "WARN") {
+		t.Errorf("expected R-A9 WARN, got: %v", findings)
+	}
+}
+
+// TestInfraAlign_RA9_CleanKey_DoesNotFire verifies the canonical SPACES key
+// (BMW/core-dump pattern) does not trigger R-A9.
+func TestInfraAlign_RA9_CleanKey_DoesNotFire(t *testing.T) {
+	yaml := `
+secrets:
+  provider: github
+  config:
+    repo: example/test
+    token_env: GH_TOKEN
+  generate:
+    - key: SPACES
+      type: provider_credential
+      source: digitalocean.spaces
+      name: example-deploy-key
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A9") {
+		t.Errorf("unexpected R-A9 finding for canonical key: %v", findings)
+	}
+}
+
 func TestInfraAlign_RenderMarkdown(t *testing.T) {
 	findings := []AlignFinding{
 		{Rule: "R-A6", Severity: "WARN", Resource: "nats-broker", Message: "internal service should use expose: internal"},

--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -252,6 +252,14 @@ var providerCredentialSubKeys = map[string][]string{
 	"digitalocean.spaces": {"access_key", "secret_key"},
 }
 
+// subKeysForSource returns the sub-key names for a given provider_credential
+// source (e.g. "digitalocean.spaces" → ["access_key", "secret_key"]).
+// Returns nil, false when the source is not registered.
+func subKeysForSource(source string) ([]string, bool) {
+	subs, ok := providerCredentialSubKeys[source]
+	return subs, ok
+}
+
 // generateSecret is the package-level hook used by bootstrapSecrets. Tests
 // override it to exercise provider_credential code paths without reaching
 // out to cloud APIs.


### PR DESCRIPTION
## Summary

- Adds R-A9 align rule to `wfctl infra align` that warns when a `secrets.generate` entry with `type: provider_credential` uses a key ending in an auto-generated sub-key suffix (e.g. `SPACES_access_key` instead of `SPACES`)
- This pattern causes double-suffixed storage keys at bootstrap time (`SPACES_access_key_access_key`) because `bootstrapSecrets` appends the sub-key suffix itself
- Canonical fix: use the root key (e.g. `SPACES`) and let bootstrap derive sub-keys automatically

## Changes

- `infra_bootstrap.go`: add `subKeysForSource()` getter exposing `providerCredentialSubKeys`
- `infra_align_rules.go`: add `secretGens []SecretGen` to `alignContext`, populate from `cfg.Secrets.Generate`, implement `checkRA9`
- `infra_align.go`: register R-A9 after R-A8 in `runInfraAlignChecks`
- `infra_align_test.go`: 8 new tests (5 unit table cases + 2 end-to-end integration + 1 clean-path)

## Regression Invariant Proof

With `checkRA9` registration removed from `runInfraAlignChecks`:
```
$ GOFLAGS=-mod=mod GOWORK=off go test ./cmd/wfctl/ -run TestInfraAlign_RA9_SuspiciousKey_Fires -v
--- FAIL: TestInfraAlign_RA9_SuspiciousKey_Fires (0.00s)
```

With fix restored:
```
$ GOFLAGS=-mod=mod GOWORK=off go test ./cmd/wfctl/ -run TestInfraAlign_RA9_SuspiciousKey_Fires -v
--- PASS: TestInfraAlign_RA9_SuspiciousKey_Fires (0.00s)
```

## Test plan

- [x] `GOFLAGS=-mod=mod GOWORK=off go test ./cmd/wfctl/ -run TestCheckRA9` — all 5 unit cases pass
- [x] `GOFLAGS=-mod=mod GOWORK=off go test ./cmd/wfctl/ -run TestInfraAlign_RA9` — both integration tests pass
- [x] Full `cmd/wfctl` suite green (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)