### PR TITLE
feat(iac): wire RevokeProviderCredential through remoteIaCProvider

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -625,8 +625,8 @@ func (r *remoteIaCProvider) SupportedCanonicalKeys() []string {
 // see ADR 0012 in the workflow repo decisions/).
 func (r *remoteIaCProvider) RevokeProviderCredential(ctx context.Context, source string, credentialID string) error {
 	args := map[string]any{
-		"source":       source,
-		"credentialID": credentialID,
+		"source":        source,
+		"credential_id": credentialID,
 	}
 	var (
 		res map[string]any

--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -617,6 +617,36 @@ func (r *remoteIaCProvider) SupportedCanonicalKeys() []string {
 	return interfaces.CanonicalKeys()
 }
 
+// RevokeProviderCredential implements interfaces.ProviderCredentialRevoker.
+// It dispatches through InvokeService to the plugin subprocess, which calls
+// the provider's upstream DELETE endpoint (e.g. DO SpacesKeys.Delete).
+// This method is called by `wfctl infra bootstrap --force-rotate <name>` after
+// the new credential has been minted and stored (mint-new-then-revoke-old,
+// see ADR 0012 in the workflow repo decisions/).
+func (r *remoteIaCProvider) RevokeProviderCredential(ctx context.Context, source string, credentialID string) error {
+	args := map[string]any{
+		"source":       source,
+		"credentialID": credentialID,
+	}
+	var (
+		res map[string]any
+		err error
+	)
+	if invoker, ok := r.invoker.(remoteServiceContextInvoker); ok {
+		res, err = invoker.InvokeServiceContext(ctx, "IaCProvider.RevokeProviderCredential", args)
+	} else {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		res, err = r.invoker.InvokeService("IaCProvider.RevokeProviderCredential", args)
+	}
+	if err != nil {
+		return fmt.Errorf("IaCProvider.RevokeProviderCredential: %w", err)
+	}
+	_ = res
+	return nil
+}
+
 func (r *remoteIaCProvider) Close() error { return nil }
 
 // remoteResourceDriver routes ResourceDriver calls to the plugin via InvokeService.

--- a/cmd/wfctl/deploy_providers_remote_iac_test.go
+++ b/cmd/wfctl/deploy_providers_remote_iac_test.go
@@ -698,6 +698,72 @@ func TestRemoteIaCProvider_RepairDirtyMigration_UsesContext(t *testing.T) {
 	}
 }
 
+// ── RevokeProviderCredential ─────────────────────────────────────────────────
+
+func TestRemoteIaCProvider_RevokeProviderCredential(t *testing.T) {
+	si := &stubInvoker{resp: map[string]any{}}
+	p := newIaCProvider(si)
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID123")
+	if err != nil {
+		t.Fatalf("RevokeProviderCredential: unexpected error: %v", err)
+	}
+	if si.method != "IaCProvider.RevokeProviderCredential" {
+		t.Errorf("method: got %q, want IaCProvider.RevokeProviderCredential", si.method)
+	}
+	if si.args["source"] != "digitalocean.spaces" {
+		t.Errorf("args[source]: got %q, want digitalocean.spaces", si.args["source"])
+	}
+	if si.args["credentialID"] != "AKID123" {
+		t.Errorf("args[credentialID]: got %q, want AKID123", si.args["credentialID"])
+	}
+}
+
+func TestRemoteIaCProvider_RevokeProviderCredential_PropagatesError(t *testing.T) {
+	si := &stubInvoker{err: fmt.Errorf("upstream revoke failed")}
+	p := newIaCProvider(si)
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_FAIL")
+	if err == nil {
+		t.Fatal("expected error from RevokeProviderCredential when invoker fails")
+	}
+	if !strings.Contains(err.Error(), "IaCProvider.RevokeProviderCredential") {
+		t.Errorf("error message should include method name, got: %v", err)
+	}
+}
+
+func TestRemoteIaCProvider_RevokeProviderCredential_UsesContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	ci := &contextRecordingInvoker{resp: map[string]any{}}
+	p := &remoteIaCProvider{invoker: ci}
+
+	err := p.RevokeProviderCredential(ctx, "digitalocean.spaces", "AKID_CTX")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if !ci.usedContext {
+		t.Fatal("RevokeProviderCredential did not use context-aware invoker")
+	}
+	if ci.fallbackUsed {
+		t.Fatal("RevokeProviderCredential used context-free fallback")
+	}
+}
+
+// ── ProviderCredentialRevoker interface satisfaction ─────────────────────────
+
+// TestRemoteIaCProvider_ImplementsProviderCredentialRevoker asserts that
+// *remoteIaCProvider satisfies interfaces.ProviderCredentialRevoker at compile
+// time. The type assertion below will cause a compile error if the method
+// signature doesn't match — this is the compile-time contract check that was
+// deferred from the initial ADR 0012 implementation.
+func TestRemoteIaCProvider_ImplementsProviderCredentialRevoker(t *testing.T) {
+	p := &remoteIaCProvider{}
+	var _ interfaces.ProviderCredentialRevoker = p // compile-time assertion
+	t.Log("remoteIaCProvider satisfies interfaces.ProviderCredentialRevoker")
+}
+
 type contextRecordingInvoker struct {
 	resp         map[string]any
 	usedContext  bool

--- a/cmd/wfctl/deploy_providers_remote_iac_test.go
+++ b/cmd/wfctl/deploy_providers_remote_iac_test.go
@@ -714,8 +714,8 @@ func TestRemoteIaCProvider_RevokeProviderCredential(t *testing.T) {
 	if si.args["source"] != "digitalocean.spaces" {
 		t.Errorf("args[source]: got %q, want digitalocean.spaces", si.args["source"])
 	}
-	if si.args["credentialID"] != "AKID123" {
-		t.Errorf("args[credentialID]: got %q, want AKID123", si.args["credentialID"])
+	if si.args["credential_id"] != "AKID123" {
+		t.Errorf("args[credential_id]: got %q, want AKID123", si.args["credential_id"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `RevokeProviderCredential` to `remoteIaCProvider` so that plugin-backed IaC providers participate in the `ProviderCredentialRevoker` interface
- Without this method, the type assertion in `infra_bootstrap.go` line 331 always fails for remote/plugin-loaded providers, logging "warn: IaC provider does not implement ProviderCredentialRevoker" and skipping revocation entirely
- Uses the existing `remoteServiceContextInvoker` duality so context cancellation is honoured when the plugin supports it

## Root cause
The `tc2-rotate-spaces-keys.yml` rotation workflow (run 25503485781) successfully minted new SPACES credentials and stored them in GH secrets, but the old DO Spaces key was NOT revoked at DO because `remoteIaCProvider` lacked this method. This PR closes that gap.

## Still required (DO plugin side)
`workflow-plugin-digitalocean/internal/module_instance.go` `InvokeMethodContext` switch also needs `case "IaCProvider.RevokeProviderCredential"` — that fix is a separate DO plugin PR that will follow this one, then core-dump will get a pin bump to bring both fixes through.

## Test plan
- [x] `TestRemoteIaCProvider_RevokeProviderCredential` — happy path; verifies method name and args forwarded to invoker
- [x] `TestRemoteIaCProvider_RevokeProviderCredential_PropagatesError` — error from invoker surfaces through
- [x] `TestRemoteIaCProvider_RevokeProviderCredential_UsesContext` — context-aware invoker branch used when available
- [x] `TestRemoteIaCProvider_ImplementsProviderCredentialRevoker` — compile-time assertion `var _ interfaces.ProviderCredentialRevoker = p`
- [x] All 35 `TestRemoteIaC*` tests pass (`GOWORK=off go test -count=1 -run TestRemoteIaC ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)