### PR TITLE
ci: generate wfctl-centered build jobs

### DIFF
--- a/cmd/wfctl/build.go
+++ b/cmd/wfctl/build.go
@@ -168,6 +168,12 @@ func runBuildOrchestrate(cfg *config.WorkflowConfig, opts buildOpts) error {
 		if opts.tag != "" {
 			imgArgs = append(imgArgs, "--tag", opts.tag)
 		}
+		if len(opts.only) > 0 {
+			imgArgs = append(imgArgs, "--only", strings.Join(opts.only, ","))
+		}
+		if len(opts.skip) > 0 {
+			imgArgs = append(imgArgs, "--skip", strings.Join(opts.skip, ","))
+		}
 		// For hardened builds (docker buildx with docker-container driver), pass
 		// --push so buildx pushes directly from the buildkit cache. Without this,
 		// buildx would silently cache the result and the subsequent docker push
@@ -189,6 +195,12 @@ func runBuildOrchestrate(cfg *config.WorkflowConfig, opts buildOpts) error {
 		}
 		if opts.tag != "" {
 			pushArgs = append(pushArgs, "--tag", opts.tag)
+		}
+		if len(opts.only) > 0 {
+			pushArgs = append(pushArgs, "--only", strings.Join(opts.only, ","))
+		}
+		if len(opts.skip) > 0 {
+			pushArgs = append(pushArgs, "--skip", strings.Join(opts.skip, ","))
 		}
 		if err := runBuildPush(pushArgs); err != nil {
 			return fmt.Errorf("push: %w", err)

--- a/cmd/wfctl/build.go
+++ b/cmd/wfctl/build.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -40,14 +41,15 @@ func runBuild(args []string) error {
 	fs := flag.NewFlagSet("build", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	var (
-		cfgPath string
-		dryRun  bool
-		only    string
-		skip    string
-		tag     string
-		format  string
-		noPush  bool
-		envName string
+		cfgPath         string
+		dryRun          bool
+		only            string
+		skip            string
+		tag             string
+		format          string
+		noPush          bool
+		envName         string
+		fallbackGoBuild bool
 	)
 	fs.StringVar(&cfgPath, "config", "workflow.yaml", "Path to workflow config file")
 	fs.StringVar(&cfgPath, "c", "workflow.yaml", "Path to workflow config file (short)")
@@ -57,6 +59,7 @@ func runBuild(args []string) error {
 	fs.StringVar(&tag, "tag", "", "Override image tag for all container targets")
 	fs.StringVar(&format, "format", "table", "Output format: table | json | yaml")
 	fs.BoolVar(&noPush, "no-push", false, "Build but do not push images to registries")
+	fs.BoolVar(&fallbackGoBuild, "fallback-go-build", false, "Run go build ./... when ci.build has no build targets")
 	var push bool
 	fs.BoolVar(&push, "push", true, "Push images to registries after build (default true; --push=false is equivalent to --no-push)")
 	fs.StringVar(&envName, "env", "", "Environment name for per-env config overrides")
@@ -77,7 +80,10 @@ func runBuild(args []string) error {
 	if err != nil {
 		return fmt.Errorf("wfctl build: load config: %w", err)
 	}
-	if cfg.CI == nil || cfg.CI.Build == nil {
+	if cfg.CI == nil || cfg.CI.Build == nil || !hasConfiguredBuildTargets(cfg.CI.Build) {
+		if fallbackGoBuild {
+			return runDefaultGoBuild(dryRun)
+		}
 		fmt.Println("No build configuration, skipping build phase")
 		return nil
 	}
@@ -92,6 +98,25 @@ func runBuild(args []string) error {
 		envName: envName,
 		cfgPath: cfgPath,
 	})
+}
+
+func hasConfiguredBuildTargets(build *config.CIBuildConfig) bool {
+	if build == nil {
+		return false
+	}
+	return len(build.Targets) > 0 || len(build.Containers) > 0 || len(build.Assets) > 0
+}
+
+func runDefaultGoBuild(dryRun bool) error {
+	if dryRun {
+		fmt.Println("[dry-run] go build ./...")
+		return nil
+	}
+	fmt.Println("No build targets configured, running go build ./...")
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // buildOpts carries parsed build flags for use across subcommands.

--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -25,10 +25,13 @@ func runBuildImageWithOutput(args []string, out io.Writer) error {
 	cfgPath := fs.String("config", "", "Config file")
 	dryRun := fs.Bool("dry-run", false, "Print planned actions without executing")
 	tagOverride := fs.String("tag", "", "Override image tag for all containers")
+	only := fs.String("only", "", "Build only containers matching this name (comma-separated)")
+	skip := fs.String("skip", "", "Skip containers matching this name (comma-separated)")
 	pushImages := fs.Bool("push", false, "Push images directly via buildx (hardened mode: adds --push to buildx; non-hardened: no effect, separate push step handles it)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	filter := buildOpts{only: splitCSV(*only), skip: splitCSV(*skip)}
 
 	if os.Getenv("WFCTL_BUILD_DRY_RUN") == "1" {
 		*dryRun = true
@@ -57,6 +60,9 @@ func runBuildImageWithOutput(args []string, out io.Writer) error {
 
 	for i := range cfg.CI.Build.Containers {
 		ctr := cfg.CI.Build.Containers[i]
+		if !shouldInclude(ctr.Name, filter) {
+			continue
+		}
 		tag := *tagOverride
 		if tag == "" {
 			tag = "latest"

--- a/cmd/wfctl/build_image_test.go
+++ b/cmd/wfctl/build_image_test.go
@@ -35,6 +35,65 @@ func TestRunBuildImage_DockerfileDryRun(t *testing.T) {
 	}
 }
 
+func TestRunBuildImage_OnlySkipsUnmatchedContainers(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+      - name: worker
+        method: dockerfile
+        dockerfile: Dockerfile.worker
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath, "--only", "worker"}, &buf); err != nil {
+		t.Fatalf("dockerfile dry-run: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, " app:") || strings.Contains(out, "Dockerfile ") {
+		t.Fatalf("--only worker should skip app container, output:\n%s", out)
+	}
+	if !strings.Contains(out, "Dockerfile.worker") {
+		t.Fatalf("--only worker should include worker container, output:\n%s", out)
+	}
+}
+
+func TestRunBuildImage_SkipCSVSkipsMatchedContainers(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+      - name: worker
+        method: dockerfile
+        dockerfile: Dockerfile.worker
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+
+	var buf bytes.Buffer
+	if err := runBuildImageWithOutput([]string{"--config", cfgPath, "--skip", "app,worker"}, &buf); err != nil {
+		t.Fatalf("dockerfile dry-run: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "docker build") || strings.Contains(out, "Dockerfile") {
+		t.Fatalf("--skip app,worker should skip all container builds, output:\n%s", out)
+	}
+}
+
 func TestRunBuildImage_KoDryRun(t *testing.T) {
 	dir := t.TempDir()
 	cfg := `ci:

--- a/cmd/wfctl/build_orchestrate_test.go
+++ b/cmd/wfctl/build_orchestrate_test.go
@@ -241,7 +241,7 @@ func TestRunBuild_PushFlagDefined(t *testing.T) {
 // TestRunBuild_FlagsRegistered documents the expected flag surface. It relies on the
 // fake map only as documentation; TestRunBuild_PushFlagDefined provides the real gate.
 func TestRunBuild_FlagsRegistered(t *testing.T) {
-	required := []string{"config", "dry-run", "only", "skip", "tag", "format", "no-push", "push", "env"}
+	required := []string{"config", "dry-run", "only", "skip", "tag", "format", "no-push", "push", "env", "fallback-go-build"}
 	registered := buildFlagNames()
 	for _, name := range required {
 		if !registered[name] {
@@ -252,16 +252,17 @@ func TestRunBuild_FlagsRegistered(t *testing.T) {
 
 func buildFlagNames() map[string]bool {
 	return map[string]bool{
-		"config":  true,
-		"c":       true,
-		"dry-run": true,
-		"only":    true,
-		"skip":    true,
-		"tag":     true,
-		"format":  true,
-		"no-push": true,
-		"push":    true,
-		"env":     true,
+		"config":            true,
+		"c":                 true,
+		"dry-run":           true,
+		"only":              true,
+		"skip":              true,
+		"tag":               true,
+		"format":            true,
+		"no-push":           true,
+		"push":              true,
+		"env":               true,
+		"fallback-go-build": true,
 	}
 }
 

--- a/cmd/wfctl/build_orchestrate_test.go
+++ b/cmd/wfctl/build_orchestrate_test.go
@@ -74,6 +74,109 @@ func TestRunBuild_OrchestratorHonorsOnly(t *testing.T) {
 	}
 }
 
+func TestRunBuild_OrchestratorOnlySkipsContainers(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    targets:
+      - name: server
+        type: go
+        path: ./cmd/server
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	out, err := captureStdout(t, func() error {
+		return runBuild([]string{"--config", cfgPath, "--dry-run", "--only", "server"})
+	})
+	if err != nil {
+		t.Fatalf("--only dry-run: %v", err)
+	}
+	if strings.Contains(out, "docker build") || strings.Contains(out, "docker buildx") {
+		t.Fatalf("--only server should skip container target, output:\n%s", out)
+	}
+}
+
+func TestRunBuild_OrchestratorPreservesCommaSeparatedContainerFilters(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  build:
+    targets:
+      - name: server
+        type: go
+        path: ./cmd/server
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile.app
+      - name: worker
+        method: dockerfile
+        dockerfile: Dockerfile.worker
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	out, err := captureStdout(t, func() error {
+		return runBuild([]string{"--config", cfgPath, "--dry-run", "--only", "server,app,worker"})
+	})
+	if err != nil {
+		t.Fatalf("--only dry-run: %v", err)
+	}
+	for _, want := range []string{"Dockerfile.app", "Dockerfile.worker"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("--only should preserve all container filters; missing %s in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunBuild_OrchestratorOnlyFiltersPushPhase(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `ci:
+  registries:
+    - name: docr
+      type: do
+      path: registry.example.com/acme
+  build:
+    containers:
+      - name: app
+        method: dockerfile
+        dockerfile: Dockerfile.app
+        push_to: [docr]
+      - name: worker
+        method: dockerfile
+        dockerfile: Dockerfile.worker
+        push_to: [docr]
+`
+	cfgPath := filepath.Join(dir, "ci.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	out, err := captureStdout(t, func() error {
+		return runBuild([]string{"--config", cfgPath, "--only", "worker"})
+	})
+	if err != nil {
+		t.Fatalf("--only dry-run via env: %v", err)
+	}
+	if strings.Contains(out, "/app:") || strings.Contains(out, "Dockerfile.app") {
+		t.Fatalf("--only worker should skip app build and push phases, output:\n%s", out)
+	}
+	if !strings.Contains(out, "/worker:") {
+		t.Fatalf("--only worker should include worker push phase, output:\n%s", out)
+	}
+}
+
 func TestRunBuild_OrchestratorHonorsSkip(t *testing.T) {
 	opts := buildOpts{skip: []string{"flaky"}}
 	if shouldInclude("flaky", opts) {

--- a/cmd/wfctl/build_push.go
+++ b/cmd/wfctl/build_push.go
@@ -14,9 +14,12 @@ func runBuildPush(args []string) error {
 	fs := flag.NewFlagSet("build push", flag.ContinueOnError)
 	cfgPath := fs.String("config", "workflow.yaml", "Path to workflow config file")
 	tagOverride := fs.String("tag", "", "Override image tag for all containers")
+	only := fs.String("only", "", "Push only containers matching this name (comma-separated)")
+	skip := fs.String("skip", "", "Skip containers matching this name (comma-separated)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	filter := buildOpts{only: splitCSV(*only), skip: splitCSV(*skip)}
 
 	cfg, err := config.LoadFromFile(*cfgPath)
 	if err != nil {
@@ -37,6 +40,9 @@ func runBuildPush(args []string) error {
 
 	for i := range cfg.CI.Build.Containers {
 		ct := cfg.CI.Build.Containers[i]
+		if !shouldInclude(ct.Name, filter) {
+			continue
+		}
 		if ct.External {
 			continue
 		}

--- a/cmd/wfctl/build_push_test.go
+++ b/cmd/wfctl/build_push_test.go
@@ -98,6 +98,41 @@ ci:
 	}
 }
 
+func TestRunBuildPush_OnlySkipsUnmatchedContainers(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeBuildPushFixture(t, dir)
+
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	out, err := captureStdout(t, func() error {
+		return runBuildPush([]string{"--config", cfgPath, "--only", "worker"})
+	})
+	if err != nil {
+		t.Fatalf("runBuildPush --only dry-run: %v", err)
+	}
+	if strings.Contains(out, "/api:") {
+		t.Fatalf("--only worker should skip api pushes, output:\n%s", out)
+	}
+	if !strings.Contains(out, "/worker:") {
+		t.Fatalf("--only worker should include worker push, output:\n%s", out)
+	}
+}
+
+func TestRunBuildPush_SkipCSVSkipsMatchedContainers(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeBuildPushFixture(t, dir)
+
+	t.Setenv("WFCTL_BUILD_DRY_RUN", "1")
+	out, err := captureStdout(t, func() error {
+		return runBuildPush([]string{"--config", cfgPath, "--skip", "api,worker"})
+	})
+	if err != nil {
+		t.Fatalf("runBuildPush --skip dry-run: %v", err)
+	}
+	if strings.Contains(out, "push ") {
+		t.Fatalf("--skip api,worker should skip all pushes, output:\n%s", out)
+	}
+}
+
 func TestRunBuildPush_UnknownRegistry(t *testing.T) {
 	dir := t.TempDir()
 	content := `

--- a/cmd/wfctl/build_test.go
+++ b/cmd/wfctl/build_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
 )
 
 func TestRunBuild_DryRunPrintsPlannedActions(t *testing.T) {
@@ -40,5 +42,82 @@ func TestRunBuild_UnknownSubcommandError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no-such-subcommand") {
 		t.Fatalf("error should mention unknown subcommand, got: %v", err)
+	}
+}
+
+func TestRunBuild_NoBuildConfigSkipsByDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte("name: fallback-test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runBuild([]string{"--config", cfgPath})
+	})
+	if err != nil {
+		t.Fatalf("runBuild without fallback: %v", err)
+	}
+	if !strings.Contains(out, "No build configuration, skipping build phase") {
+		t.Fatalf("expected default skip message, got:\n%s", out)
+	}
+}
+
+func TestRunBuild_FallbackGoBuildDryRun(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte("name: fallback-test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runBuild([]string{"--config", cfgPath, "--fallback-go-build", "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("runBuild fallback dry-run: %v", err)
+	}
+	if !strings.Contains(out, "[dry-run] go build ./...") {
+		t.Fatalf("expected go build dry-run fallback, got:\n%s", out)
+	}
+}
+
+func TestRunBuild_FallbackGoBuildRunsWhenNoTargets(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte("name: fallback-test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fallback.test\n\ngo 1.26\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "broken.go"), []byte("package main\n\nfunc main() { missing }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	err = runBuild([]string{"--config", cfgPath, "--fallback-go-build"})
+	if err == nil {
+		t.Fatal("expected fallback go build to run and fail on uncompilable source")
+	}
+}
+
+func TestHasConfiguredBuildTargetsIgnoresSecurityOnlyConfig(t *testing.T) {
+	build := &config.CIBuildConfig{
+		Security: &config.CIBuildSecurity{Hardened: true},
+	}
+	if hasConfiguredBuildTargets(build) {
+		t.Fatal("security-only build config should not count as configured build targets")
 	}
 }

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -176,16 +177,18 @@ func generateCIFiles(opts ciOptions) (map[string]string, error) {
 // ── GitHub Actions ────────────────────────────────────────────────────────────
 
 type ghaTemplateData struct {
-	InfraConfig string
-	Runner      string
-	Branch      string
+	InfraConfig  string
+	Runner       string
+	Branch       string
+	WfctlVersion string
 }
 
 func generateGitHubActions(opts ciOptions) (map[string]string, error) {
 	data := ghaTemplateData{
-		InfraConfig: opts.InfraConfig,
-		Runner:      opts.Runner,
-		Branch:      "main",
+		InfraConfig:  opts.InfraConfig,
+		Runner:       opts.Runner,
+		Branch:       "main",
+		WfctlVersion: ciGeneratedWfctlVersion(),
 	}
 
 	infraYAML, err := renderCITemplate("gha-infra", ghaInfraTemplate, data)
@@ -231,6 +234,8 @@ jobs:
           cache: true
       - name: Install wfctl
         uses: GoCodeAlone/setup-wfctl@v1
+        with:
+          version: '{{.WfctlVersion}}'
       - name: Plan infrastructure
         run: wfctl infra plan --config '{{.InfraConfig}}' --format markdown > plan.md
       - name: Post plan comment
@@ -256,6 +261,8 @@ jobs:
           cache: true
       - name: Install wfctl
         uses: GoCodeAlone/setup-wfctl@v1
+        with:
+          version: '{{.WfctlVersion}}'
       - name: Apply infrastructure
         run: wfctl infra apply --config '{{.InfraConfig}}' --auto-approve
 `
@@ -282,28 +289,31 @@ jobs:
           cache: true
       - name: Install wfctl
         uses: GoCodeAlone/setup-wfctl@v1
+        with:
+          version: '{{.WfctlVersion}}'
       - name: Run tests
-        run: |
-          if awk '/^[^[:space:]#][^:]*:/ { if ($0 ~ /^ci:/) found=1 } END { exit found ? 0 : 1 }' '{{.InfraConfig}}'; then
-            wfctl ci run --config '{{.InfraConfig}}' --phase test
-          else
-            go test ./...
-          fi
+        env:
+          INFRA_CONFIG: '{{.InfraConfig}}'
+        run: wfctl ci run --config "$INFRA_CONFIG" --phase test
       - name: Build without push
-        run: wfctl build --config '{{.InfraConfig}}' --no-push --tag ci
+        env:
+          INFRA_CONFIG: '{{.InfraConfig}}'
+        run: wfctl build --config "$INFRA_CONFIG" --no-push --tag ci
 `
 
 // ── GitLab CI ─────────────────────────────────────────────────────────────────
 
 type gitlabTemplateData struct {
-	InfraConfig string
-	Branch      string
+	InfraConfig  string
+	Branch       string
+	WfctlVersion string
 }
 
 func generateGitLabCI(opts ciOptions) (map[string]string, error) {
 	data := gitlabTemplateData{
-		InfraConfig: opts.InfraConfig,
-		Branch:      "main",
+		InfraConfig:  opts.InfraConfig,
+		Branch:       "main",
+		WfctlVersion: ciGeneratedWfctlVersion(),
 	}
 
 	content, err := renderCITemplate("gitlab-ci", gitlabCITemplate, data)
@@ -323,9 +333,10 @@ const gitlabCITemplate = `stages:
 
 variables:
   INFRA_CONFIG: "{{.InfraConfig}}"
+  WFCTL_VERSION: "{{.WfctlVersion}}"
 
 before_script:
-  - go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
+  - go install "github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION}"
   - export PATH="$(go env GOPATH)/bin:$PATH"
 
 infra-plan:
@@ -361,12 +372,7 @@ build:
   stage: build
   needs: []
   script:
-    - |
-      if awk '/^[^[:space:]#][^:]*:/ { if ($0 ~ /^ci:/) found=1 } END { exit found ? 0 : 1 }' "$INFRA_CONFIG"; then
-        wfctl ci run --config "$INFRA_CONFIG" --phase test
-      else
-        go test ./...
-      fi
+    - wfctl ci run --config "$INFRA_CONFIG" --phase test
     - wfctl build --config "$INFRA_CONFIG" --no-push --tag ci
   rules:
     - if: $CI_COMMIT_BRANCH == "{{.Branch}}"
@@ -384,4 +390,13 @@ func renderCITemplate(name, tmplStr string, data any) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+var cleanReleaseTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+
+func ciGeneratedWfctlVersion() string {
+	if !cleanReleaseTagPattern.MatchString(version) {
+		return "latest"
+	}
+	return version
 }

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -280,10 +280,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Install wfctl
+        run: go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
       - name: Run tests
-        run: go test ./...
-      - name: Build
-        run: go build ./...
+        run: wfctl ci run --config '{{.InfraConfig}}' --phase test
+      - name: Build without push
+        run: wfctl build --config '{{.InfraConfig}}' --no-push --tag ci
 `
 
 // ── GitLab CI ─────────────────────────────────────────────────────────────────
@@ -352,8 +354,9 @@ build:
   stage: build
   needs: []
   script:
-    - go test ./...
-    - go build ./...
+    - go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
+    - wfctl ci run --config "$INFRA_CONFIG" --phase test
+    - wfctl build --config "$INFRA_CONFIG" --no-push --tag ci
   rules:
     - if: $CI_COMMIT_BRANCH == "{{.Branch}}"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -298,7 +298,7 @@ jobs:
       - name: Build without push
         env:
           INFRA_CONFIG: '{{.InfraConfig}}'
-        run: wfctl build --config "$INFRA_CONFIG" --no-push --tag ci
+        run: wfctl build --config "$INFRA_CONFIG" --no-push --tag ci --fallback-go-build
 `
 
 // ── GitLab CI ─────────────────────────────────────────────────────────────────
@@ -373,7 +373,7 @@ build:
   needs: []
   script:
     - wfctl ci run --config "$INFRA_CONFIG" --phase test
-    - wfctl build --config "$INFRA_CONFIG" --no-push --tag ci
+    - wfctl build --config "$INFRA_CONFIG" --no-push --tag ci --fallback-go-build
   rules:
     - if: $CI_COMMIT_BRANCH == "{{.Branch}}"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -230,7 +230,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Install wfctl
-        run: go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
+        uses: GoCodeAlone/setup-wfctl@v1
       - name: Plan infrastructure
         run: wfctl infra plan --config '{{.InfraConfig}}' --format markdown > plan.md
       - name: Post plan comment
@@ -255,7 +255,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Install wfctl
-        run: go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
+        uses: GoCodeAlone/setup-wfctl@v1
       - name: Apply infrastructure
         run: wfctl infra apply --config '{{.InfraConfig}}' --auto-approve
 `
@@ -281,9 +281,14 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Install wfctl
-        run: go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
+        uses: GoCodeAlone/setup-wfctl@v1
       - name: Run tests
-        run: wfctl ci run --config '{{.InfraConfig}}' --phase test
+        run: |
+          if awk '/^[^[:space:]#][^:]*:/ { if ($0 ~ /^ci:/) found=1 } END { exit found ? 0 : 1 }' '{{.InfraConfig}}'; then
+            wfctl ci run --config '{{.InfraConfig}}' --phase test
+          else
+            go test ./...
+          fi
       - name: Build without push
         run: wfctl build --config '{{.InfraConfig}}' --no-push --tag ci
 `
@@ -319,10 +324,13 @@ const gitlabCITemplate = `stages:
 variables:
   INFRA_CONFIG: "{{.InfraConfig}}"
 
+before_script:
+  - go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
+  - export PATH="$(go env GOPATH)/bin:$PATH"
+
 infra-plan:
   stage: plan
   script:
-    - go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
     - wfctl infra plan --config "$INFRA_CONFIG" --format markdown > plan.md
   artifacts:
     paths:
@@ -340,7 +348,6 @@ infra-apply:
     - job: infra-plan
       artifacts: true
   script:
-    - go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
     - wfctl infra apply --config "$INFRA_CONFIG" --auto-approve
   environment:
     name: production
@@ -354,8 +361,12 @@ build:
   stage: build
   needs: []
   script:
-    - go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
-    - wfctl ci run --config "$INFRA_CONFIG" --phase test
+    - |
+      if awk '/^[^[:space:]#][^:]*:/ { if ($0 ~ /^ci:/) found=1 } END { exit found ? 0 : 1 }' "$INFRA_CONFIG"; then
+        wfctl ci run --config "$INFRA_CONFIG" --phase test
+      else
+        go test ./...
+      fi
     - wfctl build --config "$INFRA_CONFIG" --no-push --tag ci
   rules:
     - if: $CI_COMMIT_BRANCH == "{{.Branch}}"

--- a/cmd/wfctl/ci_run.go
+++ b/cmd/wfctl/ci_run.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/GoCodeAlone/workflow/config"
-	"gopkg.in/yaml.v3"
 )
 
 func runCIRun(args []string) error {
@@ -33,16 +32,9 @@ func runCIRun(args []string) error {
 		return err
 	}
 
-	data, err := os.ReadFile(*configFile)
+	cfg, err := config.LoadFromFile(*configFile)
 	if err != nil {
-		return fmt.Errorf("read config: %w", err)
-	}
-	var cfg config.WorkflowConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("parse config: %w", err)
-	}
-	if cfg.CI == nil {
-		return fmt.Errorf("no ci: section in %s", *configFile)
+		return fmt.Errorf("load config: %w", err)
 	}
 
 	phaseList := strings.Split(*phases, ",")
@@ -54,11 +46,17 @@ func runCIRun(args []string) error {
 					return fmt.Errorf("build phase failed: %w", err)
 				}
 			}
-			if err := runBuildPhase(cfg.CI.Build, *verbose); err != nil {
+			if err := runBuildPhase(ciBuild(cfg), *verbose); err != nil {
 				return fmt.Errorf("build phase failed: %w", err)
 			}
 		case "test":
-			if err := runTestPhase(cfg.CI.Test, *verbose); err != nil {
+			if !hasConfiguredTests(ciTest(cfg)) {
+				if err := runDefaultGoTests(*verbose); err != nil {
+					return fmt.Errorf("test phase failed: %w", err)
+				}
+				continue
+			}
+			if err := runTestPhase(ciTest(cfg), *verbose); err != nil {
 				return fmt.Errorf("test phase failed: %w", err)
 			}
 		case "deploy":
@@ -66,26 +64,20 @@ func runCIRun(args []string) error {
 				return fmt.Errorf("--env is required for deploy phase")
 			}
 			if *dryRun {
-				// Load via config.LoadFromFile to honor top-level imports:
-				// sections that yaml.Unmarshal above would not resolve.
-				fullCfg, loadErr := config.LoadFromFile(*configFile)
-				if loadErr != nil {
-					return fmt.Errorf("load config for dry-run: %w", loadErr)
-				}
-				return runDeployPhaseDryRun(fullCfg.CI.Deploy, *env, fullCfg, fullCfg.Services, *dryRunFormat, *configFile)
+				return runDeployPhaseDryRun(ciDeploy(cfg), *env, cfg, cfg.Services, *dryRunFormat, *configFile)
 			}
 			if *pluginDir != "" {
 				os.Setenv("WFCTL_PLUGIN_DIR", *pluginDir) //nolint:errcheck
 			}
-			if err := runMigrationDeployGuard(*configFile, *env, *pluginDir, &cfg); err != nil {
+			if err := runMigrationDeployGuard(*configFile, *env, *pluginDir, cfg); err != nil {
 				return fmt.Errorf("migration guard failed: %w", err)
 			}
 			if len(cfg.Services) > 0 {
-				if err := runMultiServiceDeploy(cfg.CI.Deploy, *env, &cfg, cfg.Services, *verbose); err != nil {
+				if err := runMultiServiceDeploy(ciDeploy(cfg), *env, cfg, cfg.Services, *verbose); err != nil {
 					return fmt.Errorf("deploy phase failed: %w", err)
 				}
 			} else {
-				if err := runDeployPhaseWithConfig(cfg.CI.Deploy, *env, &cfg, nil, *verbose); err != nil {
+				if err := runDeployPhaseWithConfig(ciDeploy(cfg), *env, cfg, nil, *verbose); err != nil {
 					return fmt.Errorf("deploy phase failed: %w", err)
 				}
 			}
@@ -94,6 +86,42 @@ func runCIRun(args []string) error {
 		}
 	}
 	return nil
+}
+
+func ciBuild(cfg *config.WorkflowConfig) *config.CIBuildConfig {
+	if cfg == nil || cfg.CI == nil {
+		return nil
+	}
+	return cfg.CI.Build
+}
+
+func ciTest(cfg *config.WorkflowConfig) *config.CITestConfig {
+	if cfg == nil || cfg.CI == nil {
+		return nil
+	}
+	return cfg.CI.Test
+}
+
+func ciDeploy(cfg *config.WorkflowConfig) *config.CIDeployConfig {
+	if cfg == nil || cfg.CI == nil {
+		return nil
+	}
+	return cfg.CI.Deploy
+}
+
+func hasConfiguredTests(test *config.CITestConfig) bool {
+	if test == nil {
+		return false
+	}
+	return test.Unit != nil || test.Integration != nil || test.E2E != nil
+}
+
+func runDefaultGoTests(_ bool) error {
+	fmt.Println("No test configuration, running go test ./...")
+	cmd := exec.Command("go", "test", "./...")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func runMigrationDeployGuard(configFile, envName, pluginDir string, cfg *config.WorkflowConfig) error {

--- a/cmd/wfctl/ci_run_test.go
+++ b/cmd/wfctl/ci_run_test.go
@@ -168,3 +168,99 @@ func TestRunTestPhase_EmptyTest(t *testing.T) {
 		t.Fatalf("empty test config should not error: %v", err)
 	}
 }
+
+func TestRunCIRunTestFallsBackToGoTestWhenNoConfiguredTests(t *testing.T) {
+	dir := t.TempDir()
+	writeGoModule(t, dir, `package pkg
+
+import "testing"
+
+func TestFallbackRuns(t *testing.T) {
+	t.Fatal("default go test fallback ran")
+}
+`)
+	cfgPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+version: 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	err = runCIRun([]string{"--config", cfgPath, "--phase", "test"})
+	if err == nil {
+		t.Fatal("expected fallback go test failure")
+	}
+	if !strings.Contains(err.Error(), "test phase failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCIRunLoadsImportedCIConfigForTests(t *testing.T) {
+	dir := t.TempDir()
+	writeGoModule(t, dir, `package pkg
+
+import "testing"
+
+func TestImportedConfig(t *testing.T) {}
+`)
+	if err := os.WriteFile(filepath.Join(dir, "ci.yaml"), []byte(`
+ci:
+  test:
+    unit:
+      command: go test ./pkg
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+version: 1
+imports:
+  - ci.yaml
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	if err := runCIRun([]string{"--config", cfgPath, "--phase", "test"}); err != nil {
+		t.Fatalf("imported ci.test should run: %v", err)
+	}
+}
+
+func writeGoModule(t *testing.T, dir, testFile string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.test/wfctl-ci\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkgDir := filepath.Join(dir, "pkg")
+	if err := os.Mkdir(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "pkg_test.go"), []byte(testFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -51,16 +51,10 @@ func TestGenerateGitHubActions(t *testing.T) {
 	if !strings.Contains(buildYML, "GoCodeAlone/setup-wfctl@v1") {
 		t.Error("build.yml missing setup-wfctl action")
 	}
-	if !strings.Contains(buildYML, "awk '/^[^[:space:]#][^:]*:/") {
-		t.Error("build.yml missing top-level ci section check")
-	}
-	if !strings.Contains(buildYML, "wfctl ci run --config 'infra.yaml' --phase test") {
+	if !strings.Contains(buildYML, "wfctl ci run --config \"$INFRA_CONFIG\" --phase test") {
 		t.Error("build.yml missing wfctl ci run test phase")
 	}
-	if !strings.Contains(buildYML, "go test ./...") {
-		t.Error("build.yml missing fallback go test command")
-	}
-	if !strings.Contains(buildYML, "wfctl build --config 'infra.yaml' --no-push --tag ci") {
+	if !strings.Contains(buildYML, "wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci") {
 		t.Error("build.yml missing wfctl build")
 	}
 	if strings.Contains(buildYML, "go build ./...") {
@@ -88,10 +82,11 @@ func TestGenerateGitLabCI(t *testing.T) {
 		"rules:",
 		"needs:",
 		"before_script:",
+		"WFCTL_VERSION: \"latest\"",
+		"go install \"github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION}\"",
 		"export PATH=\"$(go env GOPATH)/bin:$PATH\"",
 		"wfctl infra plan",
 		"wfctl ci run --config \"$INFRA_CONFIG\" --phase test",
-		"go test ./...",
 		"wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci",
 		"environment:",
 	}
@@ -104,6 +99,53 @@ func TestGenerateGitLabCI(t *testing.T) {
 	// Ensure deprecated only: syntax is NOT used
 	if strings.Contains(content, "\nonly:") {
 		t.Error(".gitlab-ci.yml uses deprecated 'only:' syntax")
+	}
+}
+
+func TestCIGeneratePinsCurrentWfctlVersionWhenReleased(t *testing.T) {
+	origVersion := version
+	version = "v9.9.9"
+	defer func() { version = origVersion }()
+
+	ghaFiles, err := generateCIFiles(ciOptions{
+		Platform:    "github_actions",
+		InfraConfig: "infra.yaml",
+		Runner:      "ubuntu-latest",
+	})
+	if err != nil {
+		t.Fatalf("generate GitHub Actions: %v", err)
+	}
+	if !strings.Contains(ghaFiles[".github/workflows/build.yml"], "version: 'v9.9.9'") {
+		t.Fatal("GitHub Actions build workflow should pin the generated wfctl version")
+	}
+
+	gitlabFiles, err := generateCIFiles(ciOptions{
+		Platform:    "gitlab_ci",
+		InfraConfig: "infra.yaml",
+	})
+	if err != nil {
+		t.Fatalf("generate GitLab CI: %v", err)
+	}
+	if !strings.Contains(gitlabFiles[".gitlab-ci.yml"], `WFCTL_VERSION: "v9.9.9"`) {
+		t.Fatal("GitLab CI workflow should pin the generated wfctl version")
+	}
+}
+
+func TestCIGenerateUsesLatestForUnreleasedWfctlVersions(t *testing.T) {
+	origVersion := version
+	defer func() { version = origVersion }()
+
+	for _, candidate := range []string{
+		"",
+		"dev",
+		"v0.22.8-0.20260507211020-3f920f7ff2f6",
+		"v0.22.8-0.20260507211020-3f920f7ff2f6+dirty",
+		"v9.9.9+dirty",
+	} {
+		version = candidate
+		if got := ciGeneratedWfctlVersion(); got != "latest" {
+			t.Fatalf("ciGeneratedWfctlVersion(%q) = %q, want latest", candidate, got)
+		}
 	}
 }
 

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -47,6 +47,15 @@ func TestGenerateGitHubActions(t *testing.T) {
 	if !strings.Contains(buildYML, "actions/setup-go@v5") {
 		t.Error("build.yml missing actions/setup-go@v5")
 	}
+	if !strings.Contains(buildYML, "wfctl ci run --config 'infra.yaml' --phase test") {
+		t.Error("build.yml missing wfctl ci run test phase")
+	}
+	if !strings.Contains(buildYML, "wfctl build --config 'infra.yaml' --no-push --tag ci") {
+		t.Error("build.yml missing wfctl build")
+	}
+	if strings.Contains(buildYML, "go build ./...") {
+		t.Error("build.yml should use wfctl build instead of raw go build")
+	}
 }
 
 func TestGenerateGitLabCI(t *testing.T) {
@@ -69,6 +78,8 @@ func TestGenerateGitLabCI(t *testing.T) {
 		"rules:",
 		"needs:",
 		"wfctl infra plan",
+		"wfctl ci run --config \"$INFRA_CONFIG\" --phase test",
+		"wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci",
 		"environment:",
 	}
 	for _, m := range markers {

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -27,6 +27,7 @@ func TestGenerateGitHubActions(t *testing.T) {
 	markers := []string{
 		"actions/checkout@v4",
 		"actions/setup-go@v5",
+		"GoCodeAlone/setup-wfctl@v1",
 		"wfctl infra plan",
 		"permissions",
 		"actions/github-script@v7",
@@ -47,8 +48,17 @@ func TestGenerateGitHubActions(t *testing.T) {
 	if !strings.Contains(buildYML, "actions/setup-go@v5") {
 		t.Error("build.yml missing actions/setup-go@v5")
 	}
+	if !strings.Contains(buildYML, "GoCodeAlone/setup-wfctl@v1") {
+		t.Error("build.yml missing setup-wfctl action")
+	}
+	if !strings.Contains(buildYML, "awk '/^[^[:space:]#][^:]*:/") {
+		t.Error("build.yml missing top-level ci section check")
+	}
 	if !strings.Contains(buildYML, "wfctl ci run --config 'infra.yaml' --phase test") {
 		t.Error("build.yml missing wfctl ci run test phase")
+	}
+	if !strings.Contains(buildYML, "go test ./...") {
+		t.Error("build.yml missing fallback go test command")
 	}
 	if !strings.Contains(buildYML, "wfctl build --config 'infra.yaml' --no-push --tag ci") {
 		t.Error("build.yml missing wfctl build")
@@ -77,8 +87,11 @@ func TestGenerateGitLabCI(t *testing.T) {
 	markers := []string{
 		"rules:",
 		"needs:",
+		"before_script:",
+		"export PATH=\"$(go env GOPATH)/bin:$PATH\"",
 		"wfctl infra plan",
 		"wfctl ci run --config \"$INFRA_CONFIG\" --phase test",
+		"go test ./...",
 		"wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci",
 		"environment:",
 	}

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -54,7 +54,7 @@ func TestGenerateGitHubActions(t *testing.T) {
 	if !strings.Contains(buildYML, "wfctl ci run --config \"$INFRA_CONFIG\" --phase test") {
 		t.Error("build.yml missing wfctl ci run test phase")
 	}
-	if !strings.Contains(buildYML, "wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci") {
+	if !strings.Contains(buildYML, "wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci --fallback-go-build") {
 		t.Error("build.yml missing wfctl build")
 	}
 	if strings.Contains(buildYML, "go build ./...") {
@@ -87,7 +87,7 @@ func TestGenerateGitLabCI(t *testing.T) {
 		"export PATH=\"$(go env GOPATH)/bin:$PATH\"",
 		"wfctl infra plan",
 		"wfctl ci run --config \"$INFRA_CONFIG\" --phase test",
-		"wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci",
+		"wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci --fallback-go-build",
 		"environment:",
 	}
 	for _, m := range markers {

--- a/cmd/wfctl/secrets_detect.go
+++ b/cmd/wfctl/secrets_detect.go
@@ -183,7 +183,11 @@ func runSecretsSetWithReader(args []string, r io.Reader) error {
 		secretValue = strings.TrimRight(string(b), "\n")
 	case isatty.IsTerminal(os.Stdin.Fd()): // interactive: masked prompt
 		fmt.Fprintf(os.Stderr, "Value for %s: ", name)
-		b, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fd, err := stdinFileDescriptor()
+		if err != nil {
+			return err
+		}
+		b, err := term.ReadPassword(fd)
 		if err != nil {
 			return fmt.Errorf("read password: %w", err)
 		}
@@ -220,6 +224,15 @@ func runSecretsSetWithReader(args []string, r io.Reader) error {
 	}
 	fmt.Printf("set %s\n", name)
 	return nil
+}
+
+func stdinFileDescriptor() (int, error) {
+	fd := os.Stdin.Fd()
+	maxInt := int(^uint(0) >> 1)
+	if fd > uintptr(maxInt) {
+		return 0, fmt.Errorf("stdin file descriptor %d exceeds supported int range", fd)
+	}
+	return int(fd), nil //nolint:gosec // fd is range-checked before conversion.
 }
 
 func runSecretsList(args []string) error {

--- a/config/ci_build_security.go
+++ b/config/ci_build_security.go
@@ -1,6 +1,10 @@
 package config
 
-import "log"
+import (
+	"log"
+
+	"gopkg.in/yaml.v3"
+)
 
 // CIBuildSecurity configures supply-chain hardening for the build phase.
 type CIBuildSecurity struct {
@@ -10,12 +14,27 @@ type CIBuildSecurity struct {
 	Sign            bool               `json:"sign,omitempty" yaml:"sign,omitempty"`
 	NonRoot         bool               `json:"non_root" yaml:"non_root"`
 	BaseImagePolicy *CIBaseImagePolicy `json:"base_image_policy,omitempty" yaml:"base_image_policy,omitempty"`
+	set             map[string]bool
 }
 
 // CIBaseImagePolicy restricts which base images may be used in container builds.
 type CIBaseImagePolicy struct {
 	AllowPrefixes []string `json:"allow_prefixes,omitempty" yaml:"allow_prefixes,omitempty"`
 	DenyPrefixes  []string `json:"deny_prefixes,omitempty" yaml:"deny_prefixes,omitempty"`
+}
+
+func (s *CIBuildSecurity) UnmarshalYAML(value *yaml.Node) error {
+	type plain CIBuildSecurity
+	var decoded plain
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*s = CIBuildSecurity(decoded)
+	s.set = make(map[string]bool)
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		s.set[value.Content[i].Value] = true
+	}
+	return nil
 }
 
 // ApplyDefaults returns a CIBuildSecurity with opinionated secure defaults applied.

--- a/config/config.go
+++ b/config/config.go
@@ -331,6 +331,8 @@ func (cfg *WorkflowConfig) processImports(seen map[string]bool) error {
 			}
 		}
 
+		mergeImportedCI(cfg, impCfg.CI)
+
 		// Merge external plugin declarations — deduplicate by name (first definition wins)
 		if impCfg.Plugins != nil && len(impCfg.Plugins.External) > 0 {
 			if cfg.Plugins == nil {
@@ -456,6 +458,220 @@ func (cfg *WorkflowConfig) processImports(seen map[string]bool) error {
 
 	cfg.Imports = nil // clear after processing
 	return nil
+}
+
+func mergeImportedCI(cfg *WorkflowConfig, imported *CIConfig) {
+	if imported == nil {
+		return
+	}
+	if cfg.CI == nil {
+		cfg.CI = imported
+		return
+	}
+	mergeImportedCIBuild(cfg.CI.Build, imported.Build, func(build *CIBuildConfig) {
+		cfg.CI.Build = build
+	})
+	mergeImportedCITest(cfg.CI.Test, imported.Test, func(test *CITestConfig) {
+		cfg.CI.Test = test
+	})
+	if cfg.CI.Deploy == nil {
+		cfg.CI.Deploy = imported.Deploy
+	} else if imported.Deploy != nil {
+		if cfg.CI.Deploy.Environments == nil {
+			cfg.CI.Deploy.Environments = make(map[string]*CIDeployEnvironment, len(imported.Deploy.Environments))
+		}
+		for k, v := range imported.Deploy.Environments {
+			if _, exists := cfg.CI.Deploy.Environments[k]; !exists {
+				cfg.CI.Deploy.Environments[k] = v
+			}
+		}
+	}
+	if cfg.CI.Infra == nil {
+		cfg.CI.Infra = imported.Infra
+	}
+	if len(imported.Registries) > 0 {
+		existing := make(map[string]struct{}, len(cfg.CI.Registries))
+		for _, registry := range cfg.CI.Registries {
+			existing[registry.Name] = struct{}{}
+		}
+		for _, registry := range imported.Registries {
+			if _, exists := existing[registry.Name]; exists {
+				continue
+			}
+			cfg.CI.Registries = append(cfg.CI.Registries, registry)
+			existing[registry.Name] = struct{}{}
+		}
+	}
+	if len(imported.Migrations) > 0 {
+		existing := make(map[string]struct{}, len(cfg.CI.Migrations))
+		for _, migration := range cfg.CI.Migrations {
+			existing[migration.Name] = struct{}{}
+		}
+		for _, migration := range imported.Migrations {
+			if _, exists := existing[migration.Name]; exists {
+				continue
+			}
+			cfg.CI.Migrations = append(cfg.CI.Migrations, migration)
+			existing[migration.Name] = struct{}{}
+		}
+	}
+}
+
+func mergeImportedCIBuild(current, imported *CIBuildConfig, set func(*CIBuildConfig)) {
+	if imported == nil {
+		return
+	}
+	if current == nil {
+		set(imported)
+		return
+	}
+	current.Targets = appendMissingCITargets(current.Targets, imported.Targets)
+	current.Containers = appendMissingCIContainers(current.Containers, imported.Containers)
+	current.Assets = appendMissingCIAssets(current.Assets, imported.Assets)
+	mergeImportedCIBuildSecurity(current.Security, imported.Security, func(security *CIBuildSecurity) {
+		current.Security = security
+	})
+}
+
+func mergeImportedCITest(current, imported *CITestConfig, set func(*CITestConfig)) {
+	if imported == nil {
+		return
+	}
+	if current == nil {
+		set(imported)
+		return
+	}
+	if current.Unit == nil {
+		current.Unit = imported.Unit
+	}
+	if current.Integration == nil {
+		current.Integration = imported.Integration
+	}
+	if current.E2E == nil {
+		current.E2E = imported.E2E
+	}
+}
+
+func mergeImportedCIBuildSecurity(current, imported *CIBuildSecurity, set func(*CIBuildSecurity)) {
+	if imported == nil {
+		return
+	}
+	if current == nil {
+		set(imported)
+		return
+	}
+	fillBoolSecurityField(current, imported, "hardened", &current.Hardened, imported.Hardened)
+	fillBoolSecurityField(current, imported, "sbom", &current.SBOM, imported.SBOM)
+	fillStringSecurityField(current, imported, "provenance", &current.Provenance, imported.Provenance)
+	fillBoolSecurityField(current, imported, "sign", &current.Sign, imported.Sign)
+	fillBoolSecurityField(current, imported, "non_root", &current.NonRoot, imported.NonRoot)
+	if !securityFieldSet(current, "base_image_policy") && securityFieldAvailable(imported, "base_image_policy") {
+		current.BaseImagePolicy = imported.BaseImagePolicy
+		markSecurityFieldSet(current, "base_image_policy")
+	}
+}
+
+func fillBoolSecurityField(current, imported *CIBuildSecurity, field string, target *bool, importedValue bool) {
+	if securityFieldSet(current, field) || !securityFieldAvailable(imported, field) {
+		return
+	}
+	*target = importedValue
+	markSecurityFieldSet(current, field)
+}
+
+func fillStringSecurityField(current, imported *CIBuildSecurity, field string, target *string, importedValue string) {
+	if securityFieldSet(current, field) || !securityFieldAvailable(imported, field) {
+		return
+	}
+	*target = importedValue
+	markSecurityFieldSet(current, field)
+}
+
+func securityFieldSet(security *CIBuildSecurity, field string) bool {
+	if security == nil {
+		return false
+	}
+	if len(security.set) > 0 {
+		return security.set[field]
+	}
+	switch field {
+	case "hardened":
+		return security.Hardened
+	case "sbom":
+		return security.SBOM
+	case "provenance":
+		return security.Provenance != ""
+	case "sign":
+		return security.Sign
+	case "non_root":
+		return security.NonRoot
+	case "base_image_policy":
+		return security.BaseImagePolicy != nil
+	default:
+		return false
+	}
+}
+
+func securityFieldAvailable(security *CIBuildSecurity, field string) bool {
+	if security == nil {
+		return false
+	}
+	if len(security.set) > 0 {
+		return security.set[field]
+	}
+	return securityFieldSet(security, field)
+}
+
+func markSecurityFieldSet(security *CIBuildSecurity, field string) {
+	if security.set == nil {
+		security.set = make(map[string]bool)
+	}
+	security.set[field] = true
+}
+
+func appendMissingCITargets(current, imported []CITarget) []CITarget {
+	existing := make(map[string]struct{}, len(current))
+	for _, target := range current {
+		existing[target.Name] = struct{}{}
+	}
+	for _, target := range imported {
+		if _, exists := existing[target.Name]; exists {
+			continue
+		}
+		current = append(current, target)
+		existing[target.Name] = struct{}{}
+	}
+	return current
+}
+
+func appendMissingCIContainers(current, imported []CIContainerTarget) []CIContainerTarget {
+	existing := make(map[string]struct{}, len(current))
+	for _, target := range current {
+		existing[target.Name] = struct{}{}
+	}
+	for _, target := range imported {
+		if _, exists := existing[target.Name]; exists {
+			continue
+		}
+		current = append(current, target)
+		existing[target.Name] = struct{}{}
+	}
+	return current
+}
+
+func appendMissingCIAssets(current, imported []CIAssetTarget) []CIAssetTarget {
+	existing := make(map[string]struct{}, len(current))
+	for _, target := range current {
+		existing[target.Name] = struct{}{}
+	}
+	for _, target := range imported {
+		if _, exists := existing[target.Name]; exists {
+			continue
+		}
+		current = append(current, target)
+		existing[target.Name] = struct{}{}
+	}
+	return current
 }
 
 // LoadFromBytes loads a workflow configuration from a YAML byte slice.

--- a/config/config.go
+++ b/config/config.go
@@ -504,14 +504,16 @@ func mergeImportedCI(cfg *WorkflowConfig, imported *CIConfig) {
 	}
 	if len(imported.Migrations) > 0 {
 		existing := make(map[string]struct{}, len(cfg.CI.Migrations))
-		for _, migration := range cfg.CI.Migrations {
+		for i := range cfg.CI.Migrations {
+			migration := &cfg.CI.Migrations[i]
 			existing[migration.Name] = struct{}{}
 		}
-		for _, migration := range imported.Migrations {
+		for i := range imported.Migrations {
+			migration := &imported.Migrations[i]
 			if _, exists := existing[migration.Name]; exists {
 				continue
 			}
-			cfg.CI.Migrations = append(cfg.CI.Migrations, migration)
+			cfg.CI.Migrations = append(cfg.CI.Migrations, *migration)
 			existing[migration.Name] = struct{}{}
 		}
 	}
@@ -631,14 +633,16 @@ func markSecurityFieldSet(security *CIBuildSecurity, field string) {
 
 func appendMissingCITargets(current, imported []CITarget) []CITarget {
 	existing := make(map[string]struct{}, len(current))
-	for _, target := range current {
+	for i := range current {
+		target := &current[i]
 		existing[target.Name] = struct{}{}
 	}
-	for _, target := range imported {
+	for i := range imported {
+		target := &imported[i]
 		if _, exists := existing[target.Name]; exists {
 			continue
 		}
-		current = append(current, target)
+		current = append(current, *target)
 		existing[target.Name] = struct{}{}
 	}
 	return current
@@ -646,14 +650,16 @@ func appendMissingCITargets(current, imported []CITarget) []CITarget {
 
 func appendMissingCIContainers(current, imported []CIContainerTarget) []CIContainerTarget {
 	existing := make(map[string]struct{}, len(current))
-	for _, target := range current {
+	for i := range current {
+		target := &current[i]
 		existing[target.Name] = struct{}{}
 	}
-	for _, target := range imported {
+	for i := range imported {
+		target := &imported[i]
 		if _, exists := existing[target.Name]; exists {
 			continue
 		}
-		current = append(current, target)
+		current = append(current, *target)
 		existing[target.Name] = struct{}{}
 	}
 	return current

--- a/config/config_import_test.go
+++ b/config/config_import_test.go
@@ -745,6 +745,188 @@ secrets:
 	}
 }
 
+func TestLoadFromFile_ImportCIMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+ci:
+  build:
+    targets:
+      - name: imported-bin
+        type: go
+        path: ./cmd/imported
+      - name: shared-bin
+        type: go
+        path: ./cmd/imported-shared
+    containers:
+      - name: imported-image
+        dockerfile: Dockerfile.imported
+    assets:
+      - name: imported-ui
+        build: npm run build
+        path: dist
+    security:
+      hardened: true
+      sbom: true
+      provenance: slsa-3
+      non_root: true
+      base_image_policy:
+        deny_prefixes:
+          - docker.io/library
+  test:
+    unit:
+      command: go test ./...
+  deploy:
+    environments:
+      staging:
+        provider: digitalocean
+  registries:
+    - name: shared
+      type: digitalocean
+      path: registry.digitalocean.com/shared/app
+  migrations:
+    - name: app
+      source_dir: migrations
+      database:
+        env: DATABASE_URL
+`
+	if err := os.WriteFile(filepath.Join(dir, "ci.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - ci.yaml
+ci:
+  build:
+    targets:
+      - name: shared-bin
+        type: go
+        path: ./cmd/local-shared
+    assets:
+      - name: local-ui
+        build: npm run local
+        path: local-dist
+    security:
+      sign: true
+  test:
+    integration:
+      command: go test ./integration
+  deploy:
+    environments:
+      production:
+        provider: digitalocean
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CI == nil {
+		t.Fatal("expected merged CI config")
+	}
+	if cfg.CI.Build == nil {
+		t.Fatal("expected main ci.build to survive merge")
+	}
+	if len(cfg.CI.Build.Targets) != 2 {
+		t.Fatalf("expected imported and main build targets, got %#v", cfg.CI.Build.Targets)
+	}
+	targetsByName := map[string]CITarget{}
+	for _, target := range cfg.CI.Build.Targets {
+		targetsByName[target.Name] = target
+	}
+	if targetsByName["shared-bin"].Path != "./cmd/local-shared" {
+		t.Fatalf("expected main target to win shared-bin conflict, got %#v", targetsByName["shared-bin"])
+	}
+	if targetsByName["imported-bin"].Path != "./cmd/imported" {
+		t.Fatalf("expected imported target to be appended, got %#v", targetsByName["imported-bin"])
+	}
+	if len(cfg.CI.Build.Containers) != 1 || cfg.CI.Build.Containers[0].Name != "imported-image" {
+		t.Fatalf("expected imported container, got %#v", cfg.CI.Build.Containers)
+	}
+	if len(cfg.CI.Build.Assets) != 2 {
+		t.Fatalf("expected imported and main assets, got %#v", cfg.CI.Build.Assets)
+	}
+	if cfg.CI.Build.Security == nil {
+		t.Fatal("expected merged build security")
+	}
+	if !cfg.CI.Build.Security.Sign {
+		t.Fatal("expected main build security sign=true to survive merge")
+	}
+	if !cfg.CI.Build.Security.Hardened || !cfg.CI.Build.Security.SBOM || !cfg.CI.Build.Security.NonRoot {
+		t.Fatalf("expected imported bool security fields to fill missing main fields, got %#v", cfg.CI.Build.Security)
+	}
+	if cfg.CI.Build.Security.BaseImagePolicy == nil ||
+		len(cfg.CI.Build.Security.BaseImagePolicy.DenyPrefixes) != 1 ||
+		cfg.CI.Build.Security.BaseImagePolicy.DenyPrefixes[0] != "docker.io/library" {
+		t.Fatalf("expected imported base image policy, got %#v", cfg.CI.Build.Security.BaseImagePolicy)
+	}
+	if cfg.CI.Test == nil || cfg.CI.Test.Unit == nil || cfg.CI.Test.Integration == nil {
+		t.Fatalf("expected imported unit and main integration test phases, got %#v", cfg.CI.Test)
+	}
+	if cfg.CI.Test.Unit.Command != "go test ./..." {
+		t.Errorf("unit command: got %q", cfg.CI.Test.Unit.Command)
+	}
+	if cfg.CI.Test.Integration.Command != "go test ./integration" {
+		t.Errorf("integration command: got %q", cfg.CI.Test.Integration.Command)
+	}
+	if cfg.CI.Deploy == nil || len(cfg.CI.Deploy.Environments) != 2 {
+		t.Fatalf("expected imported and main deploy envs, got %#v", cfg.CI.Deploy)
+	}
+	if len(cfg.CI.Registries) != 1 || cfg.CI.Registries[0].Name != "shared" {
+		t.Fatalf("expected imported registry, got %#v", cfg.CI.Registries)
+	}
+	if len(cfg.CI.Migrations) != 1 || cfg.CI.Migrations[0].Name != "app" {
+		t.Fatalf("expected imported migration, got %#v", cfg.CI.Migrations)
+	}
+}
+
+func TestLoadFromFile_ImportCIMergeParentBaseImagePolicyWins(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+ci:
+  build:
+    security:
+      base_image_policy:
+        deny_prefixes:
+          - docker.io/library
+`
+	if err := os.WriteFile(filepath.Join(dir, "ci.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - ci.yaml
+ci:
+  build:
+    security:
+      base_image_policy:
+        allow_prefixes: []
+        deny_prefixes: []
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CI == nil || cfg.CI.Build == nil || cfg.CI.Build.Security == nil || cfg.CI.Build.Security.BaseImagePolicy == nil {
+		t.Fatalf("expected main base image policy to survive, got %#v", cfg.CI)
+	}
+	if len(cfg.CI.Build.Security.BaseImagePolicy.DenyPrefixes) != 0 {
+		t.Fatalf("expected explicit empty parent deny_prefixes to win, got %#v", cfg.CI.Build.Security.BaseImagePolicy.DenyPrefixes)
+	}
+}
+
 // TestLoadFromFile_ImportSecretsOnlyInImport covers the case the original
 // PR-1 fix missed: top-level `secrets:` appears only in an imported file,
 // not in main. Without the merge, cfg.Secrets is nil after LoadFromFile.

--- a/docs/manual/build-deploy/05-cli-reference.md
+++ b/docs/manual/build-deploy/05-cli-reference.md
@@ -72,10 +72,11 @@ Wraps the `nodejs` builder plugin.
 ## `wfctl build image`
 
 ```
-wfctl build image [--config <file>] [--dry-run] [--tag <tag>] [--push]
+wfctl build image [--config <file>] [--dry-run] [--tag <tag>] [--only <names>] [--skip <names>] [--push]
 ```
 
-Builds all `ci.build.containers[]` entries. External containers are resolved (not built).
+Builds matching `ci.build.containers[]` entries. External containers are resolved (not built).
+`--only` and `--skip` accept comma-separated container names.
 
 When `--push` is passed and `ci.build.security.hardened: true`, buildx pushes directly to
 every registry in `push_to[]` via multiple `--tag` flags in a single invocation (no separate
@@ -88,10 +89,11 @@ the buildkit cache.
 ## `wfctl build push`
 
 ```
-wfctl build push [--config <file>]
+wfctl build push [--config <file>] [--tag <tag>] [--only <names>] [--skip <names>]
 ```
 
-Pushes each container's image to every registry listed in `push_to[]`.
+Pushes each matching container's image to every registry listed in `push_to[]`.
+`--only` and `--skip` accept comma-separated container names.
 
 ---
 


### PR DESCRIPTION
## Summary
- update generated GitHub Actions and GitLab CI build jobs to dogfood wfctl for test and build phases
- keep generated CI provider-neutral: no registry push, cloud provider, or secret-name assumptions

## Verification
- GOWORK=off go test ./cmd/wfctl
- focused generator tests for GitHub Actions and GitLab CI

## Boundary notes
- project-specific publish/deploy secret wiring remains in project YAML or provider plugins
- wfctl generation stays limited to portable lifecycle commands