### PR TITLE
fix(wfctl): preserve ${VAR} literals in env_vars submaps through plan

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -77,6 +77,26 @@ Options:
 	return fmt.Errorf("missing or unknown action")
 }
 
+// infraPreserveKeys lists the submap keys whose contents should be left
+// as ${VAR} literals through plan serialization. Apply-time injection
+// (per the existing pattern in deploy_providers.go + driver Apply
+// methods) resolves them when the plugin actually creates/updates the
+// resource.
+//
+// Why these three keys:
+//   - env_vars: App Platform service env vars that downstream consumers
+//     reference in YAML as ${VAR}.
+//   - env_vars_secret: canonical secret-typed env vars per
+//     workflow-plugin-digitalocean's envVarsFromConfig.
+//   - secret_env_vars: legacy alias for env_vars_secret kept for
+//     backwards compat (same source).
+//
+// This preservation is the fix for core-dump#154 (R4 fired on
+// env_vars["NATS_AUTH_TOKEN"] because the secret had been eagerly
+// resolved into the plan output). See
+// docs/plans/2026-05-02-staging-deploy-blockers-design.md.
+var infraPreserveKeys = []string{"env_vars", "env_vars_secret", "secret_env_vars"}
+
 // resolveInfraConfig finds the config file from flags or defaults.
 // configFile is the resolved value from --config / -c flags (may be empty).
 func resolveInfraConfig(fs *flag.FlagSet, configFile ...string) (string, error) {
@@ -258,7 +278,7 @@ func parseInfraResourceSpecs(cfgFile string) ([]interfaces.ResourceSpec, error) 
 		if !isInfraType(m.Type) {
 			continue
 		}
-		r := &config.ResolvedModule{Name: m.Name, Type: m.Type, Config: config.ExpandEnvInMap(m.Config)}
+		r := &config.ResolvedModule{Name: m.Name, Type: m.Type, Config: config.ExpandEnvInMapPreservingKeys(m.Config, infraPreserveKeys)}
 		specs = append(specs, resourceSpecFromResolvedModule(r))
 	}
 	return specs, nil
@@ -304,7 +324,7 @@ func planResourcesForEnv(path, envName string) ([]*config.ResolvedModule, error)
 			continue
 		}
 		if envName == "" {
-			out = append(out, &config.ResolvedModule{Name: m.Name, Type: m.Type, Config: config.ExpandEnvInMap(m.Config)})
+			out = append(out, &config.ResolvedModule{Name: m.Name, Type: m.Type, Config: config.ExpandEnvInMapPreservingKeys(m.Config, infraPreserveKeys)})
 			continue
 		}
 		resolved, ok := m.ResolveForEnv(envName)
@@ -349,7 +369,10 @@ func planResourcesForEnv(path, envName string) ([]*config.ResolvedModule, error)
 		}
 		// Expand ${VAR} / $VAR references in the per-env resolved config so
 		// that plan output and apply pipeline both see substituted values.
-		resolved.Config = config.ExpandEnvInMap(resolved.Config)
+		// Use the preserving variant so that env_vars submaps retain their
+		// ${VAR} literals through plan serialization (apply-time injection
+		// resolves them when the plugin creates/updates the resource).
+		resolved.Config = config.ExpandEnvInMapPreservingKeys(resolved.Config, infraPreserveKeys)
 		out = append(out, resolved)
 	}
 	return out, nil
@@ -832,9 +855,9 @@ func resolveProviderForSpec(cfgFile, envName string, spec interfaces.ResourceSpe
 			if !ok {
 				return "", nil, fmt.Errorf("infra module %q references provider %q which is disabled for environment %q", spec.Name, moduleRef, envName)
 			}
-			modCfg = config.ExpandEnvInMap(resolved.Config)
+			modCfg = config.ExpandEnvInMapPreservingKeys(resolved.Config, infraPreserveKeys)
 		} else {
-			modCfg = config.ExpandEnvInMap(m.Config)
+			modCfg = config.ExpandEnvInMapPreservingKeys(m.Config, infraPreserveKeys)
 		}
 		providerType, _ := modCfg["provider"].(string)
 		if providerType == "" {

--- a/cmd/wfctl/infra_plan_env_vars_preserve_test.go
+++ b/cmd/wfctl/infra_plan_env_vars_preserve_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseInfraResourceSpecs_PreservesEnvVarRefs(t *testing.T) {
+	t.Setenv("DIGITALOCEAN_TOKEN", "actual-do-token")
+	t.Setenv("IMAGE_REF", "registry.example.com/api:abc123")
+	t.Setenv("AUTH_TOKEN", "would-be-resolved-secret")
+	t.Setenv("DATABASE_URL", "postgres://would-be-resolved")
+
+	specs, err := parseInfraResourceSpecs("testdata/infra-with-env-var-refs.yaml")
+	if err != nil {
+		t.Fatalf("parseInfraResourceSpecs: %v", err)
+	}
+
+	// Find the example-app spec (do-provider is iac.provider, not infra.*, so it's excluded).
+	var appCfg map[string]any
+	for _, s := range specs {
+		if s.Name == "example-app" {
+			appCfg = s.Config
+			break
+		}
+	}
+	if appCfg == nil {
+		t.Fatal("example-app spec not found in parsed specs")
+	}
+
+	// services is a slice of service maps.
+	servicesRaw, ok := appCfg["services"]
+	if !ok {
+		t.Fatal("example-app config missing 'services' key")
+	}
+	services, ok := servicesRaw.([]any)
+	if !ok {
+		t.Fatalf("services: expected []any, got %T", servicesRaw)
+	}
+	if len(services) == 0 {
+		t.Fatal("services slice is empty")
+	}
+	api, ok := services[0].(map[string]any)
+	if !ok {
+		t.Fatalf("services[0]: expected map[string]any, got %T", services[0])
+	}
+
+	// Top-level image IS resolved (not in preserve list).
+	if got := api["image"]; got != "registry.example.com/api:abc123" {
+		t.Errorf("api.image: got %q, want resolved literal registry.example.com/api:abc123", got)
+	}
+
+	// env_vars contents are PRESERVED as ${VAR} literals.
+	envVarsRaw, ok := api["env_vars"]
+	if !ok {
+		t.Fatal("api config missing 'env_vars' key")
+	}
+	envVars, ok := envVarsRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("env_vars: expected map[string]any, got %T", envVarsRaw)
+	}
+	if got := envVars["AUTH_TOKEN"]; got != "${AUTH_TOKEN}" {
+		t.Errorf("env_vars.AUTH_TOKEN: got %q, want literal ${AUTH_TOKEN} (should NOT have been resolved)", got)
+	}
+	if got := envVars["DEPLOY_ENV"]; got != "staging" {
+		t.Errorf("env_vars.DEPLOY_ENV: got %q, want literal staging", got)
+	}
+
+	// env_vars_secret contents are PRESERVED as ${VAR} literals.
+	envSecretRaw, ok := api["env_vars_secret"]
+	if !ok {
+		t.Fatal("api config missing 'env_vars_secret' key")
+	}
+	envSecret, ok := envSecretRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("env_vars_secret: expected map[string]any, got %T", envSecretRaw)
+	}
+	if got := envSecret["DB_URL"]; got != "${DATABASE_URL}" {
+		t.Errorf("env_vars_secret.DB_URL: got %q, want literal ${DATABASE_URL} (should NOT have been resolved)", got)
+	}
+}
+
+// TestPlanEnvVarPreserveTestdataExists ensures the fixture file exists and
+// has the env_vars_secret block required for the preservation test.
+func TestPlanEnvVarPreserveTestdataExists(t *testing.T) {
+	p := filepath.Join("testdata", "infra-with-env-var-refs.yaml")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("testdata fixture missing: %v", err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+	if !strings.Contains(string(b), "env_vars_secret") {
+		t.Errorf("fixture missing env_vars_secret block — needed for preservation test")
+	}
+}

--- a/cmd/wfctl/testdata/infra-with-env-var-refs.yaml
+++ b/cmd/wfctl/testdata/infra-with-env-var-refs.yaml
@@ -1,0 +1,17 @@
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+  - name: example-app
+    type: infra.container_service
+    config:
+      services:
+        - name: api
+          image: "${IMAGE_REF}"
+          env_vars:
+            DEPLOY_ENV: staging
+            AUTH_TOKEN: "${AUTH_TOKEN}"
+          env_vars_secret:
+            DB_URL: "${DATABASE_URL}"

--- a/config/env_expand.go
+++ b/config/env_expand.go
@@ -42,3 +42,83 @@ func ExpandEnvInValue(v any) any {
 		return v
 	}
 }
+
+// ExpandEnvInMapPreservingKeys is like ExpandEnvInMap but when a key in
+// preserveKeys is encountered, the corresponding value (and any nested
+// content inside it) is left untouched — ${VAR} / $VAR references are
+// preserved literally instead of being substituted from the process env.
+//
+// Use case: plan-time serialization of resource specs where certain
+// submaps (env_vars, env_vars_secret, secret_env_vars) carry secret
+// references that should resolve only at apply time. Without this,
+// security-check rules see resolved literals and incorrectly flag them
+// as accidentally-pasted secret values.
+//
+// preserveKeys is matched case-sensitively against the immediate map key
+// at every depth. An empty or nil preserveKeys list makes this function
+// behave identically to ExpandEnvInMap.
+func ExpandEnvInMapPreservingKeys(m map[string]any, preserveKeys []string) map[string]any {
+	if m == nil {
+		return nil
+	}
+	preserve := make(map[string]struct{}, len(preserveKeys))
+	for _, k := range preserveKeys {
+		preserve[k] = struct{}{}
+	}
+	return expandEnvInMapWithPreserve(m, preserve)
+}
+
+func expandEnvInMapWithPreserve(m map[string]any, preserve map[string]struct{}) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if _, isPreserved := preserve[k]; isPreserved {
+			// Copy the value verbatim. For maps/slices, deep-copy so callers
+			// can mutate without aliasing back into the source. Strings and
+			// scalars are immutable; pass through.
+			out[k] = deepCopyValue(v)
+			continue
+		}
+		out[k] = expandEnvInValueWithPreserve(v, preserve)
+	}
+	return out
+}
+
+func expandEnvInValueWithPreserve(v any, preserve map[string]struct{}) any {
+	switch val := v.(type) {
+	case string:
+		return os.ExpandEnv(val)
+	case map[string]any:
+		return expandEnvInMapWithPreserve(val, preserve)
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = expandEnvInValueWithPreserve(item, preserve)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// deepCopyValue copies a value preserving its structure. Maps and slices
+// are recursively copied; scalars (string, int, bool, nil) are returned
+// as-is. Used by ExpandEnvInMapPreservingKeys to insulate preserved
+// subtrees from caller mutation.
+func deepCopyValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, vv := range val {
+			out[k] = deepCopyValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = deepCopyValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/config/env_expand_test.go
+++ b/config/env_expand_test.go
@@ -193,3 +193,56 @@ func TestExpandEnvInValue(t *testing.T) {
 		}
 	})
 }
+
+func TestExpandEnvInMapPreservingKeys_PreservesEnvVarsSubmap(t *testing.T) {
+	t.Setenv("MY_TOKEN", "actual-secret-value")
+	t.Setenv("OTHER", "resolved-other")
+	in := map[string]any{
+		"name":   "myapp",
+		"region": "${OTHER}", // top-level: should resolve
+		"env_vars": map[string]any{
+			"AUTH_TOKEN": "${MY_TOKEN}", // inside env_vars: should PRESERVE literal
+			"PORT":       "8080",        // no var ref, preserved as-is
+		},
+		"env_vars_secret": map[string]any{
+			"DB_URL": "${OTHER}", // inside env_vars_secret: PRESERVE
+		},
+	}
+	out := ExpandEnvInMapPreservingKeys(in, []string{"env_vars", "env_vars_secret", "secret_env_vars"})
+	if got := out["region"]; got != "resolved-other" {
+		t.Errorf("top-level region: got %q, want resolved-other", got)
+	}
+	envVars := out["env_vars"].(map[string]any)
+	if got := envVars["AUTH_TOKEN"]; got != "${MY_TOKEN}" {
+		t.Errorf("env_vars.AUTH_TOKEN: got %q, want literal ${MY_TOKEN}", got)
+	}
+	envVarsSecret := out["env_vars_secret"].(map[string]any)
+	if got := envVarsSecret["DB_URL"]; got != "${OTHER}" {
+		t.Errorf("env_vars_secret.DB_URL: got %q, want literal ${OTHER}", got)
+	}
+}
+
+func TestExpandEnvInMapPreservingKeys_NestedNonPreservedSubmapsStillResolve(t *testing.T) {
+	t.Setenv("DEEP", "deep-value")
+	in := map[string]any{
+		"services": map[string]any{
+			"api": map[string]any{
+				"image": "${DEEP}", // not in preserve list: should resolve
+			},
+		},
+	}
+	out := ExpandEnvInMapPreservingKeys(in, []string{"env_vars"})
+	got := out["services"].(map[string]any)["api"].(map[string]any)["image"]
+	if got != "deep-value" {
+		t.Errorf("services.api.image: got %q, want deep-value", got)
+	}
+}
+
+func TestExpandEnvInMapPreservingKeys_EmptyPreserveListEqualsExpandEnvInMap(t *testing.T) {
+	t.Setenv("V", "vv")
+	in := map[string]any{"k": "${V}"}
+	out := ExpandEnvInMapPreservingKeys(in, []string{})
+	if out["k"] != "vv" {
+		t.Errorf("with empty preserve list, behavior should equal ExpandEnvInMap; got %q", out["k"])
+	}
+}


### PR DESCRIPTION
## Summary

Solution A for [core-dump#154](https://github.com/GoCodeAlone/core-dump/issues/154): security-check R4 was firing on `env_vars["NATS_AUTH_TOKEN"]` because parse-time env-var expansion substituted `${NATS_AUTH_TOKEN}` → resolved 64-char hex token into the plan output before R4's `${`-skip could fire.

This PR adds a preserve-keys variant to `ExpandEnvInMap` and switches the five `cmd/wfctl/infra.go` call sites to it with `["env_vars", "env_vars_secret", "secret_env_vars"]`. Apply-time injection already exists for these fields; this just defers the resolution to where it belongs.

Reference: `docs/plans/2026-05-02-staging-deploy-blockers-design.md` (workflow repo).

## Changes

- `config/env_expand.go`: add `ExpandEnvInMapPreservingKeys(m, preserveKeys)` + helpers `expandEnvInMapWithPreserve`, `expandEnvInValueWithPreserve`, `deepCopyValue`.
- `cmd/wfctl/infra.go`: switch 5 call sites; introduce `infraPreserveKeys` package var.
- `config/env_expand_test.go`: 3 new unit cases.
- `cmd/wfctl/infra_plan_env_vars_preserve_test.go` + fixture: integration test against parse path.

## Test plan

- [x] `go test ./config/...` green
- [x] `go test ./cmd/wfctl/...` green
- [ ] CI green (note: workflow#516 lint drift may fail; pre-existing)
- [ ] After merge + release: re-run core-dump deploy; security-check passes for env_vars-with-secret-references

## Backwards compatibility

`ExpandEnvInMap` unchanged (still public). `ExpandEnvInMapPreservingKeys` is additive. Plan serialization changes shape only for env_vars/env_vars_secret/secret_env_vars submaps; other plan content unchanged. Existing apply-side consumers already handle `${VAR}` in these fields via the existing ExpandEnvInMap call at apply time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)