### PR TITLE
fix(workflow): convert.go silent-drop + iac-codemod accumulator pattern (workflow#537, #539)

### DIFF
--- a/cmd/iac-codemod/lint.go
+++ b/cmd/iac-codemod/lint.go
@@ -1108,6 +1108,13 @@ func bodyReferencesField(body *ast.BlockStmt, fieldName string) bool {
 // constant inside a ForceNew branch) is still flagged. Maintainers
 // who genuinely don't propagate ForceNew leave NeedsReplace untouched
 // entirely, which the analyzer also catches.
+//
+// workflow#539 widened the matcher again to recognize struct-literal
+// assignment via *ast.KeyValueExpr (e.g. `&DiffResult{NeedsReplace:
+// needsReplace}`), the local-accumulator pattern. The same
+// literal-`false` no-assignment carve-out applies symmetrically so a
+// struct literal `{NeedsReplace: false}` inside a ForceNew-observing
+// function is still flagged.
 func bodyAssignsField(body *ast.BlockStmt, fieldName string) bool {
 	if body == nil {
 		return false
@@ -1117,25 +1124,37 @@ func bodyAssignsField(body *ast.BlockStmt, fieldName string) bool {
 		if found {
 			return false
 		}
-		assign, ok := n.(*ast.AssignStmt)
-		if !ok {
-			return true
-		}
-		for i, lhs := range assign.Lhs {
-			sel, ok := lhs.(*ast.SelectorExpr)
-			if !ok {
-				continue
-			}
-			if sel.Sel.Name != fieldName {
-				continue
-			}
-			if i < len(assign.Rhs) {
-				if id, ok := assign.Rhs[i].(*ast.Ident); ok && id.Name == "false" {
+		switch v := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range v.Lhs {
+				sel, ok := lhs.(*ast.SelectorExpr)
+				if !ok {
+					continue
+				}
+				if sel.Sel.Name != fieldName {
+					continue
+				}
+				if i < len(v.Rhs) && isLiteralFalse(v.Rhs[i]) {
 					// Literal-false assignment is treated as
 					// no-assignment so a copy-paste typo inside the
 					// ForceNew branch is still flagged.
 					continue
 				}
+				found = true
+				return false
+			}
+		case *ast.KeyValueExpr:
+			// Struct-literal assignment, e.g. `&DiffResult{NeedsReplace:
+			// needsReplace}` (workflow#539 accumulator pattern).
+			ident, ok := v.Key.(*ast.Ident)
+			if !ok || ident.Name != fieldName {
+				return true
+			}
+			if isLiteralFalse(v.Value) {
+				// Symmetric literal-false carve-out: a struct literal
+				// `{NeedsReplace: false}` inside a ForceNew-observing
+				// function is still a copy-paste bug.
+				return true
 			}
 			found = true
 			return false
@@ -1143,6 +1162,14 @@ func bodyAssignsField(body *ast.BlockStmt, fieldName string) bool {
 		return true
 	})
 	return found
+}
+
+// isLiteralFalse reports whether expr is the literal Go identifier
+// `false`. Used as a no-assignment carve-out for both AssignStmt and
+// struct-literal KeyValueExpr forms.
+func isLiteralFalse(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == "false"
 }
 
 // routeSkip records a skipped FuncDecl through the pass.Report channel

--- a/cmd/iac-codemod/lint_test.go
+++ b/cmd/iac-codemod/lint_test.go
@@ -464,6 +464,67 @@ func TestAssertDiffSetsNeedsReplaceForForceNew_RejectsLiteralFalseAssign(t *test
 	}
 }
 
+// TestAssertDiffSetsNeedsReplaceForForceNew_AccumulatorPatternIsClean pins
+// workflow#539: the local-accumulator pattern is a valid expression of
+// the W-3 force-new contract. The driver declares `var needsReplace
+// bool`, sets `needsReplace = true` inside ForceNew-driven branches,
+// then returns `&DiffResult{NeedsReplace: needsReplace, ...}`. The
+// analyzer must recognize the struct-literal `KeyValueExpr` form as an
+// assignment site, not just `*ast.AssignStmt` — otherwise the
+// accumulator pattern is reported as a contract violation.
+const diffAccumulatorSrc = driverScaffold + `
+func (d *FooDriver) Diff(ctx context.Context, desired ResourceSpec, current *ResourceOutput) (*DiffResult, error) {
+	if current == nil {
+		return &DiffResult{}, nil
+	}
+	var changes []FieldChange
+	var needsReplace bool
+	for _, c := range changes {
+		if c.ForceNew {
+			needsReplace = true
+		}
+	}
+	return &DiffResult{
+		NeedsReplace: needsReplace,
+		Changes:      changes,
+	}, nil
+}
+`
+
+func TestAssertDiffSetsNeedsReplaceForForceNew_AccumulatorPatternIsClean(t *testing.T) {
+	diags := runAnalyzerOnSource(t, diffAccumulatorSrc, AssertDiffSetsNeedsReplaceForForceNew)
+	if len(diags) != 0 {
+		t.Errorf("accumulator pattern `&DiffResult{NeedsReplace: needsReplace}` is a valid alternate canonical (workflow#539); should NOT flag; got %d:\n%s", len(diags), diagSummary(diags))
+	}
+}
+
+// TestAssertDiffSetsNeedsReplaceForForceNew_StructLiteralFalseStillFlags
+// is the symmetry test for the accumulator widening: a struct literal
+// `&DiffResult{NeedsReplace: false}` inside a function that observes
+// ForceNew is still a copy-paste bug and must be flagged. Without this
+// guard, the widened matcher would silently accept the bug-shape.
+const diffStructLiteralFalseSrc = driverScaffold + `
+func (d *FooDriver) Diff(ctx context.Context, desired ResourceSpec, current *ResourceOutput) (*DiffResult, error) {
+	var changes []FieldChange
+	for _, c := range changes {
+		if c.ForceNew {
+			_ = c
+		}
+	}
+	return &DiffResult{
+		NeedsReplace: false,
+		Changes:      changes,
+	}, nil
+}
+`
+
+func TestAssertDiffSetsNeedsReplaceForForceNew_StructLiteralFalseStillFlags(t *testing.T) {
+	diags := runAnalyzerOnSource(t, diffStructLiteralFalseSrc, AssertDiffSetsNeedsReplaceForForceNew)
+	if len(diags) != 1 {
+		t.Errorf("`&DiffResult{NeedsReplace: false}` is a copy-paste bug; analyzer must flag; got %d:\n%s", len(diags), diagSummary(diags))
+	}
+}
+
 // TestAssertDiffSetsNeedsReplaceForForceNew_NonDriverNotFlagged pins
 // review finding #3: the analyzer must NOT fire on types that have a
 // method named Diff but are not resource drivers (no Read / Create /

--- a/plugin/external/adapter.go
+++ b/plugin/external/adapter.go
@@ -220,22 +220,38 @@ func (c contractDescriptorCache) servicesFor(moduleType string) map[string]*pb.C
 
 func createTypedConfigRequest(descriptor *pb.ContractDescriptor, cfg map[string]any, resolver protoregistry.MessageTypeResolver) (*structpb.Struct, *anypb.Any, error) {
 	if descriptor == nil || descriptor.Mode == pb.ContractMode_CONTRACT_MODE_UNSPECIFIED {
-		return mapToStruct(cfg), nil, nil
+		s, err := mapToStruct(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode config as Struct: %w", err)
+		}
+		return s, nil, nil
 	}
 	if descriptor.Mode == pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT {
-		return mapToStruct(cfg), nil, nil
+		s, err := mapToStruct(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode LEGACY_STRUCT config as Struct: %w", err)
+		}
+		return s, nil, nil
 	}
 	typed, err := mapToTypedAny(descriptor.ConfigMessage, cfg, resolver)
 	if err != nil {
 		if descriptor.Mode == pb.ContractMode_CONTRACT_MODE_STRICT_PROTO {
 			return nil, nil, fmt.Errorf("STRICT_PROTO contract for config message %q cannot use legacy Struct fallback: %w", descriptor.ConfigMessage, err)
 		}
-		return mapToStruct(cfg), nil, nil
+		s, sErr := mapToStruct(cfg)
+		if sErr != nil {
+			return nil, nil, fmt.Errorf("encode config as Struct after typed fallback: %w", sErr)
+		}
+		return s, nil, nil
 	}
 	if descriptor.Mode == pb.ContractMode_CONTRACT_MODE_STRICT_PROTO {
 		return nil, typed, nil
 	}
-	return mapToStruct(cfg), typed, nil
+	s, err := mapToStruct(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode PROTO_WITH_LEGACY_STRUCT config as Struct: %w", err)
+	}
+	return s, typed, nil
 }
 
 func contractModeUsesTyped(mode pb.ContractMode) bool {

--- a/plugin/external/convert.go
+++ b/plugin/external/convert.go
@@ -16,17 +16,14 @@ import (
 )
 
 // mapToStruct converts a Go map to a protobuf Struct.
-// Returns nil if the input is nil.
-func mapToStruct(m map[string]any) *structpb.Struct {
+// Returns nil if the input is nil. Propagates errors from structpb.NewStruct
+// (workflow#537) so callers can surface conversion failures rather than
+// silently dropping unrepresentable values.
+func mapToStruct(m map[string]any) (*structpb.Struct, error) {
 	if m == nil {
-		return nil
+		return nil, nil
 	}
-	s, err := structpb.NewStruct(m)
-	if err != nil {
-		// Fall back to empty struct on conversion error
-		return &structpb.Struct{}
-	}
-	return s
+	return structpb.NewStruct(m)
 }
 
 // structToMap converts a protobuf Struct to a Go map.

--- a/plugin/external/convert_test.go
+++ b/plugin/external/convert_test.go
@@ -1,0 +1,74 @@
+package external
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// mustMapToStruct is a test helper that wraps mapToStruct and fails the test
+// if the conversion errors. Use it for fixture data that is known to be
+// representable by structpb.
+func mustMapToStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := mapToStruct(m)
+	if err != nil {
+		t.Fatalf("mustMapToStruct: %v", err)
+	}
+	return s
+}
+
+// TestMapToStruct_PropagatesErrorOnUnrepresentableType verifies that
+// mapToStruct surfaces structpb.NewStruct errors instead of silently
+// dropping the entire map (workflow#537).
+//
+// A `chan` value is not representable in structpb (per
+// google.golang.org/protobuf/types/known/structpb), so NewStruct returns an
+// error. Prior to the fix, mapToStruct swallowed the error and returned an
+// empty *structpb.Struct, hiding silent data loss in remote plugin calls.
+func TestMapToStruct_PropagatesErrorOnUnrepresentableType(t *testing.T) {
+	m := map[string]any{
+		"ok_key":  "value",
+		"bad_key": make(chan int),
+	}
+	s, err := mapToStruct(m)
+	if err == nil {
+		t.Fatal("expected error from structpb.NewStruct on chan, got nil")
+	}
+	if s != nil {
+		t.Errorf("expected nil struct on error, got %v", s)
+	}
+}
+
+// TestMapToStruct_NilInputReturnsNil documents the canonical nil-passthrough.
+func TestMapToStruct_NilInputReturnsNil(t *testing.T) {
+	s, err := mapToStruct(nil)
+	if err != nil {
+		t.Fatalf("expected no error on nil input, got %v", err)
+	}
+	if s != nil {
+		t.Errorf("expected nil struct on nil input, got %v", s)
+	}
+}
+
+// TestMapToStruct_ValidMapRoundTrips verifies the happy path is preserved.
+func TestMapToStruct_ValidMapRoundTrips(t *testing.T) {
+	m := map[string]any{
+		"name":    "test",
+		"count":   float64(42), // structpb canonicalizes numbers as float64
+		"enabled": true,
+	}
+	s, err := mapToStruct(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil struct")
+	}
+	got := s.AsMap()
+	for k, v := range m {
+		if got[k] != v {
+			t.Errorf("key %q: expected %v, got %v", k, v, got[k])
+		}
+	}
+}

--- a/plugin/external/remote_module.go
+++ b/plugin/external/remote_module.go
@@ -129,22 +129,35 @@ func (m *RemoteModule) InvokeService(method string, args map[string]any) (map[st
 // InvokeServiceContext calls a named method on the remote module's service
 // interface using the caller's context.
 func (m *RemoteModule) InvokeServiceContext(ctx context.Context, method string, args map[string]any) (map[string]any, error) {
-	argsStruct, err := mapToStruct(args)
-	if err != nil {
-		return nil, fmt.Errorf("remote invoke %s: encode args as Struct: %w", method, err)
-	}
 	req := &pb.InvokeServiceRequest{
 		HandleId: m.handleID,
 		Method:   method,
-		Args:     argsStruct,
 	}
 	contract := m.serviceContracts[method]
+	// Encode args as Struct only when the wire actually carries it. STRICT_PROTO
+	// nils req.Args after a successful typed encode and relies on TypedInput;
+	// failing early on Struct encoding for values JSON can marshal but Struct
+	// cannot (e.g. time.Time targeting a strict typed payload) would break
+	// otherwise-valid STRICT_PROTO calls — Copilot review #555 finding.
+	encodeLegacyArgs := contract == nil ||
+		contract.Mode == pb.ContractMode_CONTRACT_MODE_UNSPECIFIED ||
+		contract.Mode == pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT ||
+		contract.Mode == pb.ContractMode_CONTRACT_MODE_PROTO_WITH_LEGACY_STRUCT
+	if encodeLegacyArgs {
+		argsStruct, err := mapToStruct(args)
+		if err != nil {
+			return nil, fmt.Errorf("remote invoke %s: encode args as Struct: %w", method, err)
+		}
+		req.Args = argsStruct
+	}
 	if contract != nil && contract.Mode != pb.ContractMode_CONTRACT_MODE_UNSPECIFIED && contract.Mode != pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT {
 		typedInput, err := mapToTypedAny(contract.InputMessage, args, m.types)
 		if err != nil {
 			if contract.Mode == pb.ContractMode_CONTRACT_MODE_STRICT_PROTO {
 				return nil, fmt.Errorf("remote invoke %s STRICT_PROTO input message %q cannot use legacy Struct fallback: %w", method, contract.InputMessage, err)
 			}
+			// PROTO_WITH_LEGACY_STRUCT: typed encoding failed, fall back to
+			// the legacy Struct already encoded above.
 		} else {
 			req.TypedInput = typedInput
 			if contract.Mode == pb.ContractMode_CONTRACT_MODE_STRICT_PROTO {

--- a/plugin/external/remote_module.go
+++ b/plugin/external/remote_module.go
@@ -129,10 +129,14 @@ func (m *RemoteModule) InvokeService(method string, args map[string]any) (map[st
 // InvokeServiceContext calls a named method on the remote module's service
 // interface using the caller's context.
 func (m *RemoteModule) InvokeServiceContext(ctx context.Context, method string, args map[string]any) (map[string]any, error) {
+	argsStruct, err := mapToStruct(args)
+	if err != nil {
+		return nil, fmt.Errorf("remote invoke %s: encode args as Struct: %w", method, err)
+	}
 	req := &pb.InvokeServiceRequest{
 		HandleId: m.handleID,
 		Method:   method,
-		Args:     mapToStruct(args),
+		Args:     argsStruct,
 	}
 	contract := m.serviceContracts[method]
 	if contract != nil && contract.Mode != pb.ContractMode_CONTRACT_MODE_UNSPECIFIED && contract.Mode != pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT {

--- a/plugin/external/remote_step.go
+++ b/plugin/external/remote_step.go
@@ -65,7 +65,11 @@ func (s *RemoteStep) Execute(ctx context.Context, pc *module.PipelineContext) (*
 	// Convert step outputs to proto map
 	stepOutputs := make(map[string]*structpb.Struct)
 	for k, v := range pc.StepOutputs {
-		stepOutputs[k] = mapToStruct(v)
+		out, err := mapToStruct(v)
+		if err != nil {
+			return nil, fmt.Errorf("remote step %q (handle %s) encode step output %q as Struct: %w", s.name, s.handleID, k, err)
+		}
+		stepOutputs[k] = out
 	}
 
 	req, err := s.executeRequest(pc, resolvedConfig, stepOutputs)
@@ -101,13 +105,29 @@ func (s *RemoteStep) Execute(ctx context.Context, pc *module.PipelineContext) (*
 }
 
 func (s *RemoteStep) executeRequest(pc *module.PipelineContext, resolvedConfig map[string]any, stepOutputs map[string]*structpb.Struct) (*pb.ExecuteStepRequest, error) {
+	triggerData, err := mapToStruct(pc.TriggerData)
+	if err != nil {
+		return nil, fmt.Errorf("remote step %q (handle %s) encode trigger_data as Struct: %w", s.name, s.handleID, err)
+	}
+	current, err := mapToStruct(pc.Current)
+	if err != nil {
+		return nil, fmt.Errorf("remote step %q (handle %s) encode current as Struct: %w", s.name, s.handleID, err)
+	}
+	metadata, err := mapToStruct(pc.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("remote step %q (handle %s) encode metadata as Struct: %w", s.name, s.handleID, err)
+	}
+	configStruct, err := mapToStruct(resolvedConfig)
+	if err != nil {
+		return nil, fmt.Errorf("remote step %q (handle %s) encode config as Struct: %w", s.name, s.handleID, err)
+	}
 	req := &pb.ExecuteStepRequest{
 		HandleId:    s.handleID,
-		TriggerData: mapToStruct(pc.TriggerData),
+		TriggerData: triggerData,
 		StepOutputs: stepOutputs,
-		Current:     mapToStruct(pc.Current),
-		Metadata:    mapToStruct(pc.Metadata),
-		Config:      mapToStruct(resolvedConfig),
+		Current:     current,
+		Metadata:    metadata,
+		Config:      configStruct,
 	}
 	if s.contract == nil || s.contract.Mode == pb.ContractMode_CONTRACT_MODE_UNSPECIFIED {
 		return req, nil

--- a/plugin/external/remote_step.go
+++ b/plugin/external/remote_step.go
@@ -105,29 +105,43 @@ func (s *RemoteStep) Execute(ctx context.Context, pc *module.PipelineContext) (*
 }
 
 func (s *RemoteStep) executeRequest(pc *module.PipelineContext, resolvedConfig map[string]any, stepOutputs map[string]*structpb.Struct) (*pb.ExecuteStepRequest, error) {
+	// trigger_data and metadata are always sent as Struct — there's no
+	// typed alternative — so encode them up front.
 	triggerData, err := mapToStruct(pc.TriggerData)
 	if err != nil {
 		return nil, fmt.Errorf("remote step %q (handle %s) encode trigger_data as Struct: %w", s.name, s.handleID, err)
-	}
-	current, err := mapToStruct(pc.Current)
-	if err != nil {
-		return nil, fmt.Errorf("remote step %q (handle %s) encode current as Struct: %w", s.name, s.handleID, err)
 	}
 	metadata, err := mapToStruct(pc.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("remote step %q (handle %s) encode metadata as Struct: %w", s.name, s.handleID, err)
 	}
-	configStruct, err := mapToStruct(resolvedConfig)
-	if err != nil {
-		return nil, fmt.Errorf("remote step %q (handle %s) encode config as Struct: %w", s.name, s.handleID, err)
-	}
 	req := &pb.ExecuteStepRequest{
 		HandleId:    s.handleID,
 		TriggerData: triggerData,
 		StepOutputs: stepOutputs,
-		Current:     current,
 		Metadata:    metadata,
-		Config:      configStruct,
+	}
+	// Current and Config are sent as Struct only when the contract is
+	// UNSPECIFIED, LEGACY_STRUCT, or PROTO_WITH_LEGACY_STRUCT — STRICT_PROTO
+	// nils them out and relies on TypedInput/TypedConfig instead. Defer
+	// Struct encoding so values that JSON can marshal but Struct cannot
+	// (e.g. time.Time fields targeting STRICT_PROTO typed payloads) don't
+	// fail the request unnecessarily — Copilot review #555 finding.
+	encodeLegacyStruct := s.contract == nil ||
+		s.contract.Mode == pb.ContractMode_CONTRACT_MODE_UNSPECIFIED ||
+		s.contract.Mode == pb.ContractMode_CONTRACT_MODE_LEGACY_STRUCT ||
+		s.contract.Mode == pb.ContractMode_CONTRACT_MODE_PROTO_WITH_LEGACY_STRUCT
+	if encodeLegacyStruct {
+		current, err := mapToStruct(pc.Current)
+		if err != nil {
+			return nil, fmt.Errorf("remote step %q (handle %s) encode current as Struct: %w", s.name, s.handleID, err)
+		}
+		configStruct, err := mapToStruct(resolvedConfig)
+		if err != nil {
+			return nil, fmt.Errorf("remote step %q (handle %s) encode config as Struct: %w", s.name, s.handleID, err)
+		}
+		req.Current = current
+		req.Config = configStruct
 	}
 	if s.contract == nil || s.contract.Mode == pb.ContractMode_CONTRACT_MODE_UNSPECIFIED {
 		return req, nil
@@ -140,6 +154,8 @@ func (s *RemoteStep) executeRequest(pc *module.PipelineContext, resolvedConfig m
 		if s.contract.Mode == pb.ContractMode_CONTRACT_MODE_STRICT_PROTO {
 			return nil, fmt.Errorf("remote step %q STRICT_PROTO config message %q cannot use legacy Struct fallback: %w", s.name, s.contract.ConfigMessage, err)
 		}
+		// PROTO_WITH_LEGACY_STRUCT: typed encoding failed, fall back to
+		// the legacy Struct already populated above.
 		return req, nil
 	}
 	typedInput, err := mapToTypedAnyKnownFields(s.contract.InputMessage, pc.Current, s.types)
@@ -151,6 +167,9 @@ func (s *RemoteStep) executeRequest(pc *module.PipelineContext, resolvedConfig m
 	}
 	req.TypedConfig = typedConfig
 	req.TypedInput = typedInput
+	// STRICT_PROTO drops legacy Struct payloads (already not encoded above
+	// in the deferred path; this is a no-op safety net for any future
+	// branch that ends up here with Current/Config non-nil).
 	if s.contract.Mode == pb.ContractMode_CONTRACT_MODE_STRICT_PROTO {
 		req.Config = nil
 		req.Current = nil

--- a/plugin/external/remote_step_test.go
+++ b/plugin/external/remote_step_test.go
@@ -257,7 +257,7 @@ func TestRemoteStep_Execute_StrictContractFiltersUnknownCurrentFields(t *testing
 
 func TestRemoteStep_Execute_StrictContractRequiresTypedOutput(t *testing.T) {
 	stub := &stubPluginServiceClient{
-		response: &pb.ExecuteStepResponse{Output: mapToStruct(map[string]any{
+		response: &pb.ExecuteStepResponse{Output: mustMapToStruct(t, map[string]any{
 			"name": "legacy-output",
 		})},
 	}
@@ -378,7 +378,7 @@ func TestRemoteModule_InvokeService_ProtoWithLegacyKeepsArgs(t *testing.T) {
 
 func TestRemoteModule_InvokeService_StrictContractRequiresTypedOutput(t *testing.T) {
 	stub := &stubPluginServiceClient{
-		invokeResponse: &pb.InvokeServiceResponse{Result: mapToStruct(map[string]any{
+		invokeResponse: &pb.InvokeServiceResponse{Result: mustMapToStruct(t, map[string]any{
 			"name": "legacy-output",
 		})},
 	}

--- a/plugin/external/remote_step_test.go
+++ b/plugin/external/remote_step_test.go
@@ -224,6 +224,62 @@ func TestRemoteStep_Execute_StrictContractSendsTypedPayloads(t *testing.T) {
 	}
 }
 
+// TestRemoteStep_Execute_StrictContractSkipsLegacyStructEncodeForCurrent
+// pins Copilot review #555 finding: under STRICT_PROTO, the legacy
+// Struct field req.Current is nilled before send. The new
+// error-propagating mapToStruct must not reject otherwise-valid
+// STRICT_PROTO calls that carry values in pc.Current that JSON can
+// marshal but Struct cannot. Specifically: an unknown-to-the-typed-
+// message field (filtered out by mapToTypedAnyKnownFields) whose
+// value is structpb-unrepresentable (a non-string-keyed map). The
+// deferred-encode path skips Struct encoding for Current under
+// STRICT_PROTO so this works.
+func TestRemoteStep_Execute_StrictContractSkipsLegacyStructEncodeForCurrent(t *testing.T) {
+	stub := &stubPluginServiceClient{
+		response: &pb.ExecuteStepResponse{TypedOutput: mustAnyFromMapForTest(t, "workflow.plugin.v1.Manifest", map[string]any{
+			"name":    "typed-output",
+			"version": "v1",
+		})},
+	}
+	contract := &pb.ContractDescriptor{
+		Kind:          pb.ContractKind_CONTRACT_KIND_STEP,
+		StepType:      "test.strict",
+		ConfigMessage: "workflow.plugin.v1.Manifest",
+		InputMessage:  "workflow.plugin.v1.Manifest",
+		OutputMessage: "workflow.plugin.v1.Manifest",
+		Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+	}
+	step := NewRemoteStep("test-step", "handle-strict", stub, map[string]any{
+		"name":    "typed-config",
+		"version": "v1",
+	}, contract)
+
+	// Set pc.Current directly with a Struct-unrepresentable value in an
+	// unknown-to-Manifest field. The typed encoder filters unknowns
+	// (mapToTypedAnyKnownFields), so the value never reaches the typed
+	// payload. The deferred Struct encode path skips Current under
+	// STRICT_PROTO so the value never reaches structpb.NewStruct either.
+	pc := module.NewPipelineContext(map[string]any{
+		"name":    "typed-input",
+		"version": "v1",
+	}, nil)
+	pc.Current["unrepresentable"] = map[int]string{1: "a"}
+
+	_, err := step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("STRICT_PROTO execute should not encode legacy Struct for Current; got %v", err)
+	}
+	if stub.lastRequest == nil {
+		t.Fatal("expected ExecuteStep to be called")
+	}
+	if stub.lastRequest.Current != nil {
+		t.Fatalf("expected strict step to omit legacy Current, got %v", stub.lastRequest.Current)
+	}
+	if stub.lastRequest.Config != nil {
+		t.Fatalf("expected strict step to omit legacy Config, got %v", stub.lastRequest.Config)
+	}
+}
+
 func TestRemoteStep_Execute_StrictContractFiltersUnknownCurrentFields(t *testing.T) {
 	stub := &stubPluginServiceClient{
 		response: &pb.ExecuteStepResponse{TypedOutput: mustAnyFromMapForTest(t, "workflow.plugin.v1.Manifest", map[string]any{
@@ -404,6 +460,56 @@ func TestRemoteModule_InvokeService_StrictContractRequiresTypedOutput(t *testing
 	if !strings.Contains(err.Error(), "requires typed_output") {
 		t.Fatalf("expected missing typed output error, got %v", err)
 	}
+}
+
+// TestRemoteModule_InvokeService_StrictContractOmitsArgsStruct pins
+// Copilot review #555 finding: STRICT_PROTO nils req.Args after a
+// successful typed encode. The deferred-encode path skips Struct
+// encoding for STRICT_PROTO entirely, so a Struct-unrepresentable
+// value in args (here: a non-string-keyed map) does not eagerly fail
+// the encode. mapToTypedAny is non-filtering so the value would still
+// fail typed JSON marshaling — but that path's error is the legitimate
+// "STRICT_PROTO cannot use legacy Struct fallback" surfaced from
+// typed encoding, not a spurious early Struct-encode error from the
+// deferred path. This test asserts the deferred path produces zero
+// Struct-encoding errors when STRICT_PROTO is in effect by sending
+// only typed-message-known fields (which JSON-marshal fine) and
+// confirming req.Args is nil.
+func TestRemoteModule_InvokeService_StrictContractOmitsArgsStruct(t *testing.T) {
+	stub := &stubPluginServiceClient{
+		invokeResponse: &pb.InvokeServiceResponse{
+			TypedOutput: mustAnyFromMapForTest(t, "workflow.plugin.v1.Manifest", map[string]any{
+				"name":    "typed-output",
+				"version": "v1",
+			}),
+		},
+	}
+	module := NewRemoteModule("test-module", "module-handle", stub, remoteModuleContracts{
+		services: map[string]*pb.ContractDescriptor{
+			"Scan": {
+				Kind:          pb.ContractKind_CONTRACT_KIND_SERVICE,
+				Method:        "Scan",
+				InputMessage:  "workflow.plugin.v1.Manifest",
+				OutputMessage: "workflow.plugin.v1.Manifest",
+				Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+			},
+		},
+	})
+
+	_, err := module.InvokeService("Scan", map[string]any{
+		"name":    "typed-input",
+		"version": "v1",
+	})
+	if err != nil {
+		t.Fatalf("STRICT_PROTO invoke unexpectedly errored: %v", err)
+	}
+	if stub.lastInvokeRequest == nil {
+		t.Fatal("expected InvokeService to be called")
+	}
+	if stub.lastInvokeRequest.Args != nil {
+		t.Fatalf("STRICT_PROTO must omit legacy Args, got %v", stub.lastInvokeRequest.Args)
+	}
+	assertAnyTypeForTest(t, stub.lastInvokeRequest.TypedInput, "workflow.plugin.v1.Manifest")
 }
 
 func TestRemoteModule_InvokeService_PreservesStatusErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

Two precision fixes from the IaC deferred-cleanup plan (PR 2 / W-Precision):

- **workflow#537** — `plugin/external/convert.go::mapToStruct` now propagates `structpb.NewStruct` errors instead of silently dropping the entire map and returning an empty `*structpb.Struct`. Signature changed to `(*structpb.Struct, error)`; every caller in `plugin/external/` (adapter, remote_module, remote_step, createTypedConfigRequest) now wraps the encode error with caller context (which step, which field) so operators can locate the offending value.
- **workflow#539** — `iac-codemod` analyzer `AssertDiffSetsNeedsReplaceForForceNew` no longer false-positives on the local-accumulator pattern (`var needsReplace bool; ... needsReplace = true; return &DiffResult{NeedsReplace: needsReplace}`). `bodyAssignsField` now also inspects `*ast.KeyValueExpr` (struct-literal assignments). The existing literal-`false` no-assignment carve-out is applied symmetrically so `&DiffResult{NeedsReplace: false}` inside a ForceNew-observing function is still flagged.

## Plan reference

- `docs/plans/2026-05-05-iac-deferred-cleanup.md` §PR 2
- Issues: workflow#537, workflow#539

## Test plan

- [x] `GOWORK=off go test -race -count=1 ./plugin/external/...` (all pass)
- [x] `GOWORK=off go test -race -count=1 ./cmd/iac-codemod/...` (all pass, 7/7 NeedsReplace tests)
- [x] 3 new unit tests in `plugin/external/convert_test.go`: nil input, valid round-trip, chan-error propagation
- [x] 2 new unit tests in `cmd/iac-codemod/lint_test.go`: `AccumulatorPatternIsClean`, `StructLiteralFalseStillFlags`
- [x] `GOWORK=off go build ./...` succeeds
- [x] Verified in practice: `iac-codemod lint /Users/jon/workspace/workflow-plugin-digitalocean/` produces zero `AssertDiffSetsNeedsReplaceForForceNew` findings

## Rollback

Each commit reverts independently. No behavior change for unaffected paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)