### PR TITLE
fix(wfctl): disambiguate iac_provider from impl-level provider in resource configs

### DIFF
--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -1030,10 +1030,28 @@ func findInfraSpecByName(cfgFile, envName, name string) (interfaces.ResourceSpec
 	return interfaces.ResourceSpec{}, fmt.Errorf("infra resource %q not found in %s", name, cfgFile)
 }
 
+// resolveIaCProviderRef returns the iac.provider module name to dispatch to
+// for a resource. Reads "iac_provider" first (canonical, disambiguates
+// implementation from IaC routing), falls back to "provider" for backward
+// compatibility. Resources whose plugin schema uses "provider" as the
+// implementation identifier (e.g. infra.eventbus's provider="nats" |
+// "kafka") should declare iac_provider explicitly. Resources where
+// "provider" is itself the iac.provider module name (e.g. infra.database's
+// provider="do-provider") continue to work via the fallback.
+func resolveIaCProviderRef(cfg map[string]any) string {
+	if v, ok := cfg["iac_provider"].(string); ok && v != "" {
+		return v
+	}
+	if v, ok := cfg["provider"].(string); ok {
+		return v
+	}
+	return ""
+}
+
 func resolveProviderForSpec(cfgFile, envName string, spec interfaces.ResourceSpec) (string, map[string]any, error) {
-	moduleRef, _ := spec.Config["provider"].(string)
+	moduleRef := resolveIaCProviderRef(spec.Config)
 	if moduleRef == "" {
-		return "", nil, fmt.Errorf("infra module %q (%s): missing required 'provider' field", spec.Name, spec.Type)
+		return "", nil, fmt.Errorf("infra module %q (%s): missing required 'iac_provider' or 'provider' field", spec.Name, spec.Type)
 	}
 	cfg, err := config.LoadFromFile(cfgFile)
 	if err != nil {
@@ -1060,7 +1078,7 @@ func resolveProviderForSpec(cfgFile, envName string, spec interfaces.ResourceSpe
 		}
 		return providerType, modCfg, nil
 	}
-	return "", nil, fmt.Errorf("infra module %q references provider %q which is not declared as an iac.provider module", spec.Name, moduleRef)
+	return "", nil, fmt.Errorf("infra module %q references iac.provider module %q (resolved from iac_provider/provider) which is not declared in modules", spec.Name, moduleRef)
 }
 
 func isNoopStateStore(store infraStateStore) bool {

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -1078,7 +1078,7 @@ func resolveProviderForSpec(cfgFile, envName string, spec interfaces.ResourceSpe
 		}
 		return providerType, modCfg, nil
 	}
-	return "", nil, fmt.Errorf("infra module %q references iac.provider module %q (resolved from iac_provider/provider) which is not declared in modules", spec.Name, moduleRef)
+	return "", nil, fmt.Errorf("infra module %q references iac.provider module %q (resolved from iac_provider/provider field) which is not declared as an iac.provider module", spec.Name, moduleRef)
 }
 
 func isNoopStateStore(store infraStateStore) bool {

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -345,16 +345,14 @@ func resourceStateProviderRef(st interfaces.ResourceState) string {
 	if st.AppliedConfig == nil {
 		return ""
 	}
-	providerRef, _ := st.AppliedConfig["provider"].(string)
-	return providerRef
+	return resolveIaCProviderRef(st.AppliedConfig)
 }
 
 func resourceSpecProviderRef(spec interfaces.ResourceSpec) string {
 	if spec.Config == nil {
 		return ""
 	}
-	providerRef, _ := spec.Config["provider"].(string)
-	return providerRef
+	return resolveIaCProviderRef(spec.Config)
 }
 
 // applyWithProviderAndStore computes a diff plan for the given specs against
@@ -554,7 +552,7 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 			for i := range specs {
 				if specs[i].Name == r.Name {
 					appliedCfg = specs[i].Config
-					providerRef, _ = specs[i].Config["provider"].(string)
+					providerRef = resolveIaCProviderRef(specs[i].Config)
 					dependencies = append([]string(nil), specs[i].DependsOn...)
 					break
 				}
@@ -1166,22 +1164,22 @@ func applyFromPrecomputedPlan(ctx context.Context, plan interfaces.IaCPlan, cfgF
 
 	for i := range plan.Actions {
 		action := &plan.Actions[i]
-		moduleRef, _ := action.Resource.Config["provider"].(string)
+		moduleRef := resolveIaCProviderRef(action.Resource.Config)
 		// delete actions from ComputePlan carry an empty Resource.Config — the
 		// provider ref must be recovered from the recorded current state instead.
 		if moduleRef == "" && action.Current != nil {
 			moduleRef = action.Current.ProviderRef
 			if moduleRef == "" {
-				moduleRef, _ = action.Current.AppliedConfig["provider"].(string)
+				moduleRef = resolveIaCProviderRef(action.Current.AppliedConfig)
 			}
 		}
 		if moduleRef == "" {
-			return runHydrated, fmt.Errorf("plan action for %q: missing 'provider' field in resource config (delete actions require a current state record)", action.Resource.Name)
+			return runHydrated, fmt.Errorf("plan action for %q: missing 'iac_provider' or 'provider' field in resource config (delete actions require a current state record)", action.Resource.Name)
 		}
 		if _, exists := groups[moduleRef]; !exists {
 			def, ok := providerDefs[moduleRef]
 			if !ok {
-				return runHydrated, fmt.Errorf("plan action for %q references provider %q which is not declared as an iac.provider module", action.Resource.Name, moduleRef)
+				return runHydrated, fmt.Errorf("plan action for %q references iac.provider module %q (resolved from iac_provider/provider) which is not declared in modules", action.Resource.Name, moduleRef)
 			}
 			groups[moduleRef] = &actionGroup{provType: def.provType, provCfg: def.provCfg}
 			groupOrder = append(groupOrder, moduleRef)
@@ -1339,7 +1337,7 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 			for i := range plan.Actions {
 				if plan.Actions[i].Resource.Name == r.Name {
 					appliedCfg = plan.Actions[i].Resource.Config
-					providerRef, _ = plan.Actions[i].Resource.Config["provider"].(string)
+					providerRef = resolveIaCProviderRef(plan.Actions[i].Resource.Config)
 					dependencies = append([]string(nil), plan.Actions[i].Resource.DependsOn...)
 					break
 				}

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -1179,7 +1179,7 @@ func applyFromPrecomputedPlan(ctx context.Context, plan interfaces.IaCPlan, cfgF
 		if _, exists := groups[moduleRef]; !exists {
 			def, ok := providerDefs[moduleRef]
 			if !ok {
-				return runHydrated, fmt.Errorf("plan action for %q references iac.provider module %q (resolved from iac_provider/provider) which is not declared in modules", action.Resource.Name, moduleRef)
+				return runHydrated, fmt.Errorf("plan action for %q references iac.provider module %q (resolved from iac_provider/provider field) which is not declared as an iac.provider module", action.Resource.Name, moduleRef)
 			}
 			groups[moduleRef] = &actionGroup{provType: def.provType, provCfg: def.provCfg}
 			groupOrder = append(groupOrder, moduleRef)

--- a/cmd/wfctl/infra_apply_dryrun.go
+++ b/cmd/wfctl/infra_apply_dryrun.go
@@ -153,7 +153,7 @@ func printDryRunJSON(cfgFile, envName string, plan interfaces.IaCPlan, providerG
 	actions := make([]DryRunAction, 0, len(plan.Actions))
 	for i := range plan.Actions {
 		a := &plan.Actions[i]
-		provRef, _ := a.Resource.Config["provider"].(string)
+		provRef := resolveIaCProviderRef(a.Resource.Config)
 		actions = append(actions, DryRunAction{
 			Action:       a.Action,
 			ResourceName: a.Resource.Name,
@@ -223,7 +223,7 @@ func collectProviderGroups(cfgFile, envName string, specs []interfaces.ResourceS
 		if !strings.HasPrefix(spec.Type, "infra.") {
 			continue
 		}
-		moduleRef, _ := spec.Config["provider"].(string)
+		moduleRef := resolveIaCProviderRef(spec.Config)
 		if moduleRef == "" {
 			continue
 		}

--- a/cmd/wfctl/infra_destroy.go
+++ b/cmd/wfctl/infra_destroy.go
@@ -66,7 +66,7 @@ func destroyInfraModules(ctx context.Context, cfgFile, envName string) error { /
 		moduleRef := resourceStateProviderRef(*st)
 		if spec, ok := specByName[st.Name]; ok {
 			if moduleRef == "" {
-				moduleRef, _ = spec.Config["provider"].(string)
+				moduleRef = resolveIaCProviderRef(spec.Config)
 			}
 		}
 

--- a/cmd/wfctl/infra_iac_provider_ref_test.go
+++ b/cmd/wfctl/infra_iac_provider_ref_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+// TestResolveIaCProviderRef covers the disambiguation between an
+// implementation-level "provider" field (e.g. infra.eventbus's provider="nats")
+// and the iac.provider module reference. The canonical key is iac_provider;
+// "provider" is the backward-compat fallback.
+func TestResolveIaCProviderRef(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  map[string]any
+		want string
+	}{
+		{
+			name: "iac_provider_only",
+			cfg:  map[string]any{"iac_provider": "do-provider"},
+			want: "do-provider",
+		},
+		{
+			name: "provider_only_back_compat",
+			cfg:  map[string]any{"provider": "do-provider"},
+			want: "do-provider",
+		},
+		{
+			name: "iac_provider_wins_over_provider",
+			cfg: map[string]any{
+				"iac_provider": "do-provider",
+				"provider":     "nats", // implementation, ignored for IaC routing
+			},
+			want: "do-provider",
+		},
+		{
+			name: "empty_iac_provider_falls_back",
+			cfg: map[string]any{
+				"iac_provider": "",
+				"provider":     "do-provider",
+			},
+			want: "do-provider",
+		},
+		{
+			name: "neither_set",
+			cfg:  map[string]any{},
+			want: "",
+		},
+		{
+			name: "nil_config",
+			cfg:  nil,
+			want: "",
+		},
+		{
+			name: "non_string_iac_provider_falls_back",
+			cfg: map[string]any{
+				"iac_provider": 42, // type mismatch, treated as missing
+				"provider":     "do-provider",
+			},
+			want: "do-provider",
+		},
+		{
+			name: "non_string_provider",
+			cfg:  map[string]any{"provider": 42},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveIaCProviderRef(tc.cfg)
+			if got != tc.want {
+				t.Errorf("resolveIaCProviderRef(%v) = %q; want %q", tc.cfg, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/wfctl/infra_provider_dispatch.go
+++ b/cmd/wfctl/infra_provider_dispatch.go
@@ -115,18 +115,18 @@ func groupSpecsByProviderRef(specs []interfaces.ResourceSpec, defs map[string]pr
 	for _, spec := range specs {
 		var moduleRef string
 		if spec.Config != nil {
-			moduleRef, _ = spec.Config["provider"].(string)
+			moduleRef = resolveIaCProviderRef(spec.Config)
 		}
 		if moduleRef == "" {
-			return nil, nil, fmt.Errorf("infra module %q (%s): missing required 'provider' field", spec.Name, spec.Type)
+			return nil, nil, fmt.Errorf("infra module %q (%s): missing required 'iac_provider' or 'provider' field", spec.Name, spec.Type)
 		}
 		if _, exists := groups[moduleRef]; !exists {
 			def, ok := defs[moduleRef]
 			if !ok {
 				if _, isDisabled := disabled[moduleRef]; isDisabled {
-					return nil, nil, fmt.Errorf("infra module %q references provider %q which is disabled for environment %q", spec.Name, moduleRef, envName)
+					return nil, nil, fmt.Errorf("infra module %q references iac.provider %q which is disabled for environment %q", spec.Name, moduleRef, envName)
 				}
-				return nil, nil, fmt.Errorf("infra module %q references provider %q which is not declared as an iac.provider module", spec.Name, moduleRef)
+				return nil, nil, fmt.Errorf("infra module %q references iac.provider module %q (resolved from iac_provider/provider) which is not declared in modules", spec.Name, moduleRef)
 			}
 			if def.provType == "" {
 				return nil, nil, fmt.Errorf("provider module %q has no 'provider' type configured", moduleRef)

--- a/cmd/wfctl/infra_provider_dispatch.go
+++ b/cmd/wfctl/infra_provider_dispatch.go
@@ -126,7 +126,7 @@ func groupSpecsByProviderRef(specs []interfaces.ResourceSpec, defs map[string]pr
 				if _, isDisabled := disabled[moduleRef]; isDisabled {
 					return nil, nil, fmt.Errorf("infra module %q references iac.provider %q which is disabled for environment %q", spec.Name, moduleRef, envName)
 				}
-				return nil, nil, fmt.Errorf("infra module %q references iac.provider module %q (resolved from iac_provider/provider) which is not declared in modules", spec.Name, moduleRef)
+				return nil, nil, fmt.Errorf("infra module %q references iac.provider module %q (resolved from iac_provider/provider field) which is not declared as an iac.provider module", spec.Name, moduleRef)
 			}
 			if def.provType == "" {
 				return nil, nil, fmt.Errorf("provider module %q has no 'provider' type configured", moduleRef)

--- a/cmd/wfctl/infra_status_drift.go
+++ b/cmd/wfctl/infra_status_drift.go
@@ -210,7 +210,7 @@ func groupStatesByProvider(states []interfaces.ResourceState, cfgFile, envName s
 		moduleRef := resourceStateProviderRef(*st)
 		if spec, ok := specByName[st.Name]; ok {
 			if moduleRef == "" {
-				moduleRef, _ = spec.Config["provider"].(string)
+				moduleRef = resolveIaCProviderRef(spec.Config)
 			}
 		}
 		if moduleRef == "" {


### PR DESCRIPTION
## Why

BMW deploy [run 25625555953](https://github.com/GoCodeAlone/buymywishlist/actions/runs/25625555953) (attempt 2) failed with:

\`\`\`
error: plan action for \"bmw-eventbus\" references provider \"nats\"
       which is not declared as an iac.provider module
\`\`\`

The \`bmw-eventbus\` resource declares \`provider: nats\` (the eventbus implementation, per workflow-plugin-eventbus's typed proto schema where \`ClusterConfig.provider\` ∈ {nats, kafka}) and \`deploy_target: digitalocean.app_platform\` (the IaC target hint).

wfctl's plan/apply code reads \`Resource.Config[\"provider\"]\` for iac.provider routing and looks up \"nats\" in the iac.provider module set — there is no NATS iac.provider, so dispatch fails. \`infra.database\` works because there \`provider: do-provider\` happens to name the iac.provider module directly. Resources where \`provider\` carries impl semantics (eventbus today, possibly others in the future) need a separate field for IaC routing.

## What

Introduce \`iac_provider\` as the canonical field for selecting the iac.provider module to dispatch to. New helper:

\`\`\`go
func resolveIaCProviderRef(cfg map[string]any) string {
    if v, ok := cfg[\"iac_provider\"].(string); ok && v != \"\" { return v }
    if v, ok := cfg[\"provider\"].(string); ok { return v }
    return \"\"
}
\`\`\`

Reads \`iac_provider\` first, falls back to \`provider\` for backward compatibility. Updated all 9 read sites across infra.go, infra_apply.go, infra_apply_dryrun.go, infra_destroy.go, infra_provider_dispatch.go, infra_status_drift.go.

Module-internal \`provider\` reads (cloud.account, iac.provider's own \`provider: digitalocean\`) intentionally left alone — those name impl types on the module itself, not resource-level routing.

## What this enables

bmw-eventbus can now declare both fields without conflict:

\`\`\`yaml
- name: bmw-eventbus
  type: infra.eventbus
  config:
    provider: nats                            # impl (read by eventbus plugin)
    iac_provider: do-provider                 # IaC routing (read by wfctl)
    deploy_target: digitalocean.app_platform
    version: \"2.10\"
    replicas: 2
\`\`\`

infra.database keeps working unchanged via the fallback.

## Tests

- \`TestResolveIaCProviderRef\` — 8 sub-cases: iac_provider-only, provider-only-back-compat, iac_provider-wins-over-provider, empty-iac_provider-falls-back, neither-set, nil-config, non-string-iac_provider-falls-back, non-string-provider.
- Existing Infra/Provider/Apply/Plan/Dispatch test suites green — no regressions.

\`\`\`
$ GOWORK=off go test ./cmd/wfctl/ -run 'TestResolveIaCProviderRef' -v
... 8 sub-tests PASS
$ GOWORK=off go test ./cmd/wfctl/ -run 'Infra|Provider|Apply|Plan|Dispatch' -count=1
ok  	github.com/GoCodeAlone/workflow/cmd/wfctl	4.897s
\`\`\`

## Test plan

- [x] Targeted tests pass locally
- [x] \`go build ./cmd/wfctl/\` clean
- [x] \`go vet ./cmd/wfctl/\` clean
- [ ] CI green
- [ ] Once tagged: BMW infra.yaml adds \`iac_provider\` to bmw-eventbus + dependents → next deploy passes Apply step

🤖 Generated with [Claude Code](https://claude.com/claude-code)