### PR TITLE
fix: dispatch plugin CLI commands

### DIFF
--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -186,6 +186,27 @@ func main() {
 		updateNoticeDone = checkForUpdateNotice()
 	}
 
+	if _, isStatic := commands[cmd]; !isStatic {
+		registry, err := BuildCLIRegistry(defaultPluginCommandDir())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: load plugin CLI commands: %v\n", err) //nolint:gosec // G705
+			os.Exit(1)
+		}
+		if entry := registry.LookupCLICommand(cmd); entry != nil {
+			if err := DispatchCLICommand(entry, os.Args[1:]); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err) //nolint:gosec // G705
+				os.Exit(1)
+			}
+			if updateNoticeDone != nil {
+				select {
+				case <-updateNoticeDone:
+				case <-time.After(time.Second):
+				}
+			}
+			return
+		}
+	}
+
 	// Set up a context that is cancelled on SIGINT/SIGTERM so that long-running
 	// commands (e.g. wfctl mcp, wfctl run) can be interrupted cleanly.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -221,4 +242,11 @@ func main() {
 		case <-time.After(time.Second):
 		}
 	}
+}
+
+func defaultPluginCommandDir() string {
+	if pluginDir := strings.TrimSpace(os.Getenv("WFCTL_PLUGIN_DIR")); pluginDir != "" {
+		return pluginDir
+	}
+	return defaultDataDir
 }

--- a/cmd/wfctl/plugin_cli_commands.go
+++ b/cmd/wfctl/plugin_cli_commands.go
@@ -40,7 +40,10 @@ var reservedCLICommands = map[string]struct{}{
 
 // isReservedCLICommand reports whether name is a reserved static wfctl command.
 func isReservedCLICommand(name string) bool {
-	_, ok := reservedCLICommands[name]
+	if _, ok := reservedCLICommands[name]; ok {
+		return true
+	}
+	_, ok := commands[name]
 	return ok
 }
 

--- a/cmd/wfctl/plugin_cli_commands_test.go
+++ b/cmd/wfctl/plugin_cli_commands_test.go
@@ -30,7 +30,7 @@ func writeCLIPlugin(t *testing.T, pluginsDir, name string, commands []string) {
 func TestPluginCLIRegistry_TwoPluginsTwoCommands(t *testing.T) {
 	dir := t.TempDir()
 	writeCLIPlugin(t, dir, "supply-chain", []string{"supply-chain"})
-	writeCLIPlugin(t, dir, "migrate", []string{"migrate"})
+	writeCLIPlugin(t, dir, "data-migrate", []string{"data-migrate"})
 
 	reg, err := BuildCLIRegistry(dir)
 	if err != nil {
@@ -39,8 +39,8 @@ func TestPluginCLIRegistry_TwoPluginsTwoCommands(t *testing.T) {
 	if _, ok := reg["supply-chain"]; !ok {
 		t.Error("supply-chain command should be registered")
 	}
-	if _, ok := reg["migrate"]; !ok {
-		t.Error("migrate command should be registered")
+	if _, ok := reg["data-migrate"]; !ok {
+		t.Error("data-migrate command should be registered")
 	}
 }
 
@@ -86,5 +86,13 @@ func TestStaticCommandWins(t *testing.T) {
 	// "validate" is a static command — it should be in the reserved list.
 	if !isReservedCLICommand("validate") {
 		t.Error("validate should be in the reserved list")
+	}
+}
+
+func TestPluginCLIRegistry_AllStaticCommandsReserved(t *testing.T) {
+	for name := range commands {
+		if !isReservedCLICommand(name) {
+			t.Fatalf("static command %q should be reserved", name)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- dispatch unknown top-level `wfctl` commands through installed plugin `cliCommands`
- use `$WFCTL_PLUGIN_DIR` or `data/plugins` for plugin command discovery
- reserve every static wfctl command name when validating plugin CLI declarations

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestPluginCLIRegistry|TestStaticCommandWins|TestRunValidatePluginDir'`
- `GOWORK=off go test ./cmd/wfctl`
- live local smoke with `workflow-plugin-compute`: `wfctl compute audit`, `pools`, `run`, and `enroll` routed through the installed plugin path to a local compute-server

## Review
- Antagonistic/security review completed before commit; no blocking findings on the Workflow routing patch.
- Plugin-side follow-up findings were fixed in `workflow-plugin-compute` before relying on this path.