### PR TITLE
Fix external plugin trigger callbacks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -123,6 +123,7 @@ func buildEngine(cfg *config.WorkflowConfig, logger *slog.Logger) (*workflow.Std
 	// External plugins run as separate processes communicating over gRPC.
 	// Failures are non-fatal — the engine works fine with only builtin plugins.
 	extMgr := pluginexternal.NewExternalPluginManager(extPluginDir, log.Default())
+	extMgr.SetCallbackServer(newExternalCallbackServer(engine))
 	discovered, discoverErr := extMgr.DiscoverPlugins()
 	if discoverErr != nil {
 		logger.Warn("Failed to discover external plugins", "error", discoverErr)
@@ -168,6 +169,16 @@ func buildEngine(cfg *config.WorkflowConfig, logger *slog.Logger) (*workflow.Std
 	}
 
 	return engine, loader, registry, nil
+}
+
+func newExternalCallbackServer(engine *workflow.StdEngine) *pluginexternal.CallbackServer {
+	return pluginexternal.NewCallbackServer(
+		func(triggerType, action string, data map[string]any) error {
+			return engine.TriggerWorkflow(context.Background(), triggerType, action, data)
+		},
+		nil,
+		log.Default(),
+	)
 }
 
 // loadConfig loads a workflow configuration from the configured file path,
@@ -824,6 +835,7 @@ func (app *serverApp) initStores(logger *slog.Logger) error {
 
 	extPluginDir2 := filepath.Join(*dataDir, "plugins")
 	extPluginMgr := pluginexternal.NewExternalPluginManager(extPluginDir2, log.Default())
+	extPluginMgr.SetCallbackServer(newExternalCallbackServer(engine))
 	extPluginHandler := pluginexternal.NewPluginHandler(extPluginMgr)
 	extPluginMux := http.NewServeMux()
 	extPluginHandler.RegisterRoutes(extPluginMux)

--- a/plugin/external/adapter.go
+++ b/plugin/external/adapter.go
@@ -37,6 +37,7 @@ type ExternalPluginAdapter struct {
 	contractTypes       *protoregistry.Types
 	configFragment      []byte
 	pluginDir           string
+	triggerSetupErr     error
 }
 
 type contractDescriptorCache struct {
@@ -86,10 +87,30 @@ func NewExternalPluginAdapter(name string, client *PluginClient) (*ExternalPlugi
 	if err != nil {
 		return nil, fmt.Errorf("get manifest from plugin %s: %w", name, err)
 	}
+	var triggerSetupErr error
+	triggerTypes, triggerErr := client.client.GetTriggerTypes(ctx, &emptypb.Empty{})
+	if triggerErr != nil && status.Code(triggerErr) != codes.Unimplemented {
+		triggerSetupErr = fmt.Errorf("get trigger types from plugin %s before callback setup: %w", name, triggerErr)
+	}
+	if triggerTypes != nil && len(triggerTypes.Types) > 0 {
+		if client.callbackBrokerID == 0 {
+			triggerSetupErr = fmt.Errorf("configure callback for plugin %s: callback broker unavailable", name)
+		} else {
+			resp, callbackErr := client.client.ConfigureCallback(ctx, &pb.ConfigureCallbackRequest{
+				BrokerId: client.callbackBrokerID,
+			})
+			if callbackErr != nil {
+				triggerSetupErr = fmt.Errorf("configure callback for plugin %s: %w", name, callbackErr)
+			} else if resp.Error != "" {
+				triggerSetupErr = fmt.Errorf("configure callback for plugin %s: %s", name, resp.Error)
+			}
+		}
+	}
 	a := &ExternalPluginAdapter{
-		name:     name,
-		client:   client,
-		manifest: manifest,
+		name:            name,
+		client:          client,
+		manifest:        manifest,
+		triggerSetupErr: triggerSetupErr,
 	}
 	if registry, registryErr := client.client.GetContractRegistry(ctx, &emptypb.Empty{}); registryErr == nil {
 		a.contractRegistry = registry
@@ -414,6 +435,9 @@ func (a *ExternalPluginAdapter) StepFactories() map[string]plugin.StepFactory {
 }
 
 func (a *ExternalPluginAdapter) TriggerFactories() map[string]plugin.TriggerFactory {
+	if a.triggerSetupErr != nil {
+		return nil
+	}
 	ctx := context.Background()
 	resp, err := a.client.client.GetTriggerTypes(ctx, &emptypb.Empty{})
 	if err != nil || resp == nil || len(resp.Types) == 0 {
@@ -423,15 +447,7 @@ func (a *ExternalPluginAdapter) TriggerFactories() map[string]plugin.TriggerFact
 	for _, typeName := range resp.Types {
 		tn := typeName // capture
 		factories[tn] = func() any {
-			createResp, createErr := a.client.client.CreateModule(ctx, &pb.CreateModuleRequest{
-				Type:   tn,
-				Name:   tn,
-				Config: nil,
-			})
-			if createErr != nil || createResp.Error != "" {
-				return nil
-			}
-			return NewRemoteTrigger(tn, tn, createResp.HandleId, a.client.client, nil)
+			return NewRemoteTrigger(tn, tn, a.client.client)
 		}
 	}
 	return factories

--- a/plugin/external/adapter_test.go
+++ b/plugin/external/adapter_test.go
@@ -35,6 +35,7 @@ type adapterTestPluginServiceClient struct {
 	registryErr       error
 	moduleTypes       []string
 	stepTypes         []string
+	triggerTypes      []string
 	lastCreateModReq  *pb.CreateModuleRequest
 	lastCreateStepReq *pb.CreateStepRequest
 }
@@ -52,6 +53,10 @@ func (c *adapterTestPluginServiceClient) GetContractRegistry(_ context.Context, 
 
 func (c *adapterTestPluginServiceClient) GetStepTypes(_ context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*pb.TypeList, error) {
 	return &pb.TypeList{Types: c.stepTypes}, nil
+}
+
+func (c *adapterTestPluginServiceClient) GetTriggerTypes(_ context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*pb.TypeList, error) {
+	return &pb.TypeList{Types: c.triggerTypes}, nil
 }
 
 func (c *adapterTestPluginServiceClient) GetModuleTypes(_ context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*pb.TypeList, error) {
@@ -212,6 +217,119 @@ func TestContractRegistry_UnimplementedUsesEmptyRegistry(t *testing.T) {
 	}
 }
 
+func TestNewExternalPluginAdapterConfiguresCallbackBroker(t *testing.T) {
+	client := &adapterTestPluginServiceClient{
+		manifest:     &pb.Manifest{Name: "callback-plugin"},
+		registry:     &pb.ContractRegistry{},
+		triggerTypes: []string{"trigger.test"},
+	}
+	_, err := NewExternalPluginAdapter("callback-plugin", &PluginClient{
+		client:           client,
+		callbackBrokerID: 42,
+	})
+	if err != nil {
+		t.Fatalf("NewExternalPluginAdapter: %v", err)
+	}
+	if client.configureCallbackReq == nil {
+		t.Fatal("expected ConfigureCallback request")
+	}
+	if client.configureCallbackReq.BrokerId != 42 {
+		t.Fatalf("expected broker id 42, got %d", client.configureCallbackReq.BrokerId)
+	}
+}
+
+func TestNewExternalPluginAdapterSkipsCallbackForLegacyPluginWithoutTriggers(t *testing.T) {
+	client := &adapterTestPluginServiceClient{
+		manifest: &pb.Manifest{Name: "legacy-plugin"},
+		registry: &pb.ContractRegistry{},
+	}
+	_, err := NewExternalPluginAdapter("legacy-plugin", &PluginClient{
+		client:           client,
+		callbackBrokerID: 42,
+	})
+	if err != nil {
+		t.Fatalf("NewExternalPluginAdapter: %v", err)
+	}
+	if client.configureCallbackReq != nil {
+		t.Fatal("did not expect ConfigureCallback request for plugin without triggers")
+	}
+}
+
+func TestNewExternalPluginAdapterDisablesTriggersWhenCallbackUnsupported(t *testing.T) {
+	client := &unimplementedConfigureCallbackClient{
+		adapterTestPluginServiceClient: adapterTestPluginServiceClient{
+			manifest:     &pb.Manifest{Name: "legacy-trigger-plugin"},
+			registry:     &pb.ContractRegistry{},
+			triggerTypes: []string{"trigger.test"},
+		},
+	}
+	adapter, err := NewExternalPluginAdapter("legacy-trigger-plugin", &PluginClient{
+		client:           client,
+		callbackBrokerID: 42,
+	})
+	if err != nil {
+		t.Fatalf("NewExternalPluginAdapter should preserve module/step compatibility: %v", err)
+	}
+	if factories := adapter.TriggerFactories(); factories != nil {
+		t.Fatalf("expected trigger factories disabled when callback setup is unsupported, got %#v", factories)
+	}
+}
+
+func TestNewExternalPluginAdapterDisablesTriggersWithoutCallbackBroker(t *testing.T) {
+	client := &adapterTestPluginServiceClient{
+		manifest:     &pb.Manifest{Name: "trigger-plugin"},
+		registry:     &pb.ContractRegistry{},
+		triggerTypes: []string{"trigger.test"},
+	}
+	adapter, err := NewExternalPluginAdapter("trigger-plugin", &PluginClient{client: client})
+	if err != nil {
+		t.Fatalf("NewExternalPluginAdapter: %v", err)
+	}
+	if factories := adapter.TriggerFactories(); factories != nil {
+		t.Fatalf("expected trigger factories disabled without callback broker, got %#v", factories)
+	}
+}
+
+func TestTriggerFactoryDefersCreateUntilConfigure(t *testing.T) {
+	client := &adapterTestPluginServiceClient{
+		manifest:     &pb.Manifest{Name: "trigger-plugin"},
+		registry:     &pb.ContractRegistry{},
+		triggerTypes: []string{"trigger.test"},
+	}
+	adapter, err := NewExternalPluginAdapter("trigger-plugin", &PluginClient{
+		client:           client,
+		callbackBrokerID: 42,
+	})
+	if err != nil {
+		t.Fatalf("NewExternalPluginAdapter: %v", err)
+	}
+
+	factories := adapter.TriggerFactories()
+	factory := factories["trigger.test"]
+	if factory == nil {
+		t.Fatal("expected trigger.test factory")
+	}
+	instance := factory()
+	trigger, ok := instance.(*RemoteTrigger)
+	if !ok {
+		t.Fatalf("expected *RemoteTrigger, got %T", instance)
+	}
+	if client.lastCreateTriggerReq != nil {
+		t.Fatal("trigger factory should not create remote trigger before Configure")
+	}
+
+	err = trigger.Configure(nil, map[string]any{"pool": "private"})
+	if err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+	if client.lastCreateTriggerReq == nil {
+		t.Fatal("expected CreateTrigger request during Configure")
+	}
+	if client.lastCreateTriggerReq.Config.AsMap()["pool"] != "private" {
+		t.Fatalf("expected trigger config to be forwarded, got %#v", client.lastCreateTriggerReq.Config.AsMap())
+	}
+}
+
 // errorOnCreateModuleClient overrides CreateModule to return a plugin-reported
 // error in the response Error field (not as a gRPC error).
 type errorOnCreateModuleClient struct {
@@ -222,6 +340,14 @@ type errorOnCreateModuleClient struct {
 func (c *errorOnCreateModuleClient) CreateModule(_ context.Context, req *pb.CreateModuleRequest, _ ...grpc.CallOption) (*pb.HandleResponse, error) {
 	c.lastCreateModReq = req
 	return &pb.HandleResponse{Error: c.createModuleError}, nil
+}
+
+type unimplementedConfigureCallbackClient struct {
+	adapterTestPluginServiceClient
+}
+
+func (c *unimplementedConfigureCallbackClient) ConfigureCallback(context.Context, *pb.ConfigureCallbackRequest, ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ConfigureCallback not implemented")
 }
 
 // TestModuleFactoriesPropagatesPluginError is a regression gate for the class

--- a/plugin/external/manager.go
+++ b/plugin/external/manager.go
@@ -21,6 +21,8 @@ type ExternalPluginManager struct {
 
 	mu      sync.RWMutex
 	clients map[string]*goplugin.Client
+
+	callbackServer *CallbackServer
 }
 
 // NewExternalPluginManager creates a new manager that scans the given directory for plugins.
@@ -33,6 +35,14 @@ func NewExternalPluginManager(pluginsDir string, logger *log.Logger) *ExternalPl
 		logger:     logger,
 		clients:    make(map[string]*goplugin.Client),
 	}
+}
+
+// SetCallbackServer configures the host callback server used by plugins that
+// expose triggers or host callback features.
+func (m *ExternalPluginManager) SetCallbackServer(server *CallbackServer) {
+	m.mu.Lock()
+	m.callbackServer = server
+	m.mu.Unlock()
 }
 
 // DiscoverPlugins scans the plugins directory for subdirectories that contain
@@ -131,7 +141,7 @@ func (m *ExternalPluginManager) LoadPlugin(name string) (*ExternalPluginAdapter,
 
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  Handshake,
-		Plugins:          goplugin.PluginSet{"plugin": &GRPCPlugin{}},
+		Plugins:          goplugin.PluginSet{"plugin": &GRPCPlugin{CallbackServer: m.callbackServer}},
 		Cmd:              cmd,
 		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
 	})

--- a/plugin/external/manager_test.go
+++ b/plugin/external/manager_test.go
@@ -1,0 +1,17 @@
+package external
+
+import (
+	"log"
+	"testing"
+)
+
+func TestExternalPluginManagerStoresCallbackServer(t *testing.T) {
+	manager := NewExternalPluginManager(t.TempDir(), log.Default())
+	callback := NewCallbackServer(nil, nil, log.Default())
+
+	manager.SetCallbackServer(callback)
+
+	if manager.callbackServer != callback {
+		t.Fatal("expected manager to retain callback server for plugin load")
+	}
+}

--- a/plugin/external/proto/plugin.pb.go
+++ b/plugin/external/proto/plugin.pb.go
@@ -964,6 +964,112 @@ func (x *CreateStepRequest) GetTypedConfig() *anypb.Any {
 	return nil
 }
 
+// CreateTriggerRequest asks the plugin to instantiate a trigger.
+type CreateTriggerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Config        *structpb.Struct       `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateTriggerRequest) Reset() {
+	*x = CreateTriggerRequest{}
+	mi := &file_plugin_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateTriggerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateTriggerRequest) ProtoMessage() {}
+
+func (x *CreateTriggerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateTriggerRequest.ProtoReflect.Descriptor instead.
+func (*CreateTriggerRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *CreateTriggerRequest) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *CreateTriggerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateTriggerRequest) GetConfig() *structpb.Struct {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+// ConfigureCallbackRequest carries the go-plugin broker ID for callbacks.
+type ConfigureCallbackRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	BrokerId      uint32                 `protobuf:"varint,1,opt,name=broker_id,json=brokerId,proto3" json:"broker_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigureCallbackRequest) Reset() {
+	*x = ConfigureCallbackRequest{}
+	mi := &file_plugin_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureCallbackRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureCallbackRequest) ProtoMessage() {}
+
+func (x *ConfigureCallbackRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureCallbackRequest.ProtoReflect.Descriptor instead.
+func (*ConfigureCallbackRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ConfigureCallbackRequest) GetBrokerId() uint32 {
+	if x != nil {
+		return x.BrokerId
+	}
+	return 0
+}
+
 // HandleResponse returns a handle ID for a created resource.
 type HandleResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -975,7 +1081,7 @@ type HandleResponse struct {
 
 func (x *HandleResponse) Reset() {
 	*x = HandleResponse{}
-	mi := &file_plugin_proto_msgTypes[12]
+	mi := &file_plugin_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -987,7 +1093,7 @@ func (x *HandleResponse) String() string {
 func (*HandleResponse) ProtoMessage() {}
 
 func (x *HandleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[12]
+	mi := &file_plugin_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1000,7 +1106,7 @@ func (x *HandleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HandleResponse.ProtoReflect.Descriptor instead.
 func (*HandleResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{12}
+	return file_plugin_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *HandleResponse) GetHandleId() string {
@@ -1027,7 +1133,7 @@ type HandleRequest struct {
 
 func (x *HandleRequest) Reset() {
 	*x = HandleRequest{}
-	mi := &file_plugin_proto_msgTypes[13]
+	mi := &file_plugin_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1039,7 +1145,7 @@ func (x *HandleRequest) String() string {
 func (*HandleRequest) ProtoMessage() {}
 
 func (x *HandleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[13]
+	mi := &file_plugin_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1052,7 +1158,7 @@ func (x *HandleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HandleRequest.ProtoReflect.Descriptor instead.
 func (*HandleRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{13}
+	return file_plugin_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *HandleRequest) GetHandleId() string {
@@ -1072,7 +1178,7 @@ type ErrorResponse struct {
 
 func (x *ErrorResponse) Reset() {
 	*x = ErrorResponse{}
-	mi := &file_plugin_proto_msgTypes[14]
+	mi := &file_plugin_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1084,7 +1190,7 @@ func (x *ErrorResponse) String() string {
 func (*ErrorResponse) ProtoMessage() {}
 
 func (x *ErrorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[14]
+	mi := &file_plugin_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1097,7 +1203,7 @@ func (x *ErrorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ErrorResponse.ProtoReflect.Descriptor instead.
 func (*ErrorResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{14}
+	return file_plugin_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ErrorResponse) GetError() string {
@@ -1127,7 +1233,7 @@ type ExecuteStepRequest struct {
 
 func (x *ExecuteStepRequest) Reset() {
 	*x = ExecuteStepRequest{}
-	mi := &file_plugin_proto_msgTypes[15]
+	mi := &file_plugin_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1139,7 +1245,7 @@ func (x *ExecuteStepRequest) String() string {
 func (*ExecuteStepRequest) ProtoMessage() {}
 
 func (x *ExecuteStepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[15]
+	mi := &file_plugin_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1152,7 +1258,7 @@ func (x *ExecuteStepRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteStepRequest.ProtoReflect.Descriptor instead.
 func (*ExecuteStepRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{15}
+	return file_plugin_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ExecuteStepRequest) GetHandleId() string {
@@ -1224,7 +1330,7 @@ type ExecuteStepResponse struct {
 
 func (x *ExecuteStepResponse) Reset() {
 	*x = ExecuteStepResponse{}
-	mi := &file_plugin_proto_msgTypes[16]
+	mi := &file_plugin_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1236,7 +1342,7 @@ func (x *ExecuteStepResponse) String() string {
 func (*ExecuteStepResponse) ProtoMessage() {}
 
 func (x *ExecuteStepResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[16]
+	mi := &file_plugin_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1249,7 +1355,7 @@ func (x *ExecuteStepResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteStepResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteStepResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{16}
+	return file_plugin_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExecuteStepResponse) GetOutput() *structpb.Struct {
@@ -1293,7 +1399,7 @@ type InvokeServiceRequest struct {
 
 func (x *InvokeServiceRequest) Reset() {
 	*x = InvokeServiceRequest{}
-	mi := &file_plugin_proto_msgTypes[17]
+	mi := &file_plugin_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1305,7 +1411,7 @@ func (x *InvokeServiceRequest) String() string {
 func (*InvokeServiceRequest) ProtoMessage() {}
 
 func (x *InvokeServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[17]
+	mi := &file_plugin_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1318,7 +1424,7 @@ func (x *InvokeServiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvokeServiceRequest.ProtoReflect.Descriptor instead.
 func (*InvokeServiceRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{17}
+	return file_plugin_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *InvokeServiceRequest) GetHandleId() string {
@@ -1361,7 +1467,7 @@ type InvokeServiceResponse struct {
 
 func (x *InvokeServiceResponse) Reset() {
 	*x = InvokeServiceResponse{}
-	mi := &file_plugin_proto_msgTypes[18]
+	mi := &file_plugin_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1373,7 +1479,7 @@ func (x *InvokeServiceResponse) String() string {
 func (*InvokeServiceResponse) ProtoMessage() {}
 
 func (x *InvokeServiceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[18]
+	mi := &file_plugin_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1386,7 +1492,7 @@ func (x *InvokeServiceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvokeServiceResponse.ProtoReflect.Descriptor instead.
 func (*InvokeServiceResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{18}
+	return file_plugin_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *InvokeServiceResponse) GetResult() *structpb.Struct {
@@ -1423,7 +1529,7 @@ type TriggerWorkflowRequest struct {
 
 func (x *TriggerWorkflowRequest) Reset() {
 	*x = TriggerWorkflowRequest{}
-	mi := &file_plugin_proto_msgTypes[19]
+	mi := &file_plugin_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1435,7 +1541,7 @@ func (x *TriggerWorkflowRequest) String() string {
 func (*TriggerWorkflowRequest) ProtoMessage() {}
 
 func (x *TriggerWorkflowRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[19]
+	mi := &file_plugin_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1448,7 +1554,7 @@ func (x *TriggerWorkflowRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerWorkflowRequest.ProtoReflect.Descriptor instead.
 func (*TriggerWorkflowRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{19}
+	return file_plugin_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TriggerWorkflowRequest) GetTriggerType() string {
@@ -1489,7 +1595,7 @@ type GetServiceRequest struct {
 
 func (x *GetServiceRequest) Reset() {
 	*x = GetServiceRequest{}
-	mi := &file_plugin_proto_msgTypes[20]
+	mi := &file_plugin_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1501,7 +1607,7 @@ func (x *GetServiceRequest) String() string {
 func (*GetServiceRequest) ProtoMessage() {}
 
 func (x *GetServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[20]
+	mi := &file_plugin_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1514,7 +1620,7 @@ func (x *GetServiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServiceRequest.ProtoReflect.Descriptor instead.
 func (*GetServiceRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{20}
+	return file_plugin_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetServiceRequest) GetName() string {
@@ -1534,7 +1640,7 @@ type GetServiceResponse struct {
 
 func (x *GetServiceResponse) Reset() {
 	*x = GetServiceResponse{}
-	mi := &file_plugin_proto_msgTypes[21]
+	mi := &file_plugin_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1546,7 +1652,7 @@ func (x *GetServiceResponse) String() string {
 func (*GetServiceResponse) ProtoMessage() {}
 
 func (x *GetServiceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[21]
+	mi := &file_plugin_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1559,7 +1665,7 @@ func (x *GetServiceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServiceResponse.ProtoReflect.Descriptor instead.
 func (*GetServiceResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{21}
+	return file_plugin_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetServiceResponse) GetFound() bool {
@@ -1581,7 +1687,7 @@ type LogRequest struct {
 
 func (x *LogRequest) Reset() {
 	*x = LogRequest{}
-	mi := &file_plugin_proto_msgTypes[22]
+	mi := &file_plugin_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1593,7 +1699,7 @@ func (x *LogRequest) String() string {
 func (*LogRequest) ProtoMessage() {}
 
 func (x *LogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[22]
+	mi := &file_plugin_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1606,7 +1712,7 @@ func (x *LogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogRequest.ProtoReflect.Descriptor instead.
 func (*LogRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{22}
+	return file_plugin_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *LogRequest) GetLevel() string {
@@ -1643,7 +1749,7 @@ type PublishMessageRequest struct {
 
 func (x *PublishMessageRequest) Reset() {
 	*x = PublishMessageRequest{}
-	mi := &file_plugin_proto_msgTypes[23]
+	mi := &file_plugin_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1655,7 +1761,7 @@ func (x *PublishMessageRequest) String() string {
 func (*PublishMessageRequest) ProtoMessage() {}
 
 func (x *PublishMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[23]
+	mi := &file_plugin_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1668,7 +1774,7 @@ func (x *PublishMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishMessageRequest.ProtoReflect.Descriptor instead.
 func (*PublishMessageRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{23}
+	return file_plugin_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PublishMessageRequest) GetHandleId() string {
@@ -1710,7 +1816,7 @@ type PublishMessageResponse struct {
 
 func (x *PublishMessageResponse) Reset() {
 	*x = PublishMessageResponse{}
-	mi := &file_plugin_proto_msgTypes[24]
+	mi := &file_plugin_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1722,7 +1828,7 @@ func (x *PublishMessageResponse) String() string {
 func (*PublishMessageResponse) ProtoMessage() {}
 
 func (x *PublishMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[24]
+	mi := &file_plugin_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1735,7 +1841,7 @@ func (x *PublishMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishMessageResponse.ProtoReflect.Descriptor instead.
 func (*PublishMessageResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{24}
+	return file_plugin_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PublishMessageResponse) GetError() string {
@@ -1764,7 +1870,7 @@ type SubscribeRequest struct {
 
 func (x *SubscribeRequest) Reset() {
 	*x = SubscribeRequest{}
-	mi := &file_plugin_proto_msgTypes[25]
+	mi := &file_plugin_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1776,7 +1882,7 @@ func (x *SubscribeRequest) String() string {
 func (*SubscribeRequest) ProtoMessage() {}
 
 func (x *SubscribeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[25]
+	mi := &file_plugin_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1789,7 +1895,7 @@ func (x *SubscribeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{25}
+	return file_plugin_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SubscribeRequest) GetHandleId() string {
@@ -1824,7 +1930,7 @@ type UnsubscribeRequest struct {
 
 func (x *UnsubscribeRequest) Reset() {
 	*x = UnsubscribeRequest{}
-	mi := &file_plugin_proto_msgTypes[26]
+	mi := &file_plugin_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1836,7 +1942,7 @@ func (x *UnsubscribeRequest) String() string {
 func (*UnsubscribeRequest) ProtoMessage() {}
 
 func (x *UnsubscribeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[26]
+	mi := &file_plugin_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1849,7 +1955,7 @@ func (x *UnsubscribeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnsubscribeRequest.ProtoReflect.Descriptor instead.
 func (*UnsubscribeRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{26}
+	return file_plugin_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *UnsubscribeRequest) GetHandleId() string {
@@ -1880,7 +1986,7 @@ type DeliverMessageRequest struct {
 
 func (x *DeliverMessageRequest) Reset() {
 	*x = DeliverMessageRequest{}
-	mi := &file_plugin_proto_msgTypes[27]
+	mi := &file_plugin_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1892,7 +1998,7 @@ func (x *DeliverMessageRequest) String() string {
 func (*DeliverMessageRequest) ProtoMessage() {}
 
 func (x *DeliverMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[27]
+	mi := &file_plugin_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1905,7 +2011,7 @@ func (x *DeliverMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeliverMessageRequest.ProtoReflect.Descriptor instead.
 func (*DeliverMessageRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{27}
+	return file_plugin_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DeliverMessageRequest) GetHandleId() string {
@@ -1954,7 +2060,7 @@ type DeliverMessageResponse struct {
 
 func (x *DeliverMessageResponse) Reset() {
 	*x = DeliverMessageResponse{}
-	mi := &file_plugin_proto_msgTypes[28]
+	mi := &file_plugin_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1966,7 +2072,7 @@ func (x *DeliverMessageResponse) String() string {
 func (*DeliverMessageResponse) ProtoMessage() {}
 
 func (x *DeliverMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[28]
+	mi := &file_plugin_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1979,7 +2085,7 @@ func (x *DeliverMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeliverMessageResponse.ProtoReflect.Descriptor instead.
 func (*DeliverMessageResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{28}
+	return file_plugin_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DeliverMessageResponse) GetError() string {
@@ -2007,7 +2113,7 @@ type ConfigFragmentResponse struct {
 
 func (x *ConfigFragmentResponse) Reset() {
 	*x = ConfigFragmentResponse{}
-	mi := &file_plugin_proto_msgTypes[29]
+	mi := &file_plugin_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2019,7 +2125,7 @@ func (x *ConfigFragmentResponse) String() string {
 func (*ConfigFragmentResponse) ProtoMessage() {}
 
 func (x *ConfigFragmentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[29]
+	mi := &file_plugin_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2032,7 +2138,7 @@ func (x *ConfigFragmentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigFragmentResponse.ProtoReflect.Descriptor instead.
 func (*ConfigFragmentResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{29}
+	return file_plugin_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ConfigFragmentResponse) GetYamlConfig() []byte {
@@ -2115,7 +2221,13 @@ const file_plugin_proto_rawDesc = "" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12/\n" +
 	"\x06config\x18\x03 \x01(\v2\x17.google.protobuf.StructR\x06config\x127\n" +
-	"\ftyped_config\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\vtypedConfig\"C\n" +
+	"\ftyped_config\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\vtypedConfig\"o\n" +
+	"\x14CreateTriggerRequest\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12/\n" +
+	"\x06config\x18\x03 \x01(\v2\x17.google.protobuf.StructR\x06config\"7\n" +
+	"\x18ConfigureCallbackRequest\x12\x1b\n" +
+	"\tbroker_id\x18\x01 \x01(\rR\bbrokerId\"C\n" +
 	"\x0eHandleResponse\x12\x1b\n" +
 	"\thandle_id\x18\x01 \x01(\tR\bhandleId\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\",\n" +
@@ -2214,7 +2326,7 @@ const file_plugin_proto_rawDesc = "" +
 	"\x19CONTRACT_MODE_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bCONTRACT_MODE_LEGACY_STRUCT\x10\x01\x12*\n" +
 	"&CONTRACT_MODE_PROTO_WITH_LEGACY_STRUCT\x10\x02\x12\x1e\n" +
-	"\x1aCONTRACT_MODE_STRICT_PROTO\x10\x032\x90\f\n" +
+	"\x1aCONTRACT_MODE_STRICT_PROTO\x10\x032\xd5\r\n" +
 	"\rPluginService\x12C\n" +
 	"\vGetManifest\x12\x16.google.protobuf.Empty\x1a\x1c.workflow.plugin.v1.Manifest\x12F\n" +
 	"\x0eGetModuleTypes\x12\x16.google.protobuf.Empty\x1a\x1c.workflow.plugin.v1.TypeList\x12D\n" +
@@ -2236,7 +2348,9 @@ const file_plugin_proto_rawDesc = "" +
 	"\rInvokeService\x12(.workflow.plugin.v1.InvokeServiceRequest\x1a).workflow.plugin.v1.InvokeServiceResponse\x12g\n" +
 	"\x0eDeliverMessage\x12).workflow.plugin.v1.DeliverMessageRequest\x1a*.workflow.plugin.v1.DeliverMessageResponse\x12W\n" +
 	"\x11GetConfigFragment\x12\x16.google.protobuf.Empty\x1a*.workflow.plugin.v1.ConfigFragmentResponse\x12U\n" +
-	"\bGetAsset\x12#.workflow.plugin.v1.GetAssetRequest\x1a$.workflow.plugin.v1.GetAssetResponse2\xae\x04\n" +
+	"\bGetAsset\x12#.workflow.plugin.v1.GetAssetRequest\x1a$.workflow.plugin.v1.GetAssetResponse\x12d\n" +
+	"\x11ConfigureCallback\x12,.workflow.plugin.v1.ConfigureCallbackRequest\x1a!.workflow.plugin.v1.ErrorResponse\x12]\n" +
+	"\rCreateTrigger\x12(.workflow.plugin.v1.CreateTriggerRequest\x1a\".workflow.plugin.v1.HandleResponse2\xae\x04\n" +
 	"\x15EngineCallbackService\x12`\n" +
 	"\x0fTriggerWorkflow\x12*.workflow.plugin.v1.TriggerWorkflowRequest\x1a!.workflow.plugin.v1.ErrorResponse\x12[\n" +
 	"\n" +
@@ -2259,7 +2373,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_plugin_proto_goTypes = []any{
 	(ContractKind)(0),                      // 0: workflow.plugin.v1.ContractKind
 	(ContractMode)(0),                      // 1: workflow.plugin.v1.ContractMode
@@ -2275,117 +2389,124 @@ var file_plugin_proto_goTypes = []any{
 	(*ConfigFieldDef)(nil),                 // 11: workflow.plugin.v1.ConfigFieldDef
 	(*CreateModuleRequest)(nil),            // 12: workflow.plugin.v1.CreateModuleRequest
 	(*CreateStepRequest)(nil),              // 13: workflow.plugin.v1.CreateStepRequest
-	(*HandleResponse)(nil),                 // 14: workflow.plugin.v1.HandleResponse
-	(*HandleRequest)(nil),                  // 15: workflow.plugin.v1.HandleRequest
-	(*ErrorResponse)(nil),                  // 16: workflow.plugin.v1.ErrorResponse
-	(*ExecuteStepRequest)(nil),             // 17: workflow.plugin.v1.ExecuteStepRequest
-	(*ExecuteStepResponse)(nil),            // 18: workflow.plugin.v1.ExecuteStepResponse
-	(*InvokeServiceRequest)(nil),           // 19: workflow.plugin.v1.InvokeServiceRequest
-	(*InvokeServiceResponse)(nil),          // 20: workflow.plugin.v1.InvokeServiceResponse
-	(*TriggerWorkflowRequest)(nil),         // 21: workflow.plugin.v1.TriggerWorkflowRequest
-	(*GetServiceRequest)(nil),              // 22: workflow.plugin.v1.GetServiceRequest
-	(*GetServiceResponse)(nil),             // 23: workflow.plugin.v1.GetServiceResponse
-	(*LogRequest)(nil),                     // 24: workflow.plugin.v1.LogRequest
-	(*PublishMessageRequest)(nil),          // 25: workflow.plugin.v1.PublishMessageRequest
-	(*PublishMessageResponse)(nil),         // 26: workflow.plugin.v1.PublishMessageResponse
-	(*SubscribeRequest)(nil),               // 27: workflow.plugin.v1.SubscribeRequest
-	(*UnsubscribeRequest)(nil),             // 28: workflow.plugin.v1.UnsubscribeRequest
-	(*DeliverMessageRequest)(nil),          // 29: workflow.plugin.v1.DeliverMessageRequest
-	(*DeliverMessageResponse)(nil),         // 30: workflow.plugin.v1.DeliverMessageResponse
-	(*ConfigFragmentResponse)(nil),         // 31: workflow.plugin.v1.ConfigFragmentResponse
-	nil,                                    // 32: workflow.plugin.v1.ExecuteStepRequest.StepOutputsEntry
-	nil,                                    // 33: workflow.plugin.v1.PublishMessageRequest.MetadataEntry
-	nil,                                    // 34: workflow.plugin.v1.DeliverMessageRequest.MetadataEntry
-	(*descriptorpb.FileDescriptorSet)(nil), // 35: google.protobuf.FileDescriptorSet
-	(*structpb.Struct)(nil),                // 36: google.protobuf.Struct
-	(*anypb.Any)(nil),                      // 37: google.protobuf.Any
-	(*emptypb.Empty)(nil),                  // 38: google.protobuf.Empty
+	(*CreateTriggerRequest)(nil),           // 14: workflow.plugin.v1.CreateTriggerRequest
+	(*ConfigureCallbackRequest)(nil),       // 15: workflow.plugin.v1.ConfigureCallbackRequest
+	(*HandleResponse)(nil),                 // 16: workflow.plugin.v1.HandleResponse
+	(*HandleRequest)(nil),                  // 17: workflow.plugin.v1.HandleRequest
+	(*ErrorResponse)(nil),                  // 18: workflow.plugin.v1.ErrorResponse
+	(*ExecuteStepRequest)(nil),             // 19: workflow.plugin.v1.ExecuteStepRequest
+	(*ExecuteStepResponse)(nil),            // 20: workflow.plugin.v1.ExecuteStepResponse
+	(*InvokeServiceRequest)(nil),           // 21: workflow.plugin.v1.InvokeServiceRequest
+	(*InvokeServiceResponse)(nil),          // 22: workflow.plugin.v1.InvokeServiceResponse
+	(*TriggerWorkflowRequest)(nil),         // 23: workflow.plugin.v1.TriggerWorkflowRequest
+	(*GetServiceRequest)(nil),              // 24: workflow.plugin.v1.GetServiceRequest
+	(*GetServiceResponse)(nil),             // 25: workflow.plugin.v1.GetServiceResponse
+	(*LogRequest)(nil),                     // 26: workflow.plugin.v1.LogRequest
+	(*PublishMessageRequest)(nil),          // 27: workflow.plugin.v1.PublishMessageRequest
+	(*PublishMessageResponse)(nil),         // 28: workflow.plugin.v1.PublishMessageResponse
+	(*SubscribeRequest)(nil),               // 29: workflow.plugin.v1.SubscribeRequest
+	(*UnsubscribeRequest)(nil),             // 30: workflow.plugin.v1.UnsubscribeRequest
+	(*DeliverMessageRequest)(nil),          // 31: workflow.plugin.v1.DeliverMessageRequest
+	(*DeliverMessageResponse)(nil),         // 32: workflow.plugin.v1.DeliverMessageResponse
+	(*ConfigFragmentResponse)(nil),         // 33: workflow.plugin.v1.ConfigFragmentResponse
+	nil,                                    // 34: workflow.plugin.v1.ExecuteStepRequest.StepOutputsEntry
+	nil,                                    // 35: workflow.plugin.v1.PublishMessageRequest.MetadataEntry
+	nil,                                    // 36: workflow.plugin.v1.DeliverMessageRequest.MetadataEntry
+	(*descriptorpb.FileDescriptorSet)(nil), // 37: google.protobuf.FileDescriptorSet
+	(*structpb.Struct)(nil),                // 38: google.protobuf.Struct
+	(*anypb.Any)(nil),                      // 39: google.protobuf.Any
+	(*emptypb.Empty)(nil),                  // 40: google.protobuf.Empty
 }
 var file_plugin_proto_depIdxs = []int32{
 	4,  // 0: workflow.plugin.v1.ContractRegistry.contracts:type_name -> workflow.plugin.v1.ContractDescriptor
-	35, // 1: workflow.plugin.v1.ContractRegistry.file_descriptor_set:type_name -> google.protobuf.FileDescriptorSet
+	37, // 1: workflow.plugin.v1.ContractRegistry.file_descriptor_set:type_name -> google.protobuf.FileDescriptorSet
 	0,  // 2: workflow.plugin.v1.ContractDescriptor.kind:type_name -> workflow.plugin.v1.ContractKind
 	1,  // 3: workflow.plugin.v1.ContractDescriptor.mode:type_name -> workflow.plugin.v1.ContractMode
 	9,  // 4: workflow.plugin.v1.ModuleSchemaList.schemas:type_name -> workflow.plugin.v1.ModuleSchema
 	10, // 5: workflow.plugin.v1.ModuleSchema.inputs:type_name -> workflow.plugin.v1.ServiceIODef
 	10, // 6: workflow.plugin.v1.ModuleSchema.outputs:type_name -> workflow.plugin.v1.ServiceIODef
 	11, // 7: workflow.plugin.v1.ModuleSchema.config_fields:type_name -> workflow.plugin.v1.ConfigFieldDef
-	36, // 8: workflow.plugin.v1.CreateModuleRequest.config:type_name -> google.protobuf.Struct
-	37, // 9: workflow.plugin.v1.CreateModuleRequest.typed_config:type_name -> google.protobuf.Any
-	36, // 10: workflow.plugin.v1.CreateStepRequest.config:type_name -> google.protobuf.Struct
-	37, // 11: workflow.plugin.v1.CreateStepRequest.typed_config:type_name -> google.protobuf.Any
-	36, // 12: workflow.plugin.v1.ExecuteStepRequest.trigger_data:type_name -> google.protobuf.Struct
-	32, // 13: workflow.plugin.v1.ExecuteStepRequest.step_outputs:type_name -> workflow.plugin.v1.ExecuteStepRequest.StepOutputsEntry
-	36, // 14: workflow.plugin.v1.ExecuteStepRequest.current:type_name -> google.protobuf.Struct
-	36, // 15: workflow.plugin.v1.ExecuteStepRequest.metadata:type_name -> google.protobuf.Struct
-	36, // 16: workflow.plugin.v1.ExecuteStepRequest.config:type_name -> google.protobuf.Struct
-	37, // 17: workflow.plugin.v1.ExecuteStepRequest.typed_config:type_name -> google.protobuf.Any
-	37, // 18: workflow.plugin.v1.ExecuteStepRequest.typed_input:type_name -> google.protobuf.Any
-	36, // 19: workflow.plugin.v1.ExecuteStepResponse.output:type_name -> google.protobuf.Struct
-	37, // 20: workflow.plugin.v1.ExecuteStepResponse.typed_output:type_name -> google.protobuf.Any
-	36, // 21: workflow.plugin.v1.InvokeServiceRequest.args:type_name -> google.protobuf.Struct
-	37, // 22: workflow.plugin.v1.InvokeServiceRequest.typed_input:type_name -> google.protobuf.Any
-	36, // 23: workflow.plugin.v1.InvokeServiceResponse.result:type_name -> google.protobuf.Struct
-	37, // 24: workflow.plugin.v1.InvokeServiceResponse.typed_output:type_name -> google.protobuf.Any
-	36, // 25: workflow.plugin.v1.TriggerWorkflowRequest.data:type_name -> google.protobuf.Struct
-	37, // 26: workflow.plugin.v1.TriggerWorkflowRequest.typed_data:type_name -> google.protobuf.Any
-	36, // 27: workflow.plugin.v1.LogRequest.fields:type_name -> google.protobuf.Struct
-	33, // 28: workflow.plugin.v1.PublishMessageRequest.metadata:type_name -> workflow.plugin.v1.PublishMessageRequest.MetadataEntry
-	34, // 29: workflow.plugin.v1.DeliverMessageRequest.metadata:type_name -> workflow.plugin.v1.DeliverMessageRequest.MetadataEntry
-	36, // 30: workflow.plugin.v1.ExecuteStepRequest.StepOutputsEntry.value:type_name -> google.protobuf.Struct
-	38, // 31: workflow.plugin.v1.PluginService.GetManifest:input_type -> google.protobuf.Empty
-	38, // 32: workflow.plugin.v1.PluginService.GetModuleTypes:input_type -> google.protobuf.Empty
-	38, // 33: workflow.plugin.v1.PluginService.GetStepTypes:input_type -> google.protobuf.Empty
-	38, // 34: workflow.plugin.v1.PluginService.GetTriggerTypes:input_type -> google.protobuf.Empty
-	38, // 35: workflow.plugin.v1.PluginService.GetModuleSchemas:input_type -> google.protobuf.Empty
-	38, // 36: workflow.plugin.v1.PluginService.GetContractRegistry:input_type -> google.protobuf.Empty
-	12, // 37: workflow.plugin.v1.PluginService.CreateModule:input_type -> workflow.plugin.v1.CreateModuleRequest
-	15, // 38: workflow.plugin.v1.PluginService.InitModule:input_type -> workflow.plugin.v1.HandleRequest
-	15, // 39: workflow.plugin.v1.PluginService.StartModule:input_type -> workflow.plugin.v1.HandleRequest
-	15, // 40: workflow.plugin.v1.PluginService.StopModule:input_type -> workflow.plugin.v1.HandleRequest
-	15, // 41: workflow.plugin.v1.PluginService.DestroyModule:input_type -> workflow.plugin.v1.HandleRequest
-	13, // 42: workflow.plugin.v1.PluginService.CreateStep:input_type -> workflow.plugin.v1.CreateStepRequest
-	17, // 43: workflow.plugin.v1.PluginService.ExecuteStep:input_type -> workflow.plugin.v1.ExecuteStepRequest
-	15, // 44: workflow.plugin.v1.PluginService.DestroyStep:input_type -> workflow.plugin.v1.HandleRequest
-	19, // 45: workflow.plugin.v1.PluginService.InvokeService:input_type -> workflow.plugin.v1.InvokeServiceRequest
-	29, // 46: workflow.plugin.v1.PluginService.DeliverMessage:input_type -> workflow.plugin.v1.DeliverMessageRequest
-	38, // 47: workflow.plugin.v1.PluginService.GetConfigFragment:input_type -> google.protobuf.Empty
-	5,  // 48: workflow.plugin.v1.PluginService.GetAsset:input_type -> workflow.plugin.v1.GetAssetRequest
-	21, // 49: workflow.plugin.v1.EngineCallbackService.TriggerWorkflow:input_type -> workflow.plugin.v1.TriggerWorkflowRequest
-	22, // 50: workflow.plugin.v1.EngineCallbackService.GetService:input_type -> workflow.plugin.v1.GetServiceRequest
-	24, // 51: workflow.plugin.v1.EngineCallbackService.Log:input_type -> workflow.plugin.v1.LogRequest
-	25, // 52: workflow.plugin.v1.EngineCallbackService.PublishMessage:input_type -> workflow.plugin.v1.PublishMessageRequest
-	27, // 53: workflow.plugin.v1.EngineCallbackService.Subscribe:input_type -> workflow.plugin.v1.SubscribeRequest
-	28, // 54: workflow.plugin.v1.EngineCallbackService.Unsubscribe:input_type -> workflow.plugin.v1.UnsubscribeRequest
-	2,  // 55: workflow.plugin.v1.PluginService.GetManifest:output_type -> workflow.plugin.v1.Manifest
-	7,  // 56: workflow.plugin.v1.PluginService.GetModuleTypes:output_type -> workflow.plugin.v1.TypeList
-	7,  // 57: workflow.plugin.v1.PluginService.GetStepTypes:output_type -> workflow.plugin.v1.TypeList
-	7,  // 58: workflow.plugin.v1.PluginService.GetTriggerTypes:output_type -> workflow.plugin.v1.TypeList
-	8,  // 59: workflow.plugin.v1.PluginService.GetModuleSchemas:output_type -> workflow.plugin.v1.ModuleSchemaList
-	3,  // 60: workflow.plugin.v1.PluginService.GetContractRegistry:output_type -> workflow.plugin.v1.ContractRegistry
-	14, // 61: workflow.plugin.v1.PluginService.CreateModule:output_type -> workflow.plugin.v1.HandleResponse
-	16, // 62: workflow.plugin.v1.PluginService.InitModule:output_type -> workflow.plugin.v1.ErrorResponse
-	16, // 63: workflow.plugin.v1.PluginService.StartModule:output_type -> workflow.plugin.v1.ErrorResponse
-	16, // 64: workflow.plugin.v1.PluginService.StopModule:output_type -> workflow.plugin.v1.ErrorResponse
-	16, // 65: workflow.plugin.v1.PluginService.DestroyModule:output_type -> workflow.plugin.v1.ErrorResponse
-	14, // 66: workflow.plugin.v1.PluginService.CreateStep:output_type -> workflow.plugin.v1.HandleResponse
-	18, // 67: workflow.plugin.v1.PluginService.ExecuteStep:output_type -> workflow.plugin.v1.ExecuteStepResponse
-	16, // 68: workflow.plugin.v1.PluginService.DestroyStep:output_type -> workflow.plugin.v1.ErrorResponse
-	20, // 69: workflow.plugin.v1.PluginService.InvokeService:output_type -> workflow.plugin.v1.InvokeServiceResponse
-	30, // 70: workflow.plugin.v1.PluginService.DeliverMessage:output_type -> workflow.plugin.v1.DeliverMessageResponse
-	31, // 71: workflow.plugin.v1.PluginService.GetConfigFragment:output_type -> workflow.plugin.v1.ConfigFragmentResponse
-	6,  // 72: workflow.plugin.v1.PluginService.GetAsset:output_type -> workflow.plugin.v1.GetAssetResponse
-	16, // 73: workflow.plugin.v1.EngineCallbackService.TriggerWorkflow:output_type -> workflow.plugin.v1.ErrorResponse
-	23, // 74: workflow.plugin.v1.EngineCallbackService.GetService:output_type -> workflow.plugin.v1.GetServiceResponse
-	38, // 75: workflow.plugin.v1.EngineCallbackService.Log:output_type -> google.protobuf.Empty
-	26, // 76: workflow.plugin.v1.EngineCallbackService.PublishMessage:output_type -> workflow.plugin.v1.PublishMessageResponse
-	16, // 77: workflow.plugin.v1.EngineCallbackService.Subscribe:output_type -> workflow.plugin.v1.ErrorResponse
-	16, // 78: workflow.plugin.v1.EngineCallbackService.Unsubscribe:output_type -> workflow.plugin.v1.ErrorResponse
-	55, // [55:79] is the sub-list for method output_type
-	31, // [31:55] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	38, // 8: workflow.plugin.v1.CreateModuleRequest.config:type_name -> google.protobuf.Struct
+	39, // 9: workflow.plugin.v1.CreateModuleRequest.typed_config:type_name -> google.protobuf.Any
+	38, // 10: workflow.plugin.v1.CreateStepRequest.config:type_name -> google.protobuf.Struct
+	39, // 11: workflow.plugin.v1.CreateStepRequest.typed_config:type_name -> google.protobuf.Any
+	38, // 12: workflow.plugin.v1.CreateTriggerRequest.config:type_name -> google.protobuf.Struct
+	38, // 13: workflow.plugin.v1.ExecuteStepRequest.trigger_data:type_name -> google.protobuf.Struct
+	34, // 14: workflow.plugin.v1.ExecuteStepRequest.step_outputs:type_name -> workflow.plugin.v1.ExecuteStepRequest.StepOutputsEntry
+	38, // 15: workflow.plugin.v1.ExecuteStepRequest.current:type_name -> google.protobuf.Struct
+	38, // 16: workflow.plugin.v1.ExecuteStepRequest.metadata:type_name -> google.protobuf.Struct
+	38, // 17: workflow.plugin.v1.ExecuteStepRequest.config:type_name -> google.protobuf.Struct
+	39, // 18: workflow.plugin.v1.ExecuteStepRequest.typed_config:type_name -> google.protobuf.Any
+	39, // 19: workflow.plugin.v1.ExecuteStepRequest.typed_input:type_name -> google.protobuf.Any
+	38, // 20: workflow.plugin.v1.ExecuteStepResponse.output:type_name -> google.protobuf.Struct
+	39, // 21: workflow.plugin.v1.ExecuteStepResponse.typed_output:type_name -> google.protobuf.Any
+	38, // 22: workflow.plugin.v1.InvokeServiceRequest.args:type_name -> google.protobuf.Struct
+	39, // 23: workflow.plugin.v1.InvokeServiceRequest.typed_input:type_name -> google.protobuf.Any
+	38, // 24: workflow.plugin.v1.InvokeServiceResponse.result:type_name -> google.protobuf.Struct
+	39, // 25: workflow.plugin.v1.InvokeServiceResponse.typed_output:type_name -> google.protobuf.Any
+	38, // 26: workflow.plugin.v1.TriggerWorkflowRequest.data:type_name -> google.protobuf.Struct
+	39, // 27: workflow.plugin.v1.TriggerWorkflowRequest.typed_data:type_name -> google.protobuf.Any
+	38, // 28: workflow.plugin.v1.LogRequest.fields:type_name -> google.protobuf.Struct
+	35, // 29: workflow.plugin.v1.PublishMessageRequest.metadata:type_name -> workflow.plugin.v1.PublishMessageRequest.MetadataEntry
+	36, // 30: workflow.plugin.v1.DeliverMessageRequest.metadata:type_name -> workflow.plugin.v1.DeliverMessageRequest.MetadataEntry
+	38, // 31: workflow.plugin.v1.ExecuteStepRequest.StepOutputsEntry.value:type_name -> google.protobuf.Struct
+	40, // 32: workflow.plugin.v1.PluginService.GetManifest:input_type -> google.protobuf.Empty
+	40, // 33: workflow.plugin.v1.PluginService.GetModuleTypes:input_type -> google.protobuf.Empty
+	40, // 34: workflow.plugin.v1.PluginService.GetStepTypes:input_type -> google.protobuf.Empty
+	40, // 35: workflow.plugin.v1.PluginService.GetTriggerTypes:input_type -> google.protobuf.Empty
+	40, // 36: workflow.plugin.v1.PluginService.GetModuleSchemas:input_type -> google.protobuf.Empty
+	40, // 37: workflow.plugin.v1.PluginService.GetContractRegistry:input_type -> google.protobuf.Empty
+	12, // 38: workflow.plugin.v1.PluginService.CreateModule:input_type -> workflow.plugin.v1.CreateModuleRequest
+	17, // 39: workflow.plugin.v1.PluginService.InitModule:input_type -> workflow.plugin.v1.HandleRequest
+	17, // 40: workflow.plugin.v1.PluginService.StartModule:input_type -> workflow.plugin.v1.HandleRequest
+	17, // 41: workflow.plugin.v1.PluginService.StopModule:input_type -> workflow.plugin.v1.HandleRequest
+	17, // 42: workflow.plugin.v1.PluginService.DestroyModule:input_type -> workflow.plugin.v1.HandleRequest
+	13, // 43: workflow.plugin.v1.PluginService.CreateStep:input_type -> workflow.plugin.v1.CreateStepRequest
+	19, // 44: workflow.plugin.v1.PluginService.ExecuteStep:input_type -> workflow.plugin.v1.ExecuteStepRequest
+	17, // 45: workflow.plugin.v1.PluginService.DestroyStep:input_type -> workflow.plugin.v1.HandleRequest
+	21, // 46: workflow.plugin.v1.PluginService.InvokeService:input_type -> workflow.plugin.v1.InvokeServiceRequest
+	31, // 47: workflow.plugin.v1.PluginService.DeliverMessage:input_type -> workflow.plugin.v1.DeliverMessageRequest
+	40, // 48: workflow.plugin.v1.PluginService.GetConfigFragment:input_type -> google.protobuf.Empty
+	5,  // 49: workflow.plugin.v1.PluginService.GetAsset:input_type -> workflow.plugin.v1.GetAssetRequest
+	15, // 50: workflow.plugin.v1.PluginService.ConfigureCallback:input_type -> workflow.plugin.v1.ConfigureCallbackRequest
+	14, // 51: workflow.plugin.v1.PluginService.CreateTrigger:input_type -> workflow.plugin.v1.CreateTriggerRequest
+	23, // 52: workflow.plugin.v1.EngineCallbackService.TriggerWorkflow:input_type -> workflow.plugin.v1.TriggerWorkflowRequest
+	24, // 53: workflow.plugin.v1.EngineCallbackService.GetService:input_type -> workflow.plugin.v1.GetServiceRequest
+	26, // 54: workflow.plugin.v1.EngineCallbackService.Log:input_type -> workflow.plugin.v1.LogRequest
+	27, // 55: workflow.plugin.v1.EngineCallbackService.PublishMessage:input_type -> workflow.plugin.v1.PublishMessageRequest
+	29, // 56: workflow.plugin.v1.EngineCallbackService.Subscribe:input_type -> workflow.plugin.v1.SubscribeRequest
+	30, // 57: workflow.plugin.v1.EngineCallbackService.Unsubscribe:input_type -> workflow.plugin.v1.UnsubscribeRequest
+	2,  // 58: workflow.plugin.v1.PluginService.GetManifest:output_type -> workflow.plugin.v1.Manifest
+	7,  // 59: workflow.plugin.v1.PluginService.GetModuleTypes:output_type -> workflow.plugin.v1.TypeList
+	7,  // 60: workflow.plugin.v1.PluginService.GetStepTypes:output_type -> workflow.plugin.v1.TypeList
+	7,  // 61: workflow.plugin.v1.PluginService.GetTriggerTypes:output_type -> workflow.plugin.v1.TypeList
+	8,  // 62: workflow.plugin.v1.PluginService.GetModuleSchemas:output_type -> workflow.plugin.v1.ModuleSchemaList
+	3,  // 63: workflow.plugin.v1.PluginService.GetContractRegistry:output_type -> workflow.plugin.v1.ContractRegistry
+	16, // 64: workflow.plugin.v1.PluginService.CreateModule:output_type -> workflow.plugin.v1.HandleResponse
+	18, // 65: workflow.plugin.v1.PluginService.InitModule:output_type -> workflow.plugin.v1.ErrorResponse
+	18, // 66: workflow.plugin.v1.PluginService.StartModule:output_type -> workflow.plugin.v1.ErrorResponse
+	18, // 67: workflow.plugin.v1.PluginService.StopModule:output_type -> workflow.plugin.v1.ErrorResponse
+	18, // 68: workflow.plugin.v1.PluginService.DestroyModule:output_type -> workflow.plugin.v1.ErrorResponse
+	16, // 69: workflow.plugin.v1.PluginService.CreateStep:output_type -> workflow.plugin.v1.HandleResponse
+	20, // 70: workflow.plugin.v1.PluginService.ExecuteStep:output_type -> workflow.plugin.v1.ExecuteStepResponse
+	18, // 71: workflow.plugin.v1.PluginService.DestroyStep:output_type -> workflow.plugin.v1.ErrorResponse
+	22, // 72: workflow.plugin.v1.PluginService.InvokeService:output_type -> workflow.plugin.v1.InvokeServiceResponse
+	32, // 73: workflow.plugin.v1.PluginService.DeliverMessage:output_type -> workflow.plugin.v1.DeliverMessageResponse
+	33, // 74: workflow.plugin.v1.PluginService.GetConfigFragment:output_type -> workflow.plugin.v1.ConfigFragmentResponse
+	6,  // 75: workflow.plugin.v1.PluginService.GetAsset:output_type -> workflow.plugin.v1.GetAssetResponse
+	18, // 76: workflow.plugin.v1.PluginService.ConfigureCallback:output_type -> workflow.plugin.v1.ErrorResponse
+	16, // 77: workflow.plugin.v1.PluginService.CreateTrigger:output_type -> workflow.plugin.v1.HandleResponse
+	18, // 78: workflow.plugin.v1.EngineCallbackService.TriggerWorkflow:output_type -> workflow.plugin.v1.ErrorResponse
+	25, // 79: workflow.plugin.v1.EngineCallbackService.GetService:output_type -> workflow.plugin.v1.GetServiceResponse
+	40, // 80: workflow.plugin.v1.EngineCallbackService.Log:output_type -> google.protobuf.Empty
+	28, // 81: workflow.plugin.v1.EngineCallbackService.PublishMessage:output_type -> workflow.plugin.v1.PublishMessageResponse
+	18, // 82: workflow.plugin.v1.EngineCallbackService.Subscribe:output_type -> workflow.plugin.v1.ErrorResponse
+	18, // 83: workflow.plugin.v1.EngineCallbackService.Unsubscribe:output_type -> workflow.plugin.v1.ErrorResponse
+	58, // [58:84] is the sub-list for method output_type
+	32, // [32:58] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -2399,7 +2520,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   33,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/plugin/external/proto/plugin.proto
+++ b/plugin/external/proto/plugin.proto
@@ -64,6 +64,12 @@ service PluginService {
 
   // GetAsset returns the content of a static asset embedded in the plugin.
   rpc GetAsset(GetAssetRequest) returns (GetAssetResponse);
+
+  // ConfigureCallback tells the plugin how to reach the host callback service.
+  rpc ConfigureCallback(ConfigureCallbackRequest) returns (ErrorResponse);
+
+  // CreateTrigger instantiates a trigger of the given type.
+  rpc CreateTrigger(CreateTriggerRequest) returns (HandleResponse);
 }
 
 // EngineCallbackService is implemented by the host and called by the plugin.
@@ -200,6 +206,18 @@ message CreateStepRequest {
   string name = 2;
   google.protobuf.Struct config = 3;
   google.protobuf.Any typed_config = 4;
+}
+
+// CreateTriggerRequest asks the plugin to instantiate a trigger.
+message CreateTriggerRequest {
+  string type = 1;
+  string name = 2;
+  google.protobuf.Struct config = 3;
+}
+
+// ConfigureCallbackRequest carries the go-plugin broker ID for callbacks.
+message ConfigureCallbackRequest {
+  uint32 broker_id = 1;
 }
 
 // HandleResponse returns a handle ID for a created resource.

--- a/plugin/external/proto/plugin_grpc.pb.go
+++ b/plugin/external/proto/plugin_grpc.pb.go
@@ -38,6 +38,8 @@ const (
 	PluginService_DeliverMessage_FullMethodName      = "/workflow.plugin.v1.PluginService/DeliverMessage"
 	PluginService_GetConfigFragment_FullMethodName   = "/workflow.plugin.v1.PluginService/GetConfigFragment"
 	PluginService_GetAsset_FullMethodName            = "/workflow.plugin.v1.PluginService/GetAsset"
+	PluginService_ConfigureCallback_FullMethodName   = "/workflow.plugin.v1.PluginService/ConfigureCallback"
+	PluginService_CreateTrigger_FullMethodName       = "/workflow.plugin.v1.PluginService/CreateTrigger"
 )
 
 // PluginServiceClient is the client API for PluginService service.
@@ -82,6 +84,10 @@ type PluginServiceClient interface {
 	GetConfigFragment(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ConfigFragmentResponse, error)
 	// GetAsset returns the content of a static asset embedded in the plugin.
 	GetAsset(ctx context.Context, in *GetAssetRequest, opts ...grpc.CallOption) (*GetAssetResponse, error)
+	// ConfigureCallback tells the plugin how to reach the host callback service.
+	ConfigureCallback(ctx context.Context, in *ConfigureCallbackRequest, opts ...grpc.CallOption) (*ErrorResponse, error)
+	// CreateTrigger instantiates a trigger of the given type.
+	CreateTrigger(ctx context.Context, in *CreateTriggerRequest, opts ...grpc.CallOption) (*HandleResponse, error)
 }
 
 type pluginServiceClient struct {
@@ -272,6 +278,26 @@ func (c *pluginServiceClient) GetAsset(ctx context.Context, in *GetAssetRequest,
 	return out, nil
 }
 
+func (c *pluginServiceClient) ConfigureCallback(ctx context.Context, in *ConfigureCallbackRequest, opts ...grpc.CallOption) (*ErrorResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ErrorResponse)
+	err := c.cc.Invoke(ctx, PluginService_ConfigureCallback_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *pluginServiceClient) CreateTrigger(ctx context.Context, in *CreateTriggerRequest, opts ...grpc.CallOption) (*HandleResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(HandleResponse)
+	err := c.cc.Invoke(ctx, PluginService_CreateTrigger_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PluginServiceServer is the server API for PluginService service.
 // All implementations must embed UnimplementedPluginServiceServer
 // for forward compatibility.
@@ -314,6 +340,10 @@ type PluginServiceServer interface {
 	GetConfigFragment(context.Context, *emptypb.Empty) (*ConfigFragmentResponse, error)
 	// GetAsset returns the content of a static asset embedded in the plugin.
 	GetAsset(context.Context, *GetAssetRequest) (*GetAssetResponse, error)
+	// ConfigureCallback tells the plugin how to reach the host callback service.
+	ConfigureCallback(context.Context, *ConfigureCallbackRequest) (*ErrorResponse, error)
+	// CreateTrigger instantiates a trigger of the given type.
+	CreateTrigger(context.Context, *CreateTriggerRequest) (*HandleResponse, error)
 	mustEmbedUnimplementedPluginServiceServer()
 }
 
@@ -377,6 +407,12 @@ func (UnimplementedPluginServiceServer) GetConfigFragment(context.Context, *empt
 }
 func (UnimplementedPluginServiceServer) GetAsset(context.Context, *GetAssetRequest) (*GetAssetResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAsset not implemented")
+}
+func (UnimplementedPluginServiceServer) ConfigureCallback(context.Context, *ConfigureCallbackRequest) (*ErrorResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ConfigureCallback not implemented")
+}
+func (UnimplementedPluginServiceServer) CreateTrigger(context.Context, *CreateTriggerRequest) (*HandleResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateTrigger not implemented")
 }
 func (UnimplementedPluginServiceServer) mustEmbedUnimplementedPluginServiceServer() {}
 func (UnimplementedPluginServiceServer) testEmbeddedByValue()                       {}
@@ -723,6 +759,42 @@ func _PluginService_GetAsset_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginService_ConfigureCallback_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ConfigureCallbackRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginServiceServer).ConfigureCallback(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginService_ConfigureCallback_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginServiceServer).ConfigureCallback(ctx, req.(*ConfigureCallbackRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PluginService_CreateTrigger_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateTriggerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginServiceServer).CreateTrigger(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginService_CreateTrigger_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginServiceServer).CreateTrigger(ctx, req.(*CreateTriggerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PluginService_ServiceDesc is the grpc.ServiceDesc for PluginService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -801,6 +873,14 @@ var PluginService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetAsset",
 			Handler:    _PluginService_GetAsset_Handler,
+		},
+		{
+			MethodName: "ConfigureCallback",
+			Handler:    _PluginService_ConfigureCallback_Handler,
+		},
+		{
+			MethodName: "CreateTrigger",
+			Handler:    _PluginService_CreateTrigger_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/plugin/external/remote_step_test.go
+++ b/plugin/external/remote_step_test.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -31,9 +32,13 @@ type stubPluginServiceClient struct {
 	lastCreateTriggerReq *pb.CreateTriggerRequest
 	createTriggerResp    *pb.HandleResponse
 	createTriggerNilResp bool
+	createTriggerCalls   int
 	configureCallbackReq *pb.ConfigureCallbackRequest
 	initModuleCalls      int
 	startModuleCalls     int
+	stopModuleCalls      int
+	destroyModuleCalls   int
+	startErrorOnCall     int
 }
 
 // ExecuteStep records the request and returns the configured response.
@@ -73,12 +78,17 @@ func (c *stubPluginServiceClient) InitModule(_ context.Context, _ *pb.HandleRequ
 }
 func (c *stubPluginServiceClient) StartModule(_ context.Context, _ *pb.HandleRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
 	c.startModuleCalls++
+	if c.startErrorOnCall > 0 && c.startModuleCalls == c.startErrorOnCall {
+		return &pb.ErrorResponse{Error: "start failed"}, nil
+	}
 	return &pb.ErrorResponse{}, nil
 }
 func (c *stubPluginServiceClient) StopModule(_ context.Context, _ *pb.HandleRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	c.stopModuleCalls++
 	return &pb.ErrorResponse{}, nil
 }
 func (c *stubPluginServiceClient) DestroyModule(_ context.Context, _ *pb.HandleRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	c.destroyModuleCalls++
 	return &pb.ErrorResponse{}, nil
 }
 func (c *stubPluginServiceClient) CreateStep(_ context.Context, _ *pb.CreateStepRequest, _ ...grpc.CallOption) (*pb.HandleResponse, error) {
@@ -112,13 +122,14 @@ func (c *stubPluginServiceClient) ConfigureCallback(_ context.Context, req *pb.C
 }
 func (c *stubPluginServiceClient) CreateTrigger(_ context.Context, req *pb.CreateTriggerRequest, _ ...grpc.CallOption) (*pb.HandleResponse, error) {
 	c.lastCreateTriggerReq = req
+	c.createTriggerCalls++
 	if c.createTriggerNilResp {
 		return nil, nil
 	}
 	if c.createTriggerResp != nil {
 		return c.createTriggerResp, nil
 	}
-	return &pb.HandleResponse{HandleId: "trigger-handle"}, nil
+	return &pb.HandleResponse{HandleId: fmt.Sprintf("trigger-handle-%d", c.createTriggerCalls)}, nil
 }
 
 // TestRemoteStep_Execute_ResolvesTemplatesInConfig verifies that template

--- a/plugin/external/remote_step_test.go
+++ b/plugin/external/remote_step_test.go
@@ -27,6 +27,10 @@ type stubPluginServiceClient struct {
 	lastInvokeRequest *pb.InvokeServiceRequest
 	invokeResponse    *pb.InvokeServiceResponse
 	invokeErr         error
+
+	lastCreateTriggerReq *pb.CreateTriggerRequest
+	createTriggerResp    *pb.HandleResponse
+	configureCallbackReq *pb.ConfigureCallbackRequest
 }
 
 // ExecuteStep records the request and returns the configured response.
@@ -96,6 +100,17 @@ func (c *stubPluginServiceClient) GetConfigFragment(_ context.Context, _ *emptyp
 }
 func (c *stubPluginServiceClient) GetAsset(_ context.Context, _ *pb.GetAssetRequest, _ ...grpc.CallOption) (*pb.GetAssetResponse, error) {
 	return &pb.GetAssetResponse{}, nil
+}
+func (c *stubPluginServiceClient) ConfigureCallback(_ context.Context, req *pb.ConfigureCallbackRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	c.configureCallbackReq = req
+	return &pb.ErrorResponse{}, nil
+}
+func (c *stubPluginServiceClient) CreateTrigger(_ context.Context, req *pb.CreateTriggerRequest, _ ...grpc.CallOption) (*pb.HandleResponse, error) {
+	c.lastCreateTriggerReq = req
+	if c.createTriggerResp != nil {
+		return c.createTriggerResp, nil
+	}
+	return &pb.HandleResponse{HandleId: "trigger-handle"}, nil
 }
 
 // TestRemoteStep_Execute_ResolvesTemplatesInConfig verifies that template

--- a/plugin/external/remote_step_test.go
+++ b/plugin/external/remote_step_test.go
@@ -30,7 +30,10 @@ type stubPluginServiceClient struct {
 
 	lastCreateTriggerReq *pb.CreateTriggerRequest
 	createTriggerResp    *pb.HandleResponse
+	createTriggerNilResp bool
 	configureCallbackReq *pb.ConfigureCallbackRequest
+	initModuleCalls      int
+	startModuleCalls     int
 }
 
 // ExecuteStep records the request and returns the configured response.
@@ -65,9 +68,11 @@ func (c *stubPluginServiceClient) CreateModule(_ context.Context, _ *pb.CreateMo
 	return &pb.HandleResponse{}, nil
 }
 func (c *stubPluginServiceClient) InitModule(_ context.Context, _ *pb.HandleRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	c.initModuleCalls++
 	return &pb.ErrorResponse{}, nil
 }
 func (c *stubPluginServiceClient) StartModule(_ context.Context, _ *pb.HandleRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	c.startModuleCalls++
 	return &pb.ErrorResponse{}, nil
 }
 func (c *stubPluginServiceClient) StopModule(_ context.Context, _ *pb.HandleRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
@@ -107,6 +112,9 @@ func (c *stubPluginServiceClient) ConfigureCallback(_ context.Context, req *pb.C
 }
 func (c *stubPluginServiceClient) CreateTrigger(_ context.Context, req *pb.CreateTriggerRequest, _ ...grpc.CallOption) (*pb.HandleResponse, error) {
 	c.lastCreateTriggerReq = req
+	if c.createTriggerNilResp {
+		return nil, nil
+	}
 	if c.createTriggerResp != nil {
 		return c.createTriggerResp, nil
 	}

--- a/plugin/external/remote_trigger.go
+++ b/plugin/external/remote_trigger.go
@@ -2,32 +2,45 @@ package external
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/GoCodeAlone/modular"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	goproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
+
+const globalConfigureErrorKey = "\x00global"
 
 // RemoteTrigger implements module.Trigger by proxying to a plugin trigger type.
 // Trigger lifecycle (Start/Stop) is managed through the plugin's module RPCs,
 // treating trigger handles as module handles.
 type RemoteTrigger struct {
-	typeName     string
-	name         string
-	handleID     string
-	client       pb.PluginServiceClient
-	config       map[string]any
-	configureErr error
+	typeName              string
+	name                  string
+	handleIDs             []string
+	workflowTypes         []string
+	client                pb.PluginServiceClient
+	handlesByWorkflowType map[string]string
+	configsByWorkflowType map[string]string
+	configureErrors       map[string]error
+	configureErr          error
 }
 
 // NewRemoteTrigger creates a remote trigger proxy.
 // The plugin handle is allocated after Configure receives YAML trigger config.
 func NewRemoteTrigger(typeName, name string, client pb.PluginServiceClient) *RemoteTrigger {
 	return &RemoteTrigger{
-		typeName: typeName,
-		name:     name,
-		client:   client,
+		typeName:              typeName,
+		name:                  name,
+		client:                client,
+		handlesByWorkflowType: make(map[string]string),
+		configsByWorkflowType: make(map[string]string),
+		configureErrors:       make(map[string]error),
 	}
 }
 
@@ -38,20 +51,25 @@ func (t *RemoteTrigger) Name() string {
 }
 
 func (t *RemoteTrigger) Init(_ modular.Application) error {
-	if t.handleID == "" {
-		if t.configureErr != nil {
-			return fmt.Errorf("remote trigger init: trigger %q configure failed: %w", t.name, t.configureErr)
-		}
+	if t.configureErr != nil {
+		return fmt.Errorf("remote trigger init: trigger %q configure failed: %w", t.name, t.configureErr)
+	}
+	if len(t.handleIDs) == 0 {
 		return nil
 	}
-	resp, err := t.client.InitModule(context.Background(), &pb.HandleRequest{
-		HandleId: t.handleID,
-	})
-	if err != nil {
-		return fmt.Errorf("remote trigger init: %w", err)
-	}
-	if resp.Error != "" {
-		return fmt.Errorf("remote trigger init: %s", resp.Error)
+	for _, handleID := range t.handleIDs {
+		resp, err := t.client.InitModule(context.Background(), &pb.HandleRequest{
+			HandleId: handleID,
+		})
+		if err != nil {
+			return fmt.Errorf("remote trigger init %s: %w", handleID, err)
+		}
+		if resp == nil {
+			return fmt.Errorf("remote trigger init %s: empty response", handleID)
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("remote trigger init %s: %s", handleID, resp.Error)
+		}
 	}
 	return nil
 }
@@ -59,20 +77,27 @@ func (t *RemoteTrigger) Init(_ modular.Application) error {
 // --- modular.Startable ---
 
 func (t *RemoteTrigger) Start(ctx context.Context) error {
-	if t.handleID == "" {
-		if t.configureErr != nil {
-			return fmt.Errorf("remote trigger start: trigger %q configure failed: %w", t.name, t.configureErr)
-		}
+	if t.configureErr != nil {
+		return fmt.Errorf("remote trigger start: trigger %q configure failed: %w", t.name, t.configureErr)
+	}
+	if len(t.handleIDs) == 0 {
 		return nil
 	}
-	resp, err := t.client.StartModule(ctx, &pb.HandleRequest{
-		HandleId: t.handleID,
-	})
-	if err != nil {
-		return fmt.Errorf("remote trigger start: %w", err)
-	}
-	if resp.Error != "" {
-		return fmt.Errorf("remote trigger start: %s", resp.Error)
+	started := make([]string, 0, len(t.handleIDs))
+	for _, handleID := range t.handleIDs {
+		resp, err := t.client.StartModule(ctx, &pb.HandleRequest{
+			HandleId: handleID,
+		})
+		if err != nil {
+			return errors.Join(fmt.Errorf("remote trigger start %s: %w", handleID, err), t.stopStarted(ctx, started))
+		}
+		if resp == nil {
+			return errors.Join(fmt.Errorf("remote trigger start %s: empty response", handleID), t.stopStarted(ctx, started))
+		}
+		if resp.Error != "" {
+			return errors.Join(fmt.Errorf("remote trigger start %s: %s", handleID, resp.Error), t.stopStarted(ctx, started))
+		}
+		started = append(started, handleID)
 	}
 	return nil
 }
@@ -80,80 +105,227 @@ func (t *RemoteTrigger) Start(ctx context.Context) error {
 // --- modular.Stoppable ---
 
 func (t *RemoteTrigger) Stop(ctx context.Context) error {
-	if t.handleID == "" {
+	if len(t.handleIDs) == 0 {
 		return nil
 	}
-	resp, err := t.client.StopModule(ctx, &pb.HandleRequest{
-		HandleId: t.handleID,
-	})
-	if err != nil {
-		return fmt.Errorf("remote trigger stop: %w", err)
+	return t.stopHandles(ctx, t.handleIDs)
+}
+
+func (t *RemoteTrigger) stopStarted(ctx context.Context, handleIDs []string) error {
+	if len(handleIDs) == 0 {
+		return nil
 	}
-	if resp.Error != "" {
-		return fmt.Errorf("remote trigger stop: %s", resp.Error)
+	reversed := make([]string, len(handleIDs))
+	for i := range handleIDs {
+		reversed[i] = handleIDs[len(handleIDs)-1-i]
 	}
-	return nil
+	return t.stopHandles(ctx, reversed)
+}
+
+func (t *RemoteTrigger) stopHandles(ctx context.Context, handleIDs []string) error {
+	var errs []error
+	for _, handleID := range handleIDs {
+		resp, err := t.client.StopModule(ctx, &pb.HandleRequest{
+			HandleId: handleID,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("remote trigger stop %s: %w", handleID, err))
+			continue
+		}
+		if resp == nil {
+			errs = append(errs, fmt.Errorf("remote trigger stop %s: empty response", handleID))
+			continue
+		}
+		if resp.Error != "" {
+			errs = append(errs, fmt.Errorf("remote trigger stop %s: %s", handleID, resp.Error))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // --- module.Trigger ---
 
 // Configure applies YAML trigger config and creates the remote trigger handle.
 func (t *RemoteTrigger) Configure(_ modular.Application, triggerConfig any) error {
-	if t.handleID != "" {
-		return fmt.Errorf("remote trigger configure %s: already configured", t.name)
-	}
 	cfg, err := triggerConfigMap(triggerConfig)
 	if err != nil {
-		t.configureErr = err
+		t.setConfigureError(globalConfigureErrorKey, err)
 		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
 	}
 	pbConfig, err := mapToStruct(cfg)
 	if err != nil {
-		t.configureErr = err
+		t.setConfigureError(globalConfigureErrorKey, err)
 		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+	}
+	workflowType, err := t.workflowType(cfg)
+	if err != nil {
+		t.setConfigureError(globalConfigureErrorKey, err)
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+	}
+	configFingerprint, err := triggerConfigFingerprint(pbConfig)
+	if err != nil {
+		t.setConfigureError(globalConfigureErrorKey, err)
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+	}
+	if _, ok := t.handlesByWorkflowType[workflowType]; ok {
+		if t.configsByWorkflowType[workflowType] != configFingerprint {
+			err := fmt.Errorf("already configured with different trigger config")
+			t.setConfigureError(workflowType, err)
+			return fmt.Errorf("remote trigger configure %s: workflow %q: %w", t.name, workflowType, err)
+		}
+		t.clearConfigureError(globalConfigureErrorKey)
+		t.clearConfigureError(workflowType)
+		return nil
 	}
 	resp, err := t.client.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
 		Type:   t.typeName,
-		Name:   t.name,
+		Name:   workflowType,
 		Config: pbConfig,
 	})
 	if err != nil {
-		t.configureErr = err
-		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+		t.setConfigureError(workflowType, err)
+		return fmt.Errorf("remote trigger configure %s: workflow %q: %w", t.name, workflowType, err)
 	}
 	if resp == nil {
-		t.configureErr = errors.New("empty create trigger response")
-		return fmt.Errorf("remote trigger configure %s: %w", t.name, t.configureErr)
+		err := errors.New("empty create trigger response")
+		t.setConfigureError(workflowType, err)
+		return fmt.Errorf("remote trigger configure %s: workflow %q: %w", t.name, workflowType, err)
 	}
 	if resp.Error != "" {
-		t.configureErr = fmt.Errorf("%s", resp.Error)
-		return fmt.Errorf("remote trigger configure %s: %s", t.name, resp.Error)
+		err := fmt.Errorf("%s", resp.Error)
+		t.setConfigureError(workflowType, err)
+		return fmt.Errorf("remote trigger configure %s: workflow %q: %w", t.name, workflowType, err)
 	}
 	if resp.HandleId == "" {
-		t.configureErr = errors.New("empty create trigger handle")
-		return fmt.Errorf("remote trigger configure %s: %w", t.name, t.configureErr)
+		err := errors.New("empty create trigger handle")
+		t.setConfigureError(workflowType, err)
+		return fmt.Errorf("remote trigger configure %s: workflow %q: %w", t.name, workflowType, err)
 	}
-	t.handleID = resp.HandleId
-	t.configureErr = nil
-	t.config = cfg
+	t.handleIDs = append(t.handleIDs, resp.HandleId)
+	t.workflowTypes = append(t.workflowTypes, workflowType)
+	t.handlesByWorkflowType[workflowType] = resp.HandleId
+	t.configsByWorkflowType[workflowType] = configFingerprint
+	t.clearConfigureError(globalConfigureErrorKey)
+	t.clearConfigureError(workflowType)
 	return nil
 }
 
 // Destroy releases the remote trigger resources in the plugin process.
 func (t *RemoteTrigger) Destroy() error {
-	if t.handleID == "" {
+	if len(t.handleIDs) == 0 {
 		return nil
 	}
-	resp, err := t.client.DestroyModule(context.Background(), &pb.HandleRequest{
-		HandleId: t.handleID,
-	})
+	var errs []error
+	var destroyed []string
+	for _, workflowType := range t.workflowTypes {
+		handleID := t.handlesByWorkflowType[workflowType]
+		resp, err := t.client.DestroyModule(context.Background(), &pb.HandleRequest{
+			HandleId: handleID,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("remote trigger destroy %s: %w", handleID, err))
+			continue
+		}
+		if resp == nil {
+			errs = append(errs, fmt.Errorf("remote trigger destroy %s: empty response", handleID))
+			continue
+		}
+		if resp.Error != "" {
+			errs = append(errs, fmt.Errorf("remote trigger destroy %s: %s", handleID, resp.Error))
+			continue
+		}
+		destroyed = append(destroyed, workflowType)
+	}
+	for _, workflowType := range destroyed {
+		t.removeWorkflowType(workflowType)
+	}
+	if len(t.workflowTypes) == 0 {
+		clear(t.configureErrors)
+		t.configureErr = nil
+	}
+	return errors.Join(errs...)
+}
+
+func (t *RemoteTrigger) workflowType(cfg map[string]any) (string, error) {
+	workflowType := t.name
+	if configuredValue, ok := cfg["workflowType"]; ok {
+		configuredWorkflowType, ok := configuredValue.(string)
+		if !ok {
+			return "", fmt.Errorf("workflowType must be string, got %T", configuredValue)
+		}
+		trimmed := strings.TrimSpace(configuredWorkflowType)
+		if configuredWorkflowType != trimmed {
+			return "", fmt.Errorf("workflowType %q contains leading or trailing whitespace", configuredWorkflowType)
+		}
+		workflowType = trimmed
+	}
+	if workflowType == "" {
+		return "", errors.New("workflowType must not be empty")
+	}
+	if strings.ContainsFunc(workflowType, func(r rune) bool {
+		return r < 0x21 || r == 0x7f
+	}) {
+		return "", fmt.Errorf("workflowType %q contains whitespace or control characters", workflowType)
+	}
+	return workflowType, nil
+}
+
+func triggerConfigFingerprint(cfg *structpb.Struct) (string, error) {
+	if cfg == nil {
+		return "", nil
+	}
+	data, err := (goproto.MarshalOptions{Deterministic: true}).Marshal(cfg)
 	if err != nil {
-		return fmt.Errorf("remote trigger destroy: %w", err)
+		return "", fmt.Errorf("marshal trigger config fingerprint: %w", err)
 	}
-	if resp.Error != "" {
-		return fmt.Errorf("remote trigger destroy: %s", resp.Error)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (t *RemoteTrigger) removeWorkflowType(workflowType string) {
+	handleID := t.handlesByWorkflowType[workflowType]
+	delete(t.handlesByWorkflowType, workflowType)
+	delete(t.configsByWorkflowType, workflowType)
+	delete(t.configureErrors, workflowType)
+	t.workflowTypes = removeString(t.workflowTypes, workflowType)
+	t.handleIDs = removeString(t.handleIDs, handleID)
+	t.refreshConfigureErr()
+}
+
+func (t *RemoteTrigger) setConfigureError(workflowType string, err error) {
+	t.configureErrors[workflowType] = err
+	t.refreshConfigureErr()
+}
+
+func (t *RemoteTrigger) clearConfigureError(workflowType string) {
+	delete(t.configureErrors, workflowType)
+	t.refreshConfigureErr()
+}
+
+func (t *RemoteTrigger) refreshConfigureErr() {
+	if len(t.configureErrors) == 0 {
+		t.configureErr = nil
+		return
 	}
-	return nil
+	errs := make([]error, 0, len(t.configureErrors))
+	for workflowType, err := range t.configureErrors {
+		if workflowType == globalConfigureErrorKey {
+			errs = append(errs, err)
+			continue
+		}
+		errs = append(errs, fmt.Errorf("workflow %q: %w", workflowType, err))
+	}
+	t.configureErr = errors.Join(errs...)
+}
+
+func removeString(values []string, target string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if value != target {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func triggerConfigMap(config any) (map[string]any, error) {

--- a/plugin/external/remote_trigger.go
+++ b/plugin/external/remote_trigger.go
@@ -20,14 +20,12 @@ type RemoteTrigger struct {
 }
 
 // NewRemoteTrigger creates a remote trigger proxy.
-// The handleID is allocated by the plugin when the trigger module is created.
-func NewRemoteTrigger(typeName, name, handleID string, client pb.PluginServiceClient, config map[string]any) *RemoteTrigger {
+// The plugin handle is allocated after Configure receives YAML trigger config.
+func NewRemoteTrigger(typeName, name string, client pb.PluginServiceClient) *RemoteTrigger {
 	return &RemoteTrigger{
 		typeName: typeName,
 		name:     name,
-		handleID: handleID,
 		client:   client,
-		config:   config,
 	}
 }
 
@@ -38,6 +36,9 @@ func (t *RemoteTrigger) Name() string {
 }
 
 func (t *RemoteTrigger) Init(_ modular.Application) error {
+	if t.handleID == "" {
+		return fmt.Errorf("remote trigger init: trigger %q is not configured", t.name)
+	}
 	resp, err := t.client.InitModule(context.Background(), &pb.HandleRequest{
 		HandleId: t.handleID,
 	})
@@ -53,6 +54,9 @@ func (t *RemoteTrigger) Init(_ modular.Application) error {
 // --- modular.Startable ---
 
 func (t *RemoteTrigger) Start(ctx context.Context) error {
+	if t.handleID == "" {
+		return fmt.Errorf("remote trigger start: trigger %q is not configured", t.name)
+	}
 	resp, err := t.client.StartModule(ctx, &pb.HandleRequest{
 		HandleId: t.handleID,
 	})
@@ -68,6 +72,9 @@ func (t *RemoteTrigger) Start(ctx context.Context) error {
 // --- modular.Stoppable ---
 
 func (t *RemoteTrigger) Stop(ctx context.Context) error {
+	if t.handleID == "" {
+		return nil
+	}
 	resp, err := t.client.StopModule(ctx, &pb.HandleRequest{
 		HandleId: t.handleID,
 	})
@@ -82,15 +89,40 @@ func (t *RemoteTrigger) Stop(ctx context.Context) error {
 
 // --- module.Trigger ---
 
-// Configure applies the trigger configuration. The config was already applied at
-// creation time (CreateModule); this is a no-op for remote triggers unless the
-// plugin exposes a dedicated configure step.
-func (t *RemoteTrigger) Configure(_ modular.Application, _ any) error {
+// Configure applies YAML trigger config and creates the remote trigger handle.
+func (t *RemoteTrigger) Configure(_ modular.Application, triggerConfig any) error {
+	if t.handleID != "" {
+		return fmt.Errorf("remote trigger configure %s: already configured", t.name)
+	}
+	cfg, err := triggerConfigMap(triggerConfig)
+	if err != nil {
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+	}
+	pbConfig, err := mapToStruct(cfg)
+	if err != nil {
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+	}
+	resp, err := t.client.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
+		Type:   t.typeName,
+		Name:   t.name,
+		Config: pbConfig,
+	})
+	if err != nil {
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("remote trigger configure %s: %s", t.name, resp.Error)
+	}
+	t.handleID = resp.HandleId
+	t.config = cfg
 	return nil
 }
 
 // Destroy releases the remote trigger resources in the plugin process.
 func (t *RemoteTrigger) Destroy() error {
+	if t.handleID == "" {
+		return nil
+	}
 	resp, err := t.client.DestroyModule(context.Background(), &pb.HandleRequest{
 		HandleId: t.handleID,
 	})
@@ -101,4 +133,15 @@ func (t *RemoteTrigger) Destroy() error {
 		return fmt.Errorf("remote trigger destroy: %s", resp.Error)
 	}
 	return nil
+}
+
+func triggerConfigMap(config any) (map[string]any, error) {
+	if config == nil {
+		return nil, nil
+	}
+	cfg, ok := config.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("config must be map[string]any, got %T", config)
+	}
+	return cfg, nil
 }

--- a/plugin/external/remote_trigger.go
+++ b/plugin/external/remote_trigger.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/GoCodeAlone/modular"
@@ -12,11 +13,12 @@ import (
 // Trigger lifecycle (Start/Stop) is managed through the plugin's module RPCs,
 // treating trigger handles as module handles.
 type RemoteTrigger struct {
-	typeName string
-	name     string
-	handleID string
-	client   pb.PluginServiceClient
-	config   map[string]any
+	typeName     string
+	name         string
+	handleID     string
+	client       pb.PluginServiceClient
+	config       map[string]any
+	configureErr error
 }
 
 // NewRemoteTrigger creates a remote trigger proxy.
@@ -37,7 +39,10 @@ func (t *RemoteTrigger) Name() string {
 
 func (t *RemoteTrigger) Init(_ modular.Application) error {
 	if t.handleID == "" {
-		return fmt.Errorf("remote trigger init: trigger %q is not configured", t.name)
+		if t.configureErr != nil {
+			return fmt.Errorf("remote trigger init: trigger %q configure failed: %w", t.name, t.configureErr)
+		}
+		return nil
 	}
 	resp, err := t.client.InitModule(context.Background(), &pb.HandleRequest{
 		HandleId: t.handleID,
@@ -55,7 +60,10 @@ func (t *RemoteTrigger) Init(_ modular.Application) error {
 
 func (t *RemoteTrigger) Start(ctx context.Context) error {
 	if t.handleID == "" {
-		return fmt.Errorf("remote trigger start: trigger %q is not configured", t.name)
+		if t.configureErr != nil {
+			return fmt.Errorf("remote trigger start: trigger %q configure failed: %w", t.name, t.configureErr)
+		}
+		return nil
 	}
 	resp, err := t.client.StartModule(ctx, &pb.HandleRequest{
 		HandleId: t.handleID,
@@ -96,10 +104,12 @@ func (t *RemoteTrigger) Configure(_ modular.Application, triggerConfig any) erro
 	}
 	cfg, err := triggerConfigMap(triggerConfig)
 	if err != nil {
+		t.configureErr = err
 		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
 	}
 	pbConfig, err := mapToStruct(cfg)
 	if err != nil {
+		t.configureErr = err
 		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
 	}
 	resp, err := t.client.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
@@ -108,12 +118,23 @@ func (t *RemoteTrigger) Configure(_ modular.Application, triggerConfig any) erro
 		Config: pbConfig,
 	})
 	if err != nil {
+		t.configureErr = err
 		return fmt.Errorf("remote trigger configure %s: %w", t.name, err)
 	}
+	if resp == nil {
+		t.configureErr = errors.New("empty create trigger response")
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, t.configureErr)
+	}
 	if resp.Error != "" {
+		t.configureErr = fmt.Errorf("%s", resp.Error)
 		return fmt.Errorf("remote trigger configure %s: %s", t.name, resp.Error)
 	}
+	if resp.HandleId == "" {
+		t.configureErr = errors.New("empty create trigger handle")
+		return fmt.Errorf("remote trigger configure %s: %w", t.name, t.configureErr)
+	}
 	t.handleID = resp.HandleId
+	t.configureErr = nil
 	t.config = cfg
 	return nil
 }

--- a/plugin/external/remote_trigger_test.go
+++ b/plugin/external/remote_trigger_test.go
@@ -1,0 +1,84 @@
+package external
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+)
+
+func TestRemoteTriggerConfigureCreatesTriggerWithConfig(t *testing.T) {
+	stub := &stubPluginServiceClient{}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	err := trigger.Configure(nil, map[string]any{
+		"pool": "private",
+		"limit": map[string]any{
+			"concurrency": float64(2),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+	if stub.lastCreateTriggerReq == nil {
+		t.Fatal("expected CreateTrigger request")
+	}
+	if stub.lastCreateTriggerReq.Type != "trigger.test" || stub.lastCreateTriggerReq.Name != "test-trigger" {
+		t.Fatalf("unexpected CreateTrigger request: %#v", stub.lastCreateTriggerReq)
+	}
+	got := stub.lastCreateTriggerReq.Config.AsMap()
+	if got["pool"] != "private" {
+		t.Fatalf("expected config pool to be forwarded, got %#v", got)
+	}
+
+	if err := trigger.Init(nil); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if err := trigger.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+	if err := trigger.Destroy(); err != nil {
+		t.Fatalf("Destroy returned error: %v", err)
+	}
+}
+
+func TestRemoteTriggerInitFailsBeforeConfigure(t *testing.T) {
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+
+	if err := trigger.Init(nil); err == nil {
+		t.Fatal("expected Init to fail before Configure")
+	}
+}
+
+func TestRemoteTriggerConfigureRejectsInvalidConfigShape(t *testing.T) {
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+
+	if err := trigger.Configure(nil, []string{"not", "a", "map"}); err == nil {
+		t.Fatal("expected Configure to reject non-map config")
+	}
+}
+
+func TestRemoteTriggerConfigureRejectsSecondConfigure(t *testing.T) {
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+
+	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err != nil {
+		t.Fatalf("first Configure returned error: %v", err)
+	}
+	if err := trigger.Configure(nil, map[string]any{"pool": "other"}); err == nil {
+		t.Fatal("expected second Configure to fail")
+	}
+}
+
+func TestRemoteTriggerConfigurePropagatesPluginError(t *testing.T) {
+	stub := &stubPluginServiceClient{
+		createTriggerResp: &pb.HandleResponse{Error: "bad trigger config"},
+	}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err == nil {
+		t.Fatal("expected Configure to return plugin error")
+	}
+}

--- a/plugin/external/remote_trigger_test.go
+++ b/plugin/external/remote_trigger_test.go
@@ -12,7 +12,8 @@ func TestRemoteTriggerConfigureCreatesTriggerWithConfig(t *testing.T) {
 	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
 
 	err := trigger.Configure(nil, map[string]any{
-		"pool": "private",
+		"workflowType": "pipeline:test-trigger",
+		"pool":         "private",
 		"limit": map[string]any{
 			"concurrency": float64(2),
 		},
@@ -23,7 +24,7 @@ func TestRemoteTriggerConfigureCreatesTriggerWithConfig(t *testing.T) {
 	if stub.lastCreateTriggerReq == nil {
 		t.Fatal("expected CreateTrigger request")
 	}
-	if stub.lastCreateTriggerReq.Type != "trigger.test" || stub.lastCreateTriggerReq.Name != "test-trigger" {
+	if stub.lastCreateTriggerReq.Type != "trigger.test" || stub.lastCreateTriggerReq.Name != "pipeline:test-trigger" {
 		t.Fatalf("unexpected CreateTrigger request: %#v", stub.lastCreateTriggerReq)
 	}
 	got := stub.lastCreateTriggerReq.Config.AsMap()
@@ -42,6 +43,10 @@ func TestRemoteTriggerConfigureCreatesTriggerWithConfig(t *testing.T) {
 	}
 	if err := trigger.Destroy(); err != nil {
 		t.Fatalf("Destroy returned error: %v", err)
+	}
+	if stub.initModuleCalls != 1 || stub.startModuleCalls != 1 || stub.stopModuleCalls != 1 || stub.destroyModuleCalls != 1 {
+		t.Fatalf("unexpected lifecycle calls: init=%d start=%d stop=%d destroy=%d",
+			stub.initModuleCalls, stub.startModuleCalls, stub.stopModuleCalls, stub.destroyModuleCalls)
 	}
 }
 
@@ -68,14 +73,199 @@ func TestRemoteTriggerConfigureRejectsInvalidConfigShape(t *testing.T) {
 	}
 }
 
-func TestRemoteTriggerConfigureRejectsSecondConfigure(t *testing.T) {
-	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+func TestRemoteTriggerConfigureAllowsMultiplePipelines(t *testing.T) {
+	stub := &stubPluginServiceClient{}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
 
-	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err != nil {
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:first", "pool": "private"}); err != nil {
 		t.Fatalf("first Configure returned error: %v", err)
 	}
-	if err := trigger.Configure(nil, map[string]any{"pool": "other"}); err == nil {
-		t.Fatal("expected second Configure to fail")
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:second", "pool": "other"}); err != nil {
+		t.Fatalf("second Configure returned error: %v", err)
+	}
+	if len(trigger.handleIDs) != 2 {
+		t.Fatalf("expected two trigger handles, got %d", len(trigger.handleIDs))
+	}
+	if stub.lastCreateTriggerReq.Name != "pipeline:second" {
+		t.Fatalf("expected second workflow type to be forwarded, got %#v", stub.lastCreateTriggerReq)
+	}
+	if err := trigger.Init(nil); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if err := trigger.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+	if err := trigger.Destroy(); err != nil {
+		t.Fatalf("Destroy returned error: %v", err)
+	}
+	if stub.initModuleCalls != 2 || stub.startModuleCalls != 2 || stub.stopModuleCalls != 2 || stub.destroyModuleCalls != 2 {
+		t.Fatalf("expected lifecycle to fan out to two handles, got init=%d start=%d stop=%d destroy=%d",
+			stub.initModuleCalls, stub.startModuleCalls, stub.stopModuleCalls, stub.destroyModuleCalls)
+	}
+	if len(trigger.handleIDs) != 0 || len(trigger.workflowTypes) != 0 {
+		t.Fatalf("expected Destroy to clear local handles, got handles=%v workflowTypes=%v", trigger.handleIDs, trigger.workflowTypes)
+	}
+	if err := trigger.Destroy(); err != nil {
+		t.Fatalf("second Destroy returned error: %v", err)
+	}
+	if stub.destroyModuleCalls != 2 {
+		t.Fatalf("expected second Destroy to no-op, got destroy calls=%d", stub.destroyModuleCalls)
+	}
+}
+
+func TestRemoteTriggerConfigureDuplicateWorkflowTypeIsIdempotent(t *testing.T) {
+	stub := &stubPluginServiceClient{}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+	cfg := map[string]any{
+		"workflowType": "pipeline:first",
+		"limit": map[string]any{
+			"concurrency": 2,
+		},
+	}
+
+	if err := trigger.Configure(nil, cfg); err != nil {
+		t.Fatalf("first Configure returned error: %v", err)
+	}
+	cfg["limit"].(map[string]any)["concurrency"] = 99
+	if err := trigger.Configure(nil, map[string]any{
+		"workflowType": "pipeline:first",
+		"limit": map[string]any{
+			"concurrency": float64(2),
+		},
+	}); err != nil {
+		t.Fatalf("duplicate Configure returned error: %v", err)
+	}
+	if stub.createTriggerCalls != 1 || len(trigger.handleIDs) != 1 {
+		t.Fatalf("expected duplicate Configure to reuse handle, create calls=%d handles=%v", stub.createTriggerCalls, trigger.handleIDs)
+	}
+	if err := trigger.Configure(nil, map[string]any{
+		"workflowType": "pipeline:first",
+		"limit": map[string]any{
+			"concurrency": 3,
+		},
+	}); err == nil {
+		t.Fatal("expected conflicting duplicate workflowType to fail")
+	}
+	if err := trigger.Configure(nil, map[string]any{
+		"workflowType": "pipeline:first",
+		"limit": map[string]any{
+			"concurrency": float64(2),
+		},
+	}); err != nil {
+		t.Fatalf("matching duplicate should clear same-workflow configure error: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start after same-workflow retry returned error: %v", err)
+	}
+	if stub.createTriggerCalls != 1 {
+		t.Fatalf("expected conflicting duplicate to fail before CreateTrigger, calls=%d", stub.createTriggerCalls)
+	}
+}
+
+func TestRemoteTriggerConfigureRejectsInvalidWorkflowType(t *testing.T) {
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+	for _, cfg := range []map[string]any{
+		{"workflowType": " pipeline:first"},
+		{"workflowType": "pipeline:first "},
+		{"workflowType": "pipeline:\tfirst"},
+		{"workflowType": 123},
+	} {
+		if err := trigger.Configure(nil, cfg); err == nil {
+			t.Fatalf("expected Configure to reject workflowType in %#v", cfg)
+		}
+	}
+}
+
+func TestRemoteTriggerConfigureValidRetryClearsPreWorkflowError(t *testing.T) {
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+
+	if err := trigger.Configure(nil, []string{"not", "a", "map"}); err == nil {
+		t.Fatal("expected invalid config shape to fail")
+	}
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:first"}); err != nil {
+		t.Fatalf("valid Configure after shape error returned error: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start after valid retry returned error: %v", err)
+	}
+
+	trigger = NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+	if err := trigger.Configure(nil, map[string]any{"workflowType": 123}); err == nil {
+		t.Fatal("expected invalid workflowType to fail")
+	}
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:first"}); err != nil {
+		t.Fatalf("valid Configure after workflowType error returned error: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start after workflowType retry returned error: %v", err)
+	}
+}
+
+func TestRemoteTriggerPartialRetryDoesNotDuplicateExistingHandle(t *testing.T) {
+	stub := &stubPluginServiceClient{}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+	firstCfg := map[string]any{"workflowType": "pipeline:first"}
+	secondCfg := map[string]any{"workflowType": "pipeline:second"}
+
+	if err := trigger.Configure(nil, firstCfg); err != nil {
+		t.Fatalf("first Configure returned error: %v", err)
+	}
+	stub.createTriggerResp = &pb.HandleResponse{Error: "bad trigger config"}
+	if err := trigger.Configure(nil, secondCfg); err == nil {
+		t.Fatal("expected second Configure to return plugin error")
+	}
+	if err := trigger.Configure(nil, firstCfg); err != nil {
+		t.Fatalf("idempotent retry of first Configure returned error: %v", err)
+	}
+	stub.createTriggerResp = nil
+	if err := trigger.Configure(nil, secondCfg); err != nil {
+		t.Fatalf("retry second Configure returned error: %v", err)
+	}
+	if stub.createTriggerCalls != 3 || len(trigger.handleIDs) != 2 {
+		t.Fatalf("expected no duplicate first handle, create calls=%d handles=%v", stub.createTriggerCalls, trigger.handleIDs)
+	}
+}
+
+func TestRemoteTriggerLifecycleFailsAfterPartialConfigureError(t *testing.T) {
+	stub := &stubPluginServiceClient{}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:first"}); err != nil {
+		t.Fatalf("first Configure returned error: %v", err)
+	}
+	stub.createTriggerResp = &pb.HandleResponse{Error: "bad trigger config"}
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:second"}); err == nil {
+		t.Fatal("expected second Configure to return plugin error")
+	}
+	if err := trigger.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail after partial Configure error")
+	}
+	if stub.startModuleCalls != 0 {
+		t.Fatalf("expected Start not to run configured handles after partial Configure error, got %d", stub.startModuleCalls)
+	}
+}
+
+func TestRemoteTriggerStartRollsBackStartedHandles(t *testing.T) {
+	stub := &stubPluginServiceClient{startErrorOnCall: 2}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:first"}); err != nil {
+		t.Fatalf("first Configure returned error: %v", err)
+	}
+	if err := trigger.Configure(nil, map[string]any{"workflowType": "pipeline:second"}); err != nil {
+		t.Fatalf("second Configure returned error: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail")
+	}
+	if stub.startModuleCalls != 2 {
+		t.Fatalf("expected two Start attempts, got %d", stub.startModuleCalls)
+	}
+	if stub.stopModuleCalls != 1 {
+		t.Fatalf("expected rollback Stop for first handle, got %d", stub.stopModuleCalls)
 	}
 }
 
@@ -160,7 +350,7 @@ func TestRemoteTriggerConfigureCanRetryAfterError(t *testing.T) {
 	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err != nil {
 		t.Fatalf("second Configure returned error: %v", err)
 	}
-	if trigger.handleID == "" {
+	if len(trigger.handleIDs) != 1 {
 		t.Fatal("expected retry Configure to create trigger handle")
 	}
 	if err := trigger.Start(context.Background()); err != nil {

--- a/plugin/external/remote_trigger_test.go
+++ b/plugin/external/remote_trigger_test.go
@@ -45,11 +45,18 @@ func TestRemoteTriggerConfigureCreatesTriggerWithConfig(t *testing.T) {
 	}
 }
 
-func TestRemoteTriggerInitFailsBeforeConfigure(t *testing.T) {
-	trigger := NewRemoteTrigger("trigger.test", "test-trigger", &stubPluginServiceClient{})
+func TestRemoteTriggerLifecycleNoopsBeforeConfigure(t *testing.T) {
+	stub := &stubPluginServiceClient{}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
 
-	if err := trigger.Init(nil); err == nil {
-		t.Fatal("expected Init to fail before Configure")
+	if err := trigger.Init(nil); err != nil {
+		t.Fatalf("Init returned error before Configure: %v", err)
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error before Configure: %v", err)
+	}
+	if stub.initModuleCalls != 0 || stub.startModuleCalls != 0 {
+		t.Fatalf("unexpected remote lifecycle calls before Configure: init=%d start=%d", stub.initModuleCalls, stub.startModuleCalls)
 	}
 }
 
@@ -80,5 +87,83 @@ func TestRemoteTriggerConfigurePropagatesPluginError(t *testing.T) {
 
 	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err == nil {
 		t.Fatal("expected Configure to return plugin error")
+	}
+}
+
+func TestRemoteTriggerConfigureRejectsNilCreateResponse(t *testing.T) {
+	stub := &stubPluginServiceClient{createTriggerNilResp: true}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err == nil {
+		t.Fatal("expected Configure to reject nil CreateTrigger response")
+	}
+	if err := trigger.Init(nil); err == nil {
+		t.Fatal("expected Init to fail after nil CreateTrigger response")
+	}
+	if err := trigger.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail after nil CreateTrigger response")
+	}
+	if stub.initModuleCalls != 0 || stub.startModuleCalls != 0 {
+		t.Fatalf("unexpected remote lifecycle calls after nil CreateTrigger response: init=%d start=%d", stub.initModuleCalls, stub.startModuleCalls)
+	}
+}
+
+func TestRemoteTriggerConfigureRejectsEmptyHandle(t *testing.T) {
+	stub := &stubPluginServiceClient{createTriggerResp: &pb.HandleResponse{}}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err == nil {
+		t.Fatal("expected Configure to reject empty CreateTrigger handle")
+	}
+	if err := trigger.Init(nil); err == nil {
+		t.Fatal("expected Init to fail after empty CreateTrigger handle")
+	}
+	if err := trigger.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail after empty CreateTrigger handle")
+	}
+	if stub.initModuleCalls != 0 || stub.startModuleCalls != 0 {
+		t.Fatalf("unexpected remote lifecycle calls after empty CreateTrigger handle: init=%d start=%d", stub.initModuleCalls, stub.startModuleCalls)
+	}
+}
+
+func TestRemoteTriggerLifecycleFailsAfterConfigureError(t *testing.T) {
+	stub := &stubPluginServiceClient{
+		createTriggerResp: &pb.HandleResponse{Error: "bad trigger config"},
+	}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err == nil {
+		t.Fatal("expected Configure to return plugin error")
+	}
+	if err := trigger.Init(nil); err == nil {
+		t.Fatal("expected Init to fail after Configure error")
+	}
+	if err := trigger.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail after Configure error")
+	}
+	if stub.initModuleCalls != 0 || stub.startModuleCalls != 0 {
+		t.Fatalf("unexpected remote lifecycle calls after Configure error: init=%d start=%d", stub.initModuleCalls, stub.startModuleCalls)
+	}
+}
+
+func TestRemoteTriggerConfigureCanRetryAfterError(t *testing.T) {
+	stub := &stubPluginServiceClient{
+		createTriggerResp: &pb.HandleResponse{Error: "bad trigger config"},
+	}
+	trigger := NewRemoteTrigger("trigger.test", "test-trigger", stub)
+
+	if err := trigger.Configure(nil, map[string]any{"pool": "bad"}); err == nil {
+		t.Fatal("expected first Configure to return plugin error")
+	}
+
+	stub.createTriggerResp = nil
+	if err := trigger.Configure(nil, map[string]any{"pool": "private"}); err != nil {
+		t.Fatalf("second Configure returned error: %v", err)
+	}
+	if trigger.handleID == "" {
+		t.Fatal("expected retry Configure to create trigger handle")
+	}
+	if err := trigger.Start(context.Background()); err != nil {
+		t.Fatalf("Start after retry Configure returned error: %v", err)
 	}
 }

--- a/plugin/external/sdk/grpc_server.go
+++ b/plugin/external/sdk/grpc_server.go
@@ -318,7 +318,7 @@ func (s *grpcServer) CreateTrigger(_ context.Context, req *pb.CreateTriggerReque
 
 	inst, err := tp.CreateTrigger(req.Type, structToMap(req.Config), s.triggerCallback(req.Type))
 	if err != nil {
-		return &pb.HandleResponse{Error: err.Error()}, nil
+		return &pb.HandleResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
 	}
 
 	handle := uuid.New().String()

--- a/plugin/external/sdk/grpc_server.go
+++ b/plugin/external/sdk/grpc_server.go
@@ -50,9 +50,13 @@ func (s *grpcServer) setBroker(broker *goplugin.GRPCBroker) {
 }
 
 // SetCallbackClient stores the host callback gRPC client so that modules can
-// publish messages and manage subscriptions via the host.
+// publish messages and manage subscriptions via the host. It is intended for
+// startup/test wiring before live callbacks begin.
 func (s *grpcServer) SetCallbackClient(client pb.EngineCallbackServiceClient) {
 	s.mu.Lock()
+	if s.callbackConn != nil {
+		_ = s.callbackConn.Close()
+	}
 	s.callbackConn = nil
 	s.callbackClient = client
 	s.mu.Unlock()

--- a/plugin/external/sdk/grpc_server.go
+++ b/plugin/external/sdk/grpc_server.go
@@ -320,7 +320,11 @@ func (s *grpcServer) CreateTrigger(_ context.Context, req *pb.CreateTriggerReque
 		return &pb.HandleResponse{Error: fmt.Sprintf("unknown trigger type %q", req.Type)}, nil
 	}
 
-	inst, err := tp.CreateTrigger(req.Type, structToMap(req.Config), s.triggerCallback(req.Type))
+	callbackWorkflowType := req.Name
+	if callbackWorkflowType == "" {
+		callbackWorkflowType = req.Type
+	}
+	inst, err := tp.CreateTrigger(req.Type, structToMap(req.Config), s.triggerCallback(callbackWorkflowType))
 	if err != nil {
 		return &pb.HandleResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
 	}

--- a/plugin/external/sdk/grpc_server.go
+++ b/plugin/external/sdk/grpc_server.go
@@ -10,6 +10,7 @@ import (
 	goplugin "github.com/GoCodeAlone/go-plugin"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -27,6 +28,7 @@ type grpcServer struct {
 	messageHandlers map[string]func(payload []byte, metadata map[string]string) error
 
 	callbackClient pb.EngineCallbackServiceClient
+	callbackConn   *grpc.ClientConn
 	broker         *goplugin.GRPCBroker
 }
 
@@ -51,6 +53,7 @@ func (s *grpcServer) setBroker(broker *goplugin.GRPCBroker) {
 // publish messages and manage subscriptions via the host.
 func (s *grpcServer) SetCallbackClient(client pb.EngineCallbackServiceClient) {
 	s.mu.Lock()
+	s.callbackConn = nil
 	s.callbackClient = client
 	s.mu.Unlock()
 }
@@ -275,6 +278,105 @@ func (s *grpcServer) CreateModule(_ context.Context, req *pb.CreateModuleRequest
 	s.registerModuleInstance(handle, inst)
 
 	return &pb.HandleResponse{HandleId: handle}, nil
+}
+
+func (s *grpcServer) ConfigureCallback(_ context.Context, req *pb.ConfigureCallbackRequest) (*pb.ErrorResponse, error) {
+	if req.BrokerId == 0 {
+		return &pb.ErrorResponse{Error: "callback broker id is required"}, nil
+	}
+	s.mu.RLock()
+	broker := s.broker
+	s.mu.RUnlock()
+	if broker == nil {
+		return &pb.ErrorResponse{Error: "callback broker is not configured"}, nil
+	}
+
+	conn, err := broker.Dial(req.BrokerId)
+	if err != nil {
+		return &pb.ErrorResponse{Error: fmt.Sprintf("dial callback broker: %v", err)}, nil
+	}
+
+	s.mu.Lock()
+	if s.callbackConn != nil {
+		_ = s.callbackConn.Close()
+	}
+	s.callbackConn = conn
+	s.callbackClient = pb.NewEngineCallbackServiceClient(conn)
+	s.mu.Unlock()
+
+	return &pb.ErrorResponse{}, nil
+}
+
+func (s *grpcServer) CreateTrigger(_ context.Context, req *pb.CreateTriggerRequest) (*pb.HandleResponse, error) {
+	tp, ok := s.provider.(TriggerProvider)
+	if !ok {
+		return &pb.HandleResponse{Error: "plugin does not provide triggers"}, nil
+	}
+	if !containsString(tp.TriggerTypes(), req.Type) {
+		return &pb.HandleResponse{Error: fmt.Sprintf("unknown trigger type %q", req.Type)}, nil
+	}
+
+	inst, err := tp.CreateTrigger(req.Type, structToMap(req.Config), s.triggerCallback(req.Type))
+	if err != nil {
+		return &pb.HandleResponse{Error: err.Error()}, nil
+	}
+
+	handle := uuid.New().String()
+	s.registerModuleInstance(handle, triggerModuleAdapter{trigger: inst})
+	return &pb.HandleResponse{HandleId: handle}, nil
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *grpcServer) triggerCallback(triggerType string) TriggerCallback {
+	return func(action string, data map[string]any) error {
+		s.mu.RLock()
+		cb := s.callbackClient
+		s.mu.RUnlock()
+		if cb == nil {
+			return errors.New("trigger callback client is not configured")
+		}
+
+		payload, err := mapToStruct(data)
+		if err != nil {
+			return fmt.Errorf("trigger callback data: %w", err)
+		}
+		resp, err := cb.TriggerWorkflow(context.Background(), &pb.TriggerWorkflowRequest{
+			TriggerType: triggerType,
+			Action:      action,
+			Data:        payload,
+		})
+		if err != nil {
+			return fmt.Errorf("trigger workflow callback: %w", err)
+		}
+		if resp != nil && resp.Error != "" {
+			return fmt.Errorf("trigger workflow callback: %s", resp.Error)
+		}
+		return nil
+	}
+}
+
+type triggerModuleAdapter struct {
+	trigger TriggerInstance
+}
+
+func (m triggerModuleAdapter) Init() error {
+	return nil
+}
+
+func (m triggerModuleAdapter) Start(ctx context.Context) error {
+	return m.trigger.Start(ctx)
+}
+
+func (m triggerModuleAdapter) Stop(ctx context.Context) error {
+	return m.trigger.Stop(ctx)
 }
 
 func (s *grpcServer) registerModuleInstance(handle string, inst ModuleInstance) {

--- a/plugin/external/sdk/grpc_server_test.go
+++ b/plugin/external/sdk/grpc_server_test.go
@@ -296,7 +296,7 @@ func TestTriggerProviderCreatesTriggerThroughLifecycle(t *testing.T) {
 
 	createResp, err := srv.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
 		Type:   "trigger.test",
-		Name:   "test-trigger",
+		Name:   "pipeline:test-trigger",
 		Config: mustMapToStruct(t, map[string]any{"pool": "private"}),
 	})
 	if err != nil {
@@ -331,7 +331,7 @@ func TestTriggerProviderCreatesTriggerThroughLifecycle(t *testing.T) {
 	if callback.req == nil {
 		t.Fatal("expected callback request")
 	}
-	if callback.req.TriggerType != "trigger.test" || callback.req.Action != "completed" {
+	if callback.req.TriggerType != "pipeline:test-trigger" || callback.req.Action != "completed" {
 		t.Fatalf("unexpected callback request: %#v", callback.req)
 	}
 	if got := callback.req.Data.AsMap()["task_id"]; got != "task-1" {
@@ -343,6 +343,32 @@ func TestTriggerProviderCreatesTriggerThroughLifecycle(t *testing.T) {
 	}
 	if provider.created.stops != 1 {
 		t.Fatalf("expected one trigger stop, got %d", provider.created.stops)
+	}
+}
+
+func TestTriggerProviderCallbackFallsBackToTriggerType(t *testing.T) {
+	provider := &triggerOnlyProvider{}
+	srv := newGRPCServer(provider)
+	callback := &recordingCallbackClient{}
+	srv.SetCallbackClient(callback)
+
+	createResp, err := srv.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
+		Type: "trigger.test",
+	})
+	if err != nil {
+		t.Fatalf("CreateTrigger returned rpc error: %v", err)
+	}
+	if createResp.Error != "" {
+		t.Fatalf("unexpected CreateTrigger application error: %s", createResp.Error)
+	}
+	if err := provider.created.cb("completed", map[string]any{"task_id": "task-1"}); err != nil {
+		t.Fatalf("trigger callback returned error: %v", err)
+	}
+	if callback.req == nil {
+		t.Fatal("expected callback request")
+	}
+	if callback.req.TriggerType != "trigger.test" {
+		t.Fatalf("expected callback fallback trigger type, got %#v", callback.req)
 	}
 }
 

--- a/plugin/external/sdk/grpc_server_test.go
+++ b/plugin/external/sdk/grpc_server_test.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
@@ -342,6 +343,24 @@ func TestTriggerProviderCreatesTriggerThroughLifecycle(t *testing.T) {
 	}
 	if provider.created.stops != 1 {
 		t.Fatalf("expected one trigger stop, got %d", provider.created.stops)
+	}
+}
+
+func TestSetCallbackClientClosesExistingBrokerConnection(t *testing.T) {
+	conn, err := grpc.NewClient("passthrough:///unused", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+
+	srv := newGRPCServer(&triggerOnlyProvider{})
+	srv.callbackConn = conn
+	srv.SetCallbackClient(&recordingCallbackClient{})
+
+	if srv.callbackConn != nil {
+		t.Fatal("expected callbackConn to be cleared")
+	}
+	if got := conn.GetState(); got != connectivity.Shutdown {
+		t.Fatalf("expected previous callback connection to be closed, state=%s", got)
 	}
 }
 

--- a/plugin/external/sdk/grpc_server_test.go
+++ b/plugin/external/sdk/grpc_server_test.go
@@ -89,6 +89,90 @@ func (p *contractProvider) ContractRegistry() *pb.ContractRegistry {
 	}
 }
 
+type triggerOnlyProvider struct {
+	minimalProvider
+	created *recordingTrigger
+}
+
+func (p *triggerOnlyProvider) TriggerTypes() []string {
+	return []string{"trigger.test"}
+}
+
+func (p *triggerOnlyProvider) CreateTrigger(typeName string, config map[string]any, cb TriggerCallback) (TriggerInstance, error) {
+	if typeName != "trigger.test" {
+		return nil, errors.New("unexpected trigger type: " + typeName)
+	}
+	p.created = &recordingTrigger{
+		config: config,
+		cb:     cb,
+	}
+	return p.created, nil
+}
+
+type recordingTrigger struct {
+	config map[string]any
+	cb     TriggerCallback
+	starts int
+	stops  int
+}
+
+func (t *recordingTrigger) Start(context.Context) error {
+	t.starts++
+	return nil
+}
+
+func (t *recordingTrigger) Stop(context.Context) error {
+	t.stops++
+	return nil
+}
+
+type recordingCallbackClient struct {
+	req *pb.TriggerWorkflowRequest
+}
+
+func (c *recordingCallbackClient) TriggerWorkflow(_ context.Context, req *pb.TriggerWorkflowRequest, _ ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	c.req = req
+	return &pb.ErrorResponse{}, nil
+}
+
+func (c *recordingCallbackClient) GetService(context.Context, *pb.GetServiceRequest, ...grpc.CallOption) (*pb.GetServiceResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *recordingCallbackClient) Log(context.Context, *pb.LogRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *recordingCallbackClient) PublishMessage(context.Context, *pb.PublishMessageRequest, ...grpc.CallOption) (*pb.PublishMessageResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *recordingCallbackClient) Subscribe(context.Context, *pb.SubscribeRequest, ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *recordingCallbackClient) Unsubscribe(context.Context, *pb.UnsubscribeRequest, ...grpc.CallOption) (*pb.ErrorResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+type moduleAndTriggerProvider struct {
+	triggerOnlyProvider
+	module        ModuleInstance
+	moduleCreated int
+}
+
+func (p *moduleAndTriggerProvider) ModuleTypes() []string {
+	return []string{"trigger.test"}
+}
+
+func (p *moduleAndTriggerProvider) CreateModule(typeName, name string, config map[string]any) (ModuleInstance, error) {
+	if typeName != "trigger.test" {
+		return nil, errors.New("unexpected module type: " + typeName)
+	}
+	p.moduleCreated++
+	return p.module, nil
+}
+
 type typedServiceProvider struct {
 	minimalProvider
 	module ModuleInstance
@@ -192,6 +276,112 @@ func TestGetAsset_WithAssetProvider(t *testing.T) {
 	}
 	if resp.ContentType != "text/html" {
 		t.Errorf("expected text/html content type, got %q", resp.ContentType)
+	}
+}
+
+func TestTriggerProviderCreatesTriggerThroughLifecycle(t *testing.T) {
+	provider := &triggerOnlyProvider{}
+	srv := newGRPCServer(provider)
+	callback := &recordingCallbackClient{}
+	srv.SetCallbackClient(callback)
+
+	types, err := srv.GetTriggerTypes(context.Background(), &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("GetTriggerTypes returned rpc error: %v", err)
+	}
+	if len(types.Types) != 1 || types.Types[0] != "trigger.test" {
+		t.Fatalf("expected trigger.test type, got %#v", types.Types)
+	}
+
+	createResp, err := srv.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
+		Type:   "trigger.test",
+		Name:   "test-trigger",
+		Config: mustMapToStruct(t, map[string]any{"pool": "private"}),
+	})
+	if err != nil {
+		t.Fatalf("CreateTrigger returned rpc error: %v", err)
+	}
+	if createResp.Error != "" {
+		t.Fatalf("unexpected CreateTrigger application error: %s", createResp.Error)
+	}
+	if createResp.HandleId == "" {
+		t.Fatal("CreateTrigger returned empty HandleId")
+	}
+	if provider.created == nil {
+		t.Fatal("expected CreateTrigger to be called")
+	}
+	if got := provider.created.config["pool"]; got != "private" {
+		t.Fatalf("expected trigger config to be forwarded, got %#v", provider.created.config)
+	}
+
+	if resp, err := srv.InitModule(context.Background(), &pb.HandleRequest{HandleId: createResp.HandleId}); err != nil || resp.Error != "" {
+		t.Fatalf("InitModule = (%v, %v), want no error", resp, err)
+	}
+	if resp, err := srv.StartModule(context.Background(), &pb.HandleRequest{HandleId: createResp.HandleId}); err != nil || resp.Error != "" {
+		t.Fatalf("StartModule = (%v, %v), want no error", resp, err)
+	}
+	if provider.created.starts != 1 {
+		t.Fatalf("expected one trigger start, got %d", provider.created.starts)
+	}
+
+	if err := provider.created.cb("completed", map[string]any{"task_id": "task-1"}); err != nil {
+		t.Fatalf("trigger callback returned error: %v", err)
+	}
+	if callback.req == nil {
+		t.Fatal("expected callback request")
+	}
+	if callback.req.TriggerType != "trigger.test" || callback.req.Action != "completed" {
+		t.Fatalf("unexpected callback request: %#v", callback.req)
+	}
+	if got := callback.req.Data.AsMap()["task_id"]; got != "task-1" {
+		t.Fatalf("expected callback task_id, got %#v", callback.req.Data.AsMap())
+	}
+
+	if resp, err := srv.StopModule(context.Background(), &pb.HandleRequest{HandleId: createResp.HandleId}); err != nil || resp.Error != "" {
+		t.Fatalf("StopModule = (%v, %v), want no error", resp, err)
+	}
+	if provider.created.stops != 1 {
+		t.Fatalf("expected one trigger stop, got %d", provider.created.stops)
+	}
+}
+
+func TestCreateModulePrefersModuleProviderWhenTypeAlsoTrigger(t *testing.T) {
+	module := &typedServiceModule{}
+	provider := &moduleAndTriggerProvider{
+		triggerOnlyProvider: triggerOnlyProvider{},
+		module:              module,
+	}
+	srv := newGRPCServer(provider)
+
+	createResp, err := srv.CreateModule(context.Background(), &pb.CreateModuleRequest{
+		Type: "trigger.test",
+		Name: "module-with-trigger-name",
+	})
+	if err != nil {
+		t.Fatalf("CreateModule returned rpc error: %v", err)
+	}
+	if createResp.Error != "" {
+		t.Fatalf("unexpected CreateModule application error: %s", createResp.Error)
+	}
+	if provider.moduleCreated != 1 {
+		t.Fatalf("expected module provider to handle CreateModule, got %d", provider.moduleCreated)
+	}
+	if provider.created != nil {
+		t.Fatal("CreateModule should not route to TriggerProvider")
+	}
+
+	triggerResp, err := srv.CreateTrigger(context.Background(), &pb.CreateTriggerRequest{
+		Type: "trigger.test",
+		Name: "trigger",
+	})
+	if err != nil {
+		t.Fatalf("CreateTrigger returned rpc error: %v", err)
+	}
+	if triggerResp.Error != "" {
+		t.Fatalf("unexpected CreateTrigger application error: %s", triggerResp.Error)
+	}
+	if provider.created == nil {
+		t.Fatal("expected CreateTrigger to route to TriggerProvider")
 	}
 }
 
@@ -577,9 +767,9 @@ func TestInvokeService_PropagatesOutputEncodingError(t *testing.T) {
 // badOutputModule returns a map with a chan value which structpb cannot encode.
 type badOutputModule struct{}
 
-func (badOutputModule) Init() error                  { return nil }
-func (badOutputModule) Start(context.Context) error  { return nil }
-func (badOutputModule) Stop(context.Context) error   { return nil }
+func (badOutputModule) Init() error                 { return nil }
+func (badOutputModule) Start(context.Context) error { return nil }
+func (badOutputModule) Stop(context.Context) error  { return nil }
 func (badOutputModule) InvokeMethod(_ string, _ map[string]any) (map[string]any, error) {
 	return map[string]any{"bad": make(chan int)}, nil
 }


### PR DESCRIPTION
## Summary
- add external plugin `CreateTrigger` and `ConfigureCallback` RPCs
- configure callback broker wiring for server-loaded external plugins
- create remote triggers during `Configure` so YAML trigger config reaches plugins
- preserve module/step compatibility by disabling trigger factories when callback setup is unavailable

## Verification
- adversarial/security review PASS after fixes
- `go test ./cmd/server ./plugin/external/... ./plugin/...`
- `go test ./...`

## Context
Needed by `workflow-compute` before `trigger.compute_completed` can become a native Workflow external plugin trigger instead of a polling/callback workaround.
