### PR TITLE
feat(iac): wfctl infra refresh-outputs + cheap apply-time refresh (W-2 of 12)

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -39,6 +39,8 @@ func runInfra(args []string) error {
 		return runInfraBootstrap(args[1:])
 	case "outputs":
 		return runInfraOutputs(args[1:])
+	case "refresh-outputs":
+		return runInfraRefreshOutputs(args[1:])
 	case "align":
 		return runInfraAlign(args[1:])
 	case "security-check":
@@ -62,6 +64,7 @@ Actions:
   import         Import an existing cloud resource into state
   state          Manage IaC state (list, export, import)
   outputs        Print captured resource outputs from state
+  refresh-outputs Read live outputs and reconcile state (no cloud writes)
   align          Validate IaC config + plan alignment (8 rule families)
   security-check Scan plan.json for security policy violations
 

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -968,6 +968,8 @@ func runInfraApply(args []string) error {
 	fs.BoolVar(&refreshFlag, "refresh", false, "Detect drift and prune ghost-in-state entries before applying")
 	var allowProtectedPruneFlag bool
 	fs.BoolVar(&allowProtectedPruneFlag, "allow-protected-prune", false, "Allow pruning state entries for resources marked protected: true (requires --refresh)")
+	var skipRefreshFlag bool
+	fs.BoolVar(&skipRefreshFlag, "skip-refresh", false, "Skip the WFCTL_REFRESH_OUTPUTS pre-step refresh even if the env var is set")
 	autoApprove := &autoApproveVal
 	showSensitive := showSensitiveVal
 	if err := fs.Parse(args); err != nil {
@@ -1067,6 +1069,18 @@ func runInfraApply(args []string) error {
 			if refreshErr != nil {
 				return fmt.Errorf("refresh phase: %w", refreshErr)
 			}
+		}
+	}
+
+	// WFCTL_REFRESH_OUTPUTS pre-step (T2.3): when opted in, read live
+	// Outputs from each provider and persist any field-level changes
+	// before computing the plan, so apply doesn't make decisions on
+	// stale state. Default off; --skip-refresh always wins. Only
+	// applicable for infra.* configs (legacy platform.* path doesn't
+	// flow through iac/refreshoutputs).
+	if applyPreStepRefreshEnabled(skipRefreshFlag) && hasInfraModules(cfgFile) {
+		if err := applyPreStepRefreshOutputs(ctx, cfgFile, envName, os.Stdout); err != nil {
+			return fmt.Errorf("apply pre-step refresh-outputs: %w", err)
 		}
 	}
 

--- a/cmd/wfctl/infra_apply_refresh_pre.go
+++ b/cmd/wfctl/infra_apply_refresh_pre.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+// applyPreStepRefreshOutputsEnvVar is the environment variable that opts in
+// to running iac/refreshoutputs.Refresh as a pre-step before apply computes
+// its plan. The default is OFF so apply behaves identically to pre-W-2 for
+// every operator who doesn't set it.
+//
+// The value is parsed with strconv.ParseBool: "1", "t", "T", "TRUE",
+// "true", "True" enable; "0", "f", "F", "FALSE", "false", "False" disable;
+// unset, empty, or unrecognised values disable. Operators who use the
+// "0" / "false" convention to turn features off therefore get the
+// expected behaviour rather than the off-by-one foot-gun a presence-only
+// toggle would produce.
+const applyPreStepRefreshOutputsEnvVar = "WFCTL_REFRESH_OUTPUTS"
+
+// applyPreStepRefreshOutputs runs the read-only output refresh against
+// every iac.provider declared in cfgFile and persists any state entries
+// whose Outputs changed. It is the apply-time counterpart to wfctl infra
+// refresh-outputs (T2.2): same helpers, same error semantics. On any Read
+// or driver-resolution failure, it returns the wrapped error so apply
+// aborts before computing a plan against stale outputs.
+//
+// This function exists as its own file so reverting commit
+// "feat(iac): apply-time refresh-outputs pre-step ..." removes the entire
+// code path in one operation. The caller in runInfraApply gates this on
+// three conditions, all of which must be true for the pre-step to fire:
+//
+//   - applyPreStepRefreshEnabled returns true (WFCTL_REFRESH_OUTPUTS
+//     parses to true and --skip-refresh was not passed).
+//   - hasInfraModules(cfgFile) is true (legacy platform.* configs are
+//     skipped — they don't flow through iac/refreshoutputs).
+//
+// The helper itself is purely additive on top of those gates: it never
+// short-circuits on values it would otherwise accept, so a caller that
+// has already decided to refresh can rely on the helper to do exactly
+// that.
+func applyPreStepRefreshOutputs(ctx context.Context, cfgFile, envName string, stdout io.Writer) error {
+	providerDefs, err := discoverIaCProvidersForRefresh(cfgFile, envName)
+	if err != nil {
+		return err
+	}
+	if len(providerDefs) == 0 {
+		// No provider for this env — log and return nil rather than
+		// aborting apply: the downstream applyInfraModules call will
+		// produce a more actionable error if a provider was actually
+		// expected. The log line makes the no-op visible to operators
+		// who explicitly opted in.
+		fmt.Fprintln(stdout, "Refresh pre-step: no iac.provider modules in config; skipping.")
+		return nil
+	}
+
+	states, err := loadCurrentState(cfgFile, envName)
+	if err != nil {
+		return fmt.Errorf("load current state: %w", err)
+	}
+	if len(states) == 0 {
+		return nil
+	}
+
+	store, err := resolveStateStore(cfgFile, envName)
+	if err != nil {
+		return fmt.Errorf("open state store: %w", err)
+	}
+
+	fmt.Fprintln(stdout, "Refreshing outputs from cloud (read-only)...")
+	return refreshOutputsAcrossProviders(ctx, providerDefs, states, store, 0 /* default concurrency */, stdout)
+}
+
+// applyPreStepRefreshEnabled reports whether the opt-in env var parses
+// to true AND --skip-refresh was not passed. The flag always wins so
+// operators can disable the pre-step in environments where the env var
+// is forced on globally (e.g. CI that exports it for every job).
+//
+// Empty/unset and unrecognised values both disable: the env var is
+// strictly opt-in, never opt-out. "0" / "false" therefore disable
+// rather than (mis-)enabling, which is the convention every operator
+// expects.
+func applyPreStepRefreshEnabled(skipRefreshFlag bool) bool {
+	if skipRefreshFlag {
+		return false
+	}
+	v := os.Getenv(applyPreStepRefreshOutputsEnvVar)
+	if v == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return enabled
+}

--- a/cmd/wfctl/infra_apply_refresh_pre_test.go
+++ b/cmd/wfctl/infra_apply_refresh_pre_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// writeApplyPreRefreshConfig writes an infra YAML at <dir>/infra.yaml with
+// auto_bootstrap disabled (so the apply path doesn't try to run bootstrap),
+// a filesystem state backend pointed at <dir>/state, a single iac.provider
+// module, and one infra.vpc resource keyed to it. Returned path is the
+// absolute config path.
+func writeApplyPreRefreshConfig(t *testing.T, dir string) string {
+	t.Helper()
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	cfg := `infra:
+  auto_bootstrap: false
+modules:
+  - name: cloud-provider
+    type: iac.provider
+    config:
+      provider: fake-provider
+  - name: state-store
+    type: iac.state
+    config:
+      backend: filesystem
+      directory: ` + stateDir + `
+  - name: coredump-staging-vpc
+    type: infra.vpc
+    config:
+      provider: cloud-provider
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath
+}
+
+// seedStaleVPCState writes a single VPC ResourceState to the configured
+// filesystem state backend with no "id" output, ready for refresh to add it.
+func seedStaleVPCState(t *testing.T, cfgPath string) {
+	t.Helper()
+	store, err := resolveStateStore(cfgPath, "")
+	if err != nil {
+		t.Fatalf("resolveStateStore: %v", err)
+	}
+	stale := interfaces.ResourceState{
+		ID:          "coredump-staging-vpc",
+		Name:        "coredump-staging-vpc",
+		Type:        "infra.vpc",
+		Provider:    "fake-provider",
+		ProviderRef: "cloud-provider",
+		ProviderID:  "uuid-1",
+		Outputs:     map[string]any{"ip_range": "10.0.0.0/16"},
+	}
+	if err := store.SaveResource(context.Background(), stale); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+}
+
+// loadVPCStateOutputs returns the Outputs map for coredump-staging-vpc as
+// persisted on disk after the apply call returns.
+func loadVPCStateOutputs(t *testing.T, cfgPath string) map[string]any {
+	t.Helper()
+	states, err := loadCurrentState(cfgPath, "")
+	if err != nil {
+		t.Fatalf("loadCurrentState: %v", err)
+	}
+	for _, s := range states {
+		if s.Name == "coredump-staging-vpc" {
+			return s.Outputs
+		}
+	}
+	t.Fatalf("coredump-staging-vpc not in state after apply; got %d entries", len(states))
+	return nil
+}
+
+// installFakeRefreshProvider swaps the global resolveIaCProvider for the
+// duration of the test with a stub that handles both Read (via the embedded
+// driver) and Apply (returning an empty ApplyResult so the apply path is a
+// no-op). Returns the cleanup function.
+func installFakeRefreshProvider(t *testing.T, liveOutputs map[string]map[string]any) func() {
+	t.Helper()
+	orig := resolveIaCProvider
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+		return &refreshOutputsCmdFakeProvider{readOutputs: liveOutputs}, nil, nil
+	}
+	return func() { resolveIaCProvider = orig }
+}
+
+// TestApply_PreStepRefresh_OptInViaEnvVar verifies that setting
+// WFCTL_REFRESH_OUTPUTS=1 causes runInfraApply to read live Outputs for
+// every state entry and persist new fields BEFORE the plan+apply phase.
+// The end-to-end signal is the "id" field present in state on disk after
+// apply returns.
+func TestApply_PreStepRefresh_OptInViaEnvVar(t *testing.T) {
+	t.Setenv("WFCTL_REFRESH_OUTPUTS", "1")
+	dir := t.TempDir()
+	cfgPath := writeApplyPreRefreshConfig(t, dir)
+	seedStaleVPCState(t, cfgPath)
+
+	cleanup := installFakeRefreshProvider(t, map[string]map[string]any{
+		"uuid-1": {"ip_range": "10.0.0.0/16", "id": "uuid-1"},
+	})
+	defer cleanup()
+
+	if _, err := captureStdout(t, func() error {
+		return runInfraApply([]string{"--auto-approve", "-c", cfgPath})
+	}); err != nil {
+		t.Fatalf("runInfraApply: %v", err)
+	}
+
+	got := loadVPCStateOutputs(t, cfgPath)
+	if id, _ := got["id"].(string); id != "uuid-1" {
+		t.Errorf("apply pre-refresh should populate 'id'; got %v", got)
+	}
+}
+
+// TestApply_PreStepRefresh_DisabledByDefault verifies the opt-in semantics:
+// without WFCTL_REFRESH_OUTPUTS set, the pre-step is skipped and stale
+// state remains stale.
+func TestApply_PreStepRefresh_DisabledByDefault(t *testing.T) {
+	// Clear any inherited value to make the test resilient under -count=N.
+	t.Setenv("WFCTL_REFRESH_OUTPUTS", "")
+	os.Unsetenv("WFCTL_REFRESH_OUTPUTS")
+	dir := t.TempDir()
+	cfgPath := writeApplyPreRefreshConfig(t, dir)
+	seedStaleVPCState(t, cfgPath)
+
+	cleanup := installFakeRefreshProvider(t, map[string]map[string]any{
+		"uuid-1": {"ip_range": "10.0.0.0/16", "id": "uuid-1"},
+	})
+	defer cleanup()
+
+	if _, err := captureStdout(t, func() error {
+		return runInfraApply([]string{"--auto-approve", "-c", cfgPath})
+	}); err != nil {
+		t.Fatalf("runInfraApply: %v", err)
+	}
+
+	got := loadVPCStateOutputs(t, cfgPath)
+	if _, ok := got["id"]; ok {
+		t.Errorf("default-off pre-refresh should not populate 'id'; got %v", got)
+	}
+}
+
+// TestApply_PreStepRefresh_EnvVarFalseyValueDisables pins the
+// strconv.ParseBool semantic: "0" / "false" / "off" don't enable the
+// pre-step. Operators routinely set env vars to "0" to disable a
+// feature; without ParseBool that would be a foot-gun (any non-empty
+// value enables, including "0"). One representative falsey value is
+// enough — strconv.ParseBool's accept set is well-tested upstream.
+func TestApply_PreStepRefresh_EnvVarFalseyValueDisables(t *testing.T) {
+	t.Setenv("WFCTL_REFRESH_OUTPUTS", "0")
+	dir := t.TempDir()
+	cfgPath := writeApplyPreRefreshConfig(t, dir)
+	seedStaleVPCState(t, cfgPath)
+
+	cleanup := installFakeRefreshProvider(t, map[string]map[string]any{
+		"uuid-1": {"ip_range": "10.0.0.0/16", "id": "uuid-1"},
+	})
+	defer cleanup()
+
+	if _, err := captureStdout(t, func() error {
+		return runInfraApply([]string{"--auto-approve", "-c", cfgPath})
+	}); err != nil {
+		t.Fatalf("runInfraApply: %v", err)
+	}
+
+	got := loadVPCStateOutputs(t, cfgPath)
+	if _, ok := got["id"]; ok {
+		t.Errorf("WFCTL_REFRESH_OUTPUTS=0 must disable pre-refresh; got %v", got)
+	}
+}
+
+// TestApply_PreStepRefresh_SkipFlagOverridesEnvVar verifies that
+// --skip-refresh trumps WFCTL_REFRESH_OUTPUTS. Operators need a way to
+// disable the pre-step in the same invocation that has the env var set
+// (for example, when a CI environment forces it on globally).
+func TestApply_PreStepRefresh_SkipFlagOverridesEnvVar(t *testing.T) {
+	t.Setenv("WFCTL_REFRESH_OUTPUTS", "1")
+	dir := t.TempDir()
+	cfgPath := writeApplyPreRefreshConfig(t, dir)
+	seedStaleVPCState(t, cfgPath)
+
+	cleanup := installFakeRefreshProvider(t, map[string]map[string]any{
+		"uuid-1": {"ip_range": "10.0.0.0/16", "id": "uuid-1"},
+	})
+	defer cleanup()
+
+	if _, err := captureStdout(t, func() error {
+		return runInfraApply([]string{"--auto-approve", "--skip-refresh", "-c", cfgPath})
+	}); err != nil {
+		t.Fatalf("runInfraApply: %v", err)
+	}
+
+	got := loadVPCStateOutputs(t, cfgPath)
+	if _, ok := got["id"]; ok {
+		t.Errorf("--skip-refresh should suppress refresh even with env var set; got %v", got)
+	}
+}

--- a/cmd/wfctl/infra_refresh_outputs.go
+++ b/cmd/wfctl/infra_refresh_outputs.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/iac/refreshoutputs"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// runInfraRefreshOutputs reads live Outputs from each provider for the
+// resources already in state and persists any field-level changes back to
+// the state backend. The contract is strictly read-only at the cloud level —
+// no Update or Replace is ever invoked. See iac/refreshoutputs/refresh.go
+// for the helper this command wraps.
+//
+// When the resolved config has no usable iac.provider module for the
+// requested env, the literal error
+//
+//	refresh-outputs: provider not configured for env "<env>"
+//
+// is returned so that operators can distinguish a misconfigured workflow
+// from a transient cloud-side failure. T2.7 asserts against this exact line.
+func runInfraRefreshOutputs(args []string) error {
+	fs := flag.NewFlagSet("infra refresh-outputs", flag.ContinueOnError)
+	// Direct help/usage to stdout so `--help` is pipeable and the CI
+	// runtime-launch validator (T2.7) can capture it via captureStdout.
+	fs.SetOutput(os.Stdout)
+	var configFile, envName string
+	var concurrency int
+	fs.StringVar(&configFile, "config", "", "Config file")
+	fs.StringVar(&configFile, "c", "", "Config file (short for --config)")
+	fs.StringVar(&envName, "env", "", "Environment name (resolves per-module overrides)")
+	fs.StringVar(&envName, "e", "", "Environment name (short for --env)")
+	fs.IntVar(&concurrency, "concurrency", 0, "Maximum concurrent Read calls (default 8)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfgFile, err := resolveInfraConfig(fs, configFile)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	providerDefs, err := discoverIaCProvidersForRefresh(cfgFile, envName)
+	if err != nil {
+		return err
+	}
+	if len(providerDefs) == 0 {
+		return fmt.Errorf("refresh-outputs: provider not configured for env %q", envName)
+	}
+
+	states, err := loadCurrentState(cfgFile, envName)
+	if err != nil {
+		return fmt.Errorf("load current state: %w", err)
+	}
+	if len(states) == 0 {
+		fmt.Println("Refresh: no state to refresh.")
+		return nil
+	}
+
+	store, err := resolveStateStore(cfgFile, envName)
+	if err != nil {
+		return fmt.Errorf("open state store: %w", err)
+	}
+
+	return refreshOutputsAcrossProviders(ctx, providerDefs, states, store, concurrency, os.Stdout)
+}
+
+// refreshOutputsProviderDef captures everything refresh-outputs needs to
+// load and call a single iac.provider module: its module name, the provider
+// type, and the env-resolved config.
+type refreshOutputsProviderDef struct {
+	moduleName string
+	provType   string
+	provCfg    map[string]any
+}
+
+// discoverIaCProvidersForRefresh walks cfgFile's modules and returns one
+// providerDef per iac.provider module that resolves successfully for envName
+// (modules disabled with `environments: { <env>: ~ }` are skipped). When
+// envName is "", the top-level module config is used as-is. The returned
+// slice preserves declaration order.
+func discoverIaCProvidersForRefresh(cfgFile, envName string) ([]refreshOutputsProviderDef, error) {
+	cfg, err := config.LoadFromFile(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	var defs []refreshOutputsProviderDef
+	for i := range cfg.Modules {
+		m := &cfg.Modules[i]
+		if m.Type != "iac.provider" {
+			continue
+		}
+		var modCfg map[string]any
+		if envName != "" {
+			resolved, ok := m.ResolveForEnv(envName)
+			if !ok {
+				// Disabled for this env via null override; not "no provider"
+				// for the env unless every iac.provider is disabled.
+				continue
+			}
+			modCfg = config.ExpandEnvInMap(resolved.Config)
+		} else {
+			modCfg = config.ExpandEnvInMap(m.Config)
+		}
+		pt, _ := modCfg["provider"].(string)
+		if pt == "" {
+			fmt.Fprintf(os.Stderr, "warning: iac.provider %q has no 'provider' field; skipping\n", m.Name)
+			continue
+		}
+		defs = append(defs, refreshOutputsProviderDef{
+			moduleName: m.Name,
+			provType:   pt,
+			provCfg:    modCfg,
+		})
+	}
+	return defs, nil
+}
+
+// refreshOutputsAcrossProviders groups state entries by which iac.provider
+// module owns them, calls refreshoutputs.Refresh for each group, and
+// persists any state entries whose Outputs changed. It loads each provider
+// at most once.
+//
+// State entries with a non-empty ProviderRef are matched to the iac.provider
+// module of the same name. State entries without a ProviderRef fall back to
+// the iac.provider module whose provider type matches state.Provider, but
+// only when exactly one such module exists; otherwise the fallback is
+// ambiguous and the entry is skipped with a warning rather than refreshed
+// against the wrong provider.
+func refreshOutputsAcrossProviders(
+	ctx context.Context,
+	providerDefs []refreshOutputsProviderDef,
+	states []interfaces.ResourceState,
+	store infraStateStore,
+	concurrency int,
+	stdout io.Writer,
+) error {
+	defByName := make(map[string]refreshOutputsProviderDef, len(providerDefs))
+	defsByType := make(map[string][]string)
+	for _, d := range providerDefs {
+		defByName[d.moduleName] = d
+		defsByType[d.provType] = append(defsByType[d.provType], d.moduleName)
+	}
+
+	groups := make(map[string][]int) // moduleName → indices into states
+	var groupOrder []string
+	for i := range states {
+		s := &states[i]
+		moduleName := s.ProviderRef
+		if moduleName == "" && s.Provider != "" {
+			candidates := defsByType[s.Provider]
+			if len(candidates) == 1 {
+				moduleName = candidates[0]
+			}
+		}
+		if moduleName == "" {
+			fmt.Fprintf(stdout, "Refresh: skipping %q — cannot resolve owning provider (provider_ref=%q, provider=%q)\n",
+				s.Name, s.ProviderRef, s.Provider)
+			continue
+		}
+		if _, ok := defByName[moduleName]; !ok {
+			fmt.Fprintf(stdout, "Refresh: skipping %q — provider module %q not declared in config\n", s.Name, moduleName)
+			continue
+		}
+		if _, exists := groups[moduleName]; !exists {
+			groupOrder = append(groupOrder, moduleName)
+		}
+		groups[moduleName] = append(groups[moduleName], i)
+	}
+
+	updated := 0
+	for _, moduleName := range groupOrder {
+		def := defByName[moduleName]
+		idxs := groups[moduleName]
+		groupStates := make([]interfaces.ResourceState, len(idxs))
+		for j, idx := range idxs {
+			groupStates[j] = states[idx]
+		}
+		fmt.Fprintf(stdout, "Refresh: reading %d resource(s) via provider %q (%s)...\n",
+			len(groupStates), moduleName, def.provType)
+		if err := refreshOneProviderGroup(ctx, def, idxs, groupStates, states, store, concurrency, &updated, stdout); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(stdout, "Refresh: complete — %d resource(s) updated.\n", updated)
+	return nil
+}
+
+// refreshOneProviderGroup loads a single provider, refreshes its state
+// subset, and persists any entries whose Outputs changed. Extracted so the
+// closer is `defer`-closed for panic safety and to keep
+// refreshOutputsAcrossProviders readable.
+func refreshOneProviderGroup(
+	ctx context.Context,
+	def refreshOutputsProviderDef,
+	idxs []int,
+	groupStates []interfaces.ResourceState,
+	states []interfaces.ResourceState,
+	store infraStateStore,
+	concurrency int,
+	updated *int,
+	stdout io.Writer,
+) error {
+	provider, closer, err := resolveIaCProvider(ctx, def.provType, def.provCfg)
+	if err != nil {
+		return fmt.Errorf("provider %q (%s): load provider: %w", def.moduleName, def.provType, err)
+	}
+	if closer != nil {
+		defer func() {
+			if cerr := closer.Close(); cerr != nil {
+				fmt.Fprintf(os.Stderr, "warning: provider %q shutdown: %v\n", def.provType, cerr)
+			}
+		}()
+	}
+	refreshed, err := refreshoutputs.Refresh(ctx, provider, groupStates, refreshoutputs.Options{Concurrency: concurrency})
+	if err != nil {
+		return fmt.Errorf("provider %q: %w", def.moduleName, err)
+	}
+	for j, idx := range idxs {
+		fresh := refreshed[j]
+		// reflect.DeepEqual handles non-comparable nested values
+		// (slices, maps, structs) that the Outputs maps can carry from
+		// real cloud APIs. A `==` compare on `any` panics for those.
+		if reflect.DeepEqual(states[idx].Outputs, fresh.Outputs) {
+			continue
+		}
+		states[idx] = fresh
+		if err := store.SaveResource(ctx, fresh); err != nil {
+			return fmt.Errorf("provider %q: persist refreshed %q: %w", def.moduleName, fresh.Name, err)
+		}
+		*updated++
+		fmt.Fprintf(stdout, "Refresh: updated %s\n", fresh.Name)
+	}
+	return nil
+}

--- a/cmd/wfctl/infra_refresh_outputs_test.go
+++ b/cmd/wfctl/infra_refresh_outputs_test.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// refreshOutputsCmdFakeProvider is the IaCProvider stub used by the
+// refresh-outputs subcommand tests. It only needs to answer ResourceDriver →
+// fakeResourceDriver.Read with canned outputs; everything else can be a
+// safe no-op because the subcommand never calls them on the read-only path.
+type refreshOutputsCmdFakeProvider struct {
+	readOutputs map[string]map[string]any
+}
+
+func (f *refreshOutputsCmdFakeProvider) Name() string    { return "fake-refresh-outputs" }
+func (f *refreshOutputsCmdFakeProvider) Version() string { return "0.0.0" }
+func (f *refreshOutputsCmdFakeProvider) Initialize(_ context.Context, _ map[string]any) error {
+	return nil
+}
+func (f *refreshOutputsCmdFakeProvider) Capabilities() []interfaces.IaCCapabilityDeclaration {
+	return nil
+}
+func (f *refreshOutputsCmdFakeProvider) Plan(_ context.Context, _ []interfaces.ResourceSpec, _ []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+	return &interfaces.IaCPlan{}, nil
+}
+func (f *refreshOutputsCmdFakeProvider) Apply(_ context.Context, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	return &interfaces.ApplyResult{}, nil
+}
+func (f *refreshOutputsCmdFakeProvider) Destroy(_ context.Context, _ []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
+	return nil, nil
+}
+func (f *refreshOutputsCmdFakeProvider) Status(_ context.Context, _ []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
+	return nil, nil
+}
+func (f *refreshOutputsCmdFakeProvider) DetectDrift(_ context.Context, _ []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
+	return nil, nil
+}
+func (f *refreshOutputsCmdFakeProvider) Import(_ context.Context, _ string, _ string) (*interfaces.ResourceState, error) {
+	return nil, nil
+}
+func (f *refreshOutputsCmdFakeProvider) ResolveSizing(_ string, _ interfaces.Size, _ *interfaces.ResourceHints) (*interfaces.ProviderSizing, error) {
+	return nil, nil
+}
+func (f *refreshOutputsCmdFakeProvider) ResourceDriver(_ string) (interfaces.ResourceDriver, error) {
+	return &refreshOutputsCmdFakeDriver{outputs: f.readOutputs}, nil
+}
+func (f *refreshOutputsCmdFakeProvider) SupportedCanonicalKeys() []string { return nil }
+func (f *refreshOutputsCmdFakeProvider) BootstrapStateBackend(_ context.Context, _ map[string]any) (*interfaces.BootstrapResult, error) {
+	return nil, nil
+}
+func (f *refreshOutputsCmdFakeProvider) Close() error { return nil }
+
+// refreshOutputsCmdFakeDriver answers Read with canned outputs keyed by
+// ProviderID. All other ResourceDriver methods panic to make accidental
+// non-Read use loud during testing.
+type refreshOutputsCmdFakeDriver struct {
+	outputs map[string]map[string]any
+}
+
+func (d *refreshOutputsCmdFakeDriver) Create(context.Context, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *refreshOutputsCmdFakeDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:       ref.Name,
+		Type:       ref.Type,
+		ProviderID: ref.ProviderID,
+		Outputs:    d.outputs[ref.ProviderID],
+	}, nil
+}
+func (d *refreshOutputsCmdFakeDriver) Update(context.Context, interfaces.ResourceRef, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *refreshOutputsCmdFakeDriver) Delete(context.Context, interfaces.ResourceRef) error {
+	panic("not used")
+}
+func (d *refreshOutputsCmdFakeDriver) Diff(context.Context, interfaces.ResourceSpec, *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	panic("not used")
+}
+func (d *refreshOutputsCmdFakeDriver) HealthCheck(context.Context, interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	panic("not used")
+}
+func (d *refreshOutputsCmdFakeDriver) Scale(context.Context, interfaces.ResourceRef, int) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *refreshOutputsCmdFakeDriver) SensitiveKeys() []string { return nil }
+
+// TestRefreshOutputs_CommandHelp verifies that --help prints the standard
+// FlagSet usage banner naming the subcommand. The banner is what T2.7's
+// runtime-launch validation will exercise via the built binary.
+func TestRefreshOutputs_CommandHelp(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return runInfraRefreshOutputs([]string{"--help"})
+	})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+	if !strings.Contains(out, "Usage of infra refresh-outputs") {
+		t.Errorf("help output missing 'Usage of infra refresh-outputs'; got: %s", out)
+	}
+}
+
+// TestRefreshOutputs_PersistsNewFieldsToState exercises the end-to-end
+// persists-new-output path: pre-populate a filesystem state backend with a
+// stale VPC entry, swap the IaCProvider loader for a stub that returns an
+// extra "id" field on Read, run the subcommand, and verify the field has
+// been written back to state.
+func TestRefreshOutputs_PersistsNewFieldsToState(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	cfg := `modules:
+  - name: cloud-provider
+    type: iac.provider
+    config:
+      provider: fake-provider
+  - name: state-store
+    type: iac.state
+    config:
+      backend: filesystem
+      directory: ` + stateDir + `
+  - name: coredump-staging-vpc
+    type: infra.vpc
+    config:
+      provider: cloud-provider
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate state with a stale VPC entry (no "id" output yet).
+	store, err := resolveStateStore(cfgPath, "")
+	if err != nil {
+		t.Fatalf("resolveStateStore: %v", err)
+	}
+	stale := interfaces.ResourceState{
+		ID:          "coredump-staging-vpc",
+		Name:        "coredump-staging-vpc",
+		Type:        "infra.vpc",
+		Provider:    "fake-provider",
+		ProviderRef: "cloud-provider",
+		ProviderID:  "uuid-1",
+		Outputs:     map[string]any{"ip_range": "10.0.0.0/16"},
+	}
+	if err := store.SaveResource(context.Background(), stale); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	// Swap the provider loader so the test never touches a real cloud.
+	orig := resolveIaCProvider
+	defer func() { resolveIaCProvider = orig }()
+	resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+		return &refreshOutputsCmdFakeProvider{
+			readOutputs: map[string]map[string]any{
+				"uuid-1": {"ip_range": "10.0.0.0/16", "id": "uuid-1"},
+			},
+		}, nil, nil
+	}
+
+	if _, err := captureStdout(t, func() error {
+		return runInfraRefreshOutputs([]string{"-c", cfgPath, "--env", "staging"})
+	}); err != nil {
+		t.Fatalf("runInfraRefreshOutputs: %v", err)
+	}
+
+	refreshed, err := loadCurrentState(cfgPath, "")
+	if err != nil {
+		t.Fatalf("loadCurrentState: %v", err)
+	}
+	byName := make(map[string]interfaces.ResourceState, len(refreshed))
+	for _, s := range refreshed {
+		byName[s.Name] = s
+	}
+	got := byName["coredump-staging-vpc"]
+	if id, _ := got.Outputs["id"].(string); id != "uuid-1" {
+		t.Errorf("expected 'id' field after refresh, got %v", got.Outputs)
+	}
+}
+
+// TestRefreshOutputs_NonComparableOutputs_DoesNotPanic regression-tests
+// the Outputs-changed check against real-world Outputs that contain slices
+// and nested maps. A naive `lv != v` on `any` values panics with
+// "comparing uncomparable type" the moment a slice or map is involved —
+// reflect.DeepEqual is the correct tool. Covers both the unchanged path
+// (live == persisted) and the changed path (live grows a new field) so
+// neither code direction can regress to the panic.
+func TestRefreshOutputs_NonComparableOutputs_DoesNotPanic(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		liveOutputs  map[string]any
+		expectUpdate bool
+	}{
+		{
+			name: "unchanged-with-slice-and-nested-map",
+			liveOutputs: map[string]any{
+				"subnet_ids": []string{"a", "b"},
+				"tags":       map[string]any{"env": "staging"},
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "added-field-with-slice-and-nested-map",
+			liveOutputs: map[string]any{
+				"subnet_ids": []string{"a", "b"},
+				"tags":       map[string]any{"env": "staging"},
+				"id":         "uuid-1",
+			},
+			expectUpdate: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stateDir := filepath.Join(dir, "state")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			cfgPath := filepath.Join(dir, "infra.yaml")
+			cfg := `modules:
+  - name: cloud-provider
+    type: iac.provider
+    config:
+      provider: fake-provider
+  - name: state-store
+    type: iac.state
+    config:
+      backend: filesystem
+      directory: ` + stateDir + `
+  - name: vpc-1
+    type: infra.vpc
+    config:
+      provider: cloud-provider
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			store, err := resolveStateStore(cfgPath, "")
+			if err != nil {
+				t.Fatalf("resolveStateStore: %v", err)
+			}
+			persisted := interfaces.ResourceState{
+				ID:          "vpc-1",
+				Name:        "vpc-1",
+				Type:        "infra.vpc",
+				Provider:    "fake-provider",
+				ProviderRef: "cloud-provider",
+				ProviderID:  "uuid-1",
+				Outputs: map[string]any{
+					"subnet_ids": []string{"a", "b"},
+					"tags":       map[string]any{"env": "staging"},
+				},
+			}
+			if err := store.SaveResource(context.Background(), persisted); err != nil {
+				t.Fatalf("seed state: %v", err)
+			}
+
+			orig := resolveIaCProvider
+			defer func() { resolveIaCProvider = orig }()
+			liveOutputs := tc.liveOutputs
+			resolveIaCProvider = func(_ context.Context, _ string, _ map[string]any) (interfaces.IaCProvider, io.Closer, error) {
+				return &refreshOutputsCmdFakeProvider{
+					readOutputs: map[string]map[string]any{"uuid-1": liveOutputs},
+				}, nil, nil
+			}
+
+			// The critical assertion: this call must NOT panic with
+			// "comparing uncomparable type".
+			if _, err := captureStdout(t, func() error {
+				return runInfraRefreshOutputs([]string{"-c", cfgPath})
+			}); err != nil {
+				t.Fatalf("runInfraRefreshOutputs panicked or errored: %v", err)
+			}
+
+			refreshed, err := loadCurrentState(cfgPath, "")
+			if err != nil {
+				t.Fatalf("loadCurrentState: %v", err)
+			}
+			var got interfaces.ResourceState
+			for _, s := range refreshed {
+				if s.Name == "vpc-1" {
+					got = s
+					break
+				}
+			}
+			if tc.expectUpdate {
+				if _, ok := got.Outputs["id"]; !ok {
+					t.Errorf("expected new 'id' field after refresh; got Outputs=%v", got.Outputs)
+				}
+			}
+			// Whether updated or not, post-state must still carry the
+			// nested values intact.
+			if _, ok := got.Outputs["subnet_ids"]; !ok {
+				t.Errorf("expected subnet_ids preserved; got Outputs=%v", got.Outputs)
+			}
+		})
+	}
+}
+
+// TestRefreshOutputs_NoProviderConfigured_ReturnsLiteralError pins the
+// exact stderr line T2.7 asserts against. The wording is load-bearing —
+// changing it breaks the runtime-launch-validation gate.
+func TestRefreshOutputs_NoProviderConfigured_ReturnsLiteralError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	// Config has no iac.provider modules.
+	cfg := `modules:
+  - name: state-store
+    type: iac.state
+    config:
+      backend: filesystem
+      directory: ` + dir + `
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := runInfraRefreshOutputs([]string{"-c", cfgPath, "--env", "staging"})
+	if err == nil {
+		t.Fatal("expected error when no iac.provider configured")
+	}
+	want := `refresh-outputs: provider not configured for env "staging"`
+	if err.Error() != want {
+		t.Errorf("error mismatch:\n got: %q\nwant: %q", err.Error(), want)
+	}
+}

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -96,6 +96,7 @@ graph TD
     infra --> infra-bootstrap["bootstrap"]
     infra --> infra-state["state"]
     infra --> infra-outputs["outputs"]
+    infra --> infra-refresh-outputs["refresh-outputs"]
 
     infra-state --> infra-state-list["list"]
     infra-state --> infra-state-export["export"]
@@ -1171,6 +1172,7 @@ wfctl infra <action> [options] [config.yaml]
 | `bootstrap` | Generate secrets and initialise state backend before first apply |
 | `state` | Manage state storage (list/export/import) |
 | `outputs` | Print resource outputs from state (yaml/json/env formats) |
+| `refresh-outputs` | Read live outputs from each provider and reconcile state (no cloud writes) |
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -1214,6 +1216,63 @@ wfctl infra state import --source state.json
 wfctl infra bootstrap -c infra.yaml --env staging --force-rotate NATS_AUTH_TOKEN
 wfctl infra bootstrap -c infra.yaml --env staging --force-rotate NATS_AUTH_TOKEN,DATABASE_URL
 wfctl infra bootstrap -c infra.yaml --force-rotate FOO --force-rotate BAR
+```
+
+#### `infra refresh-outputs`
+
+Read live outputs from each `iac.provider` for resources already in state and persist any field-level changes back to the state backend. The contract is strictly read-only at the cloud level — `refresh-outputs` never invokes Update or Replace.
+
+```
+wfctl infra refresh-outputs [-c CONFIG] [--env ENV] [--concurrency N]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--config` | _(auto-detected)_ | Config file (searches `infra.yaml`, `config/infra.yaml`) |
+| `-e`, `--env` | `` | Environment name (resolves per-module overrides; iac.provider modules disabled for the env are skipped) |
+| `--concurrency` | `8` | Maximum concurrent Read calls. Values < 1 fall back to the default. |
+
+**Behavior:**
+
+- Discovers `iac.provider` modules with per-env resolution.
+- Loads current state from the configured `iac.state` backend.
+- Groups state entries by their owning provider module (`provider_ref` first, falling back to provider type when exactly one module of that type is declared).
+- Calls each provider's `ResourceDriver.Read` once per resource via the bounded-concurrency `iac/refreshoutputs.Refresh` helper.
+- Persists any state entry whose `outputs` map changed — entries whose live outputs equal the persisted outputs are left alone.
+
+**Errors:**
+
+When the resolved config has no usable `iac.provider` module for the requested env, `wfctl` exits 1 with the literal stderr line:
+
+```
+error: refresh-outputs: provider not configured for env "<env>"
+```
+
+This wording is load-bearing — CI gates and runtime-launch validation pin the exact form. On any provider Read or driver-resolution failure, the command returns the wrapped error from the `iac/refreshoutputs` helper without persisting partial progress.
+
+**Apply-time pre-step (opt-in):**
+
+`wfctl infra apply` can run the same refresh as a pre-plan step, ensuring the planner doesn't make decisions against stale outputs.
+
+| Variable / Flag | Effect |
+|------|---------|
+| `WFCTL_REFRESH_OUTPUTS=1` (or any `strconv.ParseBool` truthy value) | Enable the apply pre-step. |
+| `WFCTL_REFRESH_OUTPUTS=0` (or any falsey value, empty, or unrecognised) | Disable the apply pre-step (default). |
+| `wfctl infra apply --skip-refresh` | Suppress the apply pre-step regardless of the env var (CI escape hatch). |
+
+The pre-step only fires for `infra.*` configs; legacy `platform.*` configs are silently skipped.
+
+**Examples:**
+
+```bash
+# One-off explicit refresh against the staging env.
+wfctl infra refresh-outputs -c infra.yaml --env staging
+
+# Apply with pre-plan refresh enabled.
+WFCTL_REFRESH_OUTPUTS=1 wfctl infra apply --auto-approve -c infra.yaml --env staging
+
+# Apply with pre-step suppressed even though CI exports the env var.
+WFCTL_REFRESH_OUTPUTS=1 wfctl infra apply --auto-approve --skip-refresh -c infra.yaml
 ```
 
 ---

--- a/docs/adr/006-wfctl-refresh-outputs-env-var-parsebool.md
+++ b/docs/adr/006-wfctl-refresh-outputs-env-var-parsebool.md
@@ -1,0 +1,51 @@
+# ADR 006: WFCTL_REFRESH_OUTPUTS uses strconv.ParseBool, not bare presence
+
+## Status
+
+Accepted
+
+## Context
+
+W-2 Task T2.3 (`docs/plans/2026-05-03-iac-conformance-and-replace.md`, line 1061) specified the apply-time pre-step opt-in gate as a bare presence check:
+
+```go
+if os.Getenv("WFCTL_REFRESH_OUTPUTS") != "" {
+    // run pre-step
+}
+```
+
+Under that contract, any non-empty value enables the pre-step — including values an operator would universally read as disabling: `0`, `false`, `no`, `off`. T2.3's first quality review (code-reviewer) flagged this as a foot-gun: operators reach for the `=0` / `=false` convention to disable a feature, and the bare-presence check turns that convention into the opposite of its intent. The original commit body also leaned into the wrong mental model by listing `"yes"` as an enabling example, reinforcing the misread that the value was being parsed.
+
+`--skip-refresh` exists as a robust off-switch override, so an operator who falls into the foot-gun has an escape hatch — but discovering it requires reading the docs after the surprise hit, by which point a planner has already burned a `Read` round-trip on every state entry.
+
+## Decision
+
+Implement the gate using `strconv.ParseBool` instead of bare presence. The accept set is well-known to Go developers and matches every common operator convention:
+
+- Truthy enables: `1`, `t`, `T`, `TRUE`, `true`, `True`
+- Falsey explicitly disables: `0`, `f`, `F`, `FALSE`, `false`, `False`
+- Empty / unset / unrecognised: disabled (default; never an exception)
+
+`--skip-refresh` continues to override the env var unconditionally, preserving the CI escape-hatch contract for environments where the env var is forced on globally.
+
+## Consequences
+
+**Positive:**
+
+- Operator surprise eliminated: `WFCTL_REFRESH_OUTPUTS=0` disables, as expected.
+- Self-documenting contract: `ParseBool` is a familiar Go idiom; the godoc on `applyPreStepRefreshEnabled` enumerates the accept set.
+- Future-proofed against the same bug class for other refresh-outputs related env vars added in W-3+.
+
+**Negative:**
+
+- Plan-deviation: the implementation diverges from `docs/plans/2026-05-03-iac-conformance-and-replace.md` line 1061's literal contract. Recorded in this ADR so future contributors see the rejected alternative and the reasoning, rather than discovering it via `git blame` archaeology. A future plan revision should reflect the actual implementation; out of scope for this ADR.
+- Operators who set the env var to an unrecognised string (e.g. `WFCTL_REFRESH_OUTPUTS=enabled`) silently get the disabled default. The accept set is intentionally narrow; the alternative — accepting any non-empty as truthy — is exactly the foot-gun this ADR rejects. Mitigated by the doc table in `docs/WFCTL.md` enumerating the truthy/falsey values explicitly.
+
+**Provenance:** decided by Claude (autonomous-pipeline team-lead) after code-review/spec-review consensus on 2026-05-04. code-reviewer surfaced the foot-gun during T2.3 quality review; implementer prepared the ParseBool change; spec-reviewer requested this ADR post-hoc; team-lead approved option-1 (approve-as-is + follow-up ADR) over plan revert.
+
+## References
+
+- Plan task spec: `docs/plans/2026-05-03-iac-conformance-and-replace.md` §T2.3 (line 1061)
+- Implementation: `cmd/wfctl/infra_apply_refresh_pre.go::applyPreStepRefreshEnabled` (commit `bfd1bbe`)
+- Test pinning the falsey-disables semantic: `cmd/wfctl/infra_apply_refresh_pre_test.go::TestApply_PreStepRefresh_EnvVarFalseyValueDisables`
+- Operator-facing docs: `docs/WFCTL.md` → `infra refresh-outputs` → "Apply-time pre-step (opt-in)"

--- a/iac/refreshoutputs/refresh.go
+++ b/iac/refreshoutputs/refresh.go
@@ -1,0 +1,105 @@
+// Package refreshoutputs implements read-only state refresh — it reads
+// current Outputs from providers and updates the persisted state when fields
+// differ. It never invokes Update or Replace at the cloud level; the contract
+// is strictly "Read and reconcile in-memory state".
+//
+// Refresh is the foundation for two consumers in W-2:
+//
+//   - wfctl infra refresh-outputs (T2.2): explicit operator-driven refresh.
+//   - wfctl infra apply pre-step (T2.3): opt-in via WFCTL_REFRESH_OUTPUTS to
+//     keep stale outputs from poisoning the planner.
+package refreshoutputs
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"sync"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// defaultConcurrency is the worker count used when Options.Concurrency is
+// non-positive.
+const defaultConcurrency = 8
+
+// Options tunes Refresh behaviour. The zero value is valid and uses
+// defaultConcurrency.
+type Options struct {
+	// Concurrency is the maximum number of concurrent Read calls. Values < 1
+	// fall back to defaultConcurrency (8).
+	Concurrency int
+}
+
+// Refresh issues a bounded-concurrency Read against p for each entry in
+// states and returns a copy with Outputs reconciled to the live values.
+// Resources whose live Outputs are deeply equal to the persisted Outputs are
+// returned unchanged (callers can rely on this to skip writes).
+//
+// Refresh never mutates the input slice. The returned slice is a fresh copy
+// of states with possibly-updated Outputs maps; on any Read or
+// ResourceDriver failure, Refresh returns (nil, err) and discards partial
+// progress so callers don't half-persist a refresh.
+//
+// Aliasing: for entries whose live Outputs match the persisted Outputs,
+// out[i].Outputs is the same map as states[i].Outputs (unchanged maps are
+// not cloned). Callers must not mutate Outputs maps in the returned slice
+// in place.
+func Refresh(ctx context.Context, p interfaces.IaCProvider, states []interfaces.ResourceState, opts Options) ([]interfaces.ResourceState, error) {
+	if opts.Concurrency < 1 {
+		opts.Concurrency = defaultConcurrency
+	}
+	out := make([]interfaces.ResourceState, len(states))
+	copy(out, states)
+
+	sem := make(chan struct{}, opts.Concurrency)
+	errs := make([]error, len(states))
+	var wg sync.WaitGroup
+
+	for i := range states {
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			errs[i] = refreshOne(ctx, p, &out[i], states[i])
+		})
+	}
+	wg.Wait()
+
+	for _, e := range errs {
+		if e != nil {
+			return nil, e
+		}
+	}
+	return out, nil
+}
+
+// refreshOne performs a single resource Read and writes the live Outputs
+// into dst when they differ from src.Outputs. It returns nil on success or
+// the error otherwise.
+func refreshOne(ctx context.Context, p interfaces.IaCProvider, dst *interfaces.ResourceState, src interfaces.ResourceState) error {
+	d, err := p.ResourceDriver(src.Type)
+	if err != nil {
+		return err
+	}
+	ref := interfaces.ResourceRef{Name: src.Name, Type: src.Type, ProviderID: src.ProviderID}
+	live, err := d.Read(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("could not refresh %q: %w", src.Name, err)
+	}
+	if !reflect.DeepEqual(live.Outputs, src.Outputs) {
+		dst.Outputs = cloneMap(live.Outputs)
+	}
+	return nil
+}
+
+// cloneMap returns an independent shallow copy of m. Callers receive a map
+// they can mutate without aliasing the live driver output.
+func cloneMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	c := make(map[string]any, len(m))
+	maps.Copy(c, m)
+	return c
+}

--- a/iac/refreshoutputs/refresh_concurrency_test.go
+++ b/iac/refreshoutputs/refresh_concurrency_test.go
@@ -1,0 +1,209 @@
+package refreshoutputs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// countingProvider is a stress-test IaCProvider that hands out a single
+// shared countingDriver. Every Read call increments the per-ProviderID
+// counter so the test can assert "exactly once per resource" after
+// Refresh returns.
+type countingProvider struct {
+	driver *countingDriver
+}
+
+func (p *countingProvider) Name() string    { panic("not used") }
+func (p *countingProvider) Version() string { panic("not used") }
+func (p *countingProvider) Initialize(context.Context, map[string]any) error {
+	panic("not used")
+}
+func (p *countingProvider) Capabilities() []interfaces.IaCCapabilityDeclaration {
+	panic("not used")
+}
+func (p *countingProvider) Plan(context.Context, []interfaces.ResourceSpec, []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+	panic("not used")
+}
+func (p *countingProvider) Apply(context.Context, *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	panic("not used")
+}
+func (p *countingProvider) Destroy(context.Context, []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
+	panic("not used")
+}
+func (p *countingProvider) Status(context.Context, []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
+	panic("not used")
+}
+func (p *countingProvider) DetectDrift(context.Context, []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
+	panic("not used")
+}
+func (p *countingProvider) Import(context.Context, string, string) (*interfaces.ResourceState, error) {
+	panic("not used")
+}
+func (p *countingProvider) ResolveSizing(string, interfaces.Size, *interfaces.ResourceHints) (*interfaces.ProviderSizing, error) {
+	panic("not used")
+}
+func (p *countingProvider) SupportedCanonicalKeys() []string { panic("not used") }
+func (p *countingProvider) BootstrapStateBackend(context.Context, map[string]any) (*interfaces.BootstrapResult, error) {
+	panic("not used")
+}
+func (p *countingProvider) Close() error { return nil }
+
+func (p *countingProvider) ResourceDriver(string) (interfaces.ResourceDriver, error) {
+	return p.driver, nil
+}
+
+// countingDriver atomically tracks how many times Read was called for
+// each ProviderID and how many goroutines are inside Read at once.
+// concurrentPeak gives the test a way to assert that the bounded
+// semaphore actually enforced its cap.
+type countingDriver struct {
+	mu             sync.Mutex
+	callsByID      map[string]int
+	inFlight       atomic.Int32
+	concurrentPeak atomic.Int32
+}
+
+func (d *countingDriver) Create(context.Context, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *countingDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	now := d.inFlight.Add(1)
+	defer d.inFlight.Add(-1)
+	for {
+		peak := d.concurrentPeak.Load()
+		if now <= peak || d.concurrentPeak.CompareAndSwap(peak, now) {
+			break
+		}
+	}
+
+	// Hold each call long enough that, with N=100 and Concurrency=8, the
+	// bounded pool will queue up: every dispatched call MUST overlap with
+	// at least one other or the test's concurrency-cap check is vacuous.
+	// 5ms × 100 / 8 ≈ 63ms total wall time at the cap, well under the
+	// watchdog's 10s budget.
+	time.Sleep(5 * time.Millisecond)
+
+	d.mu.Lock()
+	d.callsByID[ref.ProviderID]++
+	d.mu.Unlock()
+	return &interfaces.ResourceOutput{
+		Name:       ref.Name,
+		Type:       ref.Type,
+		ProviderID: ref.ProviderID,
+		// Add a "id" field so Refresh sees a diff and copies the new
+		// Outputs into out[i].Outputs — gives the test a positive
+		// per-resource signal that every refresh propagated.
+		Outputs: map[string]any{"id": ref.ProviderID, "fresh": true},
+	}, nil
+}
+func (d *countingDriver) Update(context.Context, interfaces.ResourceRef, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *countingDriver) Delete(context.Context, interfaces.ResourceRef) error {
+	panic("not used")
+}
+func (d *countingDriver) Diff(context.Context, interfaces.ResourceSpec, *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	panic("not used")
+}
+func (d *countingDriver) HealthCheck(context.Context, interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	panic("not used")
+}
+func (d *countingDriver) Scale(context.Context, interfaces.ResourceRef, int) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *countingDriver) SensitiveKeys() []string { return nil }
+
+// TestRefresh_ConcurrencyStress_NoDeadlock_AllRefreshed_OnceEach exercises
+// Refresh against 100 resources with Concurrency=8 and asserts:
+//
+//  1. No deadlock — Refresh returns within a generous watchdog budget.
+//     Caught by `done` channel + 10s timeout `select`.
+//  2. Read was called exactly once per resource — no double-dispatch
+//     hidden bugs in the semaphore acquire/release pairing.
+//  3. The resulting state slice carries the refreshed Outputs for every
+//     entry — no goroutine wrote into the wrong out[i] under concurrency.
+//  4. Concurrent peak in flight is between 2 and the requested
+//     concurrency cap. ≥2 confirms the bounded pool actually parallelised
+//     work; ≤cap confirms the semaphore enforced its limit.
+func TestRefresh_ConcurrencyStress_NoDeadlock_AllRefreshed_OnceEach(t *testing.T) {
+	const (
+		nResources  = 100
+		concurrency = 8
+		watchdog    = 10 * time.Second
+	)
+
+	states := make([]interfaces.ResourceState, nResources)
+	for i := range states {
+		id := fmt.Sprintf("uuid-%03d", i)
+		states[i] = interfaces.ResourceState{
+			Name:       fmt.Sprintf("vpc-%03d", i),
+			Type:       "infra.vpc",
+			ProviderID: id,
+			Outputs:    map[string]any{"ip_range": "10.0.0.0/16"},
+		}
+	}
+
+	driver := &countingDriver{callsByID: make(map[string]int, nResources)}
+	provider := &countingProvider{driver: driver}
+
+	done := make(chan struct{})
+	var refreshed []interfaces.ResourceState
+	var refreshErr error
+	go func() {
+		defer close(done)
+		refreshed, refreshErr = Refresh(context.Background(), provider, states, Options{Concurrency: concurrency})
+	}()
+	select {
+	case <-done:
+		// Refresh returned — proceed with assertions.
+	case <-time.After(watchdog):
+		t.Fatalf("Refresh did not return within %s — possible deadlock", watchdog)
+	}
+
+	if refreshErr != nil {
+		t.Fatalf("Refresh: %v", refreshErr)
+	}
+	if len(refreshed) != nResources {
+		t.Fatalf("expected %d refreshed states, got %d", nResources, len(refreshed))
+	}
+
+	// Each ProviderID should have been Read exactly once.
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if len(driver.callsByID) != nResources {
+		t.Errorf("expected reads for %d distinct ProviderIDs, got %d", nResources, len(driver.callsByID))
+	}
+	for id, n := range driver.callsByID {
+		if n != 1 {
+			t.Errorf("ProviderID %q: Read called %d times, want exactly 1", id, n)
+		}
+	}
+
+	// Every state in the result must carry the refreshed Outputs map
+	// (driver returns "id" + "fresh": true on every Read).
+	for i, s := range refreshed {
+		if got, _ := s.Outputs["id"].(string); got != fmt.Sprintf("uuid-%03d", i) {
+			t.Errorf("refreshed[%d]: Outputs[\"id\"]=%q, want uuid-%03d", i, got, i)
+		}
+		if got, _ := s.Outputs["fresh"].(bool); !got {
+			t.Errorf("refreshed[%d]: Outputs[\"fresh\"]=%v, want true", i, got)
+		}
+	}
+
+	// Concurrency-cap invariants: peak inflight must have been >1 to
+	// prove parallelism happened, and ≤concurrency to prove the
+	// semaphore enforced its limit.
+	peak := int(driver.concurrentPeak.Load())
+	if peak < 2 {
+		t.Errorf("concurrent peak in flight = %d; expected >=2 (parallelism not exercised)", peak)
+	}
+	if peak > concurrency {
+		t.Errorf("concurrent peak in flight = %d; expected <=%d (semaphore cap exceeded)", peak, concurrency)
+	}
+}

--- a/iac/refreshoutputs/refresh_test.go
+++ b/iac/refreshoutputs/refresh_test.go
@@ -1,0 +1,148 @@
+package refreshoutputs
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// fakeIaCProvider is a minimal IaCProvider stub that returns canned
+// ResourceOutput values for Read via fakeResourceDriver. It only implements
+// the methods that Refresh exercises (ResourceDriver); the rest panic to
+// make accidental use during testing obvious.
+type fakeIaCProvider struct {
+	// readOutputs maps ProviderID → fake driver output Outputs map. nil
+	// entries produce a ResourceOutput with empty Outputs.
+	readOutputs map[string]map[string]any
+	// readErr, when non-nil, causes the driver Read to return the error
+	// regardless of the resource ref.
+	readErr error
+}
+
+func (f *fakeIaCProvider) Name() string    { panic("not used") }
+func (f *fakeIaCProvider) Version() string { panic("not used") }
+func (f *fakeIaCProvider) Initialize(context.Context, map[string]any) error {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Capabilities() []interfaces.IaCCapabilityDeclaration {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Plan(context.Context, []interfaces.ResourceSpec, []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Apply(context.Context, *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Destroy(context.Context, []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Status(context.Context, []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) DetectDrift(context.Context, []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Import(context.Context, string, string) (*interfaces.ResourceState, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) ResolveSizing(string, interfaces.Size, *interfaces.ResourceHints) (*interfaces.ProviderSizing, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) SupportedCanonicalKeys() []string { panic("not used") }
+func (f *fakeIaCProvider) BootstrapStateBackend(context.Context, map[string]any) (*interfaces.BootstrapResult, error) {
+	panic("not used")
+}
+func (f *fakeIaCProvider) Close() error { return nil }
+
+func (f *fakeIaCProvider) ResourceDriver(string) (interfaces.ResourceDriver, error) {
+	return &fakeResourceDriver{provider: f}, nil
+}
+
+// fakeResourceDriver answers Read from the parent fakeIaCProvider's
+// readOutputs map. All other methods panic to make misuse loud.
+type fakeResourceDriver struct {
+	provider *fakeIaCProvider
+}
+
+func (d *fakeResourceDriver) Create(context.Context, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *fakeResourceDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	if d.provider.readErr != nil {
+		return nil, d.provider.readErr
+	}
+	out := d.provider.readOutputs[ref.ProviderID]
+	return &interfaces.ResourceOutput{
+		Name:       ref.Name,
+		Type:       ref.Type,
+		ProviderID: ref.ProviderID,
+		Outputs:    out,
+	}, nil
+}
+func (d *fakeResourceDriver) Update(context.Context, interfaces.ResourceRef, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *fakeResourceDriver) Delete(context.Context, interfaces.ResourceRef) error {
+	panic("not used")
+}
+func (d *fakeResourceDriver) Diff(context.Context, interfaces.ResourceSpec, *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	panic("not used")
+}
+func (d *fakeResourceDriver) HealthCheck(context.Context, interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	panic("not used")
+}
+func (d *fakeResourceDriver) Scale(context.Context, interfaces.ResourceRef, int) (*interfaces.ResourceOutput, error) {
+	panic("not used")
+}
+func (d *fakeResourceDriver) SensitiveKeys() []string { return nil }
+
+func mapsEqual(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		bv, ok := b[k]
+		if !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRefreshOutputs_ReadsEachResource_PersistsChangedOnly(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{Name: "vpc-1", Type: "infra.vpc", ProviderID: "uuid-1", Outputs: map[string]any{"ip_range": "10.0.0.0/16"}},
+		{Name: "vpc-2", Type: "infra.vpc", ProviderID: "uuid-2", Outputs: map[string]any{"ip_range": "10.1.0.0/16"}},
+	}
+	fakeProvider := &fakeIaCProvider{readOutputs: map[string]map[string]any{
+		"uuid-1": {"ip_range": "10.0.0.0/16", "id": "uuid-1"}, // new "id" field
+		"uuid-2": {"ip_range": "10.1.0.0/16"},                 // unchanged
+	}}
+	refreshed, err := Refresh(context.Background(), fakeProvider, states, Options{Concurrency: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := refreshed[0].Outputs["id"]; got != "uuid-1" {
+		t.Errorf("vpc-1 should have new 'id' output: %v", refreshed[0].Outputs)
+	}
+	if !mapsEqual(refreshed[1].Outputs, states[1].Outputs) {
+		t.Errorf("vpc-2 should be unchanged: %v vs %v", refreshed[1].Outputs, states[1].Outputs)
+	}
+}
+
+func TestRefreshOutputs_PartialFailure_ReturnsError(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{Name: "vpc-1", Type: "infra.vpc", ProviderID: "uuid-1"},
+	}
+	fakeProvider := &fakeIaCProvider{readErr: errors.New("network failure")}
+	_, err := Refresh(context.Background(), fakeProvider, states, Options{Concurrency: 1})
+	if err == nil {
+		t.Fatalf("expected error on Read failure")
+	}
+	if !strings.Contains(err.Error(), "could not refresh") {
+		t.Errorf("error should mention 'could not refresh'; got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

W-2 of the 12-PR IaC plan series. Adds `iac/refreshoutputs/` package + `wfctl infra refresh-outputs` subcommand + opt-in apply-time refresh pre-step. Read-only refresh of cloud-resource Outputs without invoking Update/Replace; bounded concurrency (default 8); operator-controlled via `WFCTL_REFRESH_OUTPUTS` env var (`strconv.ParseBool` semantics) + `--skip-refresh` flag.

**Plan reference:** `docs/plans/2026-05-03-iac-conformance-and-replace.md` rev10 (commit on `design/iac-conformance-and-replace` branch).

**Base:** `feat/iac-plan-schema-diagnostic` (W-1, PR #523). When W-1 merges to main, this PR will retarget main automatically.

## What ships

6 commits in dependency order:
- 09bfe8e — refreshoutputs.Refresh (T2.1) — bounded-concurrency Read-per-resource helper
- 181e579 — wfctl infra refresh-outputs subcommand (T2.2)
- bfd1bbe — apply-time refresh as opt-in pre-step (T2.3)
- 2d77af9 — concurrency stress test (T2.5; 100 fake resources, peak inflight ≤ N, race-detector clean)
- a892c1d — docs/WFCTL.md infra refresh-outputs section + T2.7 transcript (T2.6 + T2.7)
- 8dafaa5 — ADR 006: WFCTL_REFRESH_OUTPUTS ParseBool semantics deviation from plan §T2.3

## ADR 006 — non-trivial decision

Plan §T2.3 line 1061 specified `os.Getenv("WFCTL_REFRESH_OUTPUTS") != ""` as the gate. T2.3 quality-review caught a foot-gun: an operator setting `WFCTL_REFRESH_OUTPUTS=0` to opt out would have been mis-enabled (any non-empty value qualifies). After spec/code-review consensus, implementation uses `strconv.ParseBool`: truthy values enable; explicit falsy disable; empty/unset/unrecognized disable. Documented in `docs/adr/006-wfctl-refresh-outputs-env-var-parsebool.md`.

## T2.7 runtime-launch validation transcript

Folded into the T2.6 commit body. Verified independently by code-reviewer:
- `wfctl infra refresh-outputs --help` → exit 0, prints `Usage of infra refresh-outputs:` banner
- `wfctl infra refresh-outputs -c <fake.yaml> --env staging` (no provider configured) → exit 1, stderr-only literal `error: refresh-outputs: provider not configured for env "staging"`
- No panic; no stack trace

## Test plan

- [x] `GOWORK=off go test -race -count=1 ./iac/refreshoutputs/... ./cmd/wfctl/...` PASS
- [x] `mdformat --check docs/WFCTL.md` — pre-existing failure (not introduced by W-2; same on baseline + this PR)
- [x] `markdown-link-check docs/WFCTL.md` clean
- [ ] CI: standard test + lint pipeline green
- [ ] Manual: smoke against staging-PG (deferred per plan §T2.7 line 1102; out-of-scope for in-worktree validation)

## Out of scope (deferred to later PRs)

- Replace action emission (W-3a/W-3b)
- ApplyResult fields for drift report (W-3a/T3.0.4)
- In-process apply path drift postcondition (W-3a/T3.1.5)
- conformance scenarios (W-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)