### PR TITLE
test(wfctl): state-file v0.14.2 → v1.0.0 read-path pre-flight (Task 31)

### DIFF
--- a/cmd/wfctl/state_compat_test.go
+++ b/cmd/wfctl/state_compat_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -72,14 +72,28 @@ func TestStateFileCompat_v0_14_2_to_v1_0_0(t *testing.T) {
 	if state.Provider != record.Provider {
 		t.Errorf("Provider = %q; want %q", state.Provider, record.Provider)
 	}
-	if state.ProviderID == "" {
-		t.Errorf("ProviderID is empty after decode (must default to ResourceID when source is empty)")
+	// MINOR-1: strict-equality on ProviderID rather than non-empty.
+	// Non-empty would pass silently if `provider_id` stops decoding,
+	// because iacRecordToResourceState falls back to ResourceID.
+	// The fixture provider_id is DO00FIXTURE1234567890; pin it.
+	if state.ProviderID != record.ProviderID {
+		t.Errorf("ProviderID = %q; want %q (silent fallback to ResourceID indicates "+
+			"provider_id decode regression)", state.ProviderID, record.ProviderID)
 	}
+	// MINOR-2: nil-checks on AppliedConfig / Outputs would pass when
+	// the maps decoded as empty {} (silent map-content drop). Pin to
+	// at least one known fixture key per map.
 	if state.AppliedConfig == nil {
 		t.Errorf("AppliedConfig is nil after decode (config map dropped during conversion)")
+	} else if got, ok := state.AppliedConfig["name"].(string); !ok || got != "iac-state-spaces-key" {
+		t.Errorf("AppliedConfig[\"name\"] = %v; want %q (config-map content drop?)",
+			state.AppliedConfig["name"], "iac-state-spaces-key")
 	}
 	if state.Outputs == nil {
 		t.Errorf("Outputs is nil after decode (outputs map dropped during conversion)")
+	} else if got, ok := state.Outputs["access_key"].(string); !ok || got == "" {
+		t.Errorf("Outputs[\"access_key\"] = %v; want non-empty (outputs-map content drop?)",
+			state.Outputs["access_key"])
 	}
 }
 
@@ -112,7 +126,7 @@ func TestStateFileCompat_v0_14_2_NoUnknownFieldsLost(t *testing.T) {
 		t.Fatalf("re-marshal stripped: %v", err)
 	}
 
-	dec := json.NewDecoder(strings.NewReader(string(stripped)))
+	dec := json.NewDecoder(bytes.NewReader(stripped))
 	dec.DisallowUnknownFields()
 	var record iacStateRecord
 	if err := dec.Decode(&record); err != nil {

--- a/cmd/wfctl/state_compat_test.go
+++ b/cmd/wfctl/state_compat_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestStateFileCompat_v0_14_2_to_v1_0_0 asserts that wfctl v1.0.0 reads
+// state files written by v0.14.2 cleanly — the strict-contracts force-
+// cutover changes the wfctl <-> plugin gRPC envelope but MUST NOT
+// change the on-disk JSON state-file format. This is the cycle 1 I-4
+// pre-flight that catches the cascade-block risk for PR 5 (operator
+// pin bumps) BEFORE that PR merges.
+//
+// Per Task 31 of the strict-contracts force-cutover plan:
+//
+//   - The fixture (test/fixtures/state-v0.14.2.json) is intended to be
+//     replaced by a real production state snapshot during PR 4 prep
+//     (operator copies coredump-staging/iac-state/state.json from the
+//     Spaces backend; see plan §Step 1). The synthetic fixture
+//     committed to the repo represents the v0.14.2 schema shape so the
+//     test can run in CI; the operator-captured replacement provides
+//     the real-world fidelity check.
+//
+//   - The test reads the fixture via the v1.0.0 wfctl iacStateRecord
+//     decoder (the same path loadFSState / spacesWfctlStateStore.
+//     ListResources use), then converts it via iacRecordToResourceState
+//     and asserts every load-bearing field survived.
+//
+// If this test FAILS in CI: PR 5 cascade-block surfaces. Plan response
+// (per Task 31 §If FAIL):
+//   - File a separate workflow PR (feat: state-file v0.14.2 compat
+//     shim) that adds the compatibility layer.
+//   - Hold PR 5 (and consequently PRs 6–9) until the shim PR merges.
+//   - Document the gap in PR 4's CHANGELOG.
+func TestStateFileCompat_v0_14_2_to_v1_0_0(t *testing.T) {
+	path := fixturePath(t, "state-v0.14.2.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !json.Valid(data) {
+		t.Fatalf("fixture is not valid JSON: %s", path)
+	}
+
+	var record iacStateRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("unmarshal v0.14.2 fixture into v1.0.0 iacStateRecord: %v", err)
+	}
+
+	if record.ResourceID == "" {
+		t.Fatalf("v0.14.2 fixture has empty resource_id (schema regression?)")
+	}
+	if record.ResourceType == "" {
+		t.Fatalf("v0.14.2 fixture has empty resource_type (schema regression?)")
+	}
+
+	// Convert via the same path loadCurrentState uses on the v1.0.0
+	// read pipeline. Any panics, type assertions, or schema mismatches
+	// surface as test failures here.
+	state := iacRecordToResourceState(record)
+	if state.ID != record.ResourceID {
+		t.Errorf("ID = %q; want %q", state.ID, record.ResourceID)
+	}
+	if state.Type != record.ResourceType {
+		t.Errorf("Type = %q; want %q", state.Type, record.ResourceType)
+	}
+	if state.Provider != record.Provider {
+		t.Errorf("Provider = %q; want %q", state.Provider, record.Provider)
+	}
+	if state.ProviderID == "" {
+		t.Errorf("ProviderID is empty after decode (must default to ResourceID when source is empty)")
+	}
+	if state.AppliedConfig == nil {
+		t.Errorf("AppliedConfig is nil after decode (config map dropped during conversion)")
+	}
+	if state.Outputs == nil {
+		t.Errorf("Outputs is nil after decode (outputs map dropped during conversion)")
+	}
+}
+
+// TestStateFileCompat_v0_14_2_NoUnknownFieldsLost guards against the
+// regression where v0.14.2 produced fields that v1.0.0's decoder
+// silently drops. Uses json.Decoder with DisallowUnknownFields so an
+// unexpected v0.14.2 field surfaces as a test failure naming it.
+//
+// Note: this test is INTENTIONALLY allowed to skip the fixture's
+// _fixture_metadata header (synthetic-fixture annotation, not a
+// production v0.14.2 field) by reading the bytes through a thin
+// pre-processor that strips that field before strict decoding. When
+// the operator replaces the fixture with a real v0.14.2 capture, the
+// metadata header pre-process becomes a no-op and the strict decode
+// runs against the real wire bytes.
+func TestStateFileCompat_v0_14_2_NoUnknownFieldsLost(t *testing.T) {
+	path := fixturePath(t, "state-v0.14.2.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	delete(raw, "_fixture_metadata")
+	stripped, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("re-marshal stripped: %v", err)
+	}
+
+	dec := json.NewDecoder(strings.NewReader(string(stripped)))
+	dec.DisallowUnknownFields()
+	var record iacStateRecord
+	if err := dec.Decode(&record); err != nil {
+		t.Fatalf("v1.0.0 strict decode of v0.14.2 fixture failed — schema regression: %v", err)
+	}
+}
+
+// fixturePath resolves the absolute path to a fixture under
+// test/fixtures/<name>, walking up from the package's runtime
+// directory until it finds a "test/fixtures" sibling. This avoids
+// hardcoding a relative path that breaks under `go test ./...` from
+// repo root vs from the package dir.
+func fixturePath(t *testing.T, name string) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed; cannot locate fixture %q", name)
+	}
+	dir := filepath.Dir(here)
+	for {
+		candidate := filepath.Join(dir, "test", "fixtures", name)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find test/fixtures/%s walking up from %s", name, filepath.Dir(here))
+		}
+		dir = parent
+	}
+}

--- a/test/fixtures/state-v0.14.2.json
+++ b/test/fixtures/state-v0.14.2.json
@@ -1,0 +1,28 @@
+{
+  "_fixture_metadata": {
+    "captured_from": "synthetic — replace with real coredump-staging/iac-state/<resource>.json snapshot during PR 4 prep per Task 31 §Step 1",
+    "wfctl_writer_version": "v0.14.2",
+    "schema_revision": "iacStateRecord pre-cutover (snake_case keys, Status field, no SchemaVersion)",
+    "captured_at": "2026-04-15T10:30:00Z"
+  },
+  "resource_id": "iac-state-spaces-key",
+  "resource_type": "infra.spaces_key",
+  "provider": "digitalocean",
+  "provider_ref": "iac-state-spaces-key",
+  "provider_id": "DO00FIXTURE1234567890",
+  "config_hash": "sha256:fab9d2c1e0b7e4f5a3d8c6b2e1a0f9d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8",
+  "status": "active",
+  "config": {
+    "name": "iac-state-spaces-key",
+    "purpose": "iac-state-backend",
+    "scope": "fullaccess"
+  },
+  "outputs": {
+    "access_key": "DO00FIXTURE1234567890",
+    "endpoint": "https://nyc3.digitaloceanspaces.com",
+    "region": "nyc3"
+  },
+  "dependencies": [],
+  "created_at": "2026-04-15T10:30:00Z",
+  "updated_at": "2026-04-15T10:30:00Z"
+}


### PR DESCRIPTION
## Summary

Task 31 of the strict-contracts force-cutover plan ([docs/plans/2026-05-10-strict-contracts-force-cutover.md](https://github.com/GoCodeAlone/workflow/blob/main/docs/plans/2026-05-10-strict-contracts-force-cutover.md), rev5).

Adds the **cycle 1 I-4 pre-flight test** that catches the cascade-block risk for PR 5 BEFORE that PR merges. The strict-contracts cutover changes the wfctl ↔ plugin gRPC envelope but MUST NOT change the on-disk JSON state-file format (`interfaces.ResourceState` / `iacStateRecord` schema invariant per the design's State-file compat invariant).

**Independent of the PR 2 stack** — modifies only test infrastructure. Base is `main`.

### What's added

- **`test/fixtures/state-v0.14.2.json`** — fixture in v0.14.2 schema shape (snake_case keys, `Status` field, no `SchemaVersion`). Synthetic, carries an `_fixture_metadata` header noting the operator should replace it with a real `coredump-staging/iac-state/<resource>.json` snapshot from the Spaces backend during PR 4 prep (per plan §Step 1). The synthetic version lets the test run in CI; the operator-captured replacement provides real-world fidelity.

- **`cmd/wfctl/state_compat_test.go`** — two pre-flight tests:
  - `TestStateFileCompat_v0_14_2_to_v1_0_0` — reads the fixture via `iacStateRecord` (the v1.0.0 wire decoder used by `loadFSState` and `spacesWfctlStateStore.ListResources`), then converts via `iacRecordToResourceState` and asserts `ID`, `Type`, `Provider`, `ProviderID`, `AppliedConfig`, `Outputs` all survive the decode + conversion path
  - `TestStateFileCompat_v0_14_2_NoUnknownFieldsLost` — re-decodes with `DisallowUnknownFields()` so any v0.14.2 field that v1.0.0 silently drops surfaces as a test failure. Strips the `_fixture_metadata` header before strict decode (synthetic annotation only — the strip becomes a no-op once the operator replaces with a real capture)

### If these tests FAIL

Per Task 31 §If FAIL — PR 5 cascade-block surfaces:

- File a separate workflow PR (`feat: state-file v0.14.2 compat shim`) adding the compatibility layer
- Hold PR 5 (and consequently PRs 6–9) until the shim PR merges
- Document the gap in PR 4's CHANGELOG

### Verification

- `GOWORK=off go test -race ./cmd/wfctl/...` → PASS (2/2 new tests pass)
- `GOWORK=off go vet ./cmd/wfctl/` → clean

### Rollback

Revert this commit. The pre-flight is purely additive — test fixture + Go test. Production state-file decode pipeline is unaffected.

## Test plan

- [x] `TestStateFileCompat_v0_14_2_to_v1_0_0` passes
- [x] `TestStateFileCompat_v0_14_2_NoUnknownFieldsLost` passes (no unexpected fields)
- [x] Race-mode wfctl test suite passes
- [ ] Operator replaces synthetic fixture with real coredump-staging snapshot during PR 4 prep (deferred — operator action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)