### PR TITLE
fix(wfctl): plugin CLI registry binary path uses dir name + manifest name

### DIFF
--- a/cmd/wfctl/plugin_cli_commands.go
+++ b/cmd/wfctl/plugin_cli_commands.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+
+	"github.com/GoCodeAlone/workflow/config"
 )
 
 // reservedCLICommands is the set of static wfctl command names that plugins
@@ -58,6 +61,18 @@ type CLIRegistryEntry struct {
 // CLIRegistry maps command names to their registry entries.
 type CLIRegistry map[string]*CLIRegistryEntry
 
+// pluginDirEntry pairs a plugin's on-disk directory name with its parsed
+// manifest. Both pieces are needed to resolve the binary path: setup-plugins
+// + `wfctl plugin install` extract tarballs to short directory names (e.g.
+// `data/plugins/payments`), while the binary inside is named after the
+// manifest (e.g. `workflow-plugin-payments`). Earlier code used
+// `manifest.Name` for both directory and binary, which only worked when
+// the two happened to match.
+type pluginDirEntry struct {
+	dirName  string
+	manifest *config.PluginManifestFile
+}
+
 // BuildCLIRegistry scans pluginsDir for installed plugin.json manifests and
 // builds a command-name → entry map.
 //
@@ -65,23 +80,46 @@ type CLIRegistry map[string]*CLIRegistryEntry
 //   - A plugin declares a reserved command name.
 //   - Two plugins declare the same command name (conflict).
 func BuildCLIRegistry(pluginsDir string) (CLIRegistry, error) {
-	manifests, err := LoadPluginManifests(pluginsDir)
-	if err != nil {
-		return nil, fmt.Errorf("load plugin manifests: %w", err)
-	}
-
 	registry := make(CLIRegistry)
 
-	// Sort plugin names for deterministic conflict reporting.
-	names := make([]string, 0, len(manifests))
-	for n := range manifests {
-		names = append(names, n)
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return registry, nil
+		}
+		return nil, fmt.Errorf("read plugins dir %q: %w", pluginsDir, err)
 	}
-	sort.Strings(names)
 
-	for _, pluginName := range names {
-		manifest := manifests[pluginName]
-		for _, cmd := range manifest.Capabilities.CLICommands {
+	// Walk subdirs once, capturing both the dir name and the parsed manifest
+	// per plugin. Iterating LoadPluginManifests's keyed map would lose the
+	// dir name (the map key collapses on manifest.Name) and we need both to
+	// build a correct binary path.
+	plugins := make([]pluginDirEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(pluginsDir, entry.Name(), "plugin.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			continue // plugin dir without manifest — skip
+		}
+		var manifest config.PluginManifestFile
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			continue // malformed manifest — skip
+		}
+		plugins = append(plugins, pluginDirEntry{dirName: entry.Name(), manifest: &manifest})
+	}
+
+	// Sort by dir name for deterministic conflict reporting.
+	sort.Slice(plugins, func(i, j int) bool { return plugins[i].dirName < plugins[j].dirName })
+
+	for _, p := range plugins {
+		manifestName := p.manifest.Name
+		if manifestName == "" {
+			manifestName = p.dirName
+		}
+		for _, cmd := range p.manifest.Capabilities.CLICommands {
 			name := cmd.Name
 			if name == "" {
 				continue
@@ -90,20 +128,23 @@ func BuildCLIRegistry(pluginsDir string) (CLIRegistry, error) {
 				return nil, fmt.Errorf(
 					"plugin %q declares CLI command %q which is a reserved wfctl command name; "+
 						"rename the command in the plugin manifest",
-					pluginName, name,
+					manifestName, name,
 				)
 			}
 			if existing, ok := registry[name]; ok {
 				return nil, fmt.Errorf(
 					"CLI command conflict: both plugin %q and plugin %q declare command %q; "+
 						"uninstall one of them or rename the command in one plugin manifest",
-					existing.PluginName, pluginName, name,
+					existing.PluginName, manifestName, name,
 				)
 			}
-			binaryPath := filepath.Join(pluginsDir, pluginName, pluginName)
+			// Binary path uses the actual on-disk directory (which `wfctl
+			// plugin install` controls) plus the manifest-declared binary
+			// name (which the tarball ships).
+			binaryPath := filepath.Join(pluginsDir, p.dirName, manifestName)
 			registry[name] = &CLIRegistryEntry{
 				Command:     name,
-				PluginName:  pluginName,
+				PluginName:  manifestName,
 				BinaryPath:  binaryPath,
 				Description: cmd.Description,
 			}

--- a/cmd/wfctl/plugin_cli_commands_test.go
+++ b/cmd/wfctl/plugin_cli_commands_test.go
@@ -8,22 +8,34 @@ import (
 )
 
 // writeCLIPlugin creates a fake plugin directory with a plugin.json that
-// declares one or more CLI commands.
+// declares one or more CLI commands. Uses dirName == manifestName for the
+// simple case; see writeCLIPluginNamed for the dir-vs-manifest-mismatch.
 func writeCLIPlugin(t *testing.T, pluginsDir, name string, commands []string) {
 	t.Helper()
-	dir := filepath.Join(pluginsDir, name)
+	writeCLIPluginNamed(t, pluginsDir, name, name, commands)
+}
+
+// writeCLIPluginNamed builds a plugin where the on-disk directory name and
+// the manifest name can differ — matches the real-world install convention
+// (short dir name like "payments" + full manifest name like
+// "workflow-plugin-payments"). The stub binary is named after the manifest.
+func writeCLIPluginNamed(t *testing.T, pluginsDir, dirName, manifestName string, commands []string) {
+	t.Helper()
+	dir := filepath.Join(pluginsDir, dirName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", dir, err)
 	}
-	// Build cliCommands JSON fragment.
 	var cmdParts []string
 	for _, cmd := range commands {
 		cmdParts = append(cmdParts, `{"name":"`+cmd+`","description":"desc"}`)
 	}
-	manifest := `{"name":"` + name + `","version":"1.0.0","capabilities":{"moduleTypes":[],"stepTypes":[],"triggerTypes":[],"cliCommands":[` +
+	manifest := `{"name":"` + manifestName + `","version":"1.0.0","capabilities":{"moduleTypes":[],"stepTypes":[],"triggerTypes":[],"cliCommands":[` +
 		strings.Join(cmdParts, ",") + `]}}`
 	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644); err != nil {
 		t.Fatalf("write plugin.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestName), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
 	}
 }
 
@@ -94,5 +106,68 @@ func TestPluginCLIRegistry_AllStaticCommandsReserved(t *testing.T) {
 		if !isReservedCLICommand(name) {
 			t.Fatalf("static command %q should be reserved", name)
 		}
+	}
+}
+
+// TestPluginCLIRegistry_DirVsManifestNameMismatch is the regression test for
+// the binary-path bug introduced in workflow#591. setup-plugins (and `wfctl
+// plugin install`) extract tarballs to short directory names like
+// `data/plugins/payments` while the binary inside is named after the
+// manifest (`workflow-plugin-payments`). The earlier path computation
+// joined `manifest.Name` twice — the binary path resolved to
+// `data/plugins/workflow-plugin-payments/workflow-plugin-payments`, which
+// only existed when dirName == manifestName.
+func TestPluginCLIRegistry_DirVsManifestNameMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeCLIPluginNamed(t, dir, "payments", "workflow-plugin-payments", []string{"payments"})
+
+	reg, err := BuildCLIRegistry(dir)
+	if err != nil {
+		t.Fatalf("BuildCLIRegistry: %v", err)
+	}
+	entry, ok := reg["payments"]
+	if !ok {
+		t.Fatalf("expected `payments` command registered, got %v", reg)
+	}
+	wantBin := filepath.Join(dir, "payments", "workflow-plugin-payments")
+	if entry.BinaryPath != wantBin {
+		t.Errorf("BinaryPath = %q, want %q", entry.BinaryPath, wantBin)
+	}
+	if _, err := os.Stat(entry.BinaryPath); err != nil {
+		t.Errorf("BinaryPath %q does not point at a real file: %v", entry.BinaryPath, err)
+	}
+	if entry.PluginName != "workflow-plugin-payments" {
+		t.Errorf("PluginName = %q, want %q (manifest name)", entry.PluginName, "workflow-plugin-payments")
+	}
+}
+
+// TestPluginCLIRegistry_EmptyManifestNameUsesDirName covers the fallback path:
+// when manifest.Name is empty, the dir name is used as both the registry
+// PluginName and the binary file name.
+func TestPluginCLIRegistry_EmptyManifestNameUsesDirName(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "anonymous")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	manifest := `{"version":"1.0.0","capabilities":{"cliCommands":[{"name":"anon","description":"desc"}]}}`
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write plugin.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "anonymous"), []byte(""), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	reg, err := BuildCLIRegistry(dir)
+	if err != nil {
+		t.Fatalf("BuildCLIRegistry: %v", err)
+	}
+	entry, ok := reg["anon"]
+	if !ok {
+		t.Fatalf("expected `anon` command registered")
+	}
+	wantBin := filepath.Join(dir, "anonymous", "anonymous")
+	if entry.BinaryPath != wantBin {
+		t.Errorf("BinaryPath = %q, want %q", entry.BinaryPath, wantBin)
 	}
 }


### PR DESCRIPTION
## Summary

PR #591 wired \`BuildCLIRegistry\` into \`cmd/wfctl/main.go\`'s dispatch fallback, but the binary-path computation joins \`manifest.Name\` twice:

\`\`\`go
binaryPath := filepath.Join(pluginsDir, pluginName, pluginName)
\`\`\`

This works only when the install directory name matches the manifest name. In practice the \`setup-plugins\` composite + \`wfctl plugin install\` both extract tarballs to short directory names (\`data/plugins/payments\`, \`data/plugins/digitalocean\`, …) while the binary inside is named after the manifest (\`workflow-plugin-payments\`). Path resolves to \`data/plugins/workflow-plugin-payments/workflow-plugin-payments\` which doesn't exist.

## Reproduction (pre-fix)

\`\`\`
$ tar -xzf workflow-plugin-payments-linux-amd64.tar.gz -C /tmp/data/plugins/payments/
$ WFCTL_PLUGIN_DIR=/tmp/data/plugins ./wfctl payments
error: plugin workflow-plugin-payments command payments:
  fork/exec /tmp/data/plugins/workflow-plugin-payments/workflow-plugin-payments:
  no such file or directory
\`\`\`

Surfaced from buymywishlist [#260 retrigger](https://github.com/GoCodeAlone/buymywishlist/actions/runs/25619876246) where v0.27.2 wfctl + workflow-plugin-payments v0.3.1 hit this for the first real-world plugin-CLI dispatch.

## Fix

Refactor \`BuildCLIRegistry\` to walk the plugins directory once, capturing both the dir name (for the install path) and the manifest name (for the binary file name):

\`\`\`go
binaryPath := filepath.Join(pluginsDir, dirEntry, manifest.Name)
\`\`\`

\`LoadPluginManifests\` is no longer used by this path because its keyed return collapses on \`manifest.Name\` and loses the dir name.

## Tests

| Test | Coverage |
|---|---|
| \`TestPluginCLIRegistry_DirVsManifestNameMismatch\` | dir=\`payments\` + manifest=\`workflow-plugin-payments\` (the bug); asserts BinaryPath joins both names correctly + the file exists |
| \`TestPluginCLIRegistry_EmptyManifestNameUsesDirName\` | manifest.Name empty → fallback uses dir name for both registry PluginName and binary file |
| (existing) | matching dir/manifest names continue to work; conflict + reserved name handling preserved |

## Verification

- [x] \`GOWORK=off go build ./...\` clean
- [x] \`GOWORK=off go vet ./cmd/wfctl/\` clean
- [x] \`GOWORK=off go test ./cmd/wfctl/ -count=1 -run "TestPluginCLIRegistry|TestStaticCommand"\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)