### PR TITLE
feat(release): publish grpc-versions.txt artifact (PR 2 / Task 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,10 @@ jobs:
       # workflow release.
       run: |
         set -euo pipefail
+        # protoc-gen-go ships from the google.golang.org/protobuf module
+        # (path google.golang.org/protobuf/cmd/protoc-gen-go is NOT a
+        # standalone module), so its version line resolves against the
+        # parent module — same Version, intentional dedup, not a copy-paste.
         {
           echo "grpc=$(go list -m -json google.golang.org/grpc | jq -r .Version)"
           echo "protobuf=$(go list -m -json google.golang.org/protobuf | jq -r .Version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,29 @@ jobs:
         name: admin-ui
         path: dist
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+        cache: true
+
+    - name: Generate grpc-versions.txt
+      # Cross-repo dep-sync foundation per
+      # docs/plans/2026-05-10-strict-contracts-force-cutover.md Task 2.
+      # Downstream plugins (e.g. workflow-plugin-digitalocean) gate their
+      # protoc / proto-gen toolchain pins against this artifact so they
+      # link against gRPC/protobuf versions ABI-compatible with this
+      # workflow release.
+      run: |
+        set -euo pipefail
+        {
+          echo "grpc=$(go list -m -json google.golang.org/grpc | jq -r .Version)"
+          echo "protobuf=$(go list -m -json google.golang.org/protobuf | jq -r .Version)"
+          echo "protoc-gen-go=$(go list -m -json google.golang.org/protobuf | jq -r .Version)"
+          echo "protoc-gen-go-grpc=$(go list -m -json google.golang.org/grpc/cmd/protoc-gen-go-grpc | jq -r .Version)"
+        } > dist/grpc-versions.txt
+        cat dist/grpc-versions.txt
+
     - name: Create checksums
       run: |
         cd dist

--- a/example/go.mod
+++ b/example/go.mod
@@ -232,6 +232,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/example/go.sum
+++ b/example/go.sum
@@ -826,6 +826,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1 h1:/WILD1UcXj/ujCxgoL/DvRgt2CP3txG8+FwkUbb9110=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1/go.mod h1:YNKnb2OAApgYn2oYY47Rn7alMr1zWjb2U8Q0aoGWiNc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	golang.org/x/tools v0.44.0
 	google.golang.org/api v0.272.0
 	google.golang.org/grpc v1.80.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.4

--- a/go.sum
+++ b/go.sum
@@ -980,6 +980,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1 h1:/WILD1UcXj/ujCxgoL/DvRgt2CP3txG8+FwkUbb9110=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1/go.mod h1:YNKnb2OAApgYn2oYY47Rn7alMr1zWjb2U8Q0aoGWiNc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,17 @@
+//go:build tools
+// +build tools
+
+// This file pins build-time tool dependencies that are not imported by
+// runtime code. Listed here so `go mod tidy` keeps them in go.mod/go.sum and
+// so the release pipeline can resolve their exact versions for the
+// grpc-versions.txt artifact (cross-repo dep sync foundation per
+// 2026-05-10-strict-contracts-force-cutover Task 2).
+//
+// Guarded by the `tools` build tag so it is excluded from normal builds
+// (avoids package-name conflict with the rest of the workflow root).
+package workflow
+
+import (
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
+)


### PR DESCRIPTION
## Summary
- Pin `protoc-gen-go` (via `google.golang.org/protobuf`) and `protoc-gen-go-grpc` in `tools.go` (build-tag `tools`) so `go mod tidy` keeps them tracked in `go.mod`/`go.sum`.
- Add a release-pipeline step that emits `grpc-versions.txt` listing the exact `grpc`/`protobuf`/`protoc-gen-go`/`protoc-gen-go-grpc` versions this workflow release was built against.
- Artifact is published alongside the rest of `dist/*` via the existing `softprops/action-gh-release@v2` step (covered by `checksums.txt`).
- Propagate the new indirect dep into `example/go.{mod,sum}` so the Go Mod Tidy CI gate stays green.

## Why
Foundation for PR 2 of [`docs/plans/2026-05-10-strict-contracts-force-cutover.md`](../blob/design/strict-contracts-force-cutover/docs/plans/2026-05-10-strict-contracts-force-cutover.md) (Task 2). Downstream plugins (e.g. `workflow-plugin-digitalocean`) gate their proto toolchain pins against this file so they link against ABI-compatible gRPC/protobuf versions when implementing the typed `pb.IaCProvider` services.

No runtime impact; release-pipeline-only change.

## Plan-correction notes

Plan §Task 2 (rev5 @ e82b7e0c) had two specification bugs that this PR fixes-forward without scope-lock amendment (intent preserved, PR count unchanged):

1. Step 4 verification command `go build -tags tools ./...` is impossible by Go language semantics — `protoc-gen-go` and `protoc-gen-go-grpc` are `package main` and main packages aren't importable. Substituted with: `go mod tidy && go build ./... && go list -m all | grep protoc-gen` to achieve the spec intent (verify tool dependencies resolve and pin).

2. Step 2 dependency `google.golang.org/protobuf/cmd/protoc-gen-go` is a package inside the protobuf module, not a standalone module. Substituted parent module path with same target version.

Spec-reviewer ack'd the substitutions on the team channel; team-lead chose PR-record capture over ADR (manifest unchanged, intent preserved, audit trail in the reviewer chain).

## Local dry-run
```
$ {
    echo "grpc=$(go list -m -json google.golang.org/grpc | jq -r .Version)"
    echo "protobuf=$(go list -m -json google.golang.org/protobuf | jq -r .Version)"
    echo "protoc-gen-go=$(go list -m -json google.golang.org/protobuf | jq -r .Version)"
    echo "protoc-gen-go-grpc=$(go list -m -json google.golang.org/grpc/cmd/protoc-gen-go-grpc | jq -r .Version)"
  }
grpc=v1.80.0
protobuf=v1.36.11
protoc-gen-go=v1.36.11
protoc-gen-go-grpc=v1.6.1
```

## Test plan
- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOWORK=off go test -count=1 -run='^$' ./...` — all packages compile (no test runs needed)
- [x] `GOPRIVATE='github.com/GoCodeAlone/*' GOWORK=off go mod tidy` in `example/` — no further drift after the indirect-dep refresh
- [x] `actionlint .github/workflows/release.yml` — no findings introduced by this PR (the two pre-existing shellcheck warnings on lines 145/283 are out of scope)
- [x] Local dry-run of the version-extraction shell block produces the expected 4 lines
- [ ] CI: release pipeline dry-run (verified by tag push of `v1.0.0-rc1` in PR 4 cutover)

## Rollback
Revert the commits on this branch. Release pipeline drops back to prior state; no state migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)