### PR TITLE
feat(sdk): ServeIaCPlugin high-level entrypoint with GRPCServer callback (Task 29)

### DIFF
--- a/plugin/external/sdk/iacserver.go
+++ b/plugin/external/sdk/iacserver.go
@@ -170,10 +170,19 @@ func (p *iacGRPCPlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, _ 
 // (see iacGRPCPlugin.GRPCServer), so plugin authors cannot pre-create
 // a *grpc.Server and forget to register a typed service on it.
 //
-// Blocks until the host process terminates the connection.
+// Blocks until the host process terminates the connection. Panics on
+// invalid IaCServeOptions (e.g., partial handshake override missing
+// MagicCookieKey or MagicCookieValue) — see resolveServeHandshake.
+// Plugin authors fix the misconfig at the call site; the panic is
+// preferable to a silent fallback that produces a broken handshake at
+// dial time.
 func ServeIaCPlugin(provider any, opts IaCServeOptions) {
+	hs, err := resolveServeHandshake(opts)
+	if err != nil {
+		panic(fmt.Errorf("ServeIaCPlugin: %w", err))
+	}
 	goplugin.Serve(&goplugin.ServeConfig{
-		HandshakeConfig: resolveServeHandshake(opts),
+		HandshakeConfig: hs,
 		Plugins: goplugin.PluginSet{
 			"iac": &iacGRPCPlugin{provider: provider},
 		},
@@ -182,13 +191,41 @@ func ServeIaCPlugin(provider any, opts IaCServeOptions) {
 }
 
 // resolveServeHandshake returns the goplugin handshake to use for an IaC
-// plugin. Defaults to ext.Handshake (the canonical wfctl<->plugin handshake)
-// when the caller did not supply a non-zero PluginInfo.HandshakeConfig.
+// plugin. Defaults to ext.Handshake (the canonical wfctl<->plugin
+// handshake) when the caller did not supply a PluginInfo OR supplied
+// the zero-valued HandshakeConfig. Returns an error when the caller
+// supplied a PARTIAL override (any non-zero field but missing
+// MagicCookieKey or MagicCookieValue) — partial overrides produce a
+// broken handshake at dial time, so the misconfig is rejected early
+// rather than silently coerced to defaults.
+//
+// Per cycle 4 PR 600 IMPORTANT review (Copilot finding): the previous
+// guard only checked MagicCookieKey != "", which silently accepted a
+// caller setting ProtocolVersion or MagicCookieValue alone — fields
+// that look intentional but cannot produce a valid handshake.
+//
 // Extracted from ServeIaCPlugin so the resolution rule is unit-testable
 // without invoking goplugin.Serve's blocking loop.
-func resolveServeHandshake(opts IaCServeOptions) goplugin.HandshakeConfig {
-	if opts.PluginInfo != nil && opts.PluginInfo.HandshakeConfig.MagicCookieKey != "" {
-		return opts.PluginInfo.HandshakeConfig
+func resolveServeHandshake(opts IaCServeOptions) (goplugin.HandshakeConfig, error) {
+	if opts.PluginInfo == nil {
+		return ext.Handshake, nil
 	}
-	return ext.Handshake
+	hs := opts.PluginInfo.HandshakeConfig
+	if hs == (goplugin.HandshakeConfig{}) {
+		// Zero value: caller supplied PluginInfo{} but no handshake
+		// override. Treat identically to opts.PluginInfo == nil.
+		return ext.Handshake, nil
+	}
+	if hs.MagicCookieKey == "" || hs.MagicCookieValue == "" {
+		return goplugin.HandshakeConfig{}, fmt.Errorf(
+			"IaCServeOptions.PluginInfo.HandshakeConfig is a partial "+
+				"override (MagicCookieKey=%q MagicCookieValue=%q "+
+				"ProtocolVersion=%d): both MagicCookieKey AND "+
+				"MagicCookieValue MUST be set when overriding the default "+
+				"ext.Handshake — leave the whole struct zero-valued to "+
+				"inherit the canonical wfctl<->plugin handshake",
+			hs.MagicCookieKey, hs.MagicCookieValue, hs.ProtocolVersion,
+		)
+	}
+	return hs, nil
 }

--- a/plugin/external/sdk/iacserver.go
+++ b/plugin/external/sdk/iacserver.go
@@ -1,11 +1,14 @@
 package sdk
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
+	goplugin "github.com/GoCodeAlone/go-plugin"
 	"google.golang.org/grpc"
 
+	ext "github.com/GoCodeAlone/workflow/plugin/external"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 )
 
@@ -93,4 +96,99 @@ func RegisterAllIaCProviderServices(s *grpc.Server, provider any) error {
 		pb.RegisterResourceDriverServer(s, v)
 	}
 	return nil
+}
+
+// IaCServeOptions configures the IaC plugin gRPC server entrypoint.
+//
+// Plugin authors typically zero-value this; ServeIaCPlugin then uses the
+// canonical host<->plugin handshake (ext.Handshake). The struct exists as
+// a forward-extension point so future metadata fields (PluginInfo) can be
+// added without breaking the API.
+type IaCServeOptions struct {
+	// PluginInfo overrides the default handshake/metadata. When nil,
+	// ServeIaCPlugin uses ext.Handshake (the canonical wfctl<->plugin
+	// handshake — required for compatibility with the workflow host).
+	PluginInfo *PluginInfo
+}
+
+// PluginInfo carries the metadata that go-plugin needs to serve an IaC
+// plugin. Currently only HandshakeConfig is meaningful; reserved as the
+// extension point for future Name/Version metadata fields without
+// breaking the IaCServeOptions API.
+type PluginInfo struct {
+	// HandshakeConfig is the go-plugin handshake. Plugin authors should
+	// leave this zero-valued to inherit ext.Handshake — the host (wfctl)
+	// and plugin MUST agree on the cookie + protocol version, so override
+	// only when implementing a non-workflow host.
+	HandshakeConfig goplugin.HandshakeConfig
+}
+
+// iacGRPCPlugin implements goplugin's Plugin interface for the typed IaC
+// contract. Service registration happens INSIDE GRPCServer per go-plugin
+// v1.7.0 architecture — the framework owns the *grpc.Server lifecycle, so
+// plugin authors cannot pre-create the server and forget to register a
+// service on it.
+//
+// Note: the GoCodeAlone fork of go-plugin (v1.7.0) is gRPC-only and does
+// not expose hashicorp/go-plugin's NetRPCUnsupportedPlugin embed or a
+// GRPCPlugin convenience alias; the canonical Plugin interface (just
+// GRPCServer + GRPCClient) is sufficient and matches the existing
+// servePlugin pattern in serve.go.
+type iacGRPCPlugin struct {
+	provider any
+}
+
+// GRPCServer is invoked by go-plugin once it has constructed the
+// *grpc.Server. Delegates to RegisterAllIaCProviderServices so every
+// typed IaC service the provider satisfies gets registered in one call.
+//
+// Returning an error here causes go-plugin to abort plugin startup —
+// surfacing missing required methods as a plugin-startup error rather
+// than a generic "unimplemented" status at the first RPC dispatch.
+func (p *iacGRPCPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
+	return RegisterAllIaCProviderServices(s, p.provider)
+}
+
+// GRPCClient is unused on the plugin side. The workflow host (wfctl)
+// builds its own typed pb.IaCProviderRequiredClient + per-optional
+// clients directly from the gRPC connection; the iacGRPCPlugin's
+// client-side adapter is therefore a no-op.
+func (p *iacGRPCPlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, _ *grpc.ClientConn) (any, error) {
+	return nil, nil
+}
+
+// ServeIaCPlugin starts a typed IaC plugin gRPC server with auto
+// registration of every IaC service the provider satisfies. Plugin
+// authors call this once in main.go:
+//
+//	func main() {
+//	    sdk.ServeIaCPlugin(&doProvider{}, sdk.IaCServeOptions{})
+//	}
+//
+// Per cycle 3 I-1 of the strict-contracts force-cutover design, the
+// service registration happens INSIDE go-plugin's GRPCServer callback
+// (see iacGRPCPlugin.GRPCServer), so plugin authors cannot pre-create
+// a *grpc.Server and forget to register a typed service on it.
+//
+// Blocks until the host process terminates the connection.
+func ServeIaCPlugin(provider any, opts IaCServeOptions) {
+	goplugin.Serve(&goplugin.ServeConfig{
+		HandshakeConfig: resolveServeHandshake(opts),
+		Plugins: goplugin.PluginSet{
+			"iac": &iacGRPCPlugin{provider: provider},
+		},
+		GRPCServer: goplugin.DefaultGRPCServer,
+	})
+}
+
+// resolveServeHandshake returns the goplugin handshake to use for an IaC
+// plugin. Defaults to ext.Handshake (the canonical wfctl<->plugin handshake)
+// when the caller did not supply a non-zero PluginInfo.HandshakeConfig.
+// Extracted from ServeIaCPlugin so the resolution rule is unit-testable
+// without invoking goplugin.Serve's blocking loop.
+func resolveServeHandshake(opts IaCServeOptions) goplugin.HandshakeConfig {
+	if opts.PluginInfo != nil && opts.PluginInfo.HandshakeConfig.MagicCookieKey != "" {
+		return opts.PluginInfo.HandshakeConfig
+	}
+	return ext.Handshake
 }

--- a/plugin/external/sdk/iacserver_serve_test.go
+++ b/plugin/external/sdk/iacserver_serve_test.go
@@ -1,0 +1,136 @@
+package sdk
+
+// Internal test (package sdk, not sdk_test) so the unexported
+// iacGRPCPlugin can be exercised directly without spawning a real
+// plugin subprocess.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	goplugin "github.com/GoCodeAlone/go-plugin"
+	"google.golang.org/grpc"
+
+	ext "github.com/GoCodeAlone/workflow/plugin/external"
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+)
+
+// TestIaCGRPCPlugin_GRPCServer_RegistersAllServices asserts that the
+// go-plugin framework callback delegates to RegisterAllIaCProviderServices,
+// so every typed service the provider satisfies is registered on the
+// framework-managed *grpc.Server. This is the cycle 3 I-1 invariant:
+// service registration happens INSIDE GRPCServer, not in caller-allocated
+// servers.
+func TestIaCGRPCPlugin_GRPCServer_RegistersAllServices(t *testing.T) {
+	grpcSrv := grpc.NewServer()
+	provider := &serveTestAllStub{}
+	p := &iacGRPCPlugin{provider: provider}
+
+	if err := p.GRPCServer(nil, grpcSrv); err != nil {
+		t.Fatalf("GRPCServer returned error: %v", err)
+	}
+
+	info := grpcSrv.GetServiceInfo()
+	want := []string{
+		"workflow.plugin.external.iac.IaCProviderRequired",
+		"workflow.plugin.external.iac.IaCProviderEnumerator",
+		"workflow.plugin.external.iac.ResourceDriver",
+	}
+	for _, name := range want {
+		if _, ok := info[name]; !ok {
+			t.Errorf("expected %q registered; have: %v", name, len(info))
+		}
+	}
+}
+
+// TestIaCGRPCPlugin_GRPCServer_PropagatesAutoRegisterError asserts the
+// callback surfaces RegisterAllIaCProviderServices errors so go-plugin
+// aborts plugin startup with an actionable message rather than booting
+// a half-registered server.
+func TestIaCGRPCPlugin_GRPCServer_PropagatesAutoRegisterError(t *testing.T) {
+	grpcSrv := grpc.NewServer()
+	p := &iacGRPCPlugin{provider: &emptyServeStub{}}
+
+	err := p.GRPCServer(nil, grpcSrv)
+	if err == nil {
+		t.Fatalf("expected error for unsatisfied required interface; got nil")
+	}
+	if !strings.Contains(err.Error(), "IaCProviderRequiredServer") {
+		t.Fatalf("error must name the missing interface; got %q", err.Error())
+	}
+}
+
+// TestIaCGRPCPlugin_GRPCClient_NoOp asserts the plugin-side GRPCClient
+// adapter returns (nil, nil). The host (wfctl) builds its own typed
+// pb.IaCProviderRequiredClient directly from the connection.
+func TestIaCGRPCPlugin_GRPCClient_NoOp(t *testing.T) {
+	p := &iacGRPCPlugin{}
+	out, err := p.GRPCClient(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("GRPCClient returned error: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil client; got %T", out)
+	}
+}
+
+// TestIaCGRPCPlugin_SatisfiesGoPluginPlugin guarantees that
+// iacGRPCPlugin remains compatible with the goplugin.Plugin interface
+// (GRPCServer + GRPCClient) — a refactor that renames either method
+// or changes its signature would fail this assertion at compile time.
+//
+// (The GoCodeAlone fork of go-plugin is gRPC-only; there is no separate
+// GRPCPlugin alias to assert against. Plugin is the canonical
+// interface.)
+func TestIaCGRPCPlugin_SatisfiesGoPluginPlugin(t *testing.T) {
+	var _ goplugin.Plugin = (*iacGRPCPlugin)(nil)
+}
+
+// TestServeIaCPlugin_DefaultsToWorkflowHandshake_WhenPluginInfoNil
+// asserts the entrypoint defaults to ext.Handshake when callers pass
+// IaCServeOptions{} (no override). Verified indirectly via the
+// resolveServeHandshake helper extracted from ServeIaCPlugin so the
+// blocking goplugin.Serve loop is not invoked in tests.
+func TestServeIaCPlugin_DefaultsToWorkflowHandshake_WhenPluginInfoNil(t *testing.T) {
+	got := resolveServeHandshake(IaCServeOptions{})
+	if got.MagicCookieKey != ext.Handshake.MagicCookieKey {
+		t.Fatalf("expected default ext.Handshake; got cookie key %q", got.MagicCookieKey)
+	}
+	if got.MagicCookieValue != ext.Handshake.MagicCookieValue {
+		t.Fatalf("expected default ext.Handshake; got cookie value %q", got.MagicCookieValue)
+	}
+	if got.ProtocolVersion != ext.Handshake.ProtocolVersion {
+		t.Fatalf("expected default protocol version %d; got %d",
+			ext.Handshake.ProtocolVersion, got.ProtocolVersion)
+	}
+}
+
+// TestServeIaCPlugin_HonorsOverrideHandshake_WhenProvided asserts that
+// callers can supply a non-zero handshake (e.g., for non-workflow hosts)
+// via IaCServeOptions.PluginInfo.HandshakeConfig.
+func TestServeIaCPlugin_HonorsOverrideHandshake_WhenProvided(t *testing.T) {
+	custom := goplugin.HandshakeConfig{
+		ProtocolVersion:  42,
+		MagicCookieKey:   "CUSTOM_COOKIE",
+		MagicCookieValue: "v",
+	}
+	got := resolveServeHandshake(IaCServeOptions{
+		PluginInfo: &PluginInfo{HandshakeConfig: custom},
+	})
+	if got != custom {
+		t.Fatalf("expected custom handshake; got %+v", got)
+	}
+}
+
+// serveTestAllStub satisfies Required + Enumerator + ResourceDriver to
+// exercise the auto-registration path through the GRPCServer callback.
+type serveTestAllStub struct {
+	pb.UnimplementedIaCProviderRequiredServer
+	pb.UnimplementedIaCProviderEnumeratorServer
+	pb.UnimplementedResourceDriverServer
+}
+
+// emptyServeStub satisfies no IaC interface. The GRPCServer callback
+// MUST surface this as an error so go-plugin aborts startup.
+type emptyServeStub struct{}

--- a/plugin/external/sdk/iacserver_serve_test.go
+++ b/plugin/external/sdk/iacserver_serve_test.go
@@ -93,7 +93,10 @@ func TestIaCGRPCPlugin_SatisfiesGoPluginPlugin(t *testing.T) {
 // resolveServeHandshake helper extracted from ServeIaCPlugin so the
 // blocking goplugin.Serve loop is not invoked in tests.
 func TestServeIaCPlugin_DefaultsToWorkflowHandshake_WhenPluginInfoNil(t *testing.T) {
-	got := resolveServeHandshake(IaCServeOptions{})
+	got, err := resolveServeHandshake(IaCServeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got.MagicCookieKey != ext.Handshake.MagicCookieKey {
 		t.Fatalf("expected default ext.Handshake; got cookie key %q", got.MagicCookieKey)
 	}
@@ -106,20 +109,93 @@ func TestServeIaCPlugin_DefaultsToWorkflowHandshake_WhenPluginInfoNil(t *testing
 	}
 }
 
+// TestServeIaCPlugin_DefaultsToWorkflowHandshake_WhenPluginInfoZeroValue
+// asserts that a PluginInfo with the zero-valued HandshakeConfig is
+// treated identically to a nil PluginInfo — caller passed an empty
+// PluginInfo{} for forward-extensibility, not as a partial override.
+func TestServeIaCPlugin_DefaultsToWorkflowHandshake_WhenPluginInfoZeroValue(t *testing.T) {
+	got, err := resolveServeHandshake(IaCServeOptions{PluginInfo: &PluginInfo{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ext.Handshake {
+		t.Fatalf("expected ext.Handshake; got %+v", got)
+	}
+}
+
 // TestServeIaCPlugin_HonorsOverrideHandshake_WhenProvided asserts that
 // callers can supply a non-zero handshake (e.g., for non-workflow hosts)
-// via IaCServeOptions.PluginInfo.HandshakeConfig.
+// via IaCServeOptions.PluginInfo.HandshakeConfig — both MagicCookieKey
+// AND MagicCookieValue must be set for the override to be valid.
 func TestServeIaCPlugin_HonorsOverrideHandshake_WhenProvided(t *testing.T) {
 	custom := goplugin.HandshakeConfig{
 		ProtocolVersion:  42,
 		MagicCookieKey:   "CUSTOM_COOKIE",
 		MagicCookieValue: "v",
 	}
-	got := resolveServeHandshake(IaCServeOptions{
+	got, err := resolveServeHandshake(IaCServeOptions{
 		PluginInfo: &PluginInfo{HandshakeConfig: custom},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got != custom {
 		t.Fatalf("expected custom handshake; got %+v", got)
+	}
+}
+
+// TestServeIaCPlugin_PartialHandshakeOverride_ReturnsError asserts that
+// a partial handshake override (any non-zero field but missing
+// MagicCookieKey or MagicCookieValue) is rejected with a typed error
+// rather than silently coerced to ext.Handshake. Per cycle 4 PR 600
+// IMPORTANT review (Copilot finding): partial overrides look
+// intentional but cannot produce a valid handshake; falling back to
+// defaults silently swallows the misconfig until dial-time when the
+// host rejects the cookie.
+func TestServeIaCPlugin_PartialHandshakeOverride_ReturnsError(t *testing.T) {
+	cases := []struct {
+		name string
+		hs   goplugin.HandshakeConfig
+	}{
+		{
+			name: "only_protocol_version_set",
+			hs:   goplugin.HandshakeConfig{ProtocolVersion: 7},
+		},
+		{
+			name: "only_magic_cookie_key_set",
+			hs:   goplugin.HandshakeConfig{MagicCookieKey: "X"},
+		},
+		{
+			name: "only_magic_cookie_value_set",
+			hs:   goplugin.HandshakeConfig{MagicCookieValue: "Y"},
+		},
+		{
+			name: "key_set_value_empty",
+			hs: goplugin.HandshakeConfig{
+				ProtocolVersion: 7,
+				MagicCookieKey:  "X",
+			},
+		},
+		{
+			name: "value_set_key_empty",
+			hs: goplugin.HandshakeConfig{
+				ProtocolVersion:  7,
+				MagicCookieValue: "Y",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveServeHandshake(IaCServeOptions{
+				PluginInfo: &PluginInfo{HandshakeConfig: tc.hs},
+			})
+			if err == nil {
+				t.Fatalf("expected error for partial override %+v; got nil", tc.hs)
+			}
+			if !strings.Contains(err.Error(), "partial") {
+				t.Errorf("error must name 'partial'; got %q", err.Error())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Task 29 of the strict-contracts force-cutover plan ([docs/plans/2026-05-10-strict-contracts-force-cutover.md](https://github.com/GoCodeAlone/workflow/blob/main/docs/plans/2026-05-10-strict-contracts-force-cutover.md), rev5).

Adds the high-level plugin-author API on top of Task 4's `RegisterAllIaCProviderServices`:

```go
func main() {
    sdk.ServeIaCPlugin(&doProvider{}, sdk.IaCServeOptions{})
}
```

Per **cycle 3 I-1**, service registration happens INSIDE go-plugin's `GRPCServer` callback (`iacGRPCPlugin.GRPCServer`) — the framework owns `*grpc.Server` lifecycle, so plugin authors cannot pre-create a server and forget to register a typed service on it.

**Stacked on PR #599 (Task 4).** Base branch is `feat/iac-sdk-auto-register-task4`.

### API surface (`plugin/external/sdk/iacserver.go`)

- `IaCServeOptions{ PluginInfo *PluginInfo }` — caller-side options
- `PluginInfo{ HandshakeConfig goplugin.HandshakeConfig }` — extension point for future Name/Version metadata; defaults to `ext.Handshake` when zero-valued
- `iacGRPCPlugin{provider any}` — implements `goplugin.Plugin` (`GRPCServer + GRPCClient`). The GoCodeAlone fork of go-plugin v1.7.0 is gRPC-only and exposes only the canonical `Plugin` interface (no `GRPCPlugin` alias / `NetRPCUnsupportedPlugin` embed)
- `ServeIaCPlugin(provider, opts)` — wraps `goplugin.Serve` with the resolved handshake + a single `iacGRPCPlugin` entry under the `"iac"` key
- `resolveServeHandshake(opts)` — extracted helper so the override-vs-default rule is unit-testable without invoking the blocking `goplugin.Serve` loop

### Tests (`iacserver_serve_test.go`, internal-package)

Six cases — all PASS:

- `GRPCServer_RegistersAllServices` — auto-registers Required + Enumerator + ResourceDriver on the framework-managed gRPC server
- `GRPCServer_PropagatesAutoRegisterError` — empty stub yields a startup-aborting error
- `GRPCClient_NoOp` — plugin-side client adapter returns `(nil, nil)`
- `SatisfiesGoPluginPlugin` — compile-time refactor guard
- `DefaultsToWorkflowHandshake_WhenPluginInfoNil` — default is `ext.Handshake`
- `HonorsOverrideHandshake_WhenProvided` — caller can override (e.g., for non-workflow hosts)

Subprocess-level coverage of `ServeIaCPlugin` end-to-end lands in Task 6's typed-IaC E2E test.

### Verification

- `GOWORK=off go test -race ./plugin/external/sdk/...` → PASS
- `GOWORK=off go build ./plugin/... ./cmd/... ./module/...` → clean
- `GOWORK=off go vet ./plugin/external/...` → clean

### Rollback

Revert this commit; plugin authors can fall back to manually constructing `goplugin.Serve` + `Plugins` map referencing `RegisterAllIaCProviderServices` in their own `GRPCServer` callback.

## Test plan

- [x] All 6 internal tests pass (`-v -run TestIaCGRPCPlugin|TestServeIaCPlugin`)
- [x] Race-mode test passes
- [x] No new lint or vet warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)