### PR TITLE
Register ghcr registry provider alias

### DIFF
--- a/cmd/wfctl/registry_login_test.go
+++ b/cmd/wfctl/registry_login_test.go
@@ -62,6 +62,28 @@ ci:
 	}
 }
 
+func TestRunRegistryLogin_GHCRAlias(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+ci:
+  registries:
+    - name: ghcr
+      type: ghcr
+      path: ghcr.io/myorg
+      auth:
+        env: GITHUB_TOKEN
+`
+	cfgPath := filepath.Join(dir, "workflow.yaml")
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	if err := runRegistryLogin([]string{"--config", cfgPath, "--registry", "ghcr", "--dry-run"}); err != nil {
+		t.Fatalf("runRegistryLogin ghcr alias: %v", err)
+	}
+}
+
 func TestRunRegistryLogin_UnknownRegistry(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeRegistryLoginFixture(t, dir)

--- a/plugins/registry-github/plugin.go
+++ b/plugins/registry-github/plugin.go
@@ -14,16 +14,24 @@ import (
 )
 
 func init() {
-	registry.Register(New())
+	registry.Register(&GHCRProvider{name: "github"})
+	registry.Register(&GHCRProvider{name: "ghcr"})
 }
 
 // GHCRProvider implements registry.RegistryProvider for GitHub Container Registry.
-type GHCRProvider struct{}
+type GHCRProvider struct {
+	name string
+}
 
 // New returns a new GHCRProvider.
-func New() registry.RegistryProvider { return &GHCRProvider{} }
+func New() registry.RegistryProvider { return &GHCRProvider{name: "github"} }
 
-func (g *GHCRProvider) Name() string { return "github" }
+func (g *GHCRProvider) Name() string {
+	if g.name == "" {
+		return "github"
+	}
+	return g.name
+}
 
 func (g *GHCRProvider) Login(ctx registry.Context, cfg registry.ProviderConfig) error {
 	token, err := resolveToken(cfg)


### PR DESCRIPTION
## Summary
- register GHCR container registry provider under both `github` and validated `ghcr` type names
- add coverage for `wfctl registry login` with `ci.registries[].type: ghcr`

## Verification
- `GOWORK=off go test ./plugins/registry-github ./cmd/wfctl`
- `GOWORK=off go test ./...`

## Review
- antagonistic/security pass: keeps `type: github` compatibility while making the schema-accepted `type: ghcr` usable by wfctl; no credential handling behavior changed.