### PR TITLE
Load plugin step schemas during validation

### DIFF
--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -389,3 +389,49 @@ func TestRunValidatePluginDirCapabilities(t *testing.T) {
 		schema.UnregisterModuleType("step.caps_validate_testonly")
 	})
 }
+
+func TestRunValidatePluginDirLoadsStepSchemas(t *testing.T) {
+	pluginsDir := t.TempDir()
+	pluginSubdir := filepath.Join(pluginsDir, "my-ext-plugin-step-schema")
+	if err := os.MkdirAll(pluginSubdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name": "my-ext-plugin-step-schema",
+		"version": "1.0.0",
+		"moduleTypes": ["custom.step_schema_validate_testonly"],
+		"stepSchemas": [
+			{
+				"type": "step.schema_validate_testonly",
+				"description": "test-only plugin step schema",
+				"configFields": [
+					{"key": "target", "type": "string", "required": true}
+				]
+			}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(pluginSubdir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := schema.GetStepSchemaRegistry()
+	if reg.Get("step.schema_validate_testonly") != nil {
+		t.Fatal("step.schema_validate_testonly should not exist before loading")
+	}
+
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, "workflow.yaml", `
+modules:
+  - name: ext-mod
+    type: custom.step_schema_validate_testonly
+`)
+	if err := runValidate([]string{"--plugin-dir", pluginsDir, path}); err != nil {
+		t.Fatalf("expected valid config with --plugin-dir, got: %v", err)
+	}
+	if got := reg.Get("step.schema_validate_testonly"); got == nil {
+		t.Fatal("expected runValidate --plugin-dir to load plugin step schema")
+	}
+	t.Cleanup(func() {
+		schema.UnregisterModuleType("custom.step_schema_validate_testonly")
+		reg.Unregister("step.schema_validate_testonly")
+	})
+}

--- a/cmd/wfctl/validate.go
+++ b/cmd/wfctl/validate.go
@@ -52,6 +52,7 @@ Options:
 		if err := schema.LoadPluginTypesFromDir(*pluginDir); err != nil {
 			return fmt.Errorf("failed to load plugins from %s: %w", *pluginDir, err)
 		}
+		schema.LoadPluginStepSchemasFromDir(*pluginDir)
 	}
 
 	// Collect files to validate


### PR DESCRIPTION
## Summary
- load plugin `stepSchemas` when `wfctl validate --plugin-dir` is used
- add a regression test proving validate loads plugin step schema metadata, not only plugin type names

## Verification
- GOWORK=off go test ./cmd/wfctl -run 'TestRunValidatePluginDir|TestRunValidatePluginDirCapabilities|TestRunValidatePluginDirLoadsStepSchemas'\n- GOWORK=off go test ./cmd/wfctl\n\n## Review\n- Antagonistic/security pass: current main already contains the richer external trigger factory support and IaC helper fixes, so this PR intentionally keeps only the missing validation-path change. No credential, provider, deploy, or runtime execution behavior changes.