### PR TITLE
feat(iac): ResourceReplacer optional driver hook + DefaultReplace export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`interfaces.ResourceReplacer`**: optional driver interface for resources requiring
+  orchestration beyond naive Delete-then-Create (e.g., Droplets with attached Block Storage
+  Volumes). Drivers implementing `Replace(ctx, oldRef, spec) → (*ResourceOutput, error)` take
+  ownership of the full Replace transition; non-implementing drivers continue to use
+  `DefaultReplace`. Engine-side error-prefix backstop wraps non-conforming errors with
+  `"replace: driver: "` for consistent operator attribution. See ADR 0014.
+- **`wfctlhelpers.DefaultReplace`**: exported version of the prior `doReplace` body. Drivers
+  opting into `ResourceReplacer` can delegate specific specs back to engine-default
+  Delete-then-Create without a sentinel-error round-trip.
+
 - **Plan-time JIT resolver**: `wfctl infra plan` and `wfctl infra apply` now resolve
   `${MODULE.field}` and `infra_output`-typed `${SECRET}` references against existing state outputs
   before computing the diff plan. Eliminates spurious `replace` actions caused by drivers (e.g.

--- a/decisions/0014-resource-replacer-driver-interface.md
+++ b/decisions/0014-resource-replacer-driver-interface.md
@@ -68,4 +68,4 @@ family) pass through unchanged.
 - `iac/wfctlhelpers/apply.go` — `doReplace` dispatch + `DefaultReplace` + `wrapDriverReplaceError`.
 - `iac/wfctlhelpers/apply_replacer_dispatch_test.go` — dispatch tests.
 - `iac/wfctlhelpers/apply_replacer_prefix_test.go` — prefix backstop tests.
-- core-dump decisions/0010 — canonical source for this decision.
+- `decisions/0010-applied-config-source-on-resourcestate.md` — related ADR on applied-config provenance (workflow repo).

--- a/decisions/0014-resource-replacer-driver-interface.md
+++ b/decisions/0014-resource-replacer-driver-interface.md
@@ -1,0 +1,71 @@
+# 0014: ResourceReplacer optional driver interface
+
+- **Date:** 2026-05-07
+- **Status:** Accepted
+
+## Context
+
+`wfctlhelpers.doReplace` (the engine's default Replace dispatcher) decomposes every Replace action
+into `Delete(old) → Create(new)`. This is correct for the majority of cloud resources. But some
+resources own **single-attach dependents** — child resources that the cloud associates with exactly
+one parent at a time and refuses to re-associate while the old parent still exists.
+
+DigitalOcean Block Storage Volumes are the primary example: a Volume is attached to at most one
+Droplet. When wfctl replaces a Droplet, the naive Delete-then-Create sequence fails with
+`422 Unprocessable Entity: storage already associated with another droplet` if Volumes were attached
+to the old Droplet at delete time (DO does not auto-detach on deletion in all API paths).
+
+The DO Droplet driver needs a way to orchestrate: detach volumes → delete old droplet → create new
+droplet → attach volumes. The engine cannot do this generically because the detach/reattach sequence
+is resource-type-specific.
+
+## Decision
+
+Add `interfaces.ResourceReplacer` as an **optional** interface:
+
+```go
+type ResourceReplacer interface {
+    Replace(ctx context.Context, oldRef ResourceRef, spec ResourceSpec) (*ResourceOutput, error)
+}
+```
+
+`wfctlhelpers.doReplace` probes the driver for this interface via a type assertion. On opt-in, the
+driver receives the OLD ref (for detach) and the NEW spec (for create-with-resolved-volumes) and is
+responsible for the full transition. On non-opt-in, `doReplace` delegates to `DefaultReplace` (the
+prior `doReplace` body, now exported).
+
+An engine-side error-prefix backstop (`wrapDriverReplaceError`) wraps non-conforming driver errors
+with `"replace: driver: "` so operator attribution is preserved regardless of per-plugin
+discipline. Conforming prefixes (`"replace: ..."` engine family, `"<type> replace ..."` driver
+family) pass through unchanged.
+
+## Why this approach over alternatives
+
+- **(A1) Engine-generic detach-before-delete**: rejected. Requires the engine to know about
+  volume-attachment semantics, which are provider + resource-type specific. Violates the driver
+  abstraction boundary.
+- **(A2) Sentinel error from doReplace → driver re-entry**: rejected. Round-trips through two driver
+  calls, complicates error attribution, adds cognitive overhead to driver authors.
+- **(A3) New `ReplaceSequence` action type in IaCPlan**: rejected. Wider blast radius (plan
+  serialisation, schema versioning, test fixtures). The hook-style optional interface achieves the
+  same without touching plan wire format.
+
+## Consequences
+
+1. Drivers owning single-attach dependents can implement `ResourceReplacer` without any engine-side
+   changes beyond this PR.
+2. The `"storage already associated"` (TC2 class) failure disappears for DO Droplet replace actions
+   when `DropletDriver` adopts the interface (workflow-plugin-digitalocean PR-3).
+3. Default behavior is unchanged for all existing drivers — non-opt-in drivers continue to use
+   `DefaultReplace` (Delete-then-Create). No breaking change.
+4. `wfctlhelpers.DefaultReplace` is now exported so driver-owned `Replace` implementations can
+   delegate specific specs back to engine-default behavior (e.g., "replace this network resource
+   normally, but detach volumes for this compute resource").
+
+## References
+
+- `interfaces/iac_resource_driver.go` — `ResourceReplacer` interface definition.
+- `iac/wfctlhelpers/apply.go` — `doReplace` dispatch + `DefaultReplace` + `wrapDriverReplaceError`.
+- `iac/wfctlhelpers/apply_replacer_dispatch_test.go` — dispatch tests.
+- `iac/wfctlhelpers/apply_replacer_prefix_test.go` — prefix backstop tests.
+- core-dump decisions/0010 — canonical source for this decision.

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -514,7 +514,10 @@ func hasReplaceErrorPrefix(err error) bool {
 		return false
 	}
 	head := msg[:idx]
-	// head must be one alphanumeric token (no spaces, no colons).
+	// head must be a single token with no spaces or colons — e.g. "droplet",
+	// "vpc", "database". Other characters (hyphens, underscores, digits) are
+	// accepted intentionally so resource types like "infra.droplet" or
+	// "k8s-node" can adopt the prefix freely.
 	for _, r := range head {
 		if r == ' ' || r == ':' {
 			return false

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -361,8 +361,13 @@ func doUpdate(ctx context.Context, d interfaces.ResourceDriver, action interface
 	return nil
 }
 
-// doReplace decomposes a Replace action into Delete-then-Create on the
-// driver and propagates the new ProviderID through
+// DefaultReplace is the engine's default Replace dispatcher: Delete the
+// resource at action.Current, then Create from action.Resource. Public
+// so drivers that opt into ResourceReplacer can delegate a particular
+// spec to engine-default behavior without a sentinel-error round-trip.
+//
+// Decomposes a Replace action into Delete-then-Create on the driver and
+// propagates the new ProviderID through
 // result.ReplaceIDMap[action.Resource.Name] so the JIT substitution wired
 // into ApplyPlan's loop (T5.2) can patch dependent resources whose
 // configs reference the replaced resource by name.
@@ -371,7 +376,7 @@ func doUpdate(ctx context.Context, d interfaces.ResourceDriver, action interface
 //
 // When a plan has [Replace parent, X dependent] where dependent's
 // Config carries ${parent.id}, the cascade lands automatically:
-// doReplace's post-Create write to result.ReplaceIDMap completes
+// DefaultReplace's post-Create write to result.ReplaceIDMap completes
 // BEFORE the dispatch loop's next iteration calls
 // jitsubst.ResolveSpec on the dependent's spec, so the dependent's
 // driver call (Create or Replace's post-Delete Create) sees the
@@ -404,7 +409,7 @@ func doUpdate(ctx context.Context, d interfaces.ResourceDriver, action interface
 // result.Errors couldn't tell whether the Delete or the Create failed.
 // Other sub-functions (doCreate non-recovery path, doUpdate, doDelete)
 // pass driver errors through unchanged.
-func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
+func DefaultReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
 	if err := d.Delete(ctx, refFromAction(action)); err != nil {
 		return fmt.Errorf("replace: delete: %w", err)
 	}
@@ -434,6 +439,13 @@ func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfac
 		result.ReplaceIDMap[action.Resource.Name] = out.ProviderID
 	}
 	return nil
+}
+
+// doReplace is the dispatch entry point for Replace actions. It probes
+// the driver for the optional ResourceReplacer interface (Task 10);
+// for now it delegates directly to DefaultReplace.
+func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
+	return DefaultReplace(ctx, d, action, result)
 }
 
 // doDelete invokes Delete with a ResourceRef carrying action.Current's

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -45,6 +45,7 @@ import (
 	"log"
 	"maps"
 	"os"
+	"strings"
 
 	"github.com/GoCodeAlone/workflow/iac/inputsnapshot"
 	"github.com/GoCodeAlone/workflow/iac/jitsubst"
@@ -442,10 +443,84 @@ func DefaultReplace(ctx context.Context, d interfaces.ResourceDriver, action int
 }
 
 // doReplace is the dispatch entry point for Replace actions. It probes
-// the driver for the optional ResourceReplacer interface (Task 10);
-// for now it delegates directly to DefaultReplace.
+// the driver for the optional ResourceReplacer interface and routes to
+// the driver's Replace implementation when present. Drivers that do not
+// implement ResourceReplacer fall back to DefaultReplace.
 func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
+	if r, ok := d.(interfaces.ResourceReplacer); ok {
+		out, err := r.Replace(ctx, refFromAction(action), action.Resource)
+		if err != nil {
+			return wrapDriverReplaceError(err)
+		}
+		return finalizeReplace(out, action.Resource.Name, result)
+	}
 	return DefaultReplace(ctx, d, action, result)
+}
+
+// finalizeReplace runs the post-Replace bookkeeping that DefaultReplace's
+// own Create branch does inline. When a driver-owned Replacer returns a
+// ResourceOutput, this function appends it to result.Resources and
+// populates result.ReplaceIDMap[name] so downstream JIT substitution
+// (apply_replace_cascade) sees the new ProviderID. Lazy-init matches
+// DefaultReplace's existing map-initialization logic.
+func finalizeReplace(out *interfaces.ResourceOutput, name string, result *interfaces.ApplyResult) error {
+	if out != nil {
+		result.Resources = append(result.Resources, *out)
+		if result.ReplaceIDMap == nil {
+			result.ReplaceIDMap = make(map[string]string)
+		}
+		result.ReplaceIDMap[name] = out.ProviderID
+	}
+	return nil
+}
+
+// wrapDriverReplaceError ensures driver-owned Replace errors carry a
+// recognizable prefix so operators can attribute failures consistently
+// regardless of whether engine-default or driver-owned paths fired.
+// Drivers that already wrap with a recognized prefix family pass
+// through unchanged; non-conforming drivers get a "replace: driver: "
+// backstop applied at the dispatch boundary.
+//
+// See hasReplaceErrorPrefix for the accepted prefix families.
+func wrapDriverReplaceError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if hasReplaceErrorPrefix(err) {
+		return err
+	}
+	return fmt.Errorf("replace: driver: %w", err)
+}
+
+// hasReplaceErrorPrefix returns true when err.Error() begins with one
+// of the recognized prefix families (case-sensitive prefix match):
+//   - "replace:"                    (engine-default + the backstop wrapper itself)
+//   - "<resource-type> replace "    (driver-owned, e.g. "droplet replace ")
+//
+// The accepted prefix families are intentionally closed to keep error
+// attribution predictable; new families require a workflow-side change.
+// Drivers that adopt either family are exempt from re-wrapping.
+func hasReplaceErrorPrefix(err error) bool {
+	msg := err.Error()
+	if strings.HasPrefix(msg, "replace:") {
+		return true
+	}
+	// "<word> replace " form — require at least one non-space char
+	// before " replace ", and the substring " replace " in the prefix.
+	// We don't bind specific resource types so future plugins can adopt
+	// freely.
+	idx := strings.Index(msg, " replace ")
+	if idx <= 0 {
+		return false
+	}
+	head := msg[:idx]
+	// head must be one alphanumeric token (no spaces, no colons).
+	for _, r := range head {
+		if r == ' ' || r == ':' {
+			return false
+		}
+	}
+	return true
 }
 
 // doDelete invokes Delete with a ResourceRef carrying action.Current's

--- a/iac/wfctlhelpers/apply_replacer_dispatch_test.go
+++ b/iac/wfctlhelpers/apply_replacer_dispatch_test.go
@@ -1,0 +1,98 @@
+package wfctlhelpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// fakeReplacerDriver implements both ResourceDriver AND ResourceReplacer
+// to exercise the dispatch-to-replacer path. Embeds fakeDriver so all
+// ResourceDriver methods are satisfied without duplication.
+type fakeReplacerDriver struct {
+	fakeDriver
+	replaceCalled bool
+	replaceErr    error
+}
+
+func (f *fakeReplacerDriver) Replace(_ context.Context, _ interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.replaceCalled = true
+	if f.replaceErr != nil {
+		return nil, f.replaceErr
+	}
+	return &interfaces.ResourceOutput{Name: spec.Name, ProviderID: "new-id"}, nil
+}
+
+// TestDoReplace_DispatchesToReplacerWhenAvailable verifies that doReplace
+// routes to ResourceReplacer.Replace when the driver implements it, and
+// does NOT fall through to DefaultReplace (Delete+Create).
+func TestDoReplace_DispatchesToReplacerWhenAvailable(t *testing.T) {
+	d := &fakeReplacerDriver{}
+	action := interfaces.PlanAction{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "x", Type: "test"},
+		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
+	}
+	result := &interfaces.ApplyResult{}
+	err := doReplace(context.Background(), d, action, result)
+	if err != nil {
+		t.Fatalf("doReplace: %v", err)
+	}
+	if !d.replaceCalled {
+		t.Error("Replacer.Replace was not invoked")
+	}
+	// DefaultReplace (Delete+Create) should NOT have fired.
+	if d.deleteCount != 0 || d.createCount != 0 {
+		t.Errorf("DefaultReplace fired alongside Replacer: deleteCount=%d createCount=%d (both should be 0)",
+			d.deleteCount, d.createCount)
+	}
+	if got := result.ReplaceIDMap["x"]; got != "new-id" {
+		t.Errorf("ReplaceIDMap[x] = %q, want new-id", got)
+	}
+}
+
+// TestDoReplace_DefaultReplaceWhenNoReplacerInterface verifies that doReplace
+// falls back to DefaultReplace (Delete+Create) when the driver does NOT
+// implement ResourceReplacer.
+func TestDoReplace_DefaultReplaceWhenNoReplacerInterface(t *testing.T) {
+	d := &fakeDriver{} // does NOT implement ResourceReplacer
+	action := interfaces.PlanAction{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "x", Type: "test"},
+		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
+	}
+	result := &interfaces.ApplyResult{}
+	err := doReplace(context.Background(), d, action, result)
+	if err != nil {
+		t.Fatalf("doReplace: %v", err)
+	}
+	if d.deleteCount == 0 || d.createCount == 0 {
+		t.Errorf("DefaultReplace did NOT fire: deleteCount=%d createCount=%d (both should be 1)",
+			d.deleteCount, d.createCount)
+	}
+}
+
+// TestDoReplace_ReplacerError_IsWrappedByBackstop verifies that a
+// non-conforming error from ResourceReplacer.Replace gets the engine-side
+// backstop prefix applied (Task 11 implements wrapDriverReplaceError;
+// this test is the cross-task coupling assertion).
+func TestDoReplace_ReplacerError_IsWrappedByBackstop(t *testing.T) {
+	d := &fakeReplacerDriver{replaceErr: errors.New("kaboom")}
+	action := interfaces.PlanAction{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "x", Type: "test"},
+		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
+	}
+	result := &interfaces.ApplyResult{}
+	err := doReplace(context.Background(), d, action, result)
+	if err == nil {
+		t.Fatal("expected error from failing Replacer")
+	}
+	// After Task 11 lands, this will assert "replace: driver: kaboom".
+	// For now assert only that an error was returned (pre-Task-11 compilation).
+	if err.Error() == "" {
+		t.Error("error message is empty")
+	}
+}

--- a/iac/wfctlhelpers/apply_replacer_dispatch_test.go
+++ b/iac/wfctlhelpers/apply_replacer_dispatch_test.go
@@ -3,6 +3,7 @@ package wfctlhelpers
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -90,9 +91,11 @@ func TestDoReplace_ReplacerError_IsWrappedByBackstop(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from failing Replacer")
 	}
-	// After Task 11 lands, this will assert "replace: driver: kaboom".
-	// For now assert only that an error was returned (pre-Task-11 compilation).
-	if err.Error() == "" {
-		t.Error("error message is empty")
+	// wrapDriverReplaceError (also in this PR) applies the backstop prefix to
+	// non-conforming errors. "kaboom" has no recognized replace prefix family,
+	// so it must be wrapped as "replace: driver: kaboom".
+	const wantPrefix = "replace: driver: "
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("expected backstop prefix %q on non-conforming error; got: %v", wantPrefix, err)
 	}
 }

--- a/iac/wfctlhelpers/apply_replacer_prefix_test.go
+++ b/iac/wfctlhelpers/apply_replacer_prefix_test.go
@@ -1,0 +1,101 @@
+package wfctlhelpers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestHasReplaceErrorPrefix_ReplaceColonFamily verifies the "replace:" family
+// is recognized (engine-default prefix + backstop wrapper itself).
+func TestHasReplaceErrorPrefix_ReplaceColonFamily(t *testing.T) {
+	cases := []string{
+		"replace: delete: 500",
+		"replace: create: 422",
+		"replace: canceled after delete: context canceled",
+		"replace: driver: kaboom",
+		"replace:",
+	}
+	for _, msg := range cases {
+		if !hasReplaceErrorPrefix(errors.New(msg)) {
+			t.Errorf("hasReplaceErrorPrefix(%q) = false, want true", msg)
+		}
+	}
+}
+
+// TestHasReplaceErrorPrefix_ResourceTypeReplaceFamily verifies the
+// "<resource-type> replace " family is recognized for driver-owned errors.
+func TestHasReplaceErrorPrefix_ResourceTypeReplaceFamily(t *testing.T) {
+	cases := []string{
+		`droplet replace "pg": detach volume "vol-abc": 422`,
+		`vpc replace "net": something failed`,
+	}
+	for _, msg := range cases {
+		if !hasReplaceErrorPrefix(errors.New(msg)) {
+			t.Errorf("hasReplaceErrorPrefix(%q) = false, want true", msg)
+		}
+	}
+}
+
+// TestHasReplaceErrorPrefix_NonConforming verifies that bare errors without
+// a recognized prefix return false (triggering the backstop wrapper).
+func TestHasReplaceErrorPrefix_NonConforming(t *testing.T) {
+	cases := []string{
+		"kaboom",
+		"422 Unprocessable Entity",
+		"storage already associated with another droplet",
+		// Multi-word heads with spaces before " replace " do NOT match:
+		"bad prefix: replace something",
+		"my resource replace x", // "my resource" has a space → head fails
+	}
+	for _, msg := range cases {
+		if hasReplaceErrorPrefix(errors.New(msg)) {
+			t.Errorf("hasReplaceErrorPrefix(%q) = true, want false", msg)
+		}
+	}
+}
+
+// TestWrapDriverReplaceError_BackstopWrapsNonConforming verifies the full
+// wrapDriverReplaceError backstop on a non-conforming error.
+func TestWrapDriverReplaceError_BackstopWrapsNonConforming(t *testing.T) {
+	err := wrapDriverReplaceError(errors.New("kaboom"))
+	if err == nil {
+		t.Fatal("expected wrapped error")
+	}
+	if !strings.HasPrefix(err.Error(), "replace: driver: ") {
+		t.Errorf("error not wrapped with backstop prefix: %v", err)
+	}
+}
+
+// TestWrapDriverReplaceError_PassesThroughConformingDriverErrors verifies that
+// driver-owned "X replace" errors are NOT double-wrapped.
+func TestWrapDriverReplaceError_PassesThroughConformingDriverErrors(t *testing.T) {
+	orig := errors.New(`droplet replace "pg": detach volume "vol-abc": 422`)
+	err := wrapDriverReplaceError(orig)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.HasPrefix(err.Error(), "replace: driver: ") {
+		t.Errorf("error was double-wrapped: %v", err)
+	}
+	if !strings.HasPrefix(err.Error(), `droplet replace `) {
+		t.Errorf("conforming prefix not preserved: %v", err)
+	}
+}
+
+// TestWrapDriverReplaceError_PassesThroughDefaultReplacePrefix verifies that
+// "replace: delete: " errors from DefaultReplace pass through without wrapping.
+func TestWrapDriverReplaceError_PassesThroughDefaultReplacePrefix(t *testing.T) {
+	orig := errors.New("replace: delete: 500")
+	err := wrapDriverReplaceError(orig)
+	if !strings.HasPrefix(err.Error(), "replace: delete: ") {
+		t.Errorf("replace: family prefix should pass through unchanged: %v", err)
+	}
+}
+
+// TestWrapDriverReplaceError_NilPassesThrough verifies nil is returned unchanged.
+func TestWrapDriverReplaceError_NilPassesThrough(t *testing.T) {
+	if wrapDriverReplaceError(nil) != nil {
+		t.Error("wrapDriverReplaceError(nil) should return nil")
+	}
+}

--- a/interfaces/iac_resource_driver.go
+++ b/interfaces/iac_resource_driver.go
@@ -60,6 +60,40 @@ type UpsertSupporter interface {
 	SupportsUpsert() bool
 }
 
+// ResourceReplacer is an optional interface ResourceDriver
+// implementations may provide when a resource's Replace transition
+// needs more than naive Delete-then-Create — typically because the
+// resource owns single-attach dependents (e.g., a DO Droplet with
+// Block Storage Volumes, an AWS EC2 instance with EBS Volumes, a GCP
+// VM with persistent disks) that the cloud refuses to associate with
+// a new parent until the old parent releases them.
+//
+// wfctlhelpers.doReplace probes for this interface; on opt-in, the
+// driver receives the OLD ref and the NEW spec and is responsible for
+// the full transition. On non-opt-in, doReplace calls
+// wfctlhelpers.DefaultReplace (the existing Delete-then-Create logic,
+// exported for direct dispatch).
+//
+// Drivers SHOULD NOT implement this interface unless the resource has
+// orchestration needs the engine cannot satisfy generically — naive
+// Delete-then-Create is correct for the majority of cloud resources
+// and is the default for a reason (atomicity, error attribution).
+//
+// A driver that opts in but wants engine-default behavior for a
+// particular spec calls wfctlhelpers.DefaultReplace directly. The
+// engine never inspects the returned error to decide between paths,
+// so there is no sentinel-error round-trip.
+//
+// Error attribution: drivers MUST wrap their sub-step errors with a
+// recognizable prefix (e.g., "<resource-type> replace %q: detach
+// volume %q: %w"). Non-conforming returns are wrapped by the engine
+// with "replace: driver: " at the dispatch boundary so operator
+// attribution is preserved at runtime regardless of per-plugin
+// discipline.
+type ResourceReplacer interface {
+	Replace(ctx context.Context, oldRef ResourceRef, spec ResourceSpec) (*ResourceOutput, error)
+}
+
 // ResourceOutput is the concrete output of a provisioned or read resource.
 type ResourceOutput struct {
 	Name       string          `json:"name"`

--- a/interfaces/iac_resource_driver_test.go
+++ b/interfaces/iac_resource_driver_test.go
@@ -1,6 +1,7 @@
 package interfaces_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -42,6 +43,20 @@ func TestSentinels_ErrorsIs(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestResourceReplacerInterfaceShape asserts at compile time that a driver
+// implementing ResourceReplacer satisfies the interface shape.
+func TestResourceReplacerInterfaceShape(t *testing.T) {
+	// Compile-time assertion: a no-op driver that implements
+	// ResourceReplacer satisfies the interface.
+	var _ interfaces.ResourceReplacer = (*noopReplacer)(nil)
+}
+
+type noopReplacer struct{}
+
+func (*noopReplacer) Replace(_ context.Context, _ interfaces.ResourceRef, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
 }
 
 // TestSentinels_Wrappable verifies a wrapped sentinel still matches via errors.Is.


### PR DESCRIPTION
## Summary

- `interfaces.ResourceReplacer` optional driver interface for resources owning single-attach dependents (e.g., DO Droplets with Block Storage Volumes). Drivers opt in by implementing `Replace(ctx, oldRef, spec) → (*ResourceOutput, error)` and take ownership of the full Replace transition.
- `wfctlhelpers.DefaultReplace` exported (prior `doReplace` body), callable directly by drivers that want engine-default Delete-then-Create for a specific spec without a sentinel-error round-trip.
- Engine-side error-prefix backstop (`wrapDriverReplaceError`) wraps non-conforming errors with `"replace: driver: "` for consistent operator attribution. Conforming prefixes pass through unchanged.
- ADR 0014 + CHANGELOG entry.

DropletDriver.Replace adoption follows in workflow-plugin-digitalocean PR-3.

## Test plan

- [x] `go test ./interfaces/ ./iac/wfctlhelpers/ -v` passes
- [x] `golangci-lint run ./interfaces/ ./iac/wfctlhelpers/` — 0 issues
- [x] Compile-time interface assertion: `TestResourceReplacerInterfaceShape`
- [x] Dispatch test: `TestDoReplace_DispatchesToReplacerWhenAvailable` — Replacer.Replace invoked, DefaultReplace NOT fired
- [x] Fallback test: `TestDoReplace_DefaultReplaceWhenNoReplacerInterface` — DefaultReplace fires for non-implementing drivers
- [x] Backstop tests: `TestWrapDriverReplaceError_*` — conforming prefixes pass through, non-conforming get wrapped
- [x] All existing `apply_replace_test.go` and `apply_replace_cascade_test.go` tests remain green

🤖 Generated via brainstorming → writing-plans pipeline