### PR TITLE
test(plugin): diagnostic test for manifest schema strictness (workflow#540)

### DIFF
--- a/docs/test-skips.md
+++ b/docs/test-skips.md
@@ -9,4 +9,4 @@ delete the matching row here in the same PR.
 
 | Test | Issue | Plan to remove |
 |------|-------|----------------|
-| `plugin/sdk.TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced` | [workflow#540](https://github.com/GoCodeAlone/workflow/issues/540) | Remove `t.Skip` line in fix follow-up PR once the jsonschema-library investigation completes (per plan `2026-05-05-iac-deferred-cleanup` PR 3). |
+| `plugin/sdk.TestManifest_IaCProviderAdditionalPropertiesFalse_IsEnforced` | [workflow#540](https://github.com/GoCodeAlone/workflow/issues/540) | Behaviour-probed skip: the test SKIPs only while `ParseManifest` accepts the canonical bug input and PASSes (silent regression guard) when the bug is fixed. No source change required when the fix lands; this row exists so the SKIP is grep-able while it triggers. Drop the row when workflow#540 closes. |

--- a/docs/test-skips.md
+++ b/docs/test-skips.md
@@ -9,4 +9,18 @@ delete the matching row here in the same PR.
 
 | Test | Issue | Plan to remove |
 |------|-------|----------------|
-| `plugin/sdk.TestManifest_IaCProviderAdditionalPropertiesFalse_IsEnforced` | [workflow#540](https://github.com/GoCodeAlone/workflow/issues/540) | Behaviour-probed skip: the test SKIPs only while `ParseManifest` accepts the canonical bug input and PASSes (silent regression guard) when the bug is fixed. No source change required when the fix lands; this row exists so the SKIP is grep-able while it triggers. Drop the row when workflow#540 closes. |
+
+<!--
+Currently no active skips.
+
+Removed entry (2026-05-05): the diagnostic test for workflow#540
+(`plugin/sdk.TestManifest_IaCProvider_AdditionalPropertiesFalse_IsEnforced`)
+was originally proposed in `t.Skip` shape per plan rev3 §I-5, but
+empirical verification during PR #553 showed the bug does not reproduce
+against the current jsonschema/v6 build. The test was promoted to an
+assertive regression guard on the canonical issue inputs (`name`,
+`resourceTypes`, `configSchema` plus a synthetic key) so any future
+regression turns CI red, and the runbook entry was retired alongside.
+workflow#540 stays open until the upstream investigation confirms the
+schema-loader behaviour is correct across all draft dialects.
+-->

--- a/docs/test-skips.md
+++ b/docs/test-skips.md
@@ -1,0 +1,12 @@
+# Active test skips
+
+Tests intentionally guarded with `t.Skip` because the underlying behaviour
+is a known bug or pending feature. Each row links to the tracking issue
+and the trigger for removing the skip.
+
+When a fix lands, drop the `t.Skip(...)` line in the named test and
+delete the matching row here in the same PR.
+
+| Test | Issue | Plan to remove |
+|------|-------|----------------|
+| `plugin/sdk.TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced` | [workflow#540](https://github.com/GoCodeAlone/workflow/issues/540) | Remove `t.Skip` line in fix follow-up PR once the jsonschema-library investigation completes (per plan `2026-05-05-iac-deferred-cleanup` PR 3). |

--- a/plugin/sdk/manifest_test.go
+++ b/plugin/sdk/manifest_test.go
@@ -1,9 +1,14 @@
 package sdk
 
 import (
+	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
 )
 
 // TestManifest_IaCProvider_ComputePlanVersion exercises the new
@@ -100,10 +105,12 @@ func TestManifest_RootPermitsAdditionalProperties(t *testing.T) {
 // Fixtures cover the exact key names cited in the issue
 // (`name`, `resourceTypes`, `configSchema`) plus a synthetic key, since
 // the bug surfaced on real `iacProvider` content rather than on
-// arbitrary unknown keys. Each case must produce an error whose chain
-// includes the `additionalProperties` schema rejection — accepting any
-// non-nil error would mask unrelated regressions (e.g. schema
-// compilation failure) as success.
+// arbitrary unknown keys. Each case must produce a `*jsonschema.ValidationError`
+// whose causes tree contains a `*kind.AdditionalProperties` entry naming
+// the offending keys — asserting against the structured ErrorKind
+// rather than against English error wording so the test does not break
+// when the library localises or rewords its messages (Copilot review on
+// workflow#553, commit e0ae98b).
 //
 // SHAPE: assertive regression guard. The plan rev3 §I-5 alt-shape
 // originally specified `t.Skip` because the bug was assumed live on
@@ -112,61 +119,96 @@ func TestManifest_RootPermitsAdditionalProperties(t *testing.T) {
 // shape is strictly stronger — any future regression fails CI loudly
 // with a clear pointer to workflow#540.
 func TestManifest_IaCProvider_AdditionalPropertiesFalse_IsEnforced(t *testing.T) {
-	cases := map[string]string{
-		"issue-name": `{
-			"name": "test-plugin",
-			"iacProvider": {
-				"computePlanVersion": "v2",
-				"name": "do"
-			}
-		}`,
-		"issue-resourceTypes": `{
-			"name": "test-plugin",
-			"iacProvider": {
-				"computePlanVersion": "v2",
-				"resourceTypes": ["droplet"]
-			}
-		}`,
-		"issue-configSchema": `{
-			"name": "test-plugin",
-			"iacProvider": {
-				"computePlanVersion": "v2",
-				"configSchema": {}
-			}
-		}`,
-		"issue-all-three": `{
-			"name": "test-plugin",
-			"iacProvider": {
-				"computePlanVersion": "v2",
-				"name": "do",
-				"resourceTypes": ["droplet"],
-				"configSchema": {}
-			}
-		}`,
-		"synthetic-extra-key": `{
-			"name": "test-plugin",
-			"iacProvider": {
-				"computePlanVersion": "v2",
-				"bogusKeyThatShouldBeRejected": "value"
-			}
-		}`,
+	cases := map[string]struct {
+		manifest string
+		// wantKeys is the set of extra iacProvider keys the test expects
+		// the schema validator to flag with an additionalProperties
+		// rejection. Asserting against the structured ErrorKind tree
+		// means the assertion does not depend on the library's English
+		// error wording — only on the contractual behaviour ("the
+		// `additionalProperties` keyword fired on these specific keys").
+		wantKeys []string
+	}{
+		"issue-name": {
+			manifest: `{"name":"test-plugin","iacProvider":{"computePlanVersion":"v2","name":"do"}}`,
+			wantKeys: []string{"name"},
+		},
+		"issue-resourceTypes": {
+			manifest: `{"name":"test-plugin","iacProvider":{"computePlanVersion":"v2","resourceTypes":["droplet"]}}`,
+			wantKeys: []string{"resourceTypes"},
+		},
+		"issue-configSchema": {
+			manifest: `{"name":"test-plugin","iacProvider":{"computePlanVersion":"v2","configSchema":{}}}`,
+			wantKeys: []string{"configSchema"},
+		},
+		"issue-all-three": {
+			manifest: `{"name":"test-plugin","iacProvider":{"computePlanVersion":"v2","name":"do","resourceTypes":["droplet"],"configSchema":{}}}`,
+			wantKeys: []string{"name", "resourceTypes", "configSchema"},
+		},
+		"synthetic-extra-key": {
+			manifest: `{"name":"test-plugin","iacProvider":{"computePlanVersion":"v2","bogusKeyThatShouldBeRejected":"value"}}`,
+			wantKeys: []string{"bogusKeyThatShouldBeRejected"},
+		},
 	}
-	for name, in := range cases {
+	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, err := ParseManifest([]byte(in))
+			_, err := ParseManifest([]byte(c.manifest))
 			if err == nil {
-				t.Fatalf("workflow#540 regressed: ParseManifest accepted extra iacProvider key on %q; expected schema rejection",
-					name)
+				t.Fatalf("workflow#540 regressed: ParseManifest accepted extra iacProvider key(s) %v; expected schema rejection",
+					c.wantKeys)
 			}
-			// Pin the rejection cause so unrelated failures (schema
-			// compile, JSON parse, etc.) don't masquerade as success.
-			// santhosh-tekuri/jsonschema/v6 reports the violation
-			// using the lowercase phrase below.
-			if !strings.Contains(err.Error(), "additional properties") {
-				t.Errorf("workflow#540: expected 'additional properties' rejection; got %v", err)
+			// Walk the *jsonschema.ValidationError tree and collect
+			// every key that triggered an `additionalProperties`
+			// rejection. Library wording can change; the structured
+			// ErrorKind cannot without a behaviour change.
+			rejected := collectAdditionalPropertiesRejections(err)
+			if len(rejected) == 0 {
+				t.Fatalf("workflow#540: no additionalProperties ErrorKind in error tree; got %v", err)
+			}
+			for _, want := range c.wantKeys {
+				if !rejected[want] {
+					t.Errorf("workflow#540: expected key %q rejected by additionalProperties; rejected=%v err=%v",
+						want, keysOf(rejected), err)
+				}
 			}
 		})
 	}
+}
+
+// collectAdditionalPropertiesRejections walks a validation error
+// (typically wrapped by ParseManifest) and returns every key that the
+// jsonschema library flagged via the `additionalProperties` keyword.
+// Returns an empty map if no such ErrorKind is present, which
+// distinguishes a real workflow#540 regression from an unrelated
+// failure (JSON parse, schema compile, etc.).
+func collectAdditionalPropertiesRejections(err error) map[string]bool {
+	out := map[string]bool{}
+	var verr *jsonschema.ValidationError
+	if !errors.As(err, &verr) {
+		return out
+	}
+	var visit func(*jsonschema.ValidationError)
+	visit = func(e *jsonschema.ValidationError) {
+		if ap, ok := e.ErrorKind.(*kind.AdditionalProperties); ok {
+			for _, p := range ap.Properties {
+				out[p] = true
+			}
+		}
+		for _, child := range e.Causes {
+			visit(child)
+		}
+	}
+	visit(verr)
+	return out
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out) // stable diagnostic output
+	return out
 }
 
 // TestManifestSchemaJSON_ReturnsCopy verifies that mutating the slice

--- a/plugin/sdk/manifest_test.go
+++ b/plugin/sdk/manifest_test.go
@@ -83,52 +83,90 @@ func TestManifest_RootPermitsAdditionalProperties(t *testing.T) {
 	}
 }
 
-// TestManifest_IaCProviderAdditionalPropertiesFalse_IsEnforced is a
-// diagnostic marker for workflow#540.
+// TestManifest_IaCProvider_AdditionalPropertiesFalse_IsEnforced is an
+// active regression guard for workflow#540.
 //
 // Background: workflow#540 surfaced from P-DO PR #61 as "the
 // `iacProvider` block accepts extra keys (`name`, `resourceTypes`,
 // `configSchema`) without validation error, despite the schema
-// declaring `additionalProperties: false`." The fix follow-up will
-// (a) confirm whether the jsonschema library is honouring the
-// constraint correctly across all input shapes, and (b) if a regression
-// or library quirk is found, land the schema-loader fix; once
-// `ParseManifest` rejects the extra key on the canonical bug input, the
-// probe below auto-promotes this test from SKIP to active regression
-// guard with no source change required. (Per Copilot review on
-// workflow#553: an unconditional skip can rot indefinitely; a
-// behaviour-conditioned skip self-heals when the bug is fixed.)
+// declaring `additionalProperties: false`." The bug does not reproduce
+// against the current `jsonschema/v6` build (verified empirically with
+// `ParseManifest` rejecting the canonical fixtures during the test
+// authoring); this test enforces the contract going forward so any
+// future regression — library upgrade, schema-loader change, draft
+// dialect drift — turns CI red on the same canonical inputs that
+// motivated the issue.
 //
-// SHAPE: behaviour-probed t.Skip + workflow#540 link (per plan §I-5
-// alt-shape, refined). CI stays green while the bug reproduces; the
-// SKIP surfaces in `go test -v` output, and `docs/test-skips.md`
-// tracks the active skip.
-func TestManifest_IaCProviderAdditionalPropertiesFalse_IsEnforced(t *testing.T) {
-	manifest := []byte(`{
-		"name": "test-plugin",
-		"version": "0.0.0",
-		"iacProvider": {
-			"computePlanVersion": "v2",
-			"bogusKeyThatShouldBeRejected": "value"
-		}
-	}`)
-	if _, err := ParseManifest(manifest); err == nil {
-		// Bug still reproduces: ParseManifest accepted the extra key.
-		// Skip rather than fail so workflow main CI stays green; the
-		// runbook entry in docs/test-skips.md tracks the open SKIP and
-		// the fix PR removes that row when ParseManifest starts
-		// rejecting the extra key (no source change in this test
-		// needed — the t.Skip simply stops triggering, and the test
-		// auto-promotes to an active regression guard).
-		t.Skip("BUG: workflow#540 — extra iacProvider key not rejected; " +
-			"schema declares additionalProperties:false but library accepts extra keys " +
-			"on this manifest shape. Diagnostic skip; fix follow-up PR pending.")
+// Fixtures cover the exact key names cited in the issue
+// (`name`, `resourceTypes`, `configSchema`) plus a synthetic key, since
+// the bug surfaced on real `iacProvider` content rather than on
+// arbitrary unknown keys. Each case must produce an error whose chain
+// includes the `additionalProperties` schema rejection — accepting any
+// non-nil error would mask unrelated regressions (e.g. schema
+// compilation failure) as success.
+//
+// SHAPE: assertive regression guard. The plan rev3 §I-5 alt-shape
+// originally specified `t.Skip` because the bug was assumed live on
+// main; that assumption did not hold (Copilot review on workflow#553,
+// commit 6563b57). With the bug not reproducing today, the assertive
+// shape is strictly stronger — any future regression fails CI loudly
+// with a clear pointer to workflow#540.
+func TestManifest_IaCProvider_AdditionalPropertiesFalse_IsEnforced(t *testing.T) {
+	cases := map[string]string{
+		"issue-name": `{
+			"name": "test-plugin",
+			"iacProvider": {
+				"computePlanVersion": "v2",
+				"name": "do"
+			}
+		}`,
+		"issue-resourceTypes": `{
+			"name": "test-plugin",
+			"iacProvider": {
+				"computePlanVersion": "v2",
+				"resourceTypes": ["droplet"]
+			}
+		}`,
+		"issue-configSchema": `{
+			"name": "test-plugin",
+			"iacProvider": {
+				"computePlanVersion": "v2",
+				"configSchema": {}
+			}
+		}`,
+		"issue-all-three": `{
+			"name": "test-plugin",
+			"iacProvider": {
+				"computePlanVersion": "v2",
+				"name": "do",
+				"resourceTypes": ["droplet"],
+				"configSchema": {}
+			}
+		}`,
+		"synthetic-extra-key": `{
+			"name": "test-plugin",
+			"iacProvider": {
+				"computePlanVersion": "v2",
+				"bogusKeyThatShouldBeRejected": "value"
+			}
+		}`,
 	}
-	// Bug fixed: ParseManifest rejected the extra key. The test passes
-	// silently and any future regression that re-allows the extra key
-	// will fall back into the t.Skip branch above — at which point the
-	// fix PR maintainers should investigate before re-adding the skip
-	// row to docs/test-skips.md.
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseManifest([]byte(in))
+			if err == nil {
+				t.Fatalf("workflow#540 regressed: ParseManifest accepted extra iacProvider key on %q; expected schema rejection",
+					name)
+			}
+			// Pin the rejection cause so unrelated failures (schema
+			// compile, JSON parse, etc.) don't masquerade as success.
+			// santhosh-tekuri/jsonschema/v6 reports the violation
+			// using the lowercase phrase below.
+			if !strings.Contains(err.Error(), "additional properties") {
+				t.Errorf("workflow#540: expected 'additional properties' rejection; got %v", err)
+			}
+		})
+	}
 }
 
 // TestManifestSchemaJSON_ReturnsCopy verifies that mutating the slice

--- a/plugin/sdk/manifest_test.go
+++ b/plugin/sdk/manifest_test.go
@@ -83,6 +83,40 @@ func TestManifest_RootPermitsAdditionalProperties(t *testing.T) {
 	}
 }
 
+// TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced is a
+// diagnostic marker for workflow#540.
+//
+// Background: workflow#540 surfaced from P-DO PR #61 as "the
+// `iacProvider` block accepts extra keys (`name`, `resourceTypes`,
+// `configSchema`) without validation error, despite the schema
+// declaring `additionalProperties: false`." The fix follow-up will
+// (a) confirm whether the jsonschema library is honouring the
+// constraint correctly across all input shapes, and (b) if a regression
+// or library quirk is found, land the schema-loader fix and remove the
+// t.Skip line so this test asserts strict rejection.
+//
+// SHAPE: t.Skip + workflow#540 link (per plan §I-5 alt-shape). CI stays
+// green, the SKIP surfaces in `go test -v` output, and `docs/test-skips.md`
+// tracks the active skip. Once the fix lands, drop the t.Skip line — the
+// remaining body already asserts the expected REJECT behaviour.
+func TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced(t *testing.T) {
+	t.Skip("BUG: workflow#540 — extra iacProvider key not rejected; " +
+		"schema declares additionalProperties:false but library may accept extra keys " +
+		"on some manifest shapes. Diagnostic test pending fix follow-up PR.")
+
+	manifest := []byte(`{
+		"name": "test-plugin",
+		"version": "0.0.0",
+		"iacProvider": {
+			"computePlanVersion": "v2",
+			"bogusKeyThatShouldBeRejected": "value"
+		}
+	}`)
+	if _, err := ParseManifest(manifest); err == nil {
+		t.Errorf("BUG: extra iacProvider key not rejected — see workflow#540")
+	}
+}
+
 // TestManifestSchemaJSON_ReturnsCopy verifies that mutating the slice
 // returned from ManifestSchemaJSON cannot affect the embedded schema
 // observed by subsequent callers.

--- a/plugin/sdk/manifest_test.go
+++ b/plugin/sdk/manifest_test.go
@@ -83,7 +83,7 @@ func TestManifest_RootPermitsAdditionalProperties(t *testing.T) {
 	}
 }
 
-// TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced is a
+// TestManifest_IaCProviderAdditionalPropertiesFalse_IsEnforced is a
 // diagnostic marker for workflow#540.
 //
 // Background: workflow#540 surfaced from P-DO PR #61 as "the
@@ -92,18 +92,18 @@ func TestManifest_RootPermitsAdditionalProperties(t *testing.T) {
 // declaring `additionalProperties: false`." The fix follow-up will
 // (a) confirm whether the jsonschema library is honouring the
 // constraint correctly across all input shapes, and (b) if a regression
-// or library quirk is found, land the schema-loader fix and remove the
-// t.Skip line so this test asserts strict rejection.
+// or library quirk is found, land the schema-loader fix; once
+// `ParseManifest` rejects the extra key on the canonical bug input, the
+// probe below auto-promotes this test from SKIP to active regression
+// guard with no source change required. (Per Copilot review on
+// workflow#553: an unconditional skip can rot indefinitely; a
+// behaviour-conditioned skip self-heals when the bug is fixed.)
 //
-// SHAPE: t.Skip + workflow#540 link (per plan §I-5 alt-shape). CI stays
-// green, the SKIP surfaces in `go test -v` output, and `docs/test-skips.md`
-// tracks the active skip. Once the fix lands, drop the t.Skip line — the
-// remaining body already asserts the expected REJECT behaviour.
-func TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced(t *testing.T) {
-	t.Skip("BUG: workflow#540 — extra iacProvider key not rejected; " +
-		"schema declares additionalProperties:false but library may accept extra keys " +
-		"on some manifest shapes. Diagnostic test pending fix follow-up PR.")
-
+// SHAPE: behaviour-probed t.Skip + workflow#540 link (per plan §I-5
+// alt-shape, refined). CI stays green while the bug reproduces; the
+// SKIP surfaces in `go test -v` output, and `docs/test-skips.md`
+// tracks the active skip.
+func TestManifest_IaCProviderAdditionalPropertiesFalse_IsEnforced(t *testing.T) {
 	manifest := []byte(`{
 		"name": "test-plugin",
 		"version": "0.0.0",
@@ -113,8 +113,22 @@ func TestManifest_iacProviderAdditionalPropertiesFalse_IsEnforced(t *testing.T) 
 		}
 	}`)
 	if _, err := ParseManifest(manifest); err == nil {
-		t.Errorf("BUG: extra iacProvider key not rejected — see workflow#540")
+		// Bug still reproduces: ParseManifest accepted the extra key.
+		// Skip rather than fail so workflow main CI stays green; the
+		// runbook entry in docs/test-skips.md tracks the open SKIP and
+		// the fix PR removes that row when ParseManifest starts
+		// rejecting the extra key (no source change in this test
+		// needed — the t.Skip simply stops triggering, and the test
+		// auto-promotes to an active regression guard).
+		t.Skip("BUG: workflow#540 — extra iacProvider key not rejected; " +
+			"schema declares additionalProperties:false but library accepts extra keys " +
+			"on this manifest shape. Diagnostic skip; fix follow-up PR pending.")
 	}
+	// Bug fixed: ParseManifest rejected the extra key. The test passes
+	// silently and any future regression that re-allows the extra key
+	// will fall back into the t.Skip branch above — at which point the
+	// fix PR maintainers should investigate before re-adding the skip
+	// row to docs/test-skips.md.
 }
 
 // TestManifestSchemaJSON_ReturnsCopy verifies that mutating the slice


### PR DESCRIPTION
## Summary

Active regression guard for [workflow#540](https://github.com/GoCodeAlone/workflow/issues/540) (plugin SDK manifest schema `additionalProperties:false` enforcement on the `iacProvider` sub-object).

## Shape evolution

The plan (`docs/plans/2026-05-05-iac-deferred-cleanup.md` PR 3, alignment-check PASS at 9cfa29c) originally specified a `t.Skip` diagnostic-marker shape per §I-5, on the assumption that the bug was live on main. Empirical verification during PR review showed the bug **does not reproduce** against the current `jsonschema/v6` build for the canonical issue inputs. With that assumption invalidated, the test is now an **active regression guard** rather than a skip:

- **Bug-not-reproducing today**: any future regression (library upgrade, schema-loader change, draft dialect drift) turns CI red on the same canonical inputs that motivated workflow#540.
- **Plan §I-5 t.Skip rationale (avoid red CI on main) does not apply**: there is no red CI today, so the assertive shape is strictly stronger.
- **No `docs/test-skips.md` row**: the test is not a skip; an HTML comment in that file documents the promotion and links back to workflow#540.

## Changes

- `plugin/sdk/manifest_test.go` — `TestManifest_IaCProvider_AdditionalPropertiesFalse_IsEnforced` with 5 subtests covering the exact key names cited in workflow#540 (`name`, `resourceTypes`, `configSchema`, all-three combined) plus a synthetic key. Asserts a structured `*kind.AdditionalProperties` rejection in the `*jsonschema.ValidationError` causes tree (no dependency on English error wording).
- `docs/test-skips.md` — new runbook (no active skips); HTML comment notes the workflow#540 promotion.

## Verification

```
GOWORK=off go test -race -count=1 ./plugin/sdk/...
ok  	github.com/GoCodeAlone/workflow/plugin/sdk
ok  	github.com/GoCodeAlone/workflow/plugin/sdk/iaclint
```

`go test -v` shows all 5 subtests `--- PASS`. Any regression that re-allows extra `iacProvider` keys will fail CI immediately with the rejected-key set + workflow#540 reference in the failure message.

## Plan + scope

Implements PR 3 (W-Diagnose-540) tasks 3.1 + 3.2 of `docs/plans/2026-05-05-iac-deferred-cleanup.md`. workflow#540 stays open until the upstream investigation confirms the schema-loader behaviour is correct across all draft dialects (the test guards `jsonschema/v6` draft-2020-12 today). No production code changes.

## Pre-existing CI note

`Go Mod Tidy` fails on this PR for the same reason it fails on `main` (last 5 main-branch CI runs all `failure` with the same `example/go.mod` + `example/go.sum` indirect-dependency drift, unrelated to this PR). Filed as workflow#554 for a tidy-only follow-up. Plan to admin-merge once CI completes + Copilot review settles.

Issue: workflow#540