### PR TITLE
fix(wfctl): actionable error when align --plan file missing

### DIFF
--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -221,9 +223,19 @@ func defaultAlignLoadProviders(alignCtx *alignContext, envName string, _ *interf
 }
 
 // loadPlanJSON reads and decodes a plan JSON file.
+//
+// When the file does not exist the returned error includes an actionable
+// hint: a missing plan file at align time almost always means the upstream
+// `wfctl infra plan --output <path>` step failed silently — for example
+// because of a state-backend credential error in CI where shell pipefail is
+// off and the non-zero exit was masked by `| tee $GITHUB_STEP_SUMMARY`.
+// Surfacing the hint here saves operators a triage hop.
 func loadPlanJSON(path string) (*interfaces.IaCPlan, error) {
 	f, err := os.Open(path)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("plan file %q does not exist — did the upstream `wfctl infra plan --output %s` step succeed? Check its stderr for state-backend errors (e.g. InvalidAccessKeyId, SignatureDoesNotMatch). In CI, ensure the plan step uses `set -o pipefail` so wfctl's non-zero exit is not masked by a downstream pipe (e.g. `| tee`)", path, path)
+		}
 		return nil, err
 	}
 	defer f.Close()

--- a/cmd/wfctl/infra_align.go
+++ b/cmd/wfctl/infra_align.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/fs"
+	iofs "io/fs"
 	"os"
 	"strings"
 
@@ -233,8 +233,11 @@ func defaultAlignLoadProviders(alignCtx *alignContext, envName string, _ *interf
 func loadPlanJSON(path string) (*interfaces.IaCPlan, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("plan file %q does not exist — did the upstream `wfctl infra plan --output %s` step succeed? Check its stderr for state-backend errors (e.g. InvalidAccessKeyId, SignatureDoesNotMatch). In CI, ensure the plan step uses `set -o pipefail` so wfctl's non-zero exit is not masked by a downstream pipe (e.g. `| tee`)", path, path)
+		if errors.Is(err, iofs.ErrNotExist) {
+			// Wrap (don't replace) so errors.Is(..., iofs.ErrNotExist) still
+			// matches and the underlying *PathError is preserved for callers
+			// that want to introspect the cause.
+			return nil, fmt.Errorf("plan file %q does not exist — did the upstream `wfctl infra plan --output %q` step succeed? Check its stderr for state-backend errors (e.g. InvalidAccessKeyId, SignatureDoesNotMatch). In CI, ensure the plan step uses `set -o pipefail` so wfctl's non-zero exit is not masked by a downstream pipe (e.g. `| tee`): %w", path, path, err)
 		}
 		return nil, err
 	}

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1116,6 +1118,11 @@ func TestLoadPlanJSON_MissingFileEmitsActionableHint(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message missing %q hint: %s", want, msg)
 		}
+	}
+	// The hint must wrap (not replace) the underlying error so callers can
+	// still match with errors.Is(..., iofs.ErrNotExist).
+	if !errors.Is(err, iofs.ErrNotExist) {
+		t.Errorf("expected errors.Is(err, iofs.ErrNotExist) to match wrapped error; got: %v", err)
 	}
 }
 

--- a/cmd/wfctl/infra_align_test.go
+++ b/cmd/wfctl/infra_align_test.go
@@ -1099,3 +1099,36 @@ func TestInfraAlign_RenderMarkdown(t *testing.T) {
 		t.Error("expected WARN count in summary")
 	}
 }
+
+func TestLoadPlanJSON_MissingFileEmitsActionableHint(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "plan-does-not-exist.json")
+	_, err := loadPlanJSON(missing)
+	if err == nil {
+		t.Fatal("expected error for missing plan file, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"does not exist",
+		"wfctl infra plan",
+		"state-backend",
+		"pipefail",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q hint: %s", want, msg)
+		}
+	}
+}
+
+func TestLoadPlanJSON_DecodeErrorPropagatesVerbatim(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "plan-malformed.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadPlanJSON(bad)
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("decode error should not mention does-not-exist hint: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Why

A BMW deploy ([run 25625555953](https://github.com/GoCodeAlone/buymywishlist/actions/runs/25625555953)) failed at the F2 alignment step with the cryptic message:

\`\`\`
error: no such file or directory
\`\`\`

Triage took multiple hops to land on the actual cause: \`wfctl infra plan --output plan.json\` (run earlier in the same job) had hit \`InvalidAccessKeyId\` reading state from a DO Spaces backend, exited non-zero, and the deploy.yml step's pipe to \`tee \$GITHUB_STEP_SUMMARY\` masked the non-zero exit because the shell was \`bash -e\` without \`-o pipefail\`. So the Plan step looked like it succeeded, plan.json was never written, and align tripped on the bare \`os.Open\` error.

\`wfctl\`'s exit code is correct — \`runInfraPlan\` returns the wrapped state-read error and \`main.go\` exits 1. The propagation gap is in the operator's shell setup. But the error surface at the align step gave them no signal to look upstream.

## What

\`cmd/wfctl/infra_align.go\` \`loadPlanJSON\`: when the file open returns \`fs.ErrNotExist\`, replace the bare error with one that names the likely cause + common shell failure modes:

> plan file \"plan.json\" does not exist — did the upstream \`wfctl infra plan --output plan.json\` step succeed? Check its stderr for state-backend errors (e.g. InvalidAccessKeyId, SignatureDoesNotMatch). In CI, ensure the plan step uses \`set -o pipefail\` so wfctl's non-zero exit is not masked by a downstream pipe (e.g. \`| tee\`).

Decode errors (malformed JSON) still propagate verbatim — no false-positive hint there.

## Tests

- \`TestLoadPlanJSON_MissingFileEmitsActionableHint\` — asserts every hint substring is present.
- \`TestLoadPlanJSON_DecodeErrorPropagatesVerbatim\` — asserts malformed-JSON path stays terse, no does-not-exist string.

\`\`\`
$ GOWORK=off go test ./cmd/wfctl/ -run 'TestLoadPlanJSON' -v
=== RUN   TestLoadPlanJSON_MissingFileEmitsActionableHint
--- PASS: TestLoadPlanJSON_MissingFileEmitsActionableHint (0.00s)
=== RUN   TestLoadPlanJSON_DecodeErrorPropagatesVerbatim
--- PASS: TestLoadPlanJSON_DecodeErrorPropagatesVerbatim (0.00s)
PASS
\`\`\`

## Test plan

- [x] Targeted tests pass locally
- [x] \`go build ./cmd/wfctl/\` clean
- [x] \`go vet ./cmd/wfctl/\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)