### PR TITLE
fix(wfctl): plugin CLI binary path uses dir name twice (matches ensurePluginBinary)

### DIFF
--- a/cmd/wfctl/plugin_cli_commands.go
+++ b/cmd/wfctl/plugin_cli_commands.go
@@ -138,10 +138,14 @@ func BuildCLIRegistry(pluginsDir string) (CLIRegistry, error) {
 					existing.PluginName, manifestName, name,
 				)
 			}
-			// Binary path uses the actual on-disk directory (which `wfctl
-			// plugin install` controls) plus the manifest-declared binary
-			// name (which the tarball ships).
-			binaryPath := filepath.Join(pluginsDir, p.dirName, manifestName)
+			// Binary path uses the on-disk directory name TWICE because
+			// `wfctl plugin install` calls ensurePluginBinary(destDir,
+			// pluginName) which RENAMES the largest executable in destDir
+			// to match the (short) plugin name. After install the binary
+			// lives at destDir/{shortName}/{shortName}. Earlier code joined
+			// destDir+manifestName, which only works in the rare case
+			// where the dir name and manifest name happen to coincide.
+			binaryPath := filepath.Join(pluginsDir, p.dirName, p.dirName)
 			registry[name] = &CLIRegistryEntry{
 				Command:     name,
 				PluginName:  manifestName,

--- a/cmd/wfctl/plugin_cli_commands_test.go
+++ b/cmd/wfctl/plugin_cli_commands_test.go
@@ -18,7 +18,11 @@ func writeCLIPlugin(t *testing.T, pluginsDir, name string, commands []string) {
 // writeCLIPluginNamed builds a plugin where the on-disk directory name and
 // the manifest name can differ — matches the real-world install convention
 // (short dir name like "payments" + full manifest name like
-// "workflow-plugin-payments"). The stub binary is named after the manifest.
+// "workflow-plugin-payments").
+//
+// `wfctl plugin install` runs ensurePluginBinary post-extract which renames
+// the executable to match the (short) install dir name, so the stub binary
+// here is named after dirName rather than manifestName.
 func writeCLIPluginNamed(t *testing.T, pluginsDir, dirName, manifestName string, commands []string) {
 	t.Helper()
 	dir := filepath.Join(pluginsDir, dirName)
@@ -34,7 +38,7 @@ func writeCLIPluginNamed(t *testing.T, pluginsDir, dirName, manifestName string,
 	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644); err != nil {
 		t.Fatalf("write plugin.json: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, manifestName), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, dirName), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write stub binary: %v", err)
 	}
 }
@@ -110,13 +114,20 @@ func TestPluginCLIRegistry_AllStaticCommandsReserved(t *testing.T) {
 }
 
 // TestPluginCLIRegistry_DirVsManifestNameMismatch is the regression test for
-// the binary-path bug introduced in workflow#591. setup-plugins (and `wfctl
-// plugin install`) extract tarballs to short directory names like
-// `data/plugins/payments` while the binary inside is named after the
-// manifest (`workflow-plugin-payments`). The earlier path computation
-// joined `manifest.Name` twice — the binary path resolved to
-// `data/plugins/workflow-plugin-payments/workflow-plugin-payments`, which
-// only existed when dirName == manifestName.
+// the binary-path bug. setup-plugins (and `wfctl plugin install`) extract
+// tarballs to short directory names like `data/plugins/payments`. After
+// extraction `ensurePluginBinary` renames the largest executable to match
+// the (short) install dir name. So the binary post-install lives at
+// `<dir>/<shortName>/<shortName>` regardless of what the tarball or the
+// manifest call it.
+//
+// The earlier path computation went through two iterations:
+//  1. workflow#591 joined manifest.Name twice → broke for short dirs.
+//  2. workflow#595 joined dirName + manifest.Name → broke because
+//     ensurePluginBinary renames the binary AWAY from manifest.Name.
+//
+// This test pins both sides: dir name + binary file name = the install
+// dir name; manifest name flows into PluginName for log/audit purposes.
 func TestPluginCLIRegistry_DirVsManifestNameMismatch(t *testing.T) {
 	dir := t.TempDir()
 	writeCLIPluginNamed(t, dir, "payments", "workflow-plugin-payments", []string{"payments"})
@@ -129,7 +140,7 @@ func TestPluginCLIRegistry_DirVsManifestNameMismatch(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected `payments` command registered, got %v", reg)
 	}
-	wantBin := filepath.Join(dir, "payments", "workflow-plugin-payments")
+	wantBin := filepath.Join(dir, "payments", "payments")
 	if entry.BinaryPath != wantBin {
 		t.Errorf("BinaryPath = %q, want %q", entry.BinaryPath, wantBin)
 	}


### PR DESCRIPTION
## Summary

Second pass on the dispatch binary-path bug. [workflow#595](https://github.com/GoCodeAlone/workflow/pull/595) fixed the "manifest.Name twice" failure by joining \`dirName + manifest.Name\`, but that breaks for the actual install convention:

\`ensurePluginBinary(destDir, pluginName)\` RENAMES the largest executable in \`destDir\` to match the (short) plugin name. So the binary post-install lives at \`destDir/{shortName}/{shortName}\`, not \`destDir/{shortName}/{manifestName}\`.

## Real-world impact

[buymywishlist#264 retrigger](https://github.com/GoCodeAlone/buymywishlist/actions/runs/25624319522):

\`\`\`
error: plugin workflow-plugin-payments command payments:
  fork/exec /home/runner/work/buymywishlist/buymywishlist/data/plugins/payments/workflow-plugin-payments:
  no such file or directory

$ ls data/plugins/payments
-rwxr-xr-x payments    ← actual binary post-rename
plugin.json
\`\`\`

## Fix

\`BuildCLIRegistry\` now joins \`dirName\` twice for the binary path. The \`manifest.Name\` still flows into \`PluginName\` for log/audit purposes (so error messages like \`"plugin workflow-plugin-payments command payments: …"\` remain informative), but the executable lookup uses the install convention.

Test fixture \`writeCLIPluginNamed\` updated to match: stub binary written at \`dirName\`, not \`manifestName\`, modeling the post-rename state.

## Tests

\`TestPluginCLIRegistry_DirVsManifestNameMismatch\` rewrites — pins both sides:
- dir name = binary file name = the install dir name
- manifest name flows into PluginName

\`TestPluginCLIRegistry_EmptyManifestNameUsesDirName\` already correct (dirName=anonymous, binary=anonymous).

## Verification

- [x] \`GOWORK=off go build ./...\` clean
- [x] \`GOWORK=off go vet ./cmd/wfctl/\` clean
- [x] \`GOWORK=off go test ./cmd/wfctl/ -count=1 -run "TestPluginCLIRegistry|TestStaticCommand"\` green
- [x] gofmt -l clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)