### PR TITLE
feat(wfctl): rotate-and-prune --prune-first flag for at-quota safety (v0.27.2)

### DIFF
--- a/cmd/wfctl/infra_rotate_and_prune.go
+++ b/cmd/wfctl/infra_rotate_and_prune.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -55,6 +56,12 @@ func runInfraRotateAndPruneCmd(args []string) error {
 	_ = fs.String("preserve-names", "", "Regex of names to preserve during prune")
 	_ = fs.Bool("confirm", false, "Confirmation flag")
 	_ = fs.Bool("non-interactive", false, "Skip y/N prompt")
+	// --prune-first declared here so flag.Parse doesn't error on the dispatcher
+	// pre-scan; the inner runInfraRotateAndPrune re-parses against the same
+	// args slice (Go's flag package is idempotent) and reads the value there.
+	// Default is true (per ADR 0023): the safer behavior IS the new default;
+	// the legacy quota-fragile behavior is opt-out via --prune-first=false.
+	_ = fs.Bool("prune-first", true, "Prune orphans before rotating (default true; safer at quota — see ADR 0023)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -232,7 +239,7 @@ func runInfraRotateAndPrune(args []string, provider pruneProvider, w io.Writer) 
 	fs := flag.NewFlagSet("infra rotate-and-prune", flag.ContinueOnError)
 	fs.SetOutput(w)
 	var resourceType, name, configFile, preserveNames string
-	var confirm, nonInteractive bool
+	var confirm, nonInteractive, pruneFirst bool
 	fs.StringVar(&resourceType, "type", "", "Resource type (required, e.g. infra.spaces_key)")
 	fs.StringVar(&name, "name", "", "Canonical credential name to rotate (required)")
 	fs.StringVar(&configFile, "config", "infra.yaml", "Config file")
@@ -245,6 +252,15 @@ func runInfraRotateAndPrune(args []string, provider pruneProvider, w io.Writer) 
 	fs.StringVar(&preserveNames, "preserve-names", "", "Regex of resource names to preserve during prune")
 	fs.BoolVar(&confirm, "confirm", false, "Required: explicit confirmation flag")
 	fs.BoolVar(&nonInteractive, "non-interactive", false, "Skip the prune y/N prompt")
+	// --prune-first defaults TRUE (per ADR 0023): the safer behavior is the
+	// new default. When the cloud account is at quota (e.g., DO Spaces 200-key
+	// limit), Step 1 (rotate = mint new key) fails before Step 2 (prune) gets
+	// a chance to free quota — the chicken-and-egg the operator needs the
+	// tool for. Pre-pruning orphans first frees quota, then rotation can mint,
+	// then a defensive sweep cleans up any old canonical-name remnant. The
+	// legacy "rotate-then-prune" order remains available via --prune-first=false
+	// for callers that need to preserve the v0.27.1 ordering exactly.
+	fs.BoolVar(&pruneFirst, "prune-first", true, "Prune orphans before rotating (default true; safer at quota — see ADR 0023)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -263,11 +279,28 @@ func runInfraRotateAndPrune(args []string, provider pruneProvider, w io.Writer) 
 
 	ctx := context.Background()
 
+	// Pre-prune (Step 0, when --prune-first=true / ADR 0023 default): delete
+	// orphans BEFORE rotation so the cloud account has free quota for the
+	// `Create` call that mints the new canonical key. Skips the canonical
+	// `--name` (it might still be valid; if it's old we replace it in the
+	// rotate step below) and any name matching `--preserve-names`. This
+	// closes the at-quota chicken-and-egg: when the cloud is at quota,
+	// rotation alone fails because Create returns "quota exceeded", and
+	// the operator can't get to the post-rotation prune step that would
+	// have freed the quota.
+	if pruneFirst {
+		fmt.Fprintf(w, "Step 0 (--prune-first): pruning orphan %s resources before rotation...\n", resourceType)
+		if code := runPreRotationPrune(ctx, provider, resourceType, name, preserveNames, nonInteractive, w); code != 0 {
+			fmt.Fprintf(w, "\nrotate-and-prune: pre-rotation prune failed (code=%d). No rotation attempted; no state mutated.\n", code)
+			return code
+		}
+	}
+
 	// Step 1: rotate the canonical credential via bootstrapSecrets's
 	// force-rotate path. parseSecretsConfig + resolveSecretsProvider +
 	// resolveCredentialRevoker are the existing helpers from
 	// cmd/wfctl/infra_secrets.go and infra_bootstrap.go.
-	fmt.Fprintf(w, "Step 1: rotating credential %q (type %s)...\n", name, resourceType)
+	fmt.Fprintf(w, "\nStep 1: rotating credential %q (type %s)...\n", name, resourceType)
 
 	cfg, err := parseSecretsConfig(configFile)
 	if err != nil {
@@ -319,10 +352,19 @@ func runInfraRotateAndPrune(args []string, provider pruneProvider, w io.Writer) 
 	fmt.Fprintf(w, "  recovery file written to %s\n", recoveryFilePath())
 
 	// Step 2 (user-visible): delegate to prune with the new key as the
-	// exclusion target. Step numbering matches the two banners the user
-	// sees: Step 1 is the rotate (above), Step 2 is the prune (here).
-	// The recovery-write between them is a sub-step of Step 1.
-	fmt.Fprintf(w, "\nStep 2: pruning older %s resources...\n", resourceType)
+	// exclusion target. Step numbering matches the banners the user sees:
+	// Step 0 (when --prune-first=true) was the pre-rotation orphan sweep;
+	// Step 1 is the rotate; Step 2 is the post-rotation prune. When
+	// --prune-first=true this is a defensive sweep — should be a no-op if
+	// Step 0 was complete, but covers the case where the canonical name's
+	// OLD value (now replaced in GH Secrets) is still present in the cloud
+	// and should be deleted. When --prune-first=false (legacy ordering),
+	// this is the only prune pass and does the full cleanup itself.
+	if pruneFirst {
+		fmt.Fprintf(w, "\nStep 2: defensive sweep — pruning older %s resources after rotation...\n", resourceType)
+	} else {
+		fmt.Fprintf(w, "\nStep 2: pruning older %s resources...\n", resourceType)
+	}
 	pruneArgs := []string{
 		"--type", resourceType,
 		"--created-before", rotated.CreatedAt,
@@ -355,5 +397,120 @@ func runInfraRotateAndPrune(args []string, provider pruneProvider, w io.Writer) 
 		fmt.Fprintf(w, "rotate-and-prune: warning: rotation+prune succeeded but failed to remove stale recovery file at %s: %v\n", recPath, err)
 		fmt.Fprintf(w, "rotate-and-prune: hint: this file is no longer needed; remove with `rm %s` once safe.\n", recPath)
 	}
+	return 0
+}
+
+// runPreRotationPrune deletes orphan resources of `resourceType` BEFORE the
+// rotate step runs. Used by --prune-first (default true; ADR 0023) to free
+// cloud quota so the subsequent rotate's Create call doesn't fail with
+// "quota exceeded" — the at-quota chicken-and-egg the rotate-and-prune tool
+// is supposed to recover from.
+//
+// Filter semantics (NAME-based, not time/access-key based — runInfraPrune's
+// time + access-key filter requires a successful rotation result we don't
+// have yet at this point):
+//
+//   - Skip the canonical `name` (it might still be the active credential;
+//     if it's stale, the rotate step below will replace it via mint-new-
+//     then-revoke-old per ADR 0012).
+//   - Skip any resource whose `Name` matches the `preserveNames` regex
+//     (same operator-supplied allowlist used by post-rotation prune).
+//   - Delete everything else of `resourceType`.
+//
+// Refuses to run without WFCTL_CONFIRM_PRUNE=1 — the caller
+// (runInfraRotateAndPrune) already validated this for the post-rotation
+// prune; we re-check defensively so this helper is safe if reused.
+//
+// Returns 0 on success (zero or more deletions); non-zero on enumerate
+// failure, regex compile failure, or any individual delete failure.
+//
+//nolint:cyclop // intentional: deletion-loop + filter logic + interactive prompt are tightly coupled
+func runPreRotationPrune(ctx context.Context, provider pruneProvider, resourceType, name, preserveNames string, nonInteractive bool, w io.Writer) int {
+	if os.Getenv("WFCTL_CONFIRM_PRUNE") != "1" {
+		fmt.Fprintln(w, "rotate-and-prune: pre-rotation prune requires WFCTL_CONFIRM_PRUNE=1 (defensive re-check)")
+		return 1
+	}
+
+	var preserveRe *regexp.Regexp
+	if preserveNames != "" {
+		re, reErr := regexp.Compile(preserveNames)
+		if reErr != nil {
+			fmt.Fprintf(w, "rotate-and-prune: invalid --preserve-names regex: %v\n", reErr)
+			return 1
+		}
+		preserveRe = re
+	}
+
+	outs, err := provider.EnumerateAll(ctx, resourceType)
+	if err != nil {
+		fmt.Fprintf(w, "rotate-and-prune: pre-rotation enumerate: %v\n", err)
+		return 1
+	}
+
+	var toDelete []*interfaces.ResourceOutput
+	for _, out := range outs {
+		// Use typed Name (provider contract guarantees ProviderID + Name on
+		// EnumerateAll results). Fall back to Outputs["name"] for older
+		// providers — same fallback-but-prefer-typed pattern as runInfraPrune.
+		resName := out.Name
+		if resName == "" {
+			resName, _ = out.Outputs["name"].(string)
+		}
+		if resName == name {
+			// Skip the canonical name. The rotate step replaces it in-place
+			// via mint-new-then-revoke-old (ADR 0012), so deleting it here
+			// would leave the cloud account without the active credential
+			// for the brief window between Step 0 and Step 1.
+			continue
+		}
+		if preserveRe != nil && preserveRe.MatchString(resName) {
+			continue
+		}
+		toDelete = append(toDelete, out)
+	}
+
+	fmt.Fprintf(w, "Pre-rotation dry-run: %d orphan %s resource(s) to prune (canonical name %q + preserve-names regex are skipped):\n\n", len(toDelete), resourceType, name)
+	for _, o := range toDelete {
+		resName := o.Name
+		if resName == "" {
+			resName, _ = o.Outputs["name"].(string)
+		}
+		ak := o.ProviderID
+		if ak == "" {
+			ak, _ = o.Outputs["access_key"].(string)
+		}
+		ca, _ := o.Outputs["created_at"].(string)
+		fmt.Fprintf(w, "  - %s (access_key=%s, created=%s)\n", resName, ak, ca)
+	}
+
+	if len(toDelete) == 0 {
+		return 0
+	}
+
+	if !nonInteractive {
+		fmt.Fprintf(w, "\nProceed with pre-rotation prune? (y/N): ")
+		var ans string
+		_, _ = fmt.Scanln(&ans)
+		if ans != "y" && ans != "Y" {
+			fmt.Fprintln(w, "Aborted (no rotation attempted; no state mutated).")
+			return 1
+		}
+	}
+
+	var failed int
+	for _, o := range toDelete {
+		ref := interfaces.ResourceRef{Type: o.Type, Name: o.Name, ProviderID: o.ProviderID}
+		if delErr := provider.DeleteResource(ctx, ref); delErr != nil {
+			fmt.Fprintf(w, "rotate-and-prune: pre-rotation delete %s: %v\n", o.Name, delErr)
+			failed++
+			continue
+		}
+		fmt.Fprintf(w, "  ✓ deleted %s\n", o.Name)
+	}
+	if failed > 0 {
+		fmt.Fprintf(w, "\n%d pre-rotation delete(s) failed; aborting before rotation to avoid minting on a partially-cleaned account\n", failed)
+		return 1
+	}
+	fmt.Fprintf(w, "\n%d orphan resource(s) pre-pruned successfully.\n", len(toDelete))
 	return 0
 }

--- a/cmd/wfctl/infra_rotate_and_prune_test.go
+++ b/cmd/wfctl/infra_rotate_and_prune_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -221,5 +222,383 @@ func TestInfraRotateAndPrune_RecoveryFileWrittenWithCorrectPerms(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0600 {
 		t.Errorf("recovery file perms must be 0600 (owner-only); got %o", perm)
+	}
+}
+
+// quotaCappedFakeProvider simulates a cloud account at the per-resource-type
+// quota (e.g., DO Spaces 200-key limit). EnumerateAll returns the current
+// `outputs` slice; DeleteResource shrinks `outputs` (removes the matching
+// ProviderID) and records the delete in `deleted`.
+//
+// `createOnRotate` is the metadata the bootstrapSecrets stub will return for
+// the new key. The test driver invokes the stub which appends this to
+// `outputs`; if `len(outputs) >= quota` at append time the stub errors with
+// quotaErr to simulate the at-quota Create failure. Tests assert that with
+// --prune-first=true the orphan deletes happen FIRST, freeing room before
+// the stub appends, so the rotation succeeds.
+type quotaCappedFakeProvider struct {
+	outputs []*interfaces.ResourceOutput
+	deleted []string
+}
+
+func (f *quotaCappedFakeProvider) EnumerateAll(_ context.Context, _ string) ([]*interfaces.ResourceOutput, error) {
+	// Return a copy to mimic the stable-snapshot semantics the dispatcher's
+	// cachedPruneProvider provides in production. A test that mutates the
+	// returned slice should not affect subsequent EnumerateAll calls.
+	out := make([]*interfaces.ResourceOutput, len(f.outputs))
+	copy(out, f.outputs)
+	return out, nil
+}
+
+func (f *quotaCappedFakeProvider) DeleteResource(_ context.Context, ref interfaces.ResourceRef) error {
+	for i, o := range f.outputs {
+		if o.ProviderID == ref.ProviderID {
+			f.outputs = append(f.outputs[:i], f.outputs[i+1:]...)
+			f.deleted = append(f.deleted, ref.ProviderID)
+			return nil
+		}
+	}
+	return errors.New("not found: " + ref.ProviderID)
+}
+
+// TestRotateAndPrune_PruneFirst_HappyPath_AtQuota verifies the at-quota
+// chicken-and-egg fix (ADR 0023): when the cloud account has orphan
+// resources whose names don't match the canonical `--name`, --prune-first=true
+// (the default) deletes them BEFORE the rotate step. Without this flip,
+// rotation's mint-new step would fail with "quota exceeded" before the
+// post-rotation prune ever runs to free quota.
+//
+// The test models the at-quota condition by stuffing the fake provider with
+// orphan keys (names != canonical), running rotate-and-prune with the
+// default flag (--prune-first=true), and asserting:
+//
+//  1. The pre-prune step deleted every orphan key (names != "canonical-name"
+//     and not matching --preserve-names).
+//  2. The rotate step ran successfully (bootstrapSecrets stub returned its
+//     RotationResult, indicating no quota error).
+//  3. The post-prune defensive sweep ran cleanly (no error).
+//  4. The recovery file was deleted on full success.
+func TestRotateAndPrune_PruneFirst_HappyPath_AtQuota(t *testing.T) {
+	t.Setenv("WFCTL_CONFIRM_PRUNE", "1")
+	tmpDir := t.TempDir()
+	t.Setenv("WFCTL_STATE_DIR", tmpDir)
+	cfgPath := writeMinimalRotationConfig(t, tmpDir)
+
+	origBoot := bootstrapSecrets
+	defer func() { bootstrapSecrets = origBoot }()
+	bootstrapSecrets = func(_ context.Context, _ secrets.Provider, _ *SecretsConfig, _ map[string]bool, _ ...interfaces.ProviderCredentialRevoker) (map[string]string, []RotationResult, error) {
+		return map[string]string{}, []RotationResult{
+			{Key: "canonical-name", Source: "digitalocean.spaces", AccessKey: "AK_NEW", CreatedAt: "2026-05-09T11:00:00Z"},
+		}, nil
+	}
+
+	// Two orphan keys (names != canonical) + one key matching the canonical
+	// name (the OLD canonical credential the rotate step replaces in-place).
+	// Pre-prune must delete the orphans, skip the canonical-named key.
+	fakeProv := &quotaCappedFakeProvider{
+		outputs: []*interfaces.ResourceOutput{
+			{
+				Name:       "orphan-1",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_ORPHAN_1",
+				Outputs: map[string]any{
+					"access_key": "AK_ORPHAN_1",
+					"created_at": "2026-04-01T00:00:00Z",
+					"name":       "orphan-1",
+				},
+			},
+			{
+				Name:       "orphan-2",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_ORPHAN_2",
+				Outputs: map[string]any{
+					"access_key": "AK_ORPHAN_2",
+					"created_at": "2026-04-15T00:00:00Z",
+					"name":       "orphan-2",
+				},
+			},
+			{
+				Name:       "canonical-name",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_OLD_CANONICAL",
+				Outputs: map[string]any{
+					"access_key": "AK_OLD_CANONICAL",
+					"created_at": "2026-05-01T00:00:00Z",
+					"name":       "canonical-name",
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	code := runInfraRotateAndPrune([]string{
+		"--type", "infra.spaces_key",
+		"--name", "canonical-name",
+		"--config", cfgPath,
+		"--confirm", "--non-interactive",
+		// --prune-first defaulted to true; explicitly omitted to verify the
+		// default path is the at-quota-safe path.
+	}, fakeProv, &out)
+	if code != 0 {
+		t.Fatalf("rotate-and-prune (--prune-first default) failed: code=%d, out=%s", code, out.String())
+	}
+
+	// Pre-prune deleted both orphans (names != canonical, not in preserve regex).
+	if !rotateAndPruneContains(fakeProv.deleted, "AK_ORPHAN_1") {
+		t.Errorf("AK_ORPHAN_1 must be pre-pruned; deleted = %v; out=%s", fakeProv.deleted, out.String())
+	}
+	if !rotateAndPruneContains(fakeProv.deleted, "AK_ORPHAN_2") {
+		t.Errorf("AK_ORPHAN_2 must be pre-pruned; deleted = %v; out=%s", fakeProv.deleted, out.String())
+	}
+
+	// Post-prune deleted the OLD canonical key (created before AK_NEW;
+	// access_key != AK_NEW).
+	if !rotateAndPruneContains(fakeProv.deleted, "AK_OLD_CANONICAL") {
+		t.Errorf("AK_OLD_CANONICAL must be post-pruned (older than rotation); deleted = %v; out=%s", fakeProv.deleted, out.String())
+	}
+
+	// Output banners include both Step 0 and Step 2 (defensive sweep) markers.
+	got := out.String()
+	if !strings.Contains(got, "Step 0") || !strings.Contains(got, "--prune-first") {
+		t.Errorf("output should narrate Step 0 (--prune-first); got: %s", got)
+	}
+	if !strings.Contains(got, "defensive sweep") {
+		t.Errorf("output should narrate Step 2 as defensive sweep when prune-first=true; got: %s", got)
+	}
+
+	// Recovery file deleted on full success.
+	if _, err := os.Stat(filepath.Join(tmpDir, "last-rotation.json")); !os.IsNotExist(err) {
+		t.Errorf("recovery file should be deleted on full success; stat err = %v", err)
+	}
+}
+
+// TestRotateAndPrune_PruneFirst_DefaultTrue locks in the ADR 0023 default
+// flip: omitting --prune-first must use the safer behavior. Without this
+// regression sentinel, a future refactor could silently revert the default
+// to false and reintroduce the at-quota chicken-and-egg.
+//
+// The test observes the default by checking that with NO --prune-first arg
+// passed and orphan resources in the fake provider, the pre-prune step
+// runs and deletes the orphans (vs. the legacy ordering, where they
+// would still be present after rotation because the post-prune time
+// filter catches only same-name keys).
+func TestRotateAndPrune_PruneFirst_DefaultTrue(t *testing.T) {
+	t.Setenv("WFCTL_CONFIRM_PRUNE", "1")
+	tmpDir := t.TempDir()
+	t.Setenv("WFCTL_STATE_DIR", tmpDir)
+	cfgPath := writeMinimalRotationConfig(t, tmpDir)
+
+	origBoot := bootstrapSecrets
+	defer func() { bootstrapSecrets = origBoot }()
+	bootstrapSecrets = func(_ context.Context, _ secrets.Provider, _ *SecretsConfig, _ map[string]bool, _ ...interfaces.ProviderCredentialRevoker) (map[string]string, []RotationResult, error) {
+		return map[string]string{}, []RotationResult{
+			{Key: "canonical-name", Source: "digitalocean.spaces", AccessKey: "AK_NEW", CreatedAt: "2026-05-09T11:00:00Z"},
+		}, nil
+	}
+
+	// One orphan with a created_at NEWER than AK_NEW. Under legacy ordering
+	// the post-prune time filter would skip it (created_at >= cutoff); under
+	// the new default the pre-prune name filter targets it.
+	fakeProv := &quotaCappedFakeProvider{
+		outputs: []*interfaces.ResourceOutput{
+			{
+				Name:       "orphan-future",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_ORPHAN_FUTURE",
+				Outputs: map[string]any{
+					"access_key": "AK_ORPHAN_FUTURE",
+					"created_at": "2027-01-01T00:00:00Z", // newer than AK_NEW's 2026-05-09
+					"name":       "orphan-future",
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	code := runInfraRotateAndPrune([]string{
+		"--type", "infra.spaces_key",
+		"--name", "canonical-name",
+		"--config", cfgPath,
+		"--confirm", "--non-interactive",
+	}, fakeProv, &out)
+	if code != 0 {
+		t.Fatalf("rotate-and-prune failed: code=%d, out=%s", code, out.String())
+	}
+
+	// The default-true flag means the pre-prune ran and deleted the orphan,
+	// even though its created_at is newer than the rotation timestamp.
+	if !rotateAndPruneContains(fakeProv.deleted, "AK_ORPHAN_FUTURE") {
+		t.Errorf("AK_ORPHAN_FUTURE must be pre-pruned by default (--prune-first=true); deleted = %v", fakeProv.deleted)
+	}
+}
+
+// TestRotateAndPrune_PruneFirst_False_LegacyOrder verifies the opt-out path:
+// --prune-first=false preserves the v0.27.1 ordering (rotate first, then
+// post-rotation prune only). The test asserts that with one orphan whose
+// `created_at` is NEWER than the rotation timestamp, --prune-first=false
+// does NOT delete it (the post-rotation time filter skips it because it's
+// not older than the cutoff). Under the new default it would be deleted.
+func TestRotateAndPrune_PruneFirst_False_LegacyOrder(t *testing.T) {
+	t.Setenv("WFCTL_CONFIRM_PRUNE", "1")
+	tmpDir := t.TempDir()
+	t.Setenv("WFCTL_STATE_DIR", tmpDir)
+	cfgPath := writeMinimalRotationConfig(t, tmpDir)
+
+	origBoot := bootstrapSecrets
+	defer func() { bootstrapSecrets = origBoot }()
+	bootstrapSecrets = func(_ context.Context, _ secrets.Provider, _ *SecretsConfig, _ map[string]bool, _ ...interfaces.ProviderCredentialRevoker) (map[string]string, []RotationResult, error) {
+		return map[string]string{}, []RotationResult{
+			{Key: "canonical-name", Source: "digitalocean.spaces", AccessKey: "AK_NEW", CreatedAt: "2026-05-09T11:00:00Z"},
+		}, nil
+	}
+
+	fakeProv := &quotaCappedFakeProvider{
+		outputs: []*interfaces.ResourceOutput{
+			{
+				Name:       "orphan-future",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_ORPHAN_FUTURE",
+				Outputs: map[string]any{
+					"access_key": "AK_ORPHAN_FUTURE",
+					"created_at": "2027-01-01T00:00:00Z",
+					"name":       "orphan-future",
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	code := runInfraRotateAndPrune([]string{
+		"--type", "infra.spaces_key",
+		"--name", "canonical-name",
+		"--config", cfgPath,
+		"--confirm", "--non-interactive",
+		"--prune-first=false",
+	}, fakeProv, &out)
+	if code != 0 {
+		t.Fatalf("rotate-and-prune (--prune-first=false) failed: code=%d, out=%s", code, out.String())
+	}
+
+	// AK_ORPHAN_FUTURE has created_at > rotation timestamp, so the post-
+	// rotation time filter skips it. Under legacy ordering it survives.
+	if rotateAndPruneContains(fakeProv.deleted, "AK_ORPHAN_FUTURE") {
+		t.Errorf("AK_ORPHAN_FUTURE should NOT be deleted under --prune-first=false (newer than cutoff); deleted = %v", fakeProv.deleted)
+	}
+
+	// Output should NOT mention Step 0 / pre-rotation when the flag is off.
+	got := out.String()
+	if strings.Contains(got, "Step 0") {
+		t.Errorf("output should NOT narrate Step 0 when --prune-first=false; got: %s", got)
+	}
+	if strings.Contains(got, "defensive sweep") {
+		t.Errorf("output should NOT label Step 2 as defensive sweep when --prune-first=false; got: %s", got)
+	}
+}
+
+// TestRotateAndPrune_PruneFirst_PreservesCanonicalName verifies the
+// canonical-name protection in the pre-rotation prune step: the resource
+// whose Name == --name MUST be skipped during pre-prune, even when its
+// access_key/created_at otherwise look like an orphan. This protects the
+// active credential during the brief window between Step 0 and Step 1
+// (rotation) — deleting it pre-rotation would leave the cloud account
+// without an active credential while the rotate step's mint-new call
+// runs.
+//
+// The preserve-names regex is also asserted: a resource matching the
+// regex must be preserved even if its name != canonical.
+func TestRotateAndPrune_PruneFirst_PreservesCanonicalName(t *testing.T) {
+	t.Setenv("WFCTL_CONFIRM_PRUNE", "1")
+	tmpDir := t.TempDir()
+	t.Setenv("WFCTL_STATE_DIR", tmpDir)
+	cfgPath := writeMinimalRotationConfig(t, tmpDir)
+
+	origBoot := bootstrapSecrets
+	defer func() { bootstrapSecrets = origBoot }()
+	bootstrapSecrets = func(_ context.Context, _ secrets.Provider, _ *SecretsConfig, _ map[string]bool, _ ...interfaces.ProviderCredentialRevoker) (map[string]string, []RotationResult, error) {
+		return map[string]string{}, []RotationResult{
+			{Key: "canonical-name", Source: "digitalocean.spaces", AccessKey: "AK_NEW", CreatedAt: "2026-05-09T11:00:00Z"},
+		}, nil
+	}
+
+	fakeProv := &quotaCappedFakeProvider{
+		outputs: []*interfaces.ResourceOutput{
+			{
+				// Canonical name — pre-prune must skip this even though
+				// its created_at is old. Post-prune may or may not delete
+				// it depending on the time filter; this test asserts the
+				// PRE-prune behavior.
+				Name:       "canonical-name",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_CANONICAL",
+				Outputs: map[string]any{
+					"access_key": "AK_CANONICAL",
+					"created_at": "2026-05-01T00:00:00Z",
+					"name":       "canonical-name",
+				},
+			},
+			{
+				// Matches preserve regex — pre-prune must skip.
+				Name:       "preserved-fixture",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_PRESERVED",
+				Outputs: map[string]any{
+					"access_key": "AK_PRESERVED",
+					"created_at": "2026-04-01T00:00:00Z",
+					"name":       "preserved-fixture",
+				},
+			},
+			{
+				// Plain orphan — pre-prune must delete.
+				Name:       "orphan-x",
+				Type:       "infra.spaces_key",
+				ProviderID: "AK_ORPHAN_X",
+				Outputs: map[string]any{
+					"access_key": "AK_ORPHAN_X",
+					"created_at": "2026-04-01T00:00:00Z",
+					"name":       "orphan-x",
+				},
+			},
+		},
+	}
+
+	// Snapshot deletes seen during rotate so we can assert AK_CANONICAL
+	// was not deleted in the PRE step (the post step will delete it).
+	// We do this by recording the length of `deleted` before invoking
+	// runInfraRotateAndPrune and after pre-prune via a stub. The
+	// quotaCappedFakeProvider's DeleteResource appends in order; pre-
+	// prune deletes happen FIRST, then rotation, then post-prune. So
+	// the first N entries in fakeProv.deleted are the pre-prune results.
+	// We assert AK_CANONICAL is not in the prefix where N = number of
+	// entries that ALSO appear in the orphan set.
+
+	var out bytes.Buffer
+	code := runInfraRotateAndPrune([]string{
+		"--type", "infra.spaces_key",
+		"--name", "canonical-name",
+		"--config", cfgPath,
+		"--preserve-names", "^preserved-",
+		"--confirm", "--non-interactive",
+	}, fakeProv, &out)
+	if code != 0 {
+		t.Fatalf("rotate-and-prune failed: code=%d, out=%s", code, out.String())
+	}
+
+	// Orphan was deleted (some pass — pre or post).
+	if !rotateAndPruneContains(fakeProv.deleted, "AK_ORPHAN_X") {
+		t.Errorf("orphan AK_ORPHAN_X must be deleted; deleted = %v", fakeProv.deleted)
+	}
+	// Preserved fixture must NEVER be deleted (regex match).
+	if rotateAndPruneContains(fakeProv.deleted, "AK_PRESERVED") {
+		t.Errorf("AK_PRESERVED must be preserved (matches --preserve-names); deleted = %v", fakeProv.deleted)
+	}
+
+	// Canonical's OLD access_key may be deleted by the POST-prune step
+	// (it's older than AK_NEW), but never by PRE-prune. We assert by
+	// checking the output narrates Step 0's count: with the canonical
+	// + preserved fixture skipped, only the orphan should be in the
+	// pre-rotation dry-run.
+	got := out.String()
+	if !strings.Contains(got, "Pre-rotation dry-run: 1 orphan") {
+		t.Errorf("pre-rotation dry-run must list exactly 1 orphan (canonical + preserved skipped); got: %s", got)
 	}
 }

--- a/decisions/0023-rotate-and-prune-prune-first-default.md
+++ b/decisions/0023-rotate-and-prune-prune-first-default.md
@@ -1,0 +1,144 @@
+# 0023: `wfctl infra rotate-and-prune` — `--prune-first` default flip
+
+- **Date:** 2026-05-09
+- **Status:** Accepted
+
+## Context
+
+`wfctl infra rotate-and-prune` was shipped in v0.27.x with a fixed step
+ordering:
+
+1. **Step 1 (rotate):** mint a new canonical credential via the
+   provider's `Create` call, push the result to GH Secrets via the
+   engine-routing path, and revoke the old credential per ADR 0012.
+2. **Step 2 (prune):** delegate to `runInfraPrune` with
+   `--created-before=<new.created_at>` + `--exclude-access-key=<new>`
+   to delete every older key for the same `--type`, with
+   `--preserve-names` as an additive allowlist.
+
+This ordering has a fatal flaw at quota: when the cloud account is at
+the per-resource-type cap (e.g., DigitalOcean Spaces enforces a 200-key
+limit per project), Step 1 fails with `HTTP 403: key quota exceeded`
+before Step 2 ever gets a chance to free quota. The chicken-and-egg:
+*the very condition the operator needs to clean up makes the cleanup
+tool unusable.*
+
+The recovery path before this ADR was manual: log into the DO console,
+hand-delete enough orphan keys to bring the account under quota, then
+re-invoke `wfctl infra rotate-and-prune`. That's exactly the
+pre-wfctl-rotation workflow the tool was built to eliminate.
+
+## Decision
+
+Add a `--prune-first` boolean flag that flips the step ordering:
+
+- **`--prune-first=true` (NEW DEFAULT):**
+  1. **Step 0 (pre-prune):** delete every resource of `--type` whose
+     `Name != --name` AND whose `Name` does not match `--preserve-names`.
+     This is a NAME-based filter — there is no rotation result yet, so
+     the time + access-key filter that `runInfraPrune` uses is not
+     applicable. The canonical `--name` is always skipped (the rotate
+     step replaces it in-place per ADR 0012).
+  2. **Step 1 (rotate):** unchanged from the existing flow.
+  3. **Step 2 (post-prune defensive sweep):** unchanged from the
+     existing flow. Should be a no-op if Step 0 was complete, but
+     covers the case where the canonical name's OLD value (now
+     replaced in GH Secrets) is still present in the cloud and should
+     be deleted.
+
+- **`--prune-first=false` (OPT-OUT, legacy):** preserves the v0.27.1
+  step ordering exactly. Step 1 → Step 2, no pre-prune.
+
+The default IS `--prune-first=true`. The safer behavior is the new
+default; the legacy quota-fragile behavior is opt-out. This matches
+the workspace mandate "force-strict, no fallbacks" — the strict
+behavior is the default, the legacy behavior is opt-out for callers
+that need to preserve byte-exact ordering for audit / regression
+purposes.
+
+The pre-flight `EnumerateAll` probe + `ErrProviderMethodUnimplemented`
+handling (added in v0.27.1) is unchanged: regardless of
+`--prune-first` value, if NO loaded provider's plugin actually
+implements `EnumerateAll` behind the bridge, the dispatcher errors
+loud BEFORE any state is mutated.
+
+## Consequences
+
+- The at-quota chicken-and-egg is closed for the default invocation
+  path. Operators no longer need to hand-prune via the cloud console
+  before running the tool.
+
+- The pre-prune step uses a different filter shape than the
+  post-rotation prune (NAME-based instead of TIME + ACCESS_KEY-based)
+  because no rotation result exists yet. This is a deliberate
+  asymmetry: pre-prune protects the canonical via name match,
+  post-prune protects the new key via access-key match. Both pass
+  through the same `--preserve-names` regex.
+
+- Output banners are now numbered Step 0 / Step 1 / Step 2 when
+  `--prune-first=true`, and Step 1 / Step 2 when `--prune-first=false`.
+  Operators reading the logs will see the additional pre-prune
+  narrative on the default path.
+
+- The default flip changes observable behavior: orphan keys
+  (Name != canonical, not in preserve regex) created AFTER the rotation
+  timestamp are now deleted on the default invocation, where under the
+  legacy ordering they survived because the post-rotation time filter
+  skipped anything with `created_at >= cutoff`. This is intentional —
+  orphans are orphans regardless of when they were created. Callers
+  that need the legacy semantics use `--prune-first=false`.
+
+- The two-key opt-in (WFCTL_CONFIRM_PRUNE=1 + `--confirm` flag) gates
+  the entire flow including the pre-prune step. The pre-prune helper
+  defensively re-checks WFCTL_CONFIRM_PRUNE so it remains safe if
+  reused outside `runInfraRotateAndPrune`.
+
+- A pre-prune delete failure aborts BEFORE rotation. No state is
+  mutated by the rotate step in that case — better to leave the
+  account in its current (partially-pruned) state than to mint a new
+  key on a half-cleaned account.
+
+## Alternatives considered
+
+- **Keep `--prune-first=false` as default, add the flag as opt-in:**
+  rejected. Contradicts the workspace `feedback_proper_fixes_over_workarounds`
+  guidance — making operators discover and explicitly enable the
+  safer behavior is a workaround, not a fix. The chicken-and-egg
+  failure mode is the common case for any account that has accumulated
+  orphan keys, which is most accounts running the rotation cadence
+  this tool was built for.
+
+- **Detect quota exhaustion in Step 1 and auto-retry with pre-prune:**
+  rejected. Couples Step 1's error path to provider-specific quota
+  error parsing. The error shape is not standardized across cloud
+  providers (DO returns HTTP 403 with a body string, AWS returns
+  `LimitExceededException`, Azure returns `QuotaExceeded`). A flag
+  is provider-agnostic and easier to reason about.
+
+- **Split into `wfctl infra prune-orphans` + `wfctl infra
+  rotate-and-prune`:** rejected. Two-command UX shifts the
+  ordering decision to the operator, who has to know to call both in
+  sequence. The all-in-one semantic of `rotate-and-prune` is the
+  feature; flipping its internal ordering preserves that semantic.
+
+- **Make `--prune-first` an enum (`{first, after, both, none}`):**
+  rejected. YAGNI. The two real states are "safe at quota" (default)
+  and "legacy ordering" (opt-out for byte-exact regressions). Adding
+  enum values for hypothetical future variants creates surface area
+  without a use case.
+
+## Related
+
+- `cmd/wfctl/infra_rotate_and_prune.go` — implementation; pre-prune
+  helper is `runPreRotationPrune`.
+- `cmd/wfctl/infra_rotate_and_prune_test.go` —
+  `TestRotateAndPrune_PruneFirst_HappyPath_AtQuota`,
+  `TestRotateAndPrune_PruneFirst_DefaultTrue`,
+  `TestRotateAndPrune_PruneFirst_False_LegacyOrder`,
+  `TestRotateAndPrune_PruneFirst_PreservesCanonicalName`.
+- ADR 0012 — provider credential rotation (mint-new-then-revoke-old).
+- ADR 0017 — `wfctl infra prune` two-key opt-in (the post-rotation
+  prune the defensive sweep delegates to).
+- ADR 0020 — storage filter sidecar metadata (RotationResult shape).
+- Workspace memory `feedback_proper_fixes_over_workarounds` — proper
+  fixes over easy workarounds (the default flip IS the proper fix).


### PR DESCRIPTION
## Summary

Adds `--prune-first` flag to `wfctl infra rotate-and-prune` (default `true`)
that flips step ordering: pre-prune orphans BEFORE rotation, then rotate,
then defensive post-prune sweep. Closes the at-quota chicken-and-egg.

## Why

Before this PR, `rotate-and-prune` ran rotate then prune in fixed order. When
the cloud account is at quota (DO Spaces enforces 200 keys per project),
Step 1's `Create` call fails with `HTTP 403: key quota exceeded` before
Step 2 (prune) can free quota. Operators had to hand-prune via the cloud
console first — exactly the manual workflow `rotate-and-prune` was built to
eliminate.

## What changes

- `cmd/wfctl/infra_rotate_and_prune.go`:
  - New `--prune-first` boolean flag, **default `true`** (per ADR 0023).
  - When `--prune-first=true`, runs `runPreRotationPrune` (NEW helper) BEFORE
    Step 1. The pre-prune deletes resources where `Name != --name` AND
    `Name` does not match `--preserve-names` regex.
  - Step 2 (post-rotation prune) re-labelled as "defensive sweep" when
    `--prune-first=true` — should be a no-op if Step 0 was complete, but
    covers replacement of canonical-name's old value.
  - When `--prune-first=false`, the v0.27.1 ordering is preserved exactly.
  - Pre-prune defensively re-checks `WFCTL_CONFIRM_PRUNE=1`. A failed
    pre-prune delete aborts BEFORE rotation (no minting on a half-cleaned
    account).
  - Pre-flight `EnumerateAll` probe + `ErrProviderMethodUnimplemented`
    handling unchanged.

- `cmd/wfctl/infra_rotate_and_prune_test.go`:
  - 4 new tests (see Test plan).
  - 1 new fake `quotaCappedFakeProvider` that mutates `outputs` as
    `DeleteResource` calls land — closer to real cloud-API semantics.

- `decisions/0023-rotate-and-prune-prune-first-default.md`:
  - New ADR documenting the default flip + four rejected alternatives.

## Filter shape

Pre-prune uses a NAME-based filter (canonical `--name` + `--preserve-names`
skipped). The TIME + ACCESS_KEY filter that `runInfraPrune` uses is not
applicable here because no rotation result exists yet at this point in the
flow. Post-prune retains its TIME + ACCESS_KEY filter unchanged.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./cmd/wfctl/... -count=1 -run RotateAndPrune -v` —
      8/8 pass (4 existing + 4 new)
- [x] `GOWORK=off go test ./...` — full suite passes
- [x] `golangci-lint run ./cmd/wfctl/...` — 0 issues

New test functions:

- `TestRotateAndPrune_PruneFirst_HappyPath_AtQuota` — orphans + canonical-old
  loaded; default `--prune-first=true` deletes orphans pre-rotation, rotates
  cleanly, post-prune cleans canonical-old. Asserts Step 0 + defensive sweep
  banners in output.
- `TestRotateAndPrune_PruneFirst_DefaultTrue` — regression sentinel for the
  ADR 0023 default flip. Orphan with `created_at` newer than rotation
  timestamp is deleted by default (would survive legacy ordering).
- `TestRotateAndPrune_PruneFirst_False_LegacyOrder` — opt-out path. Same
  newer-than-cutoff orphan must NOT be deleted under `--prune-first=false`.
  Output must NOT mention Step 0 / defensive sweep.
- `TestRotateAndPrune_PruneFirst_PreservesCanonicalName` — canonical
  `--name` + `--preserve-names` regex match must both be skipped during
  pre-prune. Asserted via "Pre-rotation dry-run: 1 orphan" output line.

## Behavior change call-out

Default `--prune-first=true` changes observable behavior on the
default invocation: orphan keys (Name != canonical, not in preserve regex)
created AFTER the rotation timestamp are now deleted, where previously
they survived the post-rotation time filter. This is intentional per
ADR 0023 — orphans are orphans regardless of when they were created.
Callers needing legacy semantics use `--prune-first=false`.

## DO NOT

- Do NOT merge this PR — orchestrator handles admin-merge + tag v0.27.2.

## ADR

`decisions/0023-rotate-and-prune-prune-first-default.md`

References ADR 0012 (provider credential rotation), ADR 0017 (prune two-key
opt-in), ADR 0020 (storage filter sidecar metadata).