### PR TITLE
fix(release): draft-first pattern to avoid immutability failure on retag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,15 +261,20 @@ jobs:
         cd dist
         sha256sum * > checksums.txt
 
-    - name: Create Release
+    - name: Create Release (draft during asset upload)
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ env.TAG_NAME }}
         files: |
           dist/*
-        draft: false
+        draft: true
         prerelease: ${{ contains(env.TAG_NAME, '-') }}
         generate_release_notes: true
+
+    - name: Publish release (was draft during asset upload)
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release edit ${{ env.TAG_NAME }} --draft=false --repo ${{ github.repository }}
 
   update-homebrew:
     name: Update Homebrew Tap


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml`: change `Create Release` step to `draft: true` and add a `Publish release` step after asset upload completes

## Why

The `"target_commitish cannot be changed when release is immutable"` error occurs when `softprops/action-gh-release` attempts to update an existing (already-published) release for a tag. By starting as a draft, the action can safely create/update the release and upload assets without hitting the immutability gate. The separate `gh release edit --draft=false` step only fires after all assets are uploaded successfully.

The downstream jobs (`update-homebrew`, `notify-ide-plugins`) already depend on the `release` job completing, so they fire naturally after the publish step — no sequencing changes needed.

## Test plan
- [ ] Tag a new release (e.g. `v0.25.0`) and verify the release starts as draft, all binary + UI assets upload, then the release becomes public
- [ ] Verify that retrying a failed build doesn't hit the immutability error

🤖 Generated with [Claude Code](https://claude.com/claude-code)