### PR TITLE
feat: ErrImageNotInRegistry sentinel + wfctl render-side actionable hint

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -284,7 +284,12 @@ func runInfraPlan(args []string) error {
 	// out-of-band scripts that never declared one).
 	plan, err := computePlanForInfraSpecs(context.Background(), cfgFile, envName, desired, current)
 	if err != nil {
-		return fmt.Errorf("compute plan: %w", err)
+		wrapped := fmt.Errorf("compute plan: %w", err)
+		// Emit an actionable hint to stderr if the underlying driver Diff
+		// rejected an AppSpec image that's missing from its registry. See
+		// infra_image_presence_hint.go.
+		emitImageNotInRegistryHint(os.Stderr, wrapped)
+		return wrapped
 	}
 
 	// Capture env-var fingerprints so apply (persisted-plan path: T1.5; in-process

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -504,6 +504,12 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 		}); sumErr != nil {
 			log.Printf("step summary: %v (ignored)", sumErr)
 		}
+		// Provider.Apply can surface a top-level error (vs. populating
+		// result.Errors[]). Emit the actionable hint here too if the
+		// top-level error is/wraps interfaces.ErrImageNotInRegistry —
+		// otherwise plugin paths that bubble the sentinel via err escape
+		// the result.Errors[]-only hint below. See infra_image_presence_hint.go.
+		emitImageNotInRegistryHint(os.Stderr, err)
 		return fmt.Errorf("apply: %w", err)
 	}
 	if result != nil {
@@ -982,6 +988,12 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 		}); sumErr != nil {
 			log.Printf("step summary: %v (ignored)", sumErr)
 		}
+		// Provider.Apply can surface a top-level error (vs. populating
+		// result.Errors[]). Emit the actionable hint here too if the
+		// top-level error is/wraps interfaces.ErrImageNotInRegistry —
+		// otherwise plugin paths that bubble the sentinel via err escape
+		// the result.Errors[]-only hint below. See infra_image_presence_hint.go.
+		emitImageNotInRegistryHint(os.Stderr, err)
 		return fmt.Errorf("apply: %w", err)
 	}
 

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -563,7 +563,12 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 			for _, ae := range result.Errors {
 				msgs = append(msgs, fmt.Sprintf("%s/%s: %s", ae.Action, ae.Resource, ae.Error))
 			}
-			return fmt.Errorf("%d resource(s) failed: %s", len(result.Errors), strings.Join(msgs, "; "))
+			finalErr := fmt.Errorf("%d resource(s) failed: %s", len(result.Errors), strings.Join(msgs, "; "))
+			// Emit an actionable hint to stderr if any per-resource error
+			// matches interfaces.ErrImageNotInRegistry (typed in-process or
+			// string-match across gRPC boundary). See infra_image_presence_hint.go.
+			emitImageNotInRegistryHint(os.Stderr, finalErr)
+			return finalErr
 		}
 	}
 	return nil
@@ -1033,7 +1038,12 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 			for _, ae := range result.Errors {
 				msgs = append(msgs, fmt.Sprintf("%s/%s: %s", ae.Action, ae.Resource, ae.Error))
 			}
-			return fmt.Errorf("%d resource(s) failed: %s", len(result.Errors), strings.Join(msgs, "; "))
+			finalErr := fmt.Errorf("%d resource(s) failed: %s", len(result.Errors), strings.Join(msgs, "; "))
+			// Emit an actionable hint to stderr if any per-resource error
+			// matches interfaces.ErrImageNotInRegistry (typed in-process or
+			// string-match across gRPC boundary). See infra_image_presence_hint.go.
+			emitImageNotInRegistryHint(os.Stderr, finalErr)
+			return finalErr
 		}
 	}
 	return nil

--- a/cmd/wfctl/infra_image_presence_hint.go
+++ b/cmd/wfctl/infra_image_presence_hint.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// imageNotInRegistryHintText is the actionable hint emitted to stderr when
+// wfctl detects that a Plan or Apply error is (or wraps, including across a
+// gRPC string-flattening boundary) interfaces.ErrImageNotInRegistry. The
+// "::error::" prefix is the GitHub Actions error annotation; harmless in
+// non-CI environments.
+const imageNotInRegistryHintText = "::error::image not found in registry — most likely the SHA was GC'd. Re-run the build/deploy workflow to push fresh images, or pass --image-sha override.\n"
+
+// errImageNotInRegistryMessage is the exact string in interfaces.ErrImageNotInRegistry.
+// We match it verbatim as a fallback for plugin (gRPC) drivers where structpb
+// does not preserve sentinel identity. The interfaces package has a unit test
+// asserting this string is stable.
+const errImageNotInRegistryMessage = "iac: image tag or digest not found in registry"
+
+// emitImageNotInRegistryHint writes an actionable hint to w when err matches
+// interfaces.ErrImageNotInRegistry — either via errors.Is (in-process driver
+// path) or via verbatim message-string match (gRPC plugin path).
+//
+// Safe to call with err == nil (no-op).
+func emitImageNotInRegistryHint(w io.Writer, err error) {
+	if err == nil || w == nil {
+		return
+	}
+	if errors.Is(err, interfaces.ErrImageNotInRegistry) ||
+		strings.Contains(err.Error(), errImageNotInRegistryMessage) {
+		_, _ = io.WriteString(w, imageNotInRegistryHintText)
+	}
+}

--- a/cmd/wfctl/infra_image_presence_hint.go
+++ b/cmd/wfctl/infra_image_presence_hint.go
@@ -13,25 +13,30 @@ import (
 // gRPC string-flattening boundary) interfaces.ErrImageNotInRegistry. The
 // "::error::" prefix is the GitHub Actions error annotation; harmless in
 // non-CI environments.
-const imageNotInRegistryHintText = "::error::image not found in registry — most likely the SHA was GC'd. Re-run the build/deploy workflow to push fresh images, or pass --image-sha override.\n"
-
-// errImageNotInRegistryMessage is the exact string in interfaces.ErrImageNotInRegistry.
-// We match it verbatim as a fallback for plugin (gRPC) drivers where structpb
-// does not preserve sentinel identity. The interfaces package has a unit test
-// asserting this string is stable.
-const errImageNotInRegistryMessage = "iac: image tag or digest not found in registry"
+//
+// The hint references "the build/deploy workflow" rather than a specific
+// wfctl flag, because the recovery path is operator-driven (re-run a
+// workflow that re-pushes images) — wfctl itself does not have an
+// --image-sha override. Callers that DO have a re-dispatch override
+// (e.g. tc2-cutover.yml's workflow_dispatch.inputs.image_sha) can layer
+// their own UX on top.
+const imageNotInRegistryHintText = "::error::image not found in registry — most likely the SHA was GC'd. Re-run the build/deploy workflow to push fresh images, then re-dispatch this operation.\n"
 
 // emitImageNotInRegistryHint writes an actionable hint to w when err matches
 // interfaces.ErrImageNotInRegistry — either via errors.Is (in-process driver
 // path) or via verbatim message-string match (gRPC plugin path).
 //
-// Safe to call with err == nil (no-op).
+// The string-match fallback uses interfaces.ErrImageNotInRegistry.Error()
+// directly so the two paths cannot drift. The interfaces package has a unit
+// test asserting the message string is stable; that's the guardrail.
+//
+// Safe to call with err == nil or w == nil (no-op).
 func emitImageNotInRegistryHint(w io.Writer, err error) {
 	if err == nil || w == nil {
 		return
 	}
 	if errors.Is(err, interfaces.ErrImageNotInRegistry) ||
-		strings.Contains(err.Error(), errImageNotInRegistryMessage) {
+		strings.Contains(err.Error(), interfaces.ErrImageNotInRegistry.Error()) {
 		_, _ = io.WriteString(w, imageNotInRegistryHintText)
 	}
 }

--- a/cmd/wfctl/infra_image_presence_hint_test.go
+++ b/cmd/wfctl/infra_image_presence_hint_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// TestImageNotInRegistryHint_TypedError verifies the hint fires when the
+// driver error is the typed ErrImageNotInRegistry (in-process driver path).
+func TestImageNotInRegistryHint_TypedError(t *testing.T) {
+	var buf bytes.Buffer
+	err := fmt.Errorf("apply: container_service/app: %w",
+		fmt.Errorf("image %q not found in DOCR: %w", "ref", interfaces.ErrImageNotInRegistry))
+	emitImageNotInRegistryHint(&buf, err)
+	if !strings.Contains(buf.String(), "image not found in registry") {
+		t.Fatalf("expected actionable hint; got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "Re-run") {
+		t.Fatalf("expected 're-run' suggestion; got %q", buf.String())
+	}
+	if !errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("test setup: errors.Is must match wrapped sentinel")
+	}
+}
+
+// TestImageNotInRegistryHint_StringMatchFallback verifies the hint fires when
+// the driver error has been string-flattened across a gRPC boundary (the
+// sentinel identity is gone, only the message string survives).
+func TestImageNotInRegistryHint_StringMatchFallback(t *testing.T) {
+	var buf bytes.Buffer
+	// Simulate a gRPC-wrapped error: the original sentinel identity is lost;
+	// only the message string survives.
+	err := errors.New("apply: container_service/app: image \"ref\" not found in DOCR repo \"app\": iac: image tag or digest not found in registry")
+	if errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("test setup: errors.Is must NOT match for string-only error (this proves the fallback is needed)")
+	}
+	emitImageNotInRegistryHint(&buf, err)
+	if !strings.Contains(buf.String(), "image not found in registry") {
+		t.Fatalf("expected actionable hint via string-match fallback; got %q", buf.String())
+	}
+}
+
+// TestImageNotInRegistryHint_UnrelatedError_NoHint verifies the hint does NOT
+// fire for unrelated errors.
+func TestImageNotInRegistryHint_UnrelatedError_NoHint(t *testing.T) {
+	var buf bytes.Buffer
+	err := errors.New("apply: container_service/app: 500 internal server error")
+	emitImageNotInRegistryHint(&buf, err)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no hint for unrelated error; got %q", buf.String())
+	}
+}
+
+// TestImageNotInRegistryHint_NilInputs_NoOp verifies safe behavior with nil.
+func TestImageNotInRegistryHint_NilInputs_NoOp(t *testing.T) {
+	emitImageNotInRegistryHint(nil, nil)             // both nil
+	emitImageNotInRegistryHint(&bytes.Buffer{}, nil) // nil err
+	var buf bytes.Buffer
+	emitImageNotInRegistryHint(nil, interfaces.ErrImageNotInRegistry) // nil writer
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output; got %q", buf.String())
+	}
+}

--- a/interfaces/iac_resource_driver.go
+++ b/interfaces/iac_resource_driver.go
@@ -16,6 +16,16 @@ var (
 	ErrUnauthorized          = errors.New("iac: unauthorized")            // 401
 	ErrForbidden             = errors.New("iac: forbidden")               // 403
 	ErrValidation            = errors.New("iac: validation error")        // 400/422
+	// ErrImageNotInRegistry indicates that an image tag or digest referenced
+	// by a desired ResourceSpec is not present in the registry. Drivers
+	// SHOULD return this (wrapped) from Diff, Create, and Update when an
+	// image-presence pre-flight fails. Callers can use errors.Is for typed
+	// identification, but gRPC-bound callers should ALSO match the message
+	// string "iac: image tag or digest not found in registry" for
+	// cross-process robustness — structpb does not preserve sentinel
+	// identity across the gRPC plugin boundary. The message string is
+	// load-bearing; do not change it.
+	ErrImageNotInRegistry = errors.New("iac: image tag or digest not found in registry")
 )
 
 // ResourceDriver handles CRUD for a single resource type within a provider.

--- a/interfaces/iac_resource_driver_test.go
+++ b/interfaces/iac_resource_driver_test.go
@@ -22,6 +22,7 @@ func TestSentinels_ErrorsIs(t *testing.T) {
 		{"ErrUnauthorized", interfaces.ErrUnauthorized},
 		{"ErrForbidden", interfaces.ErrForbidden},
 		{"ErrValidation", interfaces.ErrValidation},
+		{"ErrImageNotInRegistry", interfaces.ErrImageNotInRegistry},
 	}
 
 	for i, s := range sentinels {
@@ -72,6 +73,7 @@ func TestSentinels_Wrappable(t *testing.T) {
 		{"ErrUnauthorized", interfaces.ErrUnauthorized},
 		{"ErrForbidden", interfaces.ErrForbidden},
 		{"ErrValidation", interfaces.ErrValidation},
+		{"ErrImageNotInRegistry", interfaces.ErrImageNotInRegistry},
 	}
 
 	for _, c := range cases {
@@ -79,5 +81,18 @@ func TestSentinels_Wrappable(t *testing.T) {
 		if !errors.Is(wrapped, c.sentinel) {
 			t.Errorf("%s: wrapped error not matched by errors.Is", c.name)
 		}
+	}
+}
+
+// TestErrImageNotInRegistry_MessageStringStable asserts the exact message
+// string. The wfctl render layer matches this string verbatim as the
+// gRPC-boundary fallback (structpb does not preserve sentinel identity), so
+// changing this string silently breaks the actionable hint for plugin-driven
+// drivers. See decisions/0004 in core-dump for the rationale.
+func TestErrImageNotInRegistry_MessageStringStable(t *testing.T) {
+	want := "iac: image tag or digest not found in registry"
+	got := interfaces.ErrImageNotInRegistry.Error()
+	if got != want {
+		t.Fatalf("ErrImageNotInRegistry.Error() = %q; want %q (load-bearing for gRPC string-match fallback)", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `interfaces.ErrImageNotInRegistry` sentinel used by IaC drivers when an
  AppSpec image SHA is absent from the registry (e.g. DOCR GC pruned it).
- Adds wfctl-side actionable hint (Plan + Apply paths): when the driver error
  is the sentinel (or its message string survives a gRPC plugin boundary),
  wfctl emits `::error::image not found in registry — Re-run the build/deploy
  workflow ...` to stderr.
- Additive only; no new resource type; no canonical-schema changes.

This is **Wave 1 — PR 1** of the [DOCR retention + image-presence design](https://github.com/GoCodeAlone/core-dump/blob/main/docs/plans/2026-05-08-docr-retention-and-image-presence-design.md). Wave 2 (declarative retention reconciler in DO plugin) is deferred per ADR 0003 in core-dump.

The exact sentinel message string `"iac: image tag or digest not found in registry"` is **load-bearing**: the wfctl render layer matches it verbatim as the gRPC-boundary fallback (since structpb doesn't preserve sentinel identity). A unit test asserts the string is stable.

## Test plan
- [x] `go test ./interfaces/ -run \"TestSentinels|TestErrImageNotInRegistry\"` — sentinel round-trip + message-string stability
- [x] `go test ./cmd/wfctl/ -run TestImageNotInRegistryHint` — typed-error path, gRPC string-match fallback, unrelated-error no-op, nil-input no-op
- [x] `go test ./...` — full repo, no regressions
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean

## Sequenced PRs
1. **PR 1 (this)** — workflow ErrImageNotInRegistry sentinel + wfctl hint → tag v0.24.0
2. workflow-plugin-digitalocean AppPlatformDriver pre-flight → tag v0.12.0
3. core-dump infra.yaml retention bump + workflow pin updates + tc2-cutover walk-back
4. core-dump cleanup PR (after TC2 closes)

## Rollback
Ship v0.24.1 that no-ops `emitImageNotInRegistryHint`. Do NOT retag v0.24.0 (Go module proxy is immutable; consumers' go.sum locks).