### PR TITLE
test(secrets): failing test for generateDOSpacesKey created_at (PR4a Task 7)

### DIFF
--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -121,7 +121,11 @@ func runInfraBootstrap(args []string) error {
 			}()
 		}
 
-		generated, err := bootstrapSecrets(ctx, provider, secretsCfg, forceRotate, revoker)
+		// runInfraBootstrap discards the rotations slice — the CLI surface
+		// for `wfctl infra bootstrap` doesn't consume rotation metadata
+		// directly. `wfctl infra rotate-and-prune` (Task 21) is the only
+		// caller that uses it.
+		generated, _, err := bootstrapSecrets(ctx, provider, secretsCfg, forceRotate, revoker)
 		if err != nil {
 			return err
 		}
@@ -412,6 +416,22 @@ func writeBucketBackToConfig(cfgFile, bucket string) error {
 	return os.WriteFile(cfgFile, []byte(strings.Join(lines, "\n")), 0o600)
 }
 
+// RotationResult captures rotation metadata in-process during a bootstrap run.
+// It is returned alongside the storage map so callers (e.g. rotate-and-prune)
+// can identify the newly-minted credential without re-running bootstrap as a
+// subprocess and parsing stderr. Per ADR 0020 + review #2 closeout.
+//
+// AccessKey and CreatedAt come from the provider_credential generator output:
+// AccessKey is stored as a GH Secret (it's in providerCredentialSubKeys);
+// CreatedAt is filtered out by the storage-filter and surfaced here +
+// emitted to stderr as a sidecar.
+type RotationResult struct {
+	Key       string // canonical generator key, e.g. "SPACES"
+	Source    string // generator source, e.g. "digitalocean.spaces"
+	AccessKey string // newly-minted credential identifier
+	CreatedAt string // ISO8601 timestamp from provider API
+}
+
 // providerCredentialSubKeys lists the sub-key names produced by each
 // provider_credential source. Existence checks must verify ALL of them so a
 // partial prior write (e.g. one sub-key manually deleted) triggers a full
@@ -458,9 +478,13 @@ func expectedStoredKeys(gen SecretGen) []string {
 }
 
 // bootstrapSecrets generates and stores secrets that don't already exist.
-// It returns a map of every key-value pair that was newly generated in this
-// run (skipped/pre-existing keys are NOT included). The caller can export
-// these to the process environment for downstream steps.
+// It returns the storage map, a RotationResult slice (non-empty only when
+// --force-rotate triggered new credential creation; nil for idempotent
+// skip-if-exists runs), and an error.
+//
+// The function is declared as a package-level var (not a plain func) so tests
+// can override it without going through the real provider/network path. Same
+// pattern as the `var generateSecret` hook above.
 //
 // forceRotate is an optional set of secret keys to regenerate even when the
 // secret already exists. The function deletes the existing value before
@@ -473,12 +497,20 @@ func expectedStoredKeys(gen SecretGen) []string {
 // the upstream provider AFTER the new credential has been minted and stored
 // (mint-new-then-revoke-old; see ADR 0012). If revoker is nil, the old
 // credential is not explicitly revoked (operator must revoke manually).
-func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *SecretsConfig, forceRotate map[string]bool, revoker ...interfaces.ProviderCredentialRevoker) (map[string]string, error) {
+//
+// Storage-filter (ADR 0020): for provider_credential generators, only the
+// sub-keys listed in providerCredentialSubKeys[gen.Source] are persisted as
+// GH Secrets. Sidecar metadata (e.g. created_at) is captured into the
+// RotationResult AND emitted to stderr as `WFCTL_NEW_KEY_<UPPER>=<v>` lines
+// for operator observability + audit logs, but never stored in the secrets
+// provider.
+var bootstrapSecrets = func(ctx context.Context, provider secrets.Provider, cfg *SecretsConfig, forceRotate map[string]bool, revoker ...interfaces.ProviderCredentialRevoker) (map[string]string, []RotationResult, error) {
 	var credRevoker interfaces.ProviderCredentialRevoker
 	if len(revoker) > 0 {
 		credRevoker = revoker[0]
 	}
 	generated := map[string]string{}
+	var rotations []RotationResult
 
 	// Cache List() as a set so repeated probes in a bootstrap run only hit
 	// the provider once and subsequent lookups are O(1). Resolved lazily on
@@ -597,7 +629,7 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 			for _, key := range expected {
 				present, err := secretExists(key)
 				if err != nil {
-					return generated, err
+					return generated, rotations, err
 				}
 				if !present {
 					allExist = false
@@ -613,17 +645,49 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 		// Generate the secret value.
 		value, err := generateSecret(ctx, gen.Type, genConfig)
 		if err != nil {
-			return generated, fmt.Errorf("generate secret %q: %w", gen.Key, err)
+			return generated, rotations, fmt.Errorf("generate secret %q: %w", gen.Key, err)
 		}
 
-		// For provider_credential results (JSON map), store each sub-key.
+		// For provider_credential results (JSON map), apply the storage-filter:
+		// only persist keys listed in providerCredentialSubKeys[gen.Source].
+		// Sidecar metadata (e.g. created_at) is captured into RotationResult
+		// AND emitted to stderr as `WFCTL_NEW_KEY_<UPPER>=<v>` lines so
+		// operators / log scrapers can observe it, but is NOT stored as a GH
+		// Secret. Per ADR 0020 storage-filter constraint.
 		if gen.Type == "provider_credential" {
 			var subKeyMap map[string]string
 			if jsonErr := json.Unmarshal([]byte(value), &subKeyMap); jsonErr == nil {
+				allowedSubKeys, ok := providerCredentialSubKeys[gen.Source]
+				if !ok {
+					return generated, rotations, fmt.Errorf("unknown provider_credential source %q (no subkey mapping)", gen.Source)
+				}
+				allowed := make(map[string]bool, len(allowedSubKeys))
+				for _, k := range allowedSubKeys {
+					allowed[k] = true
+				}
+
+				// Capture access_key + created_at independently of storage so
+				// RotationResult always reports them on a force-rotate, even
+				// though access_key IS in the allowed set and created_at is
+				// NOT (per review #2 C5: stderr emission alone would skip
+				// access_key).
+				var newAccessKey, newCreatedAt string
 				for subKey, subVal := range subKeyMap {
+					if subKey == "access_key" {
+						newAccessKey = subVal
+					}
+					if subKey == "created_at" {
+						newCreatedAt = subVal
+					}
+					if !allowed[subKey] {
+						// Sidecar field — emit to stderr in machine-parseable form
+						// for operator observability + audit logs.
+						fmt.Fprintf(os.Stderr, "WFCTL_NEW_KEY_%s=%s\n", strings.ToUpper(subKey), subVal)
+						continue
+					}
 					fullKey := gen.Key + "_" + subKey
 					if setErr := provider.Set(ctx, fullKey, subVal); setErr != nil {
-						return generated, fmt.Errorf("store secret %q: %w", fullKey, setErr)
+						return generated, rotations, fmt.Errorf("store secret %q: %w", fullKey, setErr)
 					}
 					generated[fullKey] = subVal
 					if forceRotate[gen.Key] {
@@ -634,6 +698,16 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 				}
 				if forceRotate[gen.Key] {
 					fmt.Fprintf(os.Stderr, "wfctl: rotated provider_credential %s (replaced existing value at %s)\n", gen.Key, time.Now().UTC().Format(time.RFC3339))
+					// Record the rotation in-process so callers (rotate-and-prune)
+					// have the new credential id without re-running bootstrap.
+					if newAccessKey != "" {
+						rotations = append(rotations, RotationResult{
+							Key:       gen.Key,
+							Source:    gen.Source,
+							AccessKey: newAccessKey,
+							CreatedAt: newCreatedAt,
+						})
+					}
 					// Revoke the OLD credential at the upstream provider AFTER storing
 					// the new one. Failure is non-fatal: the new credential is valid and
 					// must not be rolled back. Log warning + continue (see ADR 0012).
@@ -652,7 +726,7 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 		}
 
 		if err := provider.Set(ctx, gen.Key, value); err != nil {
-			return generated, fmt.Errorf("store secret %q: %w", gen.Key, err)
+			return generated, rotations, fmt.Errorf("store secret %q: %w", gen.Key, err)
 		}
 		generated[gen.Key] = value
 
@@ -663,5 +737,5 @@ func bootstrapSecrets(ctx context.Context, provider secrets.Provider, cfg *Secre
 			fmt.Printf("  secret %q: created\n", gen.Key)
 		}
 	}
-	return generated, nil
+	return generated, rotations, nil
 }

--- a/cmd/wfctl/infra_bootstrap_env_test.go
+++ b/cmd/wfctl/infra_bootstrap_env_test.go
@@ -250,7 +250,7 @@ func TestBootstrap_RepeatedRunIdempotent(t *testing.T) {
 	}
 
 	// First run: generates the secret.
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("first bootstrapSecrets: %v", err)
 	}
 	if callCount != 1 {
@@ -261,7 +261,7 @@ func TestBootstrap_RepeatedRunIdempotent(t *testing.T) {
 	}
 
 	// Second run: secret already exists — generator must NOT be called again.
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("second bootstrapSecrets: %v", err)
 	}
 	if callCount != 1 {

--- a/cmd/wfctl/infra_bootstrap_force_rotate_test.go
+++ b/cmd/wfctl/infra_bootstrap_force_rotate_test.go
@@ -84,7 +84,7 @@ func TestInfraBootstrap_ForceRotate_DeletesAndRegenerates(t *testing.T) {
 	}
 	forceRotate := map[string]bool{"FOO": true}
 
-	result, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate)
+	result, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate)
 	if err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestInfraBootstrap_ForceRotate_ProviderCredential_MintsAndRevokes(t *testin
 		},
 	}
 
-	result, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate, revoker)
+	result, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate, revoker)
 	if err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestInfraBootstrap_ForceRotate_ProviderCredential_RevokeFailNonFatal(t *tes
 		},
 	}
 
-	result, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate, revoker)
+	result, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate, revoker)
 	if err != nil {
 		t.Fatalf("bootstrapSecrets should not fail on revoke error; got: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestInfraBootstrap_ForceRotate_ProviderCredential_WriteOnlyStore(t *testing
 		},
 	}
 
-	result, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate, revoker)
+	result, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate, revoker)
 	if err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
@@ -338,7 +338,7 @@ func TestInfraBootstrap_ForceRotate_BestEffortDeleteOnMissing(t *testing.T) {
 	}
 	forceRotate := map[string]bool{"FOO": true}
 
-	_, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate)
+	_, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate)
 	if err != nil {
 		t.Fatalf("bootstrapSecrets returned error on missing key: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestInfraBootstrap_ForceRotate_BestEffortDeleteNotFound(t *testing.T) {
 	}
 	forceRotate := map[string]bool{"FOO": true}
 
-	_, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate)
+	_, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate)
 	if err != nil {
 		t.Fatalf("expected no error on best-effort delete; got: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestInfraBootstrap_ForceRotate_CommaSeparated(t *testing.T) {
 		t.Fatalf("buildForceRotateSet: %v", err)
 	}
 
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 
@@ -477,7 +477,7 @@ func TestInfraBootstrap_ForceRotate_Repeatable(t *testing.T) {
 		t.Fatalf("buildForceRotateSet: %v", err)
 	}
 
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, forceRotate); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 

--- a/cmd/wfctl/infra_bootstrap_secrets_test.go
+++ b/cmd/wfctl/infra_bootstrap_secrets_test.go
@@ -70,7 +70,7 @@ func TestBootstrapSecrets_WriteOnlyProviderSkipsExisting(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if len(p.stored) != 0 {
@@ -93,7 +93,7 @@ func TestBootstrapSecrets_WriteOnlyProviderGeneratesWhenMissing(t *testing.T) {
 			{Key: "JWT_SECRET", Type: "random_hex", Length: 8},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if _, ok := p.stored["JWT_SECRET"]; !ok {
@@ -111,7 +111,7 @@ func TestBootstrapSecrets_WriteOnlyProviderListUnsupported(t *testing.T) {
 			{Key: "JWT_SECRET", Type: "random_hex", Length: 8},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if len(p.stored) != 1 {
@@ -136,7 +136,7 @@ func TestBootstrapSecrets_ProviderCredentialAllSubKeysPresent(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if len(p.stored) != 0 {
@@ -165,7 +165,7 @@ func TestBootstrapSecrets_ProviderCredentialPartialRegenerates(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if got := p.stored["SPACES_access_key"]; got != "new-access" {
@@ -216,7 +216,7 @@ func TestBootstrapSecrets_StorageFilter_OnlyPersistsSubKeys(t *testing.T) {
 		},
 	}
 
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 
@@ -258,7 +258,7 @@ func TestBootstrapSecrets_ProviderCredentialProbeIgnoresBareKey(t *testing.T) {
 			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if generateCalls != 1 {

--- a/cmd/wfctl/infra_bootstrap_secrets_test.go
+++ b/cmd/wfctl/infra_bootstrap_secrets_test.go
@@ -176,6 +176,65 @@ func TestBootstrapSecrets_ProviderCredentialPartialRegenerates(t *testing.T) {
 	}
 }
 
+// TestBootstrapSecrets_StorageFilter_OnlyPersistsSubKeys verifies that
+// provider_credential JSON is filtered to the canonical sub-keys defined in
+// providerCredentialSubKeys before being persisted as GH Secrets. Without
+// this filter, sidecar metadata that the generator now emits alongside the
+// canonical creds (e.g. created_at after Task 8) would leak into the GH
+// Secrets store as phantom keys like SPACES_created_at — breaking the
+// audit-keys/prune contract that "every GH Secret matches an upstream key"
+// (ADR 0020 same-commit constraint with Task 8).
+//
+// This is the failing test for Task 9 of the spaces-key-iac-resource plan.
+// Until Task 10 implements the sub-key allow-list filter in bootstrapSecrets,
+// this test fails at the SPACES_created_at assertion.
+func TestBootstrapSecrets_StorageFilter_OnlyPersistsSubKeys(t *testing.T) {
+	// Stub generateSecret to mimic the post-Task-8 generateDOSpacesKey shape:
+	// access_key + secret_key (canonical) plus created_at (sidecar metadata).
+	withStubGenerator(t, func(_ context.Context, _ string, _ map[string]any) (string, error) {
+		out, _ := json.Marshal(map[string]string{
+			"access_key": "AK",
+			"secret_key": "SK",
+			"created_at": "2026-05-08T10:00:00Z",
+		})
+		return string(out), nil
+	})
+
+	// Empty existing → bootstrap will generate.
+	p := &writeOnlyProvider{
+		existing: nil,
+		listOK:   true,
+	}
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{
+				Key:    "SPACES",
+				Type:   "provider_credential",
+				Source: "digitalocean.spaces",
+				Name:   "test-key",
+			},
+		},
+	}
+
+	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+		t.Fatalf("bootstrapSecrets: %v", err)
+	}
+
+	// Storage MUST contain the two canonical sub-keys.
+	if _, ok := p.stored["SPACES_access_key"]; !ok {
+		t.Errorf("SPACES_access_key should be stored; stored=%v", p.stored)
+	}
+	if _, ok := p.stored["SPACES_secret_key"]; !ok {
+		t.Errorf("SPACES_secret_key should be stored; stored=%v", p.stored)
+	}
+
+	// Storage MUST NOT contain sidecar metadata fields like created_at:
+	// these are not real GH Secrets and would pollute audit-keys/prune output.
+	if _, ok := p.stored["SPACES_created_at"]; ok {
+		t.Errorf("SPACES_created_at MUST NOT be stored as a GH Secret (storage-filter regression); stored=%v", p.stored)
+	}
+}
+
 // TestBootstrapSecrets_ProviderCredentialProbeIgnoresBareKey verifies that a
 // plain secret named the same as the provider_credential key (without the
 // _access_key / _secret_key suffixes) does not cause a false skip.

--- a/cmd/wfctl/infra_e2e_integration_test.go
+++ b/cmd/wfctl/infra_e2e_integration_test.go
@@ -101,7 +101,7 @@ secrets:
 		t.Fatal("phase 1: expected secrets config")
 	}
 	p := &fakeSecretsProvider{stored: map[string]string{}}
-	if _, err := bootstrapSecrets(context.Background(), p, secretsCfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, secretsCfg, nil); err != nil {
 		t.Fatalf("phase 1 bootstrapSecrets: %v", err)
 	}
 	if p.stored["APP_SECRET"] != "deadbeefcafe1234" {

--- a/cmd/wfctl/infra_output_secrets_test.go
+++ b/cmd/wfctl/infra_output_secrets_test.go
@@ -270,7 +270,7 @@ func TestBootstrapSecrets_SkipsInfraOutputGens(t *testing.T) {
 			{Key: "DATABASE_URL", Type: "infra_output", Source: "bmw-database.uri"},
 		},
 	}
-	if _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
 		t.Fatalf("bootstrapSecrets: %v", err)
 	}
 	if generatorCalled {

--- a/decisions/0021-spaces-key-test-hook-rewriteTransport-not-env-var.md
+++ b/decisions/0021-spaces-key-test-hook-rewriteTransport-not-env-var.md
@@ -1,0 +1,126 @@
+# ADR 0021 — Use rewriteTransport (not DIGITALOCEAN_API_URL env var) for DO API test stubbing
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Context:** Code review of PR4a (Task 8 commit 1f03a7d9) flagged a Critical
+credential-exfiltration vector in `secrets/generators.go`. Resolved by switching
+the test stub mechanism in Task 7 (`secrets/generators_test.go`) and removing the
+production hook from `generateDOSpacesKey`.
+
+---
+
+## Problem
+
+The `spaces-key-iac-resource` plan (commit 316559f7) prescribed an
+`os.Getenv("DIGITALOCEAN_API_URL")` override in `generateDOSpacesKey` so that
+the Task 7 failing test could redirect the DO API call at an `httptest.Server`
+via `t.Setenv("DIGITALOCEAN_API_URL", srv.URL)`. The hook was honored
+**unconditionally** in production code:
+
+```go
+apiURL := "https://api.digitalocean.com"
+if v := os.Getenv("DIGITALOCEAN_API_URL"); v != "" {
+    apiURL = v
+}
+req, _ := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/v2/spaces/keys", ...)
+req.Header.Set("Authorization", "Bearer "+os.Getenv("DIGITALOCEAN_TOKEN"))
+```
+
+A process whose environment includes `DIGITALOCEAN_API_URL` — set by a
+malicious `.env` checked into a repo, a hostile CI step, a multi-tenant runner,
+or a compromised dependency — would silently redirect the
+`Authorization: Bearer <DIGITALOCEAN_TOKEN>` POST to an attacker-controlled
+server. The attacker captures the production token in the request header
+without any authentication challenge and without any indication to the
+operator. **Credential exfiltration with no detection signal.**
+
+This is a textbook "innocuous test hook becomes a security backdoor" pattern.
+Copilot independently flagged it on PR #582 as a Critical security finding.
+
+---
+
+## Decision
+
+1. **Remove** the `DIGITALOCEAN_API_URL` env-var override from
+   `secrets/generators.go`. The production code path uses the hardcoded DO
+   endpoint `https://api.digitalocean.com/v2/spaces/keys`.
+
+2. **Switch** `TestGenerateDOSpacesKey_IncludesCreatedAt` (Task 7) to use the
+   package's existing `rewriteTransport` helper (defined in
+   `secrets/github_provider_test.go` line 30, used by the three sister tests
+   `TestGenerateSecret_ProviderCredential_DOSpaces*` at lines 107-109,
+   156-158, 211-213):
+
+   ```go
+   orig := http.DefaultClient.Transport
+   http.DefaultClient.Transport = rewriteTransport{base: srv.URL}
+   defer func() { http.DefaultClient.Transport = orig }()
+   ```
+
+   This pattern is hermetic — it mutates `http.DefaultClient` in-test only,
+   requires explicit Go code in the test to take effect, and has zero
+   production attack surface. It matches the convention already established
+   in this exact file for the same provider.
+
+3. **No production behavior change** beyond removing the env-var lookup.
+   The hardcoded URL is the same one Task 7's commit had before Task 8
+   modified it.
+
+---
+
+## Alternatives considered
+
+- **Constructor-injection of a `Transport` (or full `*http.Client`) into
+  `generateDOSpacesKey`.** Would also be safe, but is a larger refactor (the
+  generator is a free function, not a struct method) and would diverge from
+  the existing `rewriteTransport`+`http.DefaultClient` convention used by the
+  other DO Spaces tests in the same file. Not worth the churn for the same
+  end-state safety property.
+
+- **Honor the env var only when an in-process build tag is set** (e.g.
+  `//go:build testhook`). Workable, but adds a parallel build configuration
+  to the repo for one feature and still doesn't match the existing sister
+  pattern. Same churn-cost objection as constructor injection.
+
+- **Keep the env-var override but only honor it when a sentinel like
+  `WFCTL_TEST=1` is also set.** Defense-in-depth, but the attacker who can
+  set one env var can typically set another. Doesn't actually close the
+  vector — just adds one cheap step to the exploit. Rejected.
+
+---
+
+## Plan deviation
+
+The original plan (`docs/plans/2026-05-08-spaces-key-iac-resource.md`,
+Task 7 step 1 + Task 8 step 1) literally prescribed:
+
+> `t.Setenv("DIGITALOCEAN_API_URL", srv.URL) // hook used by generateDOSpacesKey for tests`
+>
+> Plus add a test hook for `DIGITALOCEAN_API_URL` env var if not present:
+> `apiURL := "https://api.digitalocean.com"; if v := os.Getenv("DIGITALOCEAN_API_URL"); v != "" { apiURL = v }`
+
+The plan was wrong on this. Per workspace memory
+`feedback_proper_fixes_over_workarounds`, fixing the security flaw at the
+mechanism level (rewriteTransport) is preferred over patching around the
+env var. Per `feedback_no_invented_interfaces`, switching to an already-existing
+helper in the package (rather than introducing a new test hook) is also
+preferred.
+
+The plan author has been notified. Task 8's review-cycle catch is exactly
+what the 2-stage spec/code review process exists for.
+
+---
+
+## Consequences
+
+- **Positive:** DO API URL is no longer overridable from process environment
+  in production. Test stub mechanism matches the three sibling DO Spaces
+  tests. No new test infrastructure introduced.
+
+- **Negative:** None. The `rewriteTransport` helper already existed in this
+  package, so this is a strictly subtractive change to production code +
+  a pattern-conforming change to the test.
+
+- **Follow-up:** Plan-as-written should not be re-used as a template for
+  HTTP-stub patterns in other generators. The `secrets/generators_test.go`
+  sibling tests are the canonical example to copy.

--- a/interfaces/iac_provider.go
+++ b/interfaces/iac_provider.go
@@ -84,6 +84,21 @@ type Enumerator interface {
 	EnumerateByTag(ctx context.Context, tag string) ([]ResourceRef, error)
 }
 
+// EnumeratorAll is an OPTIONAL provider interface for resource types that
+// don't support tagging (e.g. DO Spaces keys). Returns ALL resources of
+// resourceType in the account regardless of tag, with full metadata
+// (Outputs map populated) so callers can filter without re-reading.
+//
+// Returns []*ResourceOutput rather than []ResourceRef because filtering
+// (drift detection, prune) needs the metadata. Implementations should
+// paginate transparently. Returning *ResourceOutput keeps the contract
+// consistent with ResourceDriver.Read which also returns this shape.
+//
+// Per ADR 0016. Used by `wfctl infra audit-keys` + `wfctl infra prune`.
+type EnumeratorAll interface {
+	EnumerateAll(ctx context.Context, resourceType string) ([]*ResourceOutput, error)
+}
+
 // DriftConfigDetector is an OPTIONAL interface a provider MAY implement to
 // surface config-drift in addition to the existence-only Ghost / InSync /
 // Unknown classifications produced by DetectDrift.

--- a/interfaces/iac_provider_test.go
+++ b/interfaces/iac_provider_test.go
@@ -245,3 +245,19 @@ type capableIaCProvider struct{ nonValidatingProvider }
 func (*capableIaCProvider) DetectDriftWithSpecs(context.Context, []interfaces.ResourceRef, map[string]interfaces.ResourceSpec) ([]interfaces.DriftResult, error) {
 	return nil, nil
 }
+
+// TestEnumeratorAll_InterfaceShape pins the EnumeratorAll signature so
+// downstream plugins (e.g. workflow-plugin-digitalocean) can rely on it.
+// Per ADR 0016: providers whose resource types do not support tagging
+// (e.g. DO Spaces keys) implement EnumeratorAll instead of Enumerator.
+func TestEnumeratorAll_InterfaceShape(t *testing.T) {
+	// Compile-time assertion: any type implementing this interface
+	// must have the exact method signature.
+	var _ interfaces.EnumeratorAll = (*fakeEnumeratorAll)(nil)
+}
+
+type fakeEnumeratorAll struct{}
+
+func (f *fakeEnumeratorAll) EnumerateAll(ctx context.Context, resourceType string) ([]*interfaces.ResourceOutput, error) {
+	return nil, nil
+}

--- a/secrets/generators.go
+++ b/secrets/generators.go
@@ -165,7 +165,14 @@ func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, er
 	payload := map[string]any{"name": name, "grants": []map[string]any{grant}}
 	body, _ := json.Marshal(payload)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.digitalocean.com/v2/spaces/keys", bytes.NewReader(body))
+	// DIGITALOCEAN_API_URL is a test-only hook so unit tests can redirect
+	// generateDOSpacesKey at a httptest.Server. In production the env var is
+	// unset and we fall through to the canonical DO endpoint.
+	apiURL := "https://api.digitalocean.com"
+	if v := os.Getenv("DIGITALOCEAN_API_URL"); v != "" {
+		apiURL = v
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/v2/spaces/keys", bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}
@@ -187,6 +194,7 @@ func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, er
 		Key struct {
 			AccessKey string `json:"access_key"`
 			SecretKey string `json:"secret_key"`
+			CreatedAt string `json:"created_at"`
 		} `json:"key"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -196,6 +204,7 @@ func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, er
 	out, err := json.Marshal(map[string]string{
 		"access_key": result.Key.AccessKey,
 		"secret_key": result.Key.SecretKey,
+		"created_at": result.Key.CreatedAt,
 	})
 	if err != nil {
 		return "", err

--- a/secrets/generators.go
+++ b/secrets/generators.go
@@ -165,14 +165,15 @@ func generateDOSpacesKey(ctx context.Context, config map[string]any) (string, er
 	payload := map[string]any{"name": name, "grants": []map[string]any{grant}}
 	body, _ := json.Marshal(payload)
 
-	// DIGITALOCEAN_API_URL is a test-only hook so unit tests can redirect
-	// generateDOSpacesKey at a httptest.Server. In production the env var is
-	// unset and we fall through to the canonical DO endpoint.
-	apiURL := "https://api.digitalocean.com"
-	if v := os.Getenv("DIGITALOCEAN_API_URL"); v != "" {
-		apiURL = v
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/v2/spaces/keys", bytes.NewReader(body))
+	// The DO Spaces Keys endpoint is hardcoded. Tests stub it via the package's
+	// rewriteTransport helper (see generators_test.go) — a hermetic mechanism
+	// that requires explicit code in the test to take effect. Earlier drafts
+	// of this file honored a DIGITALOCEAN_API_URL env var, but that override
+	// was removed: an attacker who could set the env var (malicious .env,
+	// hostile CI step, multi-tenant runner) would redirect the
+	// `Authorization: Bearer <DIGITALOCEAN_TOKEN>` POST to their own server,
+	// exfiltrating production credentials. See ADR 0021.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.digitalocean.com/v2/spaces/keys", bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}

--- a/secrets/generators_test.go
+++ b/secrets/generators_test.go
@@ -257,6 +257,52 @@ func TestGenerateSecret_ProviderCredential_MissingToken(t *testing.T) {
 	}
 }
 
+// TestGenerateDOSpacesKey_IncludesCreatedAt asserts that generateDOSpacesKey
+// surfaces the DO API's `created_at` timestamp alongside access_key+secret_key
+// in its JSON output. This is required by the upcoming SpacesKeyDriver IaC
+// resource (PR4b), which keys observed-key adoption on creation timestamps.
+func TestGenerateDOSpacesKey_IncludesCreatedAt(t *testing.T) {
+	// Stub the DO API server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/spaces/keys" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"key": map[string]any{
+				"access_key": "AK1234567890",
+				"secret_key": "SK_full_secret_value_here",
+				"name":       "test-key",
+				"created_at": "2026-05-08T10:30:00Z",
+				"grants":     []any{map[string]any{"permission": "fullaccess"}},
+			},
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("DIGITALOCEAN_TOKEN", "stub")
+	t.Setenv("DIGITALOCEAN_API_URL", srv.URL) // hook used by generateDOSpacesKey for tests
+
+	raw, err := generateDOSpacesKey(context.Background(), map[string]any{"name": "test-key"})
+	if err != nil {
+		t.Fatalf("generateDOSpacesKey: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got["access_key"] != "AK1234567890" {
+		t.Errorf("access_key: want AK1234567890, got %q", got["access_key"])
+	}
+	if got["secret_key"] != "SK_full_secret_value_here" {
+		t.Errorf("secret_key: want SK_full..., got %q", got["secret_key"])
+	}
+	if got["created_at"] != "2026-05-08T10:30:00Z" {
+		t.Errorf("created_at: want 2026-05-08T10:30:00Z, got %q", got["created_at"])
+	}
+}
+
 // ── infra_output generator ────────────────────────────────────────────────────
 
 func sampleStateOutputs() map[string]map[string]any {

--- a/secrets/generators_test.go
+++ b/secrets/generators_test.go
@@ -261,8 +261,14 @@ func TestGenerateSecret_ProviderCredential_MissingToken(t *testing.T) {
 // surfaces the DO API's `created_at` timestamp alongside access_key+secret_key
 // in its JSON output. This is required by the upcoming SpacesKeyDriver IaC
 // resource (PR4b), which keys observed-key adoption on creation timestamps.
+//
+// Test isolation: redirects http.DefaultClient via the package's
+// rewriteTransport helper (defined in github_provider_test.go), matching the
+// sibling DOSpaces tests above. We deliberately do NOT use a process env
+// override (e.g. DIGITALOCEAN_API_URL) — that would be a credential-
+// exfiltration vector in production. Per ADR 0021.
 func TestGenerateDOSpacesKey_IncludesCreatedAt(t *testing.T) {
-	// Stub the DO API server
+	// Stub the DO API server.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v2/spaces/keys" || r.Method != http.MethodPost {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -279,8 +285,15 @@ func TestGenerateDOSpacesKey_IncludesCreatedAt(t *testing.T) {
 		})
 	}))
 	defer srv.Close()
+
 	t.Setenv("DIGITALOCEAN_TOKEN", "stub")
-	t.Setenv("DIGITALOCEAN_API_URL", srv.URL) // hook used by generateDOSpacesKey for tests
+
+	// Inject the test server URL by monkey-patching http.DefaultClient
+	// transport — same hermetic pattern as the existing
+	// TestGenerateSecret_ProviderCredential_DOSpaces tests above.
+	orig := http.DefaultClient.Transport
+	http.DefaultClient.Transport = rewriteTransport{base: srv.URL}
+	defer func() { http.DefaultClient.Transport = orig }()
 
 	raw, err := generateDOSpacesKey(context.Background(), map[string]any{"name": "test-key"})
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a failing test for `generateDOSpacesKey` that asserts the function surfaces the DO API's `created_at` timestamp alongside `access_key`+`secret_key` in its JSON output.

This is **Task 7 of PR4a** in the `spaces-key-iac-resource` plan. Per ADR 0020 same-commit constraint, PR4a Tasks 7 (failing test) → 8 (impl) → 9 (storage-filter test) → 10 (storage-filter impl) all land on this branch and squash-merge atomically.

## Why `created_at`?

The upcoming `SpacesKeyDriver` IaC resource (PR4b) keys observed-key adoption on creation timestamps — without `created_at` flowing through `generateDOSpacesKey`, the driver cannot match an in-state key to its remote counterpart.

## Test failure mode

Running `go test ./secrets -run TestGenerateDOSpacesKey_IncludesCreatedAt -v` against this commit fails — the current implementation only extracts `access_key`+`secret_key` from the response. (Failure mode in CI without the env-var hook resolves to a `DIGITALOCEAN_API_URL` test stub that Task 8 will honor; on a network-attached runner it fails with HTTP 401 from real DO since `DIGITALOCEAN_TOKEN=stub`.)

## Test plan

- [ ] **Task 7 (this commit)**: `go test ./secrets -run TestGenerateDOSpacesKey_IncludesCreatedAt -v` FAILS
- [ ] **Task 8**: extends response struct + adds `DIGITALOCEAN_API_URL` test hook → test PASSES
- [ ] **Task 9**: adds failing test for `bootstrapSecrets` storage-filter
- [ ] **Task 10**: implements storage-filter + tags workflow release

## Plan reference

`docs/plans/2026-05-08-spaces-key-iac-resource.md` (commit 316655f7), `### Task 7:` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)