### PR TITLE
fix(wfctl): R-A4 align rule consults top-level secrets.generate + entries (workflow#541)

### DIFF
--- a/cmd/wfctl/infra_align_rules.go
+++ b/cmd/wfctl/infra_align_rules.go
@@ -46,6 +46,12 @@ func buildAlignContext(cfgFile string) (*alignContext, error) {
 	}
 	if cfg.Secrets != nil {
 		ctx.secretGens = cfg.Secrets.Generate
+		for _, gen := range cfg.Secrets.Generate {
+			ctx.secretKeys[gen.Key] = struct{}{}
+		}
+		for _, entry := range cfg.Secrets.Entries {
+			ctx.secretKeys[entry.Name] = struct{}{}
+		}
 	}
 	for _, m := range cfg.Modules {
 		switch {

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -447,6 +447,63 @@ modules:
 	}
 }
 
+func TestInfraAlign_RA4_TopLevelSecretsGenerate_DoesNotFire(t *testing.T) {
+	os.Unsetenv("STAGING_PG_PASSWORD")
+	yaml := `
+appName: test
+secrets:
+  generate:
+    - key: STAGING_PG_PASSWORD
+      type: random_hex
+      length: 32
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        DATABASE_URL: "postgres://user:${STAGING_PG_PASSWORD}@host:5432/db"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A4") {
+		t.Errorf("unexpected R-A4 finding for top-level secrets.generate key: %v", findings)
+	}
+}
+
+func TestInfraAlign_RA4_TopLevelSecretsEntries_DoesNotFire(t *testing.T) {
+	os.Unsetenv("STAGING_PG_PASSWORD")
+	yaml := `
+appName: test
+secrets:
+  entries:
+    - name: STAGING_PG_PASSWORD
+      store: vault
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        DATABASE_URL: "postgres://user:${STAGING_PG_PASSWORD}@host:5432/db"
+`
+	cfg := writeAlignYAML(t, yaml)
+	opts := alignOptions{configFile: cfg}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A4") {
+		t.Errorf("unexpected R-A4 finding for top-level secrets.entries name: %v", findings)
+	}
+}
+
 // ── R-A5: migrations alignment ─────────────────────────────────────────────
 
 func TestInfraAlign_RA5_PreDeployMigrateNoDB_Fires(t *testing.T) {

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -504,6 +504,59 @@ modules:
 	}
 }
 
+// TestInfraAlign_RA4_TopLevelSecrets_FromImport_DoesNotFire pins the imports
+// merge path: when a `secrets:` block is declared in an imported file rather
+// than the main config, R-A4 must still see those keys. This requires
+// processImports to merge WorkflowConfig.Secrets — without that, cfg.Secrets
+// is nil/empty after LoadFromFile and R-A4 fires false-positive.
+func TestInfraAlign_RA4_TopLevelSecrets_FromImport_DoesNotFire(t *testing.T) {
+	os.Unsetenv("STAGING_PG_PASSWORD")
+	os.Unsetenv("STAGING_API_TOKEN")
+	dir := t.TempDir()
+
+	sharedYAML := `
+secrets:
+  generate:
+    - key: STAGING_PG_PASSWORD
+      type: random_hex
+      length: 32
+  entries:
+    - name: STAGING_API_TOKEN
+      store: vault
+`
+	if err := os.WriteFile(filepath.Join(dir, "shared.yaml"), []byte(sharedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+appName: test
+imports:
+  - shared.yaml
+modules:
+  - name: api
+    type: infra.container_service
+    config:
+      image: "myapp:latest"
+      http_port: 8080
+      env_vars:
+        DATABASE_URL: "postgres://user:${STAGING_PG_PASSWORD}@host:5432/db"
+        API_TOKEN: "${STAGING_API_TOKEN}"
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := alignOptions{configFile: mainPath}
+	findings, err := runInfraAlignChecks(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findingsHaveRule(findings, "R-A4") {
+		t.Errorf("unexpected R-A4 finding for imported top-level secrets: %v", findings)
+	}
+}
+
 // ── R-A5: migrations alignment ─────────────────────────────────────────────
 
 func TestInfraAlign_RA5_PreDeployMigrateNoDB_Fires(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -378,6 +378,24 @@ func (cfg *WorkflowConfig) processImports(seen map[string]bool) error {
 			}
 		}
 
+		// Merge Environments — per-env dedupe by name (parent wins).
+		// ResolveSecretStore consults Environments[env].SecretsStoreOverride
+		// to route secrets to a specific store for a given environment. A
+		// shared imported file commonly defines per-env overrides while the
+		// main file only redeclares envs it customizes; without merging,
+		// imported overrides are dropped and secrets fall back to
+		// defaultStore/provider — silently fetching from the wrong backend.
+		if len(impCfg.Environments) > 0 {
+			if cfg.Environments == nil {
+				cfg.Environments = make(map[string]*EnvironmentConfig, len(impCfg.Environments))
+			}
+			for k, v := range impCfg.Environments {
+				if _, exists := cfg.Environments[k]; !exists {
+					cfg.Environments[k] = v
+				}
+			}
+		}
+
 		// Merge top-level secrets. Generate (dedupe by Key) and Entries
 		// (dedupe by Name) are appended. Scalar fields follow parent-wins.
 		// `Config` is a map[string]any: per-key merge so an imported "shared

--- a/config/config.go
+++ b/config/config.go
@@ -361,6 +361,52 @@ func (cfg *WorkflowConfig) processImports(seen map[string]bool) error {
 			cfg.Sidecars = append(cfg.Sidecars, sc)
 			existingSidecars[sc.Name] = struct{}{}
 		}
+
+		// Merge top-level secrets — Generate (dedupe by Key) and Entries
+		// (dedupe by Name) are appended; scalar/map fields follow main-wins
+		// semantics consistent with the rest of processImports.
+		if impCfg.Secrets != nil {
+			if cfg.Secrets == nil {
+				cfg.Secrets = &SecretsConfig{}
+			}
+			// Scalar/map fields: parent wins; only adopt if unset on parent.
+			if cfg.Secrets.DefaultStore == "" {
+				cfg.Secrets.DefaultStore = impCfg.Secrets.DefaultStore
+			}
+			if cfg.Secrets.Provider == "" {
+				cfg.Secrets.Provider = impCfg.Secrets.Provider
+			}
+			if cfg.Secrets.Config == nil {
+				cfg.Secrets.Config = impCfg.Secrets.Config
+			}
+			if cfg.Secrets.Rotation == nil {
+				cfg.Secrets.Rotation = impCfg.Secrets.Rotation
+			}
+			// Generate slice — dedupe by Key (first definition wins).
+			existingGen := make(map[string]struct{}, len(cfg.Secrets.Generate))
+			for _, g := range cfg.Secrets.Generate {
+				existingGen[g.Key] = struct{}{}
+			}
+			for _, g := range impCfg.Secrets.Generate {
+				if _, exists := existingGen[g.Key]; exists {
+					continue
+				}
+				cfg.Secrets.Generate = append(cfg.Secrets.Generate, g)
+				existingGen[g.Key] = struct{}{}
+			}
+			// Entries slice — dedupe by Name (first definition wins).
+			existingEntries := make(map[string]struct{}, len(cfg.Secrets.Entries))
+			for _, e := range cfg.Secrets.Entries {
+				existingEntries[e.Name] = struct{}{}
+			}
+			for _, e := range impCfg.Secrets.Entries {
+				if _, exists := existingEntries[e.Name]; exists {
+					continue
+				}
+				cfg.Secrets.Entries = append(cfg.Secrets.Entries, e)
+				existingEntries[e.Name] = struct{}{}
+			}
+		}
 	}
 
 	cfg.Imports = nil // clear after processing

--- a/config/config.go
+++ b/config/config.go
@@ -362,22 +362,49 @@ func (cfg *WorkflowConfig) processImports(seen map[string]bool) error {
 			existingSidecars[sc.Name] = struct{}{}
 		}
 
-		// Merge top-level secrets — Generate (dedupe by Key) and Entries
-		// (dedupe by Name) are appended; scalar/map fields follow main-wins
-		// semantics consistent with the rest of processImports.
+		// Merge SecretStores — per-store dedupe by name (parent wins).
+		// SecretsConfig.DefaultStore + SecretEntry.Store reference these by
+		// name via ResolveSecretStore / getProviderForStore, so the import
+		// merge must include the store map; otherwise an imported store name
+		// is later treated as a raw provider and provider construction fails.
+		if len(impCfg.SecretStores) > 0 {
+			if cfg.SecretStores == nil {
+				cfg.SecretStores = make(map[string]*SecretStoreConfig, len(impCfg.SecretStores))
+			}
+			for k, v := range impCfg.SecretStores {
+				if _, exists := cfg.SecretStores[k]; !exists {
+					cfg.SecretStores[k] = v
+				}
+			}
+		}
+
+		// Merge top-level secrets. Generate (dedupe by Key) and Entries
+		// (dedupe by Name) are appended. Scalar fields follow parent-wins.
+		// `Config` is a map[string]any: per-key merge so an imported "shared
+		// defaults" config can survive a partial main-file override (e.g.
+		// import provides {repo, token_env}; main only sets {token_env}).
 		if impCfg.Secrets != nil {
 			if cfg.Secrets == nil {
 				cfg.Secrets = &SecretsConfig{}
 			}
-			// Scalar/map fields: parent wins; only adopt if unset on parent.
+			// Scalar fields: parent wins; only adopt if unset on parent.
 			if cfg.Secrets.DefaultStore == "" {
 				cfg.Secrets.DefaultStore = impCfg.Secrets.DefaultStore
 			}
 			if cfg.Secrets.Provider == "" {
 				cfg.Secrets.Provider = impCfg.Secrets.Provider
 			}
-			if cfg.Secrets.Config == nil {
-				cfg.Secrets.Config = impCfg.Secrets.Config
+			// Config map: per-key merge — main wins on conflicts, imported
+			// keys not present in main are preserved (shared-defaults pattern).
+			if len(impCfg.Secrets.Config) > 0 {
+				if cfg.Secrets.Config == nil {
+					cfg.Secrets.Config = make(map[string]any, len(impCfg.Secrets.Config))
+				}
+				for k, v := range impCfg.Secrets.Config {
+					if _, exists := cfg.Secrets.Config[k]; !exists {
+						cfg.Secrets.Config[k] = v
+					}
+				}
 			}
 			if cfg.Secrets.Rotation == nil {
 				cfg.Secrets.Rotation = impCfg.Secrets.Rotation

--- a/config/config_import_test.go
+++ b/config/config_import_test.go
@@ -802,7 +802,7 @@ secretStores:
     config:
       address: https://vault.example.com
   shared-store:
-    provider: aws-secretsmanager
+    provider: aws-secrets-manager
     config:
       region: us-east-1
 secrets:
@@ -818,7 +818,7 @@ imports:
 
 secretStores:
   shared-store:
-    provider: gcp-secretmanager
+    provider: gcp-secret-manager
     config:
       project: my-project
 `
@@ -839,7 +839,7 @@ secretStores:
 	// shared-store: parent wins.
 	if shared, ok := cfg.SecretStores["shared-store"]; !ok {
 		t.Error("expected SecretStores[shared-store]")
-	} else if shared.Provider != "gcp-secretmanager" {
+	} else if shared.Provider != "gcp-secret-manager" {
 		t.Errorf("expected main-wins on shared-store provider, got %q", shared.Provider)
 	}
 	// defaultStore came from imported secrets:
@@ -897,5 +897,76 @@ secrets:
 	// Main override wins on conflict.
 	if cfg.Secrets.Config["token_env"] != "MAIN_TOKEN" {
 		t.Errorf("expected token_env=MAIN_TOKEN (main override), got %v", cfg.Secrets.Config["token_env"])
+	}
+}
+
+// TestProcessImports_MergesEnvironmentsFromImport pins that
+// WorkflowConfig.Environments is merged across imports. ResolveSecretStore
+// consults Environments[env].SecretsStoreOverride to route secrets to a
+// specific store per environment; without the merge, an imported per-env
+// override is dropped and secret resolution silently falls back to
+// defaultStore/provider — fetching from the wrong backend.
+func TestProcessImports_MergesEnvironmentsFromImport(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+environments:
+  staging:
+    provider: aws
+    region: us-east-1
+    secretsStoreOverride: vault
+  production:
+    provider: aws
+    region: us-west-2
+    secretsStoreOverride: aws-prod
+`
+	if err := os.WriteFile(filepath.Join(dir, "imported.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - imported.yaml
+
+environments:
+  production:
+    provider: aws
+    region: us-west-2
+    secretsStoreOverride: aws-prod-main
+  local:
+    provider: docker
+    region: localhost
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// staging came from import only — must survive merge.
+	staging, ok := cfg.Environments["staging"]
+	if !ok {
+		t.Fatal("expected Environments[staging] from import")
+	}
+	if staging.SecretsStoreOverride != "vault" {
+		t.Errorf("expected staging.SecretsStoreOverride=vault from import, got %q", staging.SecretsStoreOverride)
+	}
+
+	// production: parent wins (main override).
+	prod, ok := cfg.Environments["production"]
+	if !ok {
+		t.Fatal("expected Environments[production]")
+	}
+	if prod.SecretsStoreOverride != "aws-prod-main" {
+		t.Errorf("expected main-wins on production.SecretsStoreOverride, got %q", prod.SecretsStoreOverride)
+	}
+
+	// local came from main only.
+	if _, ok := cfg.Environments["local"]; !ok {
+		t.Error("expected Environments[local] from main")
 	}
 }

--- a/config/config_import_test.go
+++ b/config/config_import_test.go
@@ -641,3 +641,148 @@ modules:
 		t.Errorf("expected exactly 4 modules (no duplicates), got %d", len(cfg.Modules))
 	}
 }
+
+// TestLoadFromFile_ImportSecretsMerge pins the processImports behavior for
+// top-level WorkflowConfig.Secrets: Generate (dedupe by Key) and Entries
+// (dedupe by Name) are merged from imports; scalar/map fields follow
+// main-wins precedence consistent with the rest of the import path.
+func TestLoadFromFile_ImportSecretsMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+secrets:
+  defaultStore: import-store
+  provider: import-provider
+  generate:
+    - key: IMPORTED_KEY
+      type: random_hex
+      length: 32
+    - key: SHARED_KEY
+      type: random_hex
+      length: 16
+  entries:
+    - name: IMPORTED_ENTRY
+      store: vault
+    - name: SHARED_ENTRY
+      store: vault
+`
+	if err := os.WriteFile(filepath.Join(dir, "imported.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - imported.yaml
+
+secrets:
+  defaultStore: main-store
+  generate:
+    - key: MAIN_KEY
+      type: random_hex
+      length: 64
+    - key: SHARED_KEY
+      type: provider_credential
+      source: main
+  entries:
+    - name: MAIN_ENTRY
+      store: vault
+    - name: SHARED_ENTRY
+      store: main-store
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Secrets == nil {
+		t.Fatal("expected merged Secrets, got nil")
+	}
+
+	// Scalar precedence: main wins where set, import fills where unset.
+	if cfg.Secrets.DefaultStore != "main-store" {
+		t.Errorf("expected DefaultStore=main-store, got %q", cfg.Secrets.DefaultStore)
+	}
+	if cfg.Secrets.Provider != "import-provider" {
+		t.Errorf("expected Provider=import-provider (filled from import), got %q", cfg.Secrets.Provider)
+	}
+
+	// Generate: dedupe by Key, main-wins on conflict, append new entries.
+	genByKey := make(map[string]SecretGen)
+	for _, g := range cfg.Secrets.Generate {
+		if _, exists := genByKey[g.Key]; exists {
+			t.Errorf("duplicate Generate key %q after merge", g.Key)
+		}
+		genByKey[g.Key] = g
+	}
+	for _, k := range []string{"MAIN_KEY", "IMPORTED_KEY", "SHARED_KEY"} {
+		if _, ok := genByKey[k]; !ok {
+			t.Errorf("expected Generate key %q present after merge", k)
+		}
+	}
+	if shared, ok := genByKey["SHARED_KEY"]; ok && shared.Type != "provider_credential" {
+		t.Errorf("expected main-wins for SHARED_KEY type, got %q", shared.Type)
+	}
+
+	// Entries: dedupe by Name, main-wins on conflict, append new entries.
+	entryByName := make(map[string]SecretEntry)
+	for _, e := range cfg.Secrets.Entries {
+		if _, exists := entryByName[e.Name]; exists {
+			t.Errorf("duplicate Entries name %q after merge", e.Name)
+		}
+		entryByName[e.Name] = e
+	}
+	for _, n := range []string{"MAIN_ENTRY", "IMPORTED_ENTRY", "SHARED_ENTRY"} {
+		if _, ok := entryByName[n]; !ok {
+			t.Errorf("expected Entries name %q present after merge", n)
+		}
+	}
+	if shared, ok := entryByName["SHARED_ENTRY"]; ok && shared.Store != "main-store" {
+		t.Errorf("expected main-wins for SHARED_ENTRY store, got %q", shared.Store)
+	}
+}
+
+// TestLoadFromFile_ImportSecretsOnlyInImport covers the case the original
+// PR-1 fix missed: top-level secrets:`appears only in an imported file, not
+// in main. Without the merge, cfg.Secrets is nil after LoadFromFile.
+func TestLoadFromFile_ImportSecretsOnlyInImport(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+secrets:
+  generate:
+    - key: ONLY_IN_IMPORT
+      type: random_hex
+      length: 32
+`
+	if err := os.WriteFile(filepath.Join(dir, "imported.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - imported.yaml
+
+modules:
+  - name: dummy
+    type: noop
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Secrets == nil {
+		t.Fatal("expected cfg.Secrets to be populated from import, got nil")
+	}
+	if len(cfg.Secrets.Generate) != 1 || cfg.Secrets.Generate[0].Key != "ONLY_IN_IMPORT" {
+		t.Errorf("expected Generate=[{Key:ONLY_IN_IMPORT}], got %v", cfg.Secrets.Generate)
+	}
+}

--- a/config/config_import_test.go
+++ b/config/config_import_test.go
@@ -746,8 +746,8 @@ secrets:
 }
 
 // TestLoadFromFile_ImportSecretsOnlyInImport covers the case the original
-// PR-1 fix missed: top-level secrets:`appears only in an imported file, not
-// in main. Without the merge, cfg.Secrets is nil after LoadFromFile.
+// PR-1 fix missed: top-level `secrets:` appears only in an imported file,
+// not in main. Without the merge, cfg.Secrets is nil after LoadFromFile.
 func TestLoadFromFile_ImportSecretsOnlyInImport(t *testing.T) {
 	dir := t.TempDir()
 
@@ -784,5 +784,118 @@ modules:
 	}
 	if len(cfg.Secrets.Generate) != 1 || cfg.Secrets.Generate[0].Key != "ONLY_IN_IMPORT" {
 		t.Errorf("expected Generate=[{Key:ONLY_IN_IMPORT}], got %v", cfg.Secrets.Generate)
+	}
+}
+
+// TestProcessImports_MergesSecretStoresFromImport pins that
+// WorkflowConfig.SecretStores is merged across imports. ResolveSecretStore
+// and getProviderForStore look up store names against this map; without the
+// merge an imported defaultStore or entries[*].store fails as an
+// unknown-provider error.
+func TestProcessImports_MergesSecretStoresFromImport(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+secretStores:
+  vault:
+    provider: vault
+    config:
+      address: https://vault.example.com
+  shared-store:
+    provider: aws-secretsmanager
+    config:
+      region: us-east-1
+secrets:
+  defaultStore: vault
+`
+	if err := os.WriteFile(filepath.Join(dir, "imported.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - imported.yaml
+
+secretStores:
+  shared-store:
+    provider: gcp-secretmanager
+    config:
+      project: my-project
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// vault came from import only — must survive the merge.
+	if _, ok := cfg.SecretStores["vault"]; !ok {
+		t.Error("expected SecretStores[vault] from import")
+	}
+	// shared-store: parent wins.
+	if shared, ok := cfg.SecretStores["shared-store"]; !ok {
+		t.Error("expected SecretStores[shared-store]")
+	} else if shared.Provider != "gcp-secretmanager" {
+		t.Errorf("expected main-wins on shared-store provider, got %q", shared.Provider)
+	}
+	// defaultStore came from imported secrets:
+	if cfg.Secrets == nil || cfg.Secrets.DefaultStore != "vault" {
+		t.Errorf("expected Secrets.DefaultStore=vault from import, got %v", cfg.Secrets)
+	}
+}
+
+// TestProcessImports_SecretsConfigMergesPerKey_LocalOverride pins the
+// per-key merge for Secrets.Config. The "shared defaults + local override"
+// pattern requires that an imported Config provides defaults (e.g. `repo`)
+// while the main file overrides only specific keys (e.g. `token_env`); the
+// imported keys not present in main must survive.
+func TestProcessImports_SecretsConfigMergesPerKey_LocalOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+secrets:
+  config:
+    repo: GoCodeAlone/workflow
+    token_env: SHARED_TOKEN
+    api_url: https://api.github.com
+`
+	if err := os.WriteFile(filepath.Join(dir, "imported.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - imported.yaml
+
+secrets:
+  config:
+    token_env: MAIN_TOKEN
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Secrets == nil {
+		t.Fatal("expected cfg.Secrets non-nil")
+	}
+	// Imported defaults survive.
+	if cfg.Secrets.Config["repo"] != "GoCodeAlone/workflow" {
+		t.Errorf("expected repo=GoCodeAlone/workflow (imported default), got %v", cfg.Secrets.Config["repo"])
+	}
+	if cfg.Secrets.Config["api_url"] != "https://api.github.com" {
+		t.Errorf("expected api_url survived from import, got %v", cfg.Secrets.Config["api_url"])
+	}
+	// Main override wins on conflict.
+	if cfg.Secrets.Config["token_env"] != "MAIN_TOKEN" {
+		t.Errorf("expected token_env=MAIN_TOKEN (main override), got %v", cfg.Secrets.Config["token_env"])
 	}
 }


### PR DESCRIPTION
## Summary

`wfctl infra align --strict` previously fired a false-positive `R-A4 FAIL` for env-var tokens that resolve via the **top-level** `secrets.generate` / `secrets.entries` blocks. `buildAlignContext` only populated `ctx.secretKeys` from the module-form (`secrets.generate` / `secrets.requires` modules), so any config using the canonical top-level `secrets:` block was unfairly flagged.

This PR fixes the original W-541 align bug. During Copilot review, three additional incomplete-merge surfaces in `config.processImports` were surfaced and addressed in follow-on commits to keep the import-merge logic internally consistent. Two further direct-parsing-caller paths (`parseSecretsConfig`, `wfctl secrets`) were scope-cut to follow-up issues for separate PRs.

Closes workflow#541. Unblocks core-dump PR #190 (which uses inline top-level `secrets.generate` to declare `STAGING_PG_PASSWORD`; verified against the actual config — no `imports:` involved).

## Scope (delta from original spec)

The original plan limited this PR to `buildAlignContext` + 2 align tests. Copilot review surfaced that `config.processImports` was missing several merge surfaces that the new align behavior would expose. Rather than ship a half-fix, the import-merge work was completed in the same PR. Honest scope:

### 1. Original W-541 fix — R-A4 align rule (commit `abc2db8c`)
- `cmd/wfctl/infra_align_rules.go`: extend `buildAlignContext`'s top-level-secrets branch to also seed `ctx.secretKeys` from `cfg.Secrets.Generate[].Key` and `cfg.Secrets.Entries[].Name`.
- Tests: `TestInfraAlign_RA4_TopLevelSecretsGenerate_DoesNotFire`, `TestInfraAlign_RA4_TopLevelSecretsEntries_DoesNotFire`.

### 2. processImports — Secrets merge (commit `8632612f`)
- `config/config.go`: `processImports` now merges `WorkflowConfig.Secrets`. Generate (dedupe by Key), Entries (dedupe by Name), scalars parent-wins.
- Tests: `TestLoadFromFile_ImportSecretsMerge`, `TestLoadFromFile_ImportSecretsOnlyInImport`, `TestInfraAlign_RA4_TopLevelSecrets_FromImport_DoesNotFire`.

### 3. processImports — SecretStores + Secrets.Config per-key merge (commit `dd81421d`)
- `config/config.go`: merge `WorkflowConfig.SecretStores` (per-store dedupe by name); change `Secrets.Config` from all-or-nothing to per-key merge to support shared-defaults + local-override pattern.
- Tests: `TestProcessImports_MergesSecretStoresFromImport`, `TestProcessImports_SecretsConfigMergesPerKey_LocalOverride`.

### 4. processImports — Environments merge + canonical provider IDs (commit `30bc8bc8`)
- `config/config.go`: merge `WorkflowConfig.Environments` per-env (parent wins). `ResolveSecretStore` consults `Environments[env].SecretsStoreOverride`; without merge, imported overrides drop and secrets route to wrong backend.
- Test fixtures: use canonical `aws-secrets-manager` and `gcp-secret-manager` (per `docs/dsl-reference.md` and `cmd/wfctl/wizard.go`).
- Tests: `TestProcessImports_MergesEnvironmentsFromImport`.

A complete `WorkflowConfig` field audit is documented in commit `30bc8bc8`'s body. Remaining unmerged top-level fields (Requires, Infrastructure, Engine, CI, Infra, Services, Mesh, Networking, Security) are intentionally out-of-scope follow-ups — none are referenced by the alignment-rule code path that motivated this PR.

## Follow-up issues

The merge work in this PR only benefits callers that go through `config.LoadFromFile`. Two direct-parsing-caller paths still bypass `processImports` and were scope-cut to keep this PR focused:

- workflow#551 — `parseSecretsConfig` (`cmd/wfctl/infra_bootstrap.go`, `cmd/wfctl/infra.go`) raw-unmarshals only the current file. After this PR, `wfctl infra align` correctly resolves imported `secrets.generate` keys, but `wfctl infra bootstrap` will silently skip generation of those secrets.
- workflow#552 — `wfctl secrets` family (`loadSecretsConfig`, `runSecretsSetup`) parses YAML directly. Configs that move `secrets.entries` / `secretStores` / per-env overrides into shared imports will look empty or route to the wrong store in `secrets get` / `validate` / `export` / `setup`.

Both are mechanical refactors (call `config.LoadFromFile` instead of `yaml.Unmarshal`) but have a wide enough blast radius to deserve their own PR + regression test coverage.

## Test plan

- [x] `GOWORK=off go test -race -count=1 ./config/ ./cmd/wfctl/` — green
- [x] Each new test verified to FAIL without its corresponding fix (proves bug + locks behavior)
- [x] Existing R-A4 module-form test (`TestInfraAlign_RA4_SecretsGenerate_DoesNotFire`) and all import precedence tests still pass
- [x] No `go.mod` / `go.sum` changes (the `Go Mod Tidy` failure on this PR is pre-existing AWS SDK drift on `main`, unrelated to this change)

## Design reference

`docs/plans/2026-05-05-iac-deferred-cleanup-design.md` (PR 1, W-541). v0.21.1 will be cut after this merges.

## Rollback

Revert the squash commit on `main`. Stopgap fallback is the env-var export pattern in core-dump's `deploy.yml` align step (`STAGING_PG_PASSWORD`, `STAGING_VPC_UUID`).