### PR TITLE
fix(wfctl plugin install): preserve cliCommands + buildHooks in installed plugin.json

### DIFF
--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -1198,6 +1198,17 @@ type installedPluginCapabilities struct {
 	StepTypes    []string             `json:"stepTypes,omitempty"`
 	TriggerTypes []string             `json:"triggerTypes,omitempty"`
 	IaCProvider  *RegistryIaCProvider `json:"iacProvider,omitempty"`
+	// CLICommands flow through to plugin.json so BuildCLIRegistry can
+	// discover plugin-provided wfctl subcommands after install. Earlier
+	// versions of writeInstalledManifest dropped this field, leaving
+	// the installed manifest stripped of cliCommands even when the
+	// registry manifest declared them — `wfctl <plugin-cmd>` then
+	// reported `unknown command` post-install.
+	CLICommands []RegistryCLICommand `json:"cliCommands,omitempty"`
+	// BuildHooks flow through for the same reason: the build-hook
+	// dispatcher reads them from the installed plugin.json, not the
+	// registry manifest.
+	BuildHooks []RegistryBuildHook `json:"buildHooks,omitempty"`
 }
 
 // writeInstalledManifest writes a full plugin.json compatible with the engine's
@@ -1220,6 +1231,8 @@ func writeInstalledManifest(path string, m *RegistryManifest) error {
 			StepTypes:    m.Capabilities.StepTypes,
 			TriggerTypes: m.Capabilities.TriggerTypes,
 			IaCProvider:  m.Capabilities.IaCProvider,
+			CLICommands:  m.Capabilities.CLICommands,
+			BuildHooks:   m.Capabilities.BuildHooks,
 		}
 	}
 	data, err := json.MarshalIndent(pj, "", "  ")

--- a/cmd/wfctl/plugin_install_e2e_test.go
+++ b/cmd/wfctl/plugin_install_e2e_test.go
@@ -423,17 +423,18 @@ func TestSafeJoin(t *testing.T) {
 	}
 }
 
-// TestInstalledManifestPreservesCLICommands is the regression test for the
-// post-install plugin-CLI dispatch bug: writeInstalledManifest used to drop
-// capabilities.cliCommands, so even when a registry manifest declared them,
-// `wfctl <plugin-cmd>` reported `unknown command` because BuildCLIRegistry
-// reads from the on-disk plugin.json (not the registry manifest).
-func TestInstalledManifestPreservesCLICommands(t *testing.T) {
+// TestInstalledManifestPreservesCLICommandsAndBuildHooks is the regression
+// test for the post-install dispatch bug: writeInstalledManifest used to drop
+// capabilities.cliCommands and capabilities.buildHooks, so even when a
+// registry manifest declared them, BuildCLIRegistry / build-hook discovery
+// reading the on-disk plugin.json saw an empty list. `wfctl <plugin-cmd>`
+// then reported `unknown command` and build hooks silently no-oped.
+func TestInstalledManifestPreservesCLICommandsAndBuildHooks(t *testing.T) {
 	rm := &RegistryManifest{
 		Name:        "workflow-plugin-payments",
 		Version:     "0.3.1",
 		Author:      "tester",
-		Description: "regression: cliCommands preserved post-install",
+		Description: "regression: cliCommands + buildHooks preserved post-install",
 		Type:        "external",
 		Tier:        "core",
 		License:     "Apache-2.0",
@@ -443,8 +444,11 @@ func TestInstalledManifestPreservesCLICommands(t *testing.T) {
 			CLICommands: []RegistryCLICommand{
 				{Name: "payments", Description: "Payment provider operations"},
 			},
+			// Use a canonical event identifier (underscore-separated) per
+			// interfaces.HookEvent* convention; using a hyphen-separated
+			// placeholder would mask future validation drift.
 			BuildHooks: []RegistryBuildHook{
-				{Event: "pre-build", Priority: 10},
+				{Event: "pre_build", Priority: 10},
 			},
 		},
 	}
@@ -469,8 +473,8 @@ func TestInstalledManifestPreservesCLICommands(t *testing.T) {
 	if len(got.Capabilities.CLICommands) != 1 || got.Capabilities.CLICommands[0].Name != "payments" {
 		t.Errorf("CLICommands = %+v, want [{Name: payments, …}]", got.Capabilities.CLICommands)
 	}
-	if len(got.Capabilities.BuildHooks) != 1 || got.Capabilities.BuildHooks[0].Event != "pre-build" {
-		t.Errorf("BuildHooks = %+v, want [{Event: pre-build, …}]", got.Capabilities.BuildHooks)
+	if len(got.Capabilities.BuildHooks) != 1 || got.Capabilities.BuildHooks[0].Event != "pre_build" {
+		t.Errorf("BuildHooks = %+v, want [{Event: pre_build, …}]", got.Capabilities.BuildHooks)
 	}
 }
 

--- a/cmd/wfctl/plugin_install_e2e_test.go
+++ b/cmd/wfctl/plugin_install_e2e_test.go
@@ -423,6 +423,57 @@ func TestSafeJoin(t *testing.T) {
 	}
 }
 
+// TestInstalledManifestPreservesCLICommands is the regression test for the
+// post-install plugin-CLI dispatch bug: writeInstalledManifest used to drop
+// capabilities.cliCommands, so even when a registry manifest declared them,
+// `wfctl <plugin-cmd>` reported `unknown command` because BuildCLIRegistry
+// reads from the on-disk plugin.json (not the registry manifest).
+func TestInstalledManifestPreservesCLICommands(t *testing.T) {
+	rm := &RegistryManifest{
+		Name:        "workflow-plugin-payments",
+		Version:     "0.3.1",
+		Author:      "tester",
+		Description: "regression: cliCommands preserved post-install",
+		Type:        "external",
+		Tier:        "core",
+		License:     "Apache-2.0",
+		Capabilities: &RegistryCapabilities{
+			ModuleTypes: []string{"payments.provider"},
+			StepTypes:   []string{"step.payment_charge"},
+			CLICommands: []RegistryCLICommand{
+				{Name: "payments", Description: "Payment provider operations"},
+			},
+			BuildHooks: []RegistryBuildHook{
+				{Event: "pre-build", Priority: 10},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.json")
+	if err := writeInstalledManifest(path, rm); err != nil {
+		t.Fatalf("writeInstalledManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read installed plugin.json: %v", err)
+	}
+	var got installedPluginJSON
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal installed plugin.json: %v", err)
+	}
+	if got.Capabilities == nil {
+		t.Fatal("expected non-nil Capabilities")
+	}
+	if len(got.Capabilities.CLICommands) != 1 || got.Capabilities.CLICommands[0].Name != "payments" {
+		t.Errorf("CLICommands = %+v, want [{Name: payments, …}]", got.Capabilities.CLICommands)
+	}
+	if len(got.Capabilities.BuildHooks) != 1 || got.Capabilities.BuildHooks[0].Event != "pre-build" {
+		t.Errorf("BuildHooks = %+v, want [{Event: pre-build, …}]", got.Capabilities.BuildHooks)
+	}
+}
+
 // TestInstalledManifestEngineValidation verifies that the plugin.json written by
 // writeInstalledManifest passes the engine's plugin.LoadManifest and Validate.
 func TestInstalledManifestEngineValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

\`writeInstalledManifest\` constructed \`installedPluginCapabilities\` from the registry manifest by hand-copying ModuleTypes / StepTypes / TriggerTypes / IaCProvider — but silently dropped \`CLICommands\` and \`BuildHooks\`. Result: plugin.json on disk after install had no cliCommands, so \`BuildCLIRegistry\` could not discover plugin-provided wfctl subcommands.

## Reproduction

[workflow-registry#28](https://github.com/GoCodeAlone/workflow-registry/pull/28) added \`cliCommands: [{name: payments, …}]\` to the \`workflow-plugin-payments\` manifest. Every BMW \`provision-stripe-issuing-webhook\` retrigger still reported:

\`\`\`
unknown command: payments
\`\`\`

Diagnostic on the runner ([buymywishlist#260 debug branch run](https://github.com/GoCodeAlone/buymywishlist/actions/runs/25622418763)) showed:

\`\`\`
$ ls -la $WFCTL_PLUGIN_DIR/payments
-rw------- 1 runner runner  1091 plugin.json   ← 1KB stub from writeInstalledManifest
-rwxr-xr-x 1 runner runner  73M  workflow-plugin-payments

$ jq .capabilities.cliCommands $WFCTL_PLUGIN_DIR/payments/plugin.json
"<<missing>>"
\`\`\`

The 27KB plugin.json the v0.3.1 release tarball shipped with cliCommands was overwritten by writeInstalledManifest's stripped version.

## Fix

Extend \`installedPluginCapabilities\` with \`CLICommands\` + \`BuildHooks\` fields and propagate them in \`writeInstalledManifest\`. The registry-side struct already carries both fields; this just plumbs them through.

## Tests

\`TestInstalledManifestPreservesCLICommands\` — regression guard: read-back of writeInstalledManifest's output must contain CLICommands + BuildHooks the registry manifest declared.

## Verification

- [x] \`GOWORK=off go build ./...\` clean
- [x] \`GOWORK=off go vet ./...\` clean
- [x] \`GOWORK=off go test ./cmd/wfctl/ -count=1 -run "TestInstalledManifest"\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)