### PR TITLE
fix(iac): refresh-outputs tolerates ErrResourceNotFound (ghosts) — skip+continue

### DIFF
--- a/decisions/0011-refresh-outputs-tolerate-ghosts.md
+++ b/decisions/0011-refresh-outputs-tolerate-ghosts.md
@@ -1,0 +1,57 @@
+# 0011 — refresh-outputs tolerates ErrResourceNotFound (ghosts) — skip with warn, not error
+
+**Date:** 2026-05-06
+**Status:** Accepted
+
+## Context
+
+PR #525 shipped `wfctl infra refresh-outputs` as an opt-in apply pre-step
+(`WFCTL_REFRESH_OUTPUTS`) and a standalone subcommand. The original
+implementation in `iac/refreshoutputs/refresh.go::refreshOne` propagated every
+`Read` error uniformly — `ErrResourceNotFound` was treated the same as a
+transient network failure or an auth error.
+
+This surface was first tested end-to-end in the TC2 cutover (run 25476341708).
+Ghost Droplet `coredump-staging-pg` (DO ID 568721969, deleted out-of-band but
+still present in persisted IaC state) caused `refresh-outputs` to hard-fail
+with `iac: resource not found` before the Phase-1 ghost-prune phase could act
+on it. The cascade aborted; the pipeline never reached the step that would have
+removed the ghost entry.
+
+## Decision
+
+`refreshOne` treats `errors.Is(err, interfaces.ErrResourceNotFound)` as a
+skip-and-continue condition: it leaves the ghost resource's `Outputs`
+unchanged and returns `nil`. All other errors from `Read` continue to
+propagate as hard failures (existing semantics).
+
+Ghost-prune (via `wfctl infra apply --refresh`) remains the canonical mechanism
+for removing stale state entries. This fix only makes refresh-outputs safe to
+run *before* ghost-prune in an operational pipeline without aborting.
+
+## Alternatives Considered
+
+**(a) Caller-side filter:** Require the caller to detect drift first, filter
+out ghosts, then call `Refresh` on the surviving set. Rejected: pushes
+complexity onto every caller; callers already have enough to coordinate.
+
+**(b) `--skip-ghosts` flag:** Expose the behaviour as opt-in. Rejected as
+overkill — there is no valid use case for "fail on ghost" semantics in
+refresh-outputs. The implicit "skip ghost, leave state alone" behaviour is
+correct in all operational contexts.
+
+## Consequences
+
+1. `refresh-outputs` is now safe to run before ghost-prune in pipelines.
+2. Operators running `wfctl infra refresh-outputs` against state with ghosts
+   receive fresh outputs for live resources and no error; ghost entries remain
+   in state until `--refresh` prunes them.
+3. Non-ghost `Read` errors (transient, auth, quota) still propagate as hard
+   failures, preserving the "no half-persist" contract documented in the
+   `Refresh` function godoc.
+
+## References
+
+- TC2 cutover run 25476341708 failure analysis
+- `iac/refreshoutputs/refresh.go::refreshOne` behaviour change (this PR)
+- `interfaces/iac_resource_driver.go`: `ErrResourceNotFound` sentinel definition

--- a/decisions/0011-refresh-outputs-tolerate-ghosts.md
+++ b/decisions/0011-refresh-outputs-tolerate-ghosts.md
@@ -1,4 +1,4 @@
-# 0011 — refresh-outputs tolerates ErrResourceNotFound (ghosts) — skip with warn, not error
+# 0011 — refresh-outputs tolerates ErrResourceNotFound (ghosts) — skip silently, not error
 
 **Date:** 2026-05-06
 **Status:** Accepted

--- a/iac/refreshoutputs/refresh.go
+++ b/iac/refreshoutputs/refresh.go
@@ -81,10 +81,11 @@ func Refresh(ctx context.Context, p interfaces.IaCProvider, states []interfaces.
 //
 // Ghost handling: if the provider reports ErrResourceNotFound, the resource
 // exists in local state but cloud has no record of it (deleted out-of-band).
-// Refresh-outputs is a non-mutating operation; it leaves the ghost's Outputs
-// unchanged so that the downstream ghost-prune phase (wfctl infra apply
-// --refresh) can act on it. This separates "refresh outputs of live resources"
-// from "remove state entries for gone resources" — they are orthogonal.
+// refreshOne skips the ghost silently — it preserves dst.Outputs == src.Outputs
+// and returns nil so the batch continues. Ghost-prune (wfctl infra apply
+// --refresh) remains the canonical mechanism for removing stale state entries.
+// This separates "refresh outputs of live resources" from "remove state entries
+// for gone resources" — they are orthogonal concerns.
 func refreshOne(ctx context.Context, p interfaces.IaCProvider, dst *interfaces.ResourceState, src interfaces.ResourceState) error {
 	d, err := p.ResourceDriver(src.Type)
 	if err != nil {
@@ -94,10 +95,12 @@ func refreshOne(ctx context.Context, p interfaces.IaCProvider, dst *interfaces.R
 	live, err := d.Read(ctx, ref)
 	if err != nil {
 		if errors.Is(err, interfaces.ErrResourceNotFound) {
-			// Ghost: cloud reports the resource does not exist. Leave Outputs
-			// unchanged; the caller's --refresh phase (or operator) handles
-			// ghost-prune separately. Refresh-outputs is non-mutating for
-			// ghosts: state remains intact for the prune phase to act on.
+			// Ghost: cloud reports the resource does not exist. Explicitly keep
+			// dst.Outputs aligned with src so refreshOne is self-contained and
+			// does not rely on the caller having pre-copied src into dst.
+			// The caller's --refresh phase (or operator) handles ghost-prune
+			// separately; refresh-outputs is non-mutating for ghosts.
+			dst.Outputs = src.Outputs
 			return nil
 		}
 		return fmt.Errorf("could not refresh %q: %w", src.Name, err)

--- a/iac/refreshoutputs/refresh.go
+++ b/iac/refreshoutputs/refresh.go
@@ -12,6 +12,7 @@ package refreshoutputs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -77,6 +78,13 @@ func Refresh(ctx context.Context, p interfaces.IaCProvider, states []interfaces.
 // refreshOne performs a single resource Read and writes the live Outputs
 // into dst when they differ from src.Outputs. It returns nil on success or
 // the error otherwise.
+//
+// Ghost handling: if the provider reports ErrResourceNotFound, the resource
+// exists in local state but cloud has no record of it (deleted out-of-band).
+// Refresh-outputs is a non-mutating operation; it leaves the ghost's Outputs
+// unchanged so that the downstream ghost-prune phase (wfctl infra apply
+// --refresh) can act on it. This separates "refresh outputs of live resources"
+// from "remove state entries for gone resources" — they are orthogonal.
 func refreshOne(ctx context.Context, p interfaces.IaCProvider, dst *interfaces.ResourceState, src interfaces.ResourceState) error {
 	d, err := p.ResourceDriver(src.Type)
 	if err != nil {
@@ -85,6 +93,13 @@ func refreshOne(ctx context.Context, p interfaces.IaCProvider, dst *interfaces.R
 	ref := interfaces.ResourceRef{Name: src.Name, Type: src.Type, ProviderID: src.ProviderID}
 	live, err := d.Read(ctx, ref)
 	if err != nil {
+		if errors.Is(err, interfaces.ErrResourceNotFound) {
+			// Ghost: cloud reports the resource does not exist. Leave Outputs
+			// unchanged; the caller's --refresh phase (or operator) handles
+			// ghost-prune separately. Refresh-outputs is non-mutating for
+			// ghosts: state remains intact for the prune phase to act on.
+			return nil
+		}
 		return fmt.Errorf("could not refresh %q: %w", src.Name, err)
 	}
 	if !reflect.DeepEqual(live.Outputs, src.Outputs) {

--- a/iac/refreshoutputs/refresh_test.go
+++ b/iac/refreshoutputs/refresh_test.go
@@ -22,6 +22,9 @@ type fakeIaCProvider struct {
 	// readErr, when non-nil, causes the driver Read to return the error
 	// regardless of the resource ref.
 	readErr error
+	// readErrByProviderID maps ProviderID → error to return for that specific
+	// resource only. Takes precedence over readErr when set for a given ID.
+	readErrByProviderID map[string]error
 }
 
 func (f *fakeIaCProvider) Name() string    { panic("not used") }
@@ -73,6 +76,9 @@ func (d *fakeResourceDriver) Create(context.Context, interfaces.ResourceSpec) (*
 	panic("not used")
 }
 func (d *fakeResourceDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	if perIDErr, ok := d.provider.readErrByProviderID[ref.ProviderID]; ok {
+		return nil, perIDErr
+	}
 	if d.provider.readErr != nil {
 		return nil, d.provider.readErr
 	}
@@ -146,5 +152,64 @@ func TestRefreshOutputs_PartialFailure_ReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "could not refresh") {
 		t.Errorf("error should mention 'could not refresh'; got: %v", err)
+	}
+}
+
+// TestRefresh_TolerateGhosts verifies that a resource returning
+// ErrResourceNotFound is silently skipped (ghost) while other resources in
+// the same batch still get refreshed, and Refresh returns no error.
+func TestRefresh_TolerateGhosts(t *testing.T) {
+	ghostOutputs := map[string]any{"region": "nyc1", "id": "568721969"}
+	liveOutputs := map[string]any{"ip": "10.0.0.1", "id": "droplet-999"}
+
+	states := []interfaces.ResourceState{
+		// ghost: deleted out-of-band, still in state
+		{Name: "coredump-staging-pg", Type: "infra.droplet", ProviderID: "568721969", Outputs: ghostOutputs},
+		// live: should be refreshed normally
+		{Name: "coredump-staging-app", Type: "infra.droplet", ProviderID: "droplet-999", Outputs: map[string]any{"ip": "10.0.0.0"}},
+	}
+
+	fakeProvider := &fakeIaCProvider{
+		readErrByProviderID: map[string]error{
+			"568721969": interfaces.ErrResourceNotFound,
+		},
+		readOutputs: map[string]map[string]any{
+			"droplet-999": liveOutputs,
+		},
+	}
+
+	refreshed, err := Refresh(context.Background(), fakeProvider, states, Options{Concurrency: 2})
+	if err != nil {
+		t.Fatalf("Refresh should not error on ghost resource; got: %v", err)
+	}
+
+	// Ghost's Outputs must remain unchanged.
+	if !mapsEqual(refreshed[0].Outputs, ghostOutputs) {
+		t.Errorf("ghost Outputs should be unchanged: got %v, want %v", refreshed[0].Outputs, ghostOutputs)
+	}
+
+	// Live resource's Outputs must be updated from the provider.
+	if !mapsEqual(refreshed[1].Outputs, liveOutputs) {
+		t.Errorf("live resource Outputs should be refreshed: got %v, want %v", refreshed[1].Outputs, liveOutputs)
+	}
+}
+
+// TestRefresh_PropagateNonGhostError verifies that transient / auth errors
+// from Read are still propagated as hard failures (existing semantics
+// unchanged).
+func TestRefresh_PropagateNonGhostError(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{Name: "app-1", Type: "infra.app", ProviderID: "app-uuid-1"},
+	}
+	fakeProvider := &fakeIaCProvider{readErr: errors.New("rate limited")}
+	_, err := Refresh(context.Background(), fakeProvider, states, Options{Concurrency: 1})
+	if err == nil {
+		t.Fatalf("expected error for non-ghost Read failure")
+	}
+	if !strings.Contains(err.Error(), "could not refresh") {
+		t.Errorf("error should mention 'could not refresh'; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error should propagate underlying cause; got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a sequencing gap in `wfctl infra refresh-outputs` (subcommand) and the `WFCTL_REFRESH_OUTPUTS` apply-time pre-step where ghost resources (cloud reports not-found) cause hard-failure instead of being skipped for the downstream ghost-prune phase to handle.

**Surfaced by:** core-dump TC2 cutover run 25476341708 — ghost Droplet `coredump-staging-pg` (DO ID 568721969, deleted out-of-band) caused refresh-outputs to error with `iac: resource not found` before Phase 1.0 ghost-prune could act on it.

**Root cause:** `iac/refreshoutputs/refresh.go::refreshOne` propagated every Read error uniformly. `ErrResourceNotFound` (ghost) was not differentiated from transient/auth errors.

## Changes

- `iac/refreshoutputs/refresh.go`: `refreshOne` treats `errors.Is(err, interfaces.ErrResourceNotFound)` as a skip+continue condition — leaves the ghost's state `Outputs` unchanged, returns nil so the batch proceeds. All other errors still propagate as hard failures.
- `iac/refreshoutputs/refresh_test.go`: `TestRefresh_TolerateGhosts` (skip ghost, refresh live resources, no error) + `TestRefresh_PropagateNonGhostError` (non-ghost errors propagate, existing semantics unchanged).
- `decisions/0011-refresh-outputs-tolerate-ghosts.md`: ADR documenting the decision and alternatives considered.

## Test plan

- [x] `go test ./iac/refreshoutputs/...` PASS (5 tests)
- [x] `go test -race ./iac/refreshoutputs/...` PASS
- [x] `go vet ./iac/refreshoutputs/...` clean
- [x] `golangci-lint run ./iac/refreshoutputs/...` 0 issues
- [ ] CI green
- [ ] Copilot reviewed at HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>