### PR TITLE
fix(iac): persist apply state per action

### DIFF
--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -714,11 +714,6 @@ func successfulDeleteNames(deleteNames map[string]struct{}, result *interfaces.A
 	if len(result.Errors) > 0 {
 		return map[string]struct{}{}
 	}
-	for _, ae := range result.Errors {
-		if ae.Action == "delete" {
-			delete(out, ae.Resource)
-		}
-	}
 	return out
 }
 

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -53,12 +53,12 @@ var infraApplyTroubleshootTimeout = 30 * time.Second
 // (mirroring resolveIaCProvider/loadIaCPlugin in deploy_providers.go).
 var computeInfraPlan = platform.ComputePlan
 
-// applyV2ApplyPlanFn is the indirection seam through which apply
-// dispatches the v2 path (wfctlhelpers.ApplyPlan). Defaults to the
-// production helper; tests override it to assert routing decisions
-// without standing up a real plugin or executing real driver calls.
-// Same var-seam pattern as computeInfraPlan / resolveIaCProvider.
-var applyV2ApplyPlanFn = wfctlhelpers.ApplyPlan
+// applyV2ApplyPlanWithHooksFn is the indirection seam through which apply
+// dispatches the v2 path. Defaults to the production helper; tests override
+// it to assert routing decisions without standing up a real plugin or
+// executing real driver calls. Same var-seam pattern as computeInfraPlan /
+// resolveIaCProvider.
+var applyV2ApplyPlanWithHooksFn = wfctlhelpers.ApplyPlanWithHooks
 
 // applyAllowReplaceSet is the per-invocation allow-list of resource
 // names whose `protected: true` annotation is overridden for this
@@ -463,11 +463,14 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 	// load time and surfaced via the optional
 	// wfctlhelpers.ComputePlanVersionDeclarer interface.
 	var result *interfaces.ApplyResult
+	var usedV2Dispatch bool
 	// DispatchVersionFor centralises the type-assertion + default; pass the
 	// raw provider rather than re-asserting ComputePlanVersionDeclarer at the
 	// call site (per dispatch.go contract).
 	if wfctlhelpers.DispatchVersionFor(provider) == wfctlhelpers.DispatchVersionV2 {
-		result, err = applyV2ApplyPlanFn(ctx, provider, &plan)
+		usedV2Dispatch = true
+		hooks := statePersistenceHooks(store, secretsProvider, provider, providerType, hydratedOut)
+		result, err = applyV2ApplyPlanWithHooksFn(ctx, provider, &plan, hooks)
 		// printDriftReportIfAny was added unwired in W-3a/T3.1.5; the
 		// v2 dispatch is the production caller that surfaces input
 		// drift to the operator. Run on success OR partial failure
@@ -529,56 +532,33 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 		return fmt.Errorf("apply: %w", err)
 	}
 	if result != nil {
-		// Pre-flight: if any driver emitted sensitive outputs but no
-		// secrets.Provider is configured, fail fast with a complete
-		// diagnostic before per-resource persistence kicks off.
-		if err := requireSecretsProviderForSensitiveOutputs(secretsProvider, result); err != nil {
-			return fmt.Errorf("state write rejected: %w", err)
+		if usedV2Dispatch {
+			if len(result.Errors) > 0 {
+				msgs := make([]string, 0, len(result.Errors))
+				for _, ae := range result.Errors {
+					msgs = append(msgs, fmt.Sprintf("%s/%s: %s", ae.Action, ae.Resource, ae.Error))
+				}
+				finalErr := fmt.Errorf("%d resource(s) failed: %s", len(result.Errors), strings.Join(msgs, "; "))
+				emitImageNotInRegistryHint(os.Stderr, finalErr)
+				return finalErr
+			}
+			return nil
+		}
+		if err := rejectSensitiveOutputsWithoutProvider(ctx, secretsProvider, result, plan.Actions, provider); err != nil {
+			return err
 		}
 		// Persist state for every successfully provisioned resource.
 		for _, r := range result.Resources {
-			fmt.Printf("  ✓ %s (%s)\n", r.Name, r.Type)
-
-			// Hard-fail when the driver returns a malformed ProviderID for a strict
-			// format. This prevents corrupt state from reaching the store.
-			if err := validateOutputProviderID(provider, providerType, &r); err != nil {
-				return fmt.Errorf("state write rejected: %w", err)
+			action, ok := planActionForOutput(plan.Actions, result.Resources, r)
+			if !ok {
+				action = interfaces.PlanAction{Resource: interfaces.ResourceSpec{Name: r.Name, Type: r.Type}}
 			}
-
-			// Find the matching spec to get the applied config.
-			var appliedCfg map[string]any
-			var providerRef string
-			var dependencies []string
-			for i := range specs {
-				if specs[i].Name == r.Name {
-					appliedCfg = specs[i].Config
-					providerRef = resolveIaCProviderRef(specs[i].Config)
-					dependencies = append([]string(nil), specs[i].DependsOn...)
-					break
-				}
-			}
-
-			now := time.Now().UTC()
-			rs := interfaces.ResourceState{
-				ID:                  r.Name,
-				Name:                r.Name,
-				Type:                r.Type,
-				Provider:            providerType,
-				ProviderRef:         providerRef,
-				ProviderID:          r.ProviderID,
-				ConfigHash:          configHashMap(appliedCfg),
-				AppliedConfig:       appliedCfg,
-				AppliedConfigSource: "apply",
-				// Outputs is set by persistResourceWithSecretRouting after Route.
-				Dependencies: dependencies,
-				CreatedAt:    now,
-				UpdatedAt:    now,
-			}
-			driver, _ := provider.ResourceDriver(r.Type) // best-effort for compensating Delete; nil-safe
-			hyd, persistErr := persistResourceWithSecretRouting(ctx, store, secretsProvider, driver, rs, r, persistModeApply)
+			driver, _ := provider.ResourceDriver(action.Resource.Type) // best-effort for compensating Delete; nil-safe
+			hyd, persistErr := persistAppliedResourceOutput(ctx, store, secretsProvider, provider, providerType, driver, action, r)
 			if persistErr != nil {
 				return persistErr
 			}
+			fmt.Printf("  ✓ %s (%s)\n", action.Resource.Name, action.Resource.Type)
 			if hydratedOut != nil {
 				for k, v := range hyd {
 					hydratedOut[k] = v
@@ -587,8 +567,8 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 		}
 
 		// Delete state records for resources that were destroyed.
-		for name := range deleteNames {
-			if delErr := store.DeleteResource(ctx, name); delErr != nil {
+		for name := range successfulDeleteNames(deleteNames, result) {
+			if delErr := deleteStateAfterCloudDelete(store, name); delErr != nil {
 				fmt.Printf("  WARNING: failed to remove state for %q: %v\n", name, delErr)
 			}
 		}
@@ -607,6 +587,190 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 		}
 	}
 	return nil
+}
+
+func statePersistenceHooks(
+	store infraStateStore,
+	secretsProvider secrets.Provider,
+	provider interfaces.IaCProvider,
+	providerType string,
+	hydratedOut map[string]string,
+) wfctlhelpers.ApplyPlanHooks {
+	return wfctlhelpers.ApplyPlanHooks{
+		OnResourceApplied: func(ctx context.Context, driver interfaces.ResourceDriver, action interfaces.PlanAction, out interfaces.ResourceOutput) error {
+			hyd, persistErr := persistAppliedResourceOutput(ctx, store, secretsProvider, provider, providerType, driver, action, out)
+			if persistErr != nil {
+				return persistErr
+			}
+			fmt.Printf("  ✓ %s (%s)\n", action.Resource.Name, action.Resource.Type)
+			if hydratedOut != nil {
+				for k, v := range hyd {
+					hydratedOut[k] = v
+				}
+			}
+			return nil
+		},
+		OnResourceDeleted: func(ctx context.Context, action interfaces.PlanAction) error {
+			return deleteStateAfterCloudDelete(store, action.Resource.Name)
+		},
+	}
+}
+
+func deleteStateAfterCloudDelete(store infraStateStore, name string) error {
+	stateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return store.DeleteResource(stateCtx, name)
+}
+
+func persistAppliedResourceOutput(
+	ctx context.Context,
+	store infraStateStore,
+	secretsProvider secrets.Provider,
+	provider interfaces.IaCProvider,
+	providerType string,
+	driver interfaces.ResourceDriver,
+	action interfaces.PlanAction,
+	out interfaces.ResourceOutput,
+) (map[string]string, error) {
+	spec := action.Resource
+	compensate := actionCreatesReplacementResource(action)
+	normalized, err := normalizeAppliedOutputIdentity(spec, out)
+	if err != nil {
+		if !compensate {
+			return nil, fmt.Errorf("state write rejected: %w", err)
+		}
+		compErr := compensateAfterIdentityValidationFailure(driver, spec, out)
+		if compErr != nil {
+			return nil, fmt.Errorf("state write rejected: %w (compensating delete failed: %v)", err, compErr)
+		}
+		return nil, fmt.Errorf("state write rejected: %w (compensating delete succeeded)", err)
+	}
+	out = normalized
+	if err := validateOutputProviderIDWithDriver(providerType, driver, &out); err != nil {
+		if !compensate {
+			return nil, fmt.Errorf("state write rejected: %w", err)
+		}
+		rs := interfaces.ResourceState{Name: spec.Name, Type: spec.Type, ProviderID: out.ProviderID}
+		compErr := compensateAfterValidationFailure(driver, rs)
+		if compErr != nil {
+			return nil, fmt.Errorf("state write rejected: %w (compensating delete failed: %v)", err, compErr)
+		}
+		return nil, fmt.Errorf("state write rejected: %w (compensating delete succeeded)", err)
+	}
+	now := time.Now().UTC()
+	rs := interfaces.ResourceState{
+		ID:                  spec.Name,
+		Name:                spec.Name,
+		Type:                spec.Type,
+		Provider:            providerType,
+		ProviderRef:         resolveIaCProviderRef(spec.Config),
+		ProviderID:          out.ProviderID,
+		ConfigHash:          configHashMap(spec.Config),
+		AppliedConfig:       spec.Config,
+		AppliedConfigSource: "apply",
+		// Outputs is set by persistResourceWithSecretRouting after Route.
+		Dependencies: append([]string(nil), spec.DependsOn...),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	mode := persistModeApplyNoCompensate
+	if compensate {
+		mode = persistModeApply
+	}
+	return persistResourceWithSecretRouting(ctx, store, secretsProvider, driver, rs, out, mode)
+}
+
+func actionCreatesReplacementResource(action interfaces.PlanAction) bool {
+	return action.Action == "create" || action.Action == "replace"
+}
+
+func planActionForOutput(actions []interfaces.PlanAction, outputs []interfaces.ResourceOutput, out interfaces.ResourceOutput) (interfaces.PlanAction, bool) {
+	if out.Name != "" {
+		for i := range actions {
+			if actions[i].Resource.Name == out.Name {
+				return actions[i], true
+			}
+		}
+	}
+	if len(outputs) != 1 {
+		return interfaces.PlanAction{}, false
+	}
+	for i := range actions {
+		if actions[i].Action != "delete" {
+			return actions[i], true
+		}
+	}
+	return interfaces.PlanAction{}, false
+}
+
+func successfulDeleteNames(deleteNames map[string]struct{}, result *interfaces.ApplyResult) map[string]struct{} {
+	out := make(map[string]struct{}, len(deleteNames))
+	for name := range deleteNames {
+		out[name] = struct{}{}
+	}
+	if result == nil {
+		return out
+	}
+	if len(result.Errors) > 0 {
+		return map[string]struct{}{}
+	}
+	for _, ae := range result.Errors {
+		if ae.Action == "delete" {
+			delete(out, ae.Resource)
+		}
+	}
+	return out
+}
+
+func rejectSensitiveOutputsWithoutProvider(ctx context.Context, secretsProvider secrets.Provider, result *interfaces.ApplyResult, actions []interfaces.PlanAction, provider interfaces.IaCProvider) error {
+	if secretsProvider != nil || result == nil {
+		return nil
+	}
+	var errs []error
+	for i := range result.Resources {
+		r := result.Resources[i]
+		if !hasSensitiveOutputs(&r) {
+			continue
+		}
+		action, ok := planActionForOutput(actions, result.Resources, r)
+		resourceName := r.Name
+		if resourceName == "" && ok {
+			resourceName = action.Resource.Name
+		}
+		routeErr := fmt.Errorf(
+			"secrets.Provider not configured but driver emitted sensitive outputs (resource %q has Sensitive keys %v); add `secrets:` block to your config or use `secrets: { provider: env }`",
+			resourceName, sensitiveKeysFor(&r))
+		if !ok || !actionCreatesReplacementResource(action) {
+			errs = append(errs, fmt.Errorf("state write rejected: %w", routeErr))
+			continue
+		}
+		driver, _ := provider.ResourceDriver(action.Resource.Type)
+		rs := interfaces.ResourceState{Name: action.Resource.Name, Type: action.Resource.Type, ProviderID: r.ProviderID}
+		compErr := compensateAfterSaveFailure(nil, driver, rs, nil)
+		if compErr != nil {
+			errs = append(errs, fmt.Errorf("state write rejected: %w (compensating delete failed: %v)", routeErr, compErr))
+		} else {
+			errs = append(errs, fmt.Errorf("state write rejected: %w (compensating delete succeeded)", routeErr))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func normalizeAppliedOutputIdentity(spec interfaces.ResourceSpec, out interfaces.ResourceOutput) (interfaces.ResourceOutput, error) {
+	if out.Name == "" {
+		out.Name = spec.Name
+	} else if out.Name != spec.Name {
+		return out, fmt.Errorf("driver returned output name %q for resource %q", out.Name, spec.Name)
+	}
+	if out.Type == "" {
+		out.Type = spec.Type
+	} else if out.Type != spec.Type {
+		return out, fmt.Errorf("driver returned output type %q for resource %q (expected %q)", out.Type, spec.Name, spec.Type)
+	}
+	return out, nil
 }
 
 func adoptExistingResources(ctx context.Context, provider interfaces.IaCProvider, providerType string, specs []interfaces.ResourceSpec, current []interfaces.ResourceState, store infraStateStore) ([]interfaces.ResourceState, error) {
@@ -828,16 +992,16 @@ type persistMode int
 const (
 	persistModeApply persistMode = iota
 	persistModeRead
+	persistModeApplyNoCompensate
 )
 
 // persistResourceWithSecretRouting builds rs.Outputs from out (routing
 // sensitive fields through provider in apply mode), calls
 // store.SaveResource, and returns the hydrated routed-secret map for
-// in-process hand-off. On SaveResource failure after provider.Set
-// succeeded (apply mode only), invokes driver.Delete + provider.Delete
+// in-process hand-off. On sensitive-route or SaveResource failure after
+// cloud mutation (apply mode only), invokes driver.Delete + provider.Delete
 // to compensate the partial cloud-resource creation. Returns a wrapped
-// error naming both the original SaveResource failure and the
-// compensating-Delete outcome.
+// error naming both the original failure and the compensating-Delete outcome.
 //
 // In read mode, the helper does NOT call provider.Set; instead it consults
 // the prior state via store.GetResource and inherits any
@@ -862,7 +1026,9 @@ func persistResourceWithSecretRouting(
 ) (map[string]string, error) {
 	switch mode {
 	case persistModeApply:
-		return persistApplyMode(ctx, store, provider, driver, rs, out)
+		return persistApplyMode(ctx, store, provider, driver, rs, out, true)
+	case persistModeApplyNoCompensate:
+		return persistApplyMode(ctx, store, provider, driver, rs, out, false)
 	case persistModeRead:
 		return nil, persistReadMode(ctx, store, rs, out, nil)
 	default:
@@ -890,7 +1056,9 @@ func persistResourceWithSecretRoutingCachedPrior(
 ) (map[string]string, error) {
 	switch mode {
 	case persistModeApply:
-		return persistApplyMode(ctx, store, provider, driver, rs, out)
+		return persistApplyMode(ctx, store, provider, driver, rs, out, true)
+	case persistModeApplyNoCompensate:
+		return persistApplyMode(ctx, store, provider, driver, rs, out, false)
 	case persistModeRead:
 		return nil, persistReadMode(ctx, store, rs, out, priorByName)
 	default:
@@ -905,24 +1073,32 @@ func persistApplyMode(
 	driver interfaces.ResourceDriver,
 	rs interfaces.ResourceState,
 	out interfaces.ResourceOutput,
+	compensate bool,
 ) (map[string]string, error) {
 	sanitized, hydrated, err := sensitive.Route(ctx, provider, rs.Name, &out)
 	if err != nil {
-		return nil, fmt.Errorf("%s/%s: route sensitive outputs: %w", rs.Type, rs.Name, err)
+		if !compensate {
+			return nil, fmt.Errorf("%s/%s: route sensitive outputs: %w", rs.Type, rs.Name, err)
+		}
+		compErr := compensateAfterSaveFailure(provider, driver, rs, hydrated)
+		if compErr != nil {
+			return nil, fmt.Errorf("%s/%s: route sensitive outputs: %w (compensating delete failed: %v)", rs.Type, rs.Name, err, compErr)
+		}
+		return nil, fmt.Errorf("%s/%s: route sensitive outputs: %w (compensating delete succeeded)", rs.Type, rs.Name, err)
 	}
 	rs.Outputs = sanitized
 	if saveErr := store.SaveResource(ctx, rs); saveErr != nil {
-		// Compensating Delete: if we routed secrets, the matching cloud
-		// resource is real but the state record didn't land. Roll back so
-		// a re-Apply doesn't double-create.
-		if len(hydrated) > 0 {
-			compErr := compensateAfterSaveFailure(provider, driver, rs, hydrated)
-			if compErr != nil {
-				return nil, fmt.Errorf("%s/%s: persist state after apply: %w (compensating delete failed: %v)", rs.Type, rs.Name, saveErr, compErr)
-			}
-			return nil, fmt.Errorf("%s/%s: persist state after apply: %w (compensating delete succeeded)", rs.Type, rs.Name, saveErr)
+		if !compensate {
+			return nil, fmt.Errorf("%s/%s: persist state after apply: %w", rs.Type, rs.Name, saveErr)
 		}
-		return nil, fmt.Errorf("%s/%s: persist state after apply: %w", rs.Type, rs.Name, saveErr)
+		// Compensating Delete: the matching cloud resource is real but
+		// the state record didn't land. Roll back so a re-Apply doesn't
+		// double-create.
+		compErr := compensateAfterSaveFailure(provider, driver, rs, hydrated)
+		if compErr != nil {
+			return nil, fmt.Errorf("%s/%s: persist state after apply: %w (compensating delete failed: %v)", rs.Type, rs.Name, saveErr, compErr)
+		}
+		return nil, fmt.Errorf("%s/%s: persist state after apply: %w (compensating delete succeeded)", rs.Type, rs.Name, saveErr)
 	}
 	return hydrated, nil
 }
@@ -981,10 +1157,11 @@ func persistReadMode(
 }
 
 // compensateAfterSaveFailure rolls back routed secrets and the underlying
-// cloud resource when SaveResource fails after provider.Set succeeded.
-// Uses a fresh 30-second context: the apply context may already be
-// canceled (operator Ctrl-C) but compensation must proceed to avoid
-// orphaning cloud resources + routed secrets.
+// cloud resource after an apply-mode failure where the just-mutated resource is
+// known to be newly created or replacement-created. Uses a fresh 30-second
+// context: the apply context may already be canceled (operator Ctrl-C), but
+// compensation must proceed to avoid orphaning cloud resources + routed
+// secrets.
 func compensateAfterSaveFailure(
 	provider secrets.Provider,
 	driver interfaces.ResourceDriver,
@@ -994,20 +1171,90 @@ func compensateAfterSaveFailure(
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	var errs []error
-	if driver != nil {
+	if driver == nil {
+		errs = append(errs, errors.New("driver.Delete unavailable"))
+	} else {
 		ref := interfaces.ResourceRef{Name: rs.Name, Type: rs.Type, ProviderID: rs.ProviderID}
 		if delErr := driver.Delete(ctx, ref); delErr != nil {
-			errs = append(errs, fmt.Errorf("driver.Delete: %w", delErr))
+			if rs.ProviderID == "" {
+				errs = append(errs, fmt.Errorf("driver.Delete: %w", delErr))
+			} else {
+				nameRef := interfaces.ResourceRef{Name: rs.Name, Type: rs.Type}
+				if nameDelErr := driver.Delete(ctx, nameRef); nameDelErr != nil {
+					errs = append(errs, fmt.Errorf("driver.Delete: %w", errors.Join(delErr, nameDelErr)))
+				}
+			}
 		}
 	}
 	if provider != nil {
-		// Reverse-engineer the original output keys from the secret names.
-		// Format: "<rs.Name>_<output_key>"; strip the prefix.
+		// Delete each routed secret by its full provider key.
 		for secretName := range hydrated {
 			if delErr := provider.Delete(ctx, secretName); delErr != nil && !errors.Is(delErr, secrets.ErrNotFound) {
 				errs = append(errs, fmt.Errorf("provider.Delete(%s): %w", secretName, delErr))
 			}
 		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// compensateAfterValidationFailure rolls back a resource whose output failed
+// identity or ProviderID validation. The ProviderID may be malformed, so a
+// name-only delete is used only when the ProviderID delete does not
+// conclusively succeed.
+func compensateAfterValidationFailure(driver interfaces.ResourceDriver, rs interfaces.ResourceState) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if driver == nil {
+		return errors.New("driver.Delete unavailable")
+	}
+	var errs []error
+	if rs.ProviderID != "" {
+		idRef := interfaces.ResourceRef{Name: rs.Name, Type: rs.Type, ProviderID: rs.ProviderID}
+		if delErr := driver.Delete(ctx, idRef); delErr != nil {
+			if !errors.Is(delErr, interfaces.ErrResourceNotFound) {
+				errs = append(errs, fmt.Errorf("driver.Delete(%s): %w", rs.ProviderID, delErr))
+			}
+		} else {
+			return nil
+		}
+	}
+	nameRef := interfaces.ResourceRef{Name: rs.Name, Type: rs.Type}
+	if delErr := driver.Delete(ctx, nameRef); delErr != nil {
+		if !errors.Is(delErr, interfaces.ErrResourceNotFound) {
+			errs = append(errs, fmt.Errorf("driver.Delete(name-only): %w", delErr))
+		}
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func compensateAfterIdentityValidationFailure(driver interfaces.ResourceDriver, spec interfaces.ResourceSpec, out interfaces.ResourceOutput) error {
+	var errs []error
+	var succeeded bool
+	seen := map[string]struct{}{}
+	add := func(name, typ string) {
+		if name == "" && typ == "" {
+			return
+		}
+		key := name + "\x00" + typ
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		rs := interfaces.ResourceState{Name: name, Type: typ, ProviderID: out.ProviderID}
+		if err := compensateAfterValidationFailure(driver, rs); err != nil {
+			errs = append(errs, err)
+		} else {
+			succeeded = true
+		}
+	}
+	add(out.Name, out.Type)
+	add(spec.Name, spec.Type)
+	if succeeded {
+		return nil
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
@@ -1306,7 +1553,19 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 
 	validateInputProviderIDs(provider, &plan)
 	fmt.Printf("  Plan: %d action(s) to execute.\n", len(plan.Actions))
-	result, err := provider.Apply(ctx, &plan)
+	var result *interfaces.ApplyResult
+	var err error
+	var usedV2Dispatch bool
+	if wfctlhelpers.DispatchVersionFor(provider) == wfctlhelpers.DispatchVersionV2 {
+		usedV2Dispatch = true
+		hooks := statePersistenceHooks(store, secretsProvider, provider, providerType, hydratedOut)
+		result, err = applyV2ApplyPlanWithHooksFn(ctx, provider, &plan, hooks)
+		if result != nil {
+			printDriftReportIfAny(w, result)
+		}
+	} else {
+		result, err = provider.Apply(ctx, &plan)
+	}
 	if err != nil {
 		ref := interfaces.ResourceRef{}
 		if len(plan.Actions) == 1 {
@@ -1345,51 +1604,32 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 	}
 
 	if result != nil {
-		// Pre-flight: same hard-fail as live-diff path.
-		if err := requireSecretsProviderForSensitiveOutputs(secretsProvider, result); err != nil {
-			return fmt.Errorf("state write rejected: %w", err)
+		if usedV2Dispatch {
+			if len(result.Errors) > 0 {
+				msgs := make([]string, 0, len(result.Errors))
+				for _, ae := range result.Errors {
+					msgs = append(msgs, fmt.Sprintf("%s/%s: %s", ae.Action, ae.Resource, ae.Error))
+				}
+				finalErr := fmt.Errorf("%d resource(s) failed: %s", len(result.Errors), strings.Join(msgs, "; "))
+				emitImageNotInRegistryHint(os.Stderr, finalErr)
+				return finalErr
+			}
+			return nil
+		}
+		if err := rejectSensitiveOutputsWithoutProvider(ctx, secretsProvider, result, plan.Actions, provider); err != nil {
+			return err
 		}
 		for _, r := range result.Resources {
-			fmt.Printf("  ✓ %s (%s)\n", r.Name, r.Type)
-
-			if err := validateOutputProviderID(provider, providerType, &r); err != nil {
-				return fmt.Errorf("state write rejected: %w", err)
+			action, ok := planActionForOutput(plan.Actions, result.Resources, r)
+			if !ok {
+				action = interfaces.PlanAction{Resource: interfaces.ResourceSpec{Name: r.Name, Type: r.Type}}
 			}
-
-			// Retrieve spec metadata from the plan action for state persistence.
-			var appliedCfg map[string]any
-			var providerRef string
-			var dependencies []string
-			for i := range plan.Actions {
-				if plan.Actions[i].Resource.Name == r.Name {
-					appliedCfg = plan.Actions[i].Resource.Config
-					providerRef = resolveIaCProviderRef(plan.Actions[i].Resource.Config)
-					dependencies = append([]string(nil), plan.Actions[i].Resource.DependsOn...)
-					break
-				}
-			}
-
-			now := time.Now().UTC()
-			rs := interfaces.ResourceState{
-				ID:                  r.Name,
-				Name:                r.Name,
-				Type:                r.Type,
-				Provider:            providerType,
-				ProviderRef:         providerRef,
-				ProviderID:          r.ProviderID,
-				ConfigHash:          configHashMap(appliedCfg),
-				AppliedConfig:       appliedCfg,
-				AppliedConfigSource: "apply",
-				// Outputs is set by persistResourceWithSecretRouting after Route.
-				Dependencies: dependencies,
-				CreatedAt:    now,
-				UpdatedAt:    now,
-			}
-			driver, _ := provider.ResourceDriver(r.Type)
-			hyd, persistErr := persistResourceWithSecretRouting(ctx, store, secretsProvider, driver, rs, r, persistModeApply)
+			driver, _ := provider.ResourceDriver(action.Resource.Type)
+			hyd, persistErr := persistAppliedResourceOutput(ctx, store, secretsProvider, provider, providerType, driver, action, r)
 			if persistErr != nil {
 				return persistErr
 			}
+			fmt.Printf("  ✓ %s (%s)\n", action.Resource.Name, action.Resource.Type)
 			if hydratedOut != nil {
 				for k, v := range hyd {
 					hydratedOut[k] = v
@@ -1397,8 +1637,8 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 			}
 		}
 
-		for name := range deleteNames {
-			if delErr := store.DeleteResource(ctx, name); delErr != nil {
+		for name := range successfulDeleteNames(deleteNames, result) {
+			if delErr := deleteStateAfterCloudDelete(store, name); delErr != nil {
 				fmt.Printf("  WARNING: failed to remove state for %q: %v\n", name, delErr)
 			}
 		}

--- a/cmd/wfctl/infra_apply_allow_replace_test.go
+++ b/cmd/wfctl/infra_apply_allow_replace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/iac/iactest"
+	"github.com/GoCodeAlone/workflow/iac/wfctlhelpers"
 	"github.com/GoCodeAlone/workflow/interfaces"
 )
 
@@ -25,7 +26,7 @@ import (
 // drive the gate.
 //
 // Read-only inside the apply path (validateAllowReplaceProtected); the
-// pkg-level pattern matches computeInfraPlan / applyV2ApplyPlanFn.
+// pkg-level pattern matches computeInfraPlan / applyV2ApplyPlanWithHooksFn.
 //
 // The test interface promises:
 //   - validateAllowReplaceProtected(plan, allow) returns nil when no
@@ -233,7 +234,7 @@ func TestApplyWithProviderAndStore_ProtectedReplace_WithoutAllowReplace_Errors(t
 // confirms the override path: with applyAllowReplaceSet listing the
 // protected resource, the gate is bypassed and the apply continues
 // past the gate. We route through the v2 dispatch (sentinel return
-// via applyV2ApplyPlanFn) so a sentinel error proves the call site
+// via applyV2ApplyPlanWithHooksFn) so a sentinel error proves the call site
 // reached dispatch — i.e. the gate did not short-circuit.
 func TestApplyWithProviderAndStore_ProtectedReplace_WithAllowReplace_Proceeds(t *testing.T) {
 	provider := &iactest.NoopProvider{ProviderName: "allow-replace-stub", DispatchVersion: "v2"}
@@ -249,11 +250,11 @@ func TestApplyWithProviderAndStore_ProtectedReplace_WithAllowReplace_Proceeds(t 
 	t.Cleanup(func() { computeInfraPlan = origCompute })
 
 	dispatched := errors.New("v2 ApplyPlan reached")
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		return nil, dispatched
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	origAllow := applyAllowReplaceSet
 	applyAllowReplaceSet = map[string]struct{}{"prod-db": {}}

--- a/cmd/wfctl/infra_apply_plan_test.go
+++ b/cmd/wfctl/infra_apply_plan_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,7 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoCodeAlone/workflow/iac/iactest"
 	"github.com/GoCodeAlone/workflow/iac/inputsnapshot"
+	"github.com/GoCodeAlone/workflow/iac/wfctlhelpers"
 	"github.com/GoCodeAlone/workflow/interfaces"
 )
 
@@ -371,6 +374,84 @@ func TestInfraApplyPrecomputedPlan_PersistsState(t *testing.T) {
 	}
 	if saved.ConfigHash == "" {
 		t.Error("ConfigHash: want non-empty, got empty")
+	}
+}
+
+func TestInfraApplyPrecomputedPlan_V2PersistsStateThroughHooks(t *testing.T) {
+	store := &fakeStateStore{}
+	spec := interfaces.ResourceSpec{
+		Name:   "first",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "test-provider"},
+	}
+	plan := interfaces.IaCPlan{
+		ID:      "v2-persist-test",
+		Actions: []interfaces.PlanAction{{Action: "create", Resource: spec}},
+	}
+	provider := &v2DriverProvider{driver: &v2ImmediatePersistDriver{store: store}}
+
+	err := applyPrecomputedPlanWithStore(t.Context(), plan, provider, "fake-cloud", store, io.Discard, "", "", nil)
+	if err != nil {
+		t.Fatalf("applyPrecomputedPlanWithStore: %v", err)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 1 {
+		t.Fatalf("saved state count = %d, want 1; saved=%+v", len(store.saved), store.saved)
+	}
+	if store.saved[0].ProviderID != "id-first" {
+		t.Fatalf("ProviderID = %q, want id-first", store.saved[0].ProviderID)
+	}
+}
+
+func TestInfraApplyPrecomputedPlan_V2PrintsDriftReport(t *testing.T) {
+	plan := interfaces.IaCPlan{
+		ID:      "v2-drift-test",
+		Actions: []interfaces.PlanAction{{Action: "create", Resource: interfaces.ResourceSpec{Name: "x", Type: "infra.test"}}},
+	}
+	provider := &iactest.NoopProvider{ProviderName: "v2-stub", DispatchVersion: "v2"}
+	driftEntries := []interfaces.DriftEntry{
+		{Name: "EXAMPLE_VAR", PlanFingerprint: "plan-fp", ApplyFingerprint: "apply-fp"},
+	}
+
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
+		return &interfaces.ApplyResult{InputDriftReport: driftEntries}, nil
+	}
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
+
+	var w bytes.Buffer
+	err := applyPrecomputedPlanWithStore(t.Context(), plan, provider, "fake-cloud", &fakeStateStore{}, &w, "test", "", nil)
+	if err != nil {
+		t.Fatalf("applyPrecomputedPlanWithStore: %v", err)
+	}
+	if !strings.Contains(w.String(), "EXAMPLE_VAR") {
+		t.Fatalf("drift report missing EXAMPLE_VAR; got:\n%s", w.String())
+	}
+}
+
+func TestInfraApplyPrecomputedPlan_FailedDeleteKeepsState(t *testing.T) {
+	current := interfaces.ResourceState{Name: "old", Type: "infra.test", ProviderID: "id-old"}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}}
+	plan := interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+		Action:   "delete",
+		Resource: interfaces.ResourceSpec{Name: "old", Type: "infra.test"},
+		Current:  &current,
+	}}}
+	provider := &stateReturningProvider{
+		applyResult: &interfaces.ApplyResult{
+			Errors: []interfaces.ActionError{{Action: "delete", Resource: "old", Error: "delete failed"}},
+		},
+	}
+
+	err := applyPrecomputedPlanWithStore(t.Context(), plan, provider, "fake-cloud", store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected delete failure, got nil")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 0 {
+		t.Fatalf("deleted state entries = %v, want none after failed delete", store.deleted)
 	}
 }
 

--- a/cmd/wfctl/infra_apply_sensitive_routing_test.go
+++ b/cmd/wfctl/infra_apply_sensitive_routing_test.go
@@ -162,6 +162,9 @@ func TestPersistResourceWithSecretRouting_NoProviderHardFails(t *testing.T) {
 	if len(store.saved) != 0 {
 		t.Error("state should NOT be saved when routing fails")
 	}
+	if len(drv.deleteCalls) != 1 {
+		t.Fatalf("expected compensating Delete after routing failure, got %d", len(drv.deleteCalls))
+	}
 }
 
 func TestPersistResourceWithSecretRouting_SaveFailureCompensatesWithDelete(t *testing.T) {
@@ -189,6 +192,30 @@ func TestPersistResourceWithSecretRouting_SaveFailureCompensatesWithDelete(t *te
 	}
 	if _, ok := prov.values[sensitive.SecretKey("myres", "secret_key")]; ok {
 		t.Errorf("compensating Delete should have removed routed secret; got %v", prov.values)
+	}
+}
+
+func TestPersistResourceWithSecretRouting_SaveFailureWithoutSecretsCompensatesWithDelete(t *testing.T) {
+	store := &stubInfraStore{saveErr: errors.New("disk full")}
+	drv := &stubSensitiveDriver{}
+	out := interfaces.ResourceOutput{
+		Name:       "myres",
+		ProviderID: "plain-id",
+		Outputs:    map[string]any{"bucket": "b"},
+	}
+	rs := interfaces.ResourceState{Name: "myres", Type: "infra.bucket", ProviderID: "plain-id"}
+	_, err := persistResourceWithSecretRouting(context.Background(), store, nil, drv, rs, out, persistModeApply)
+	if err == nil {
+		t.Fatal("expected error from SaveResource")
+	}
+	if !strings.Contains(err.Error(), "compensating delete succeeded") {
+		t.Fatalf("error = %v, want compensating delete success", err)
+	}
+	if len(drv.deleteCalls) != 1 {
+		t.Fatalf("expected 1 compensating Delete call, got %d", len(drv.deleteCalls))
+	}
+	if drv.deleteCalls[0].ProviderID != "plain-id" {
+		t.Errorf("compensating Delete used wrong ProviderID: %v", drv.deleteCalls[0])
 	}
 }
 

--- a/cmd/wfctl/infra_apply_test.go
+++ b/cmd/wfctl/infra_apply_test.go
@@ -1399,6 +1399,23 @@ func (p *stateReturningProvider) BootstrapStateBackend(_ context.Context, _ map[
 }
 func (p *stateReturningProvider) Close() error { return nil }
 
+type stateReturningProviderWithDriver struct {
+	stateReturningProvider
+	driver interfaces.ResourceDriver
+	cancel context.CancelFunc
+}
+
+func (p *stateReturningProviderWithDriver) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	return p.stateReturningProvider.Apply(ctx, plan)
+}
+
+func (p *stateReturningProviderWithDriver) ResourceDriver(string) (interfaces.ResourceDriver, error) {
+	return p.driver, nil
+}
+
 // TestApplyWithProvider_SavesStateForSuccessfulResources asserts that
 // applyWithProviderAndStore calls store.SaveResource for each resource in
 // the Apply result.
@@ -1505,6 +1522,298 @@ func TestApplyWithProvider_StoreSaveFailureFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "persist state") || !strings.Contains(err.Error(), "disk full") {
 		t.Fatalf("error = %v, want hard state persistence failure", err)
+	}
+}
+
+func TestApplyWithProvider_UpdateSaveFailureDoesNotDelete(t *testing.T) {
+	desiredCfg := map[string]any{"version": 2}
+	current := interfaces.ResourceState{
+		Name:       "r1",
+		Type:       "infra.test",
+		ProviderID: "id-existing",
+	}
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, current []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "update",
+			Resource: specs[0],
+			Current:  &current[0],
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	driver := &v2UpdateFailureDriver{}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{
+			applyResult: &interfaces.ApplyResult{
+				Resources: []interfaces.ResourceOutput{{
+					Name:       "r1",
+					Type:       "infra.test",
+					ProviderID: "id-existing",
+				}},
+			},
+		},
+		driver: driver,
+	}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}, saveErr: fmt.Errorf("disk full")}
+	specs := []interfaces.ResourceSpec{{Name: "r1", Type: "infra.test", Config: desiredCfg}}
+
+	err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", specs, []interfaces.ResourceState{current}, store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected save failure after update, got nil")
+	}
+	if strings.Contains(err.Error(), "compensating delete") {
+		t.Fatalf("error = %v, update path must not compensate with delete", err)
+	}
+	if driver.deleteCount != 0 {
+		t.Fatalf("driver delete count = %d, want 0 for update save failure", driver.deleteCount)
+	}
+}
+
+func TestApplyWithProvider_UpdateProviderIDFailureDoesNotDelete(t *testing.T) {
+	desiredCfg := map[string]any{"version": 2}
+	current := interfaces.ResourceState{
+		Name:       "r1",
+		Type:       "infra.test",
+		ProviderID: "id-existing",
+	}
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, current []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "update",
+			Resource: specs[0],
+			Current:  &current[0],
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	driver := &v2UpdateInvalidProviderIDDriver{}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{
+			applyResult: &interfaces.ApplyResult{
+				Resources: []interfaces.ResourceOutput{{
+					Name:       "r1",
+					Type:       "infra.test",
+					ProviderID: "not-a-uuid",
+				}},
+			},
+		},
+		driver: driver,
+	}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}}
+	specs := []interfaces.ResourceSpec{{Name: "r1", Type: "infra.test", Config: desiredCfg}}
+
+	err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", specs, []interfaces.ResourceState{current}, store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected ProviderID validation failure after update, got nil")
+	}
+	if strings.Contains(err.Error(), "compensating delete") {
+		t.Fatalf("error = %v, update path must not compensate with delete", err)
+	}
+	if driver.deleteCount != 0 {
+		t.Fatalf("driver delete count = %d, want 0 for update ProviderID failure", driver.deleteCount)
+	}
+}
+
+func TestApplyWithProvider_UpdateSensitiveRoutingFailureDoesNotDelete(t *testing.T) {
+	desiredCfg := map[string]any{"version": 2}
+	current := interfaces.ResourceState{
+		Name:       "r1",
+		Type:       "infra.test",
+		ProviderID: "id-existing",
+	}
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, current []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "update",
+			Resource: specs[0],
+			Current:  &current[0],
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	driver := &v2UpdateFailureDriver{}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{
+			applyResult: &interfaces.ApplyResult{
+				Resources: []interfaces.ResourceOutput{{
+					Name:       "r1",
+					Type:       "infra.test",
+					ProviderID: "id-existing",
+					Outputs:    map[string]any{"token": "secret"},
+					Sensitive:  map[string]bool{"token": true},
+				}},
+			},
+		},
+		driver: driver,
+	}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}}
+	specs := []interfaces.ResourceSpec{{Name: "r1", Type: "infra.test", Config: desiredCfg}}
+
+	err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", specs, []interfaces.ResourceState{current}, store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected sensitive routing failure after update, got nil")
+	}
+	if strings.Contains(err.Error(), "compensating delete") {
+		t.Fatalf("error = %v, update path must not compensate with delete", err)
+	}
+	if driver.deleteCount != 0 {
+		t.Fatalf("driver delete count = %d, want 0 for update sensitive-routing failure", driver.deleteCount)
+	}
+}
+
+func TestApplyWithProvider_FailedDeleteKeepsState(t *testing.T) {
+	current := interfaces.ResourceState{Name: "old", Type: "infra.test", ProviderID: "id-old"}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}}
+	fake := &stateReturningProvider{
+		applyResult: &interfaces.ApplyResult{
+			Errors: []interfaces.ActionError{{Action: "delete", Resource: "old", Error: "delete failed"}},
+		},
+	}
+
+	if err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", nil, []interfaces.ResourceState{current}, store, io.Discard, "", "", nil); err == nil {
+		t.Fatal("expected delete failure, got nil")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 0 {
+		t.Fatalf("deleted state entries = %v, want none after failed delete", store.deleted)
+	}
+}
+
+func TestApplyWithProvider_PartialFailureDoesNotInferDeleteSuccess(t *testing.T) {
+	desired := interfaces.ResourceSpec{Name: "new", Type: "infra.test", Config: map[string]any{"version": 1}}
+	current := interfaces.ResourceState{Name: "old", Type: "infra.test", ProviderID: "id-old"}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}}
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(context.Context, interfaces.IaCProvider, []interfaces.ResourceSpec, []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{
+			{Action: "create", Resource: desired},
+			{Action: "delete", Resource: interfaces.ResourceSpec{Name: "old", Type: "infra.test"}, Current: &current},
+		}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+	fake := &stateReturningProvider{
+		applyResult: &interfaces.ApplyResult{
+			Errors: []interfaces.ActionError{{Action: "create", Resource: "new", Error: "create failed before delete"}},
+		},
+	}
+
+	if err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", []interfaces.ResourceSpec{desired}, []interfaces.ResourceState{current}, store, io.Discard, "", "", nil); err == nil {
+		t.Fatal("expected partial failure, got nil")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 0 {
+		t.Fatalf("deleted state entries = %v, want none when legacy result has errors", store.deleted)
+	}
+}
+
+func TestApplyWithProvider_CreateMissingIdentitySaveFailureCompensates(t *testing.T) {
+	driver := &v2SensitiveCreateDriver{}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{
+			applyResult: &interfaces.ApplyResult{
+				Resources: []interfaces.ResourceOutput{{ProviderID: "id-created"}},
+			},
+		},
+		driver: driver,
+	}
+	store := &fakeStateStore{saveErr: fmt.Errorf("disk full")}
+	specs := []interfaces.ResourceSpec{{Name: "r1", Type: "infra.test", Config: map[string]any{"version": 1}}}
+
+	err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", specs, nil, store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected save failure after create, got nil")
+	}
+	if !strings.Contains(err.Error(), "compensating delete succeeded") {
+		t.Fatalf("error = %v, want create compensation", err)
+	}
+	if driver.deleteCount == 0 {
+		t.Fatal("expected compensating delete for create output with missing identity")
+	}
+}
+
+func TestApplyWithProvider_CreateSensitiveOutputWithoutSecretsCompensates(t *testing.T) {
+	driver := &v2SensitiveCreateDriver{}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{
+			applyResult: &interfaces.ApplyResult{
+				Resources: []interfaces.ResourceOutput{{
+					Name:       "r1",
+					Type:       "infra.test",
+					ProviderID: "id-created",
+					Outputs:    map[string]any{"token": "secret"},
+					Sensitive:  map[string]bool{"token": true},
+				}},
+			},
+		},
+		driver: driver,
+	}
+	store := &fakeStateStore{}
+	specs := []interfaces.ResourceSpec{{Name: "r1", Type: "infra.test", Config: map[string]any{"version": 1}}}
+
+	err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", specs, nil, store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected sensitive routing failure after create, got nil")
+	}
+	if !strings.Contains(err.Error(), "compensating delete succeeded") {
+		t.Fatalf("error = %v, want create compensation", err)
+	}
+	if driver.deleteCount == 0 {
+		t.Fatal("expected compensating delete for create with sensitive outputs and no provider")
+	}
+}
+
+func TestApplyWithProvider_SensitivePreflightDoesNotPartiallySave(t *testing.T) {
+	driver := &v2SensitiveCreateDriver{}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{
+			applyResult: &interfaces.ApplyResult{
+				Resources: []interfaces.ResourceOutput{
+					{Name: "plain", Type: "infra.test", ProviderID: "id-plain", Outputs: map[string]any{"url": "https://example.test"}},
+					{Name: "secret", Type: "infra.test", ProviderID: "id-secret", Outputs: map[string]any{"token": "secret"}, Sensitive: map[string]bool{"token": true}},
+				},
+			},
+		},
+		driver: driver,
+	}
+	store := &fakeStateStore{}
+	specs := []interfaces.ResourceSpec{
+		{Name: "plain", Type: "infra.test", Config: map[string]any{"version": 1}},
+		{Name: "secret", Type: "infra.test", Config: map[string]any{"version": 1}},
+	}
+
+	err := applyWithProviderAndStore(t.Context(), fake, "fake-cloud", specs, nil, store, io.Discard, "", "", nil)
+	if err == nil {
+		t.Fatal("expected sensitive routing failure, got nil")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 0 {
+		t.Fatalf("saved state = %+v, want no partial state before sensitive preflight failure", store.saved)
+	}
+	if driver.deleteCount == 0 {
+		t.Fatal("expected compensating delete for sensitive create")
+	}
+}
+
+func TestApplyWithProvider_DeletePrunesStateAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	current := interfaces.ResourceState{Name: "old", Type: "infra.test", ProviderID: "id-old"}
+	store := &cancelAwareStateStore{fakeStateStore: fakeStateStore{saved: []interfaces.ResourceState{current}}}
+	fake := &stateReturningProviderWithDriver{
+		stateReturningProvider: stateReturningProvider{applyResult: &interfaces.ApplyResult{}},
+		cancel:                 cancel,
+	}
+
+	if err := applyWithProviderAndStore(ctx, fake, "fake-cloud", nil, []interfaces.ResourceState{current}, store, io.Discard, "", "", nil); err != nil {
+		t.Fatalf("applyWithProviderAndStore: %v", err)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 1 || store.deleted[0] != "old" {
+		t.Fatalf("deleted state entries = %v, want [old]", store.deleted)
 	}
 }
 

--- a/cmd/wfctl/infra_apply_v2_loader_test.go
+++ b/cmd/wfctl/infra_apply_v2_loader_test.go
@@ -145,6 +145,17 @@ modules:
 	if len(stub.driver.createSpecs) != 1 || stub.driver.createSpecs[0].Config["region"] != "nyc1" {
 		t.Errorf("create spec = %+v, want region=nyc1 (the new desired)", stub.driver.createSpecs)
 	}
+	store := &fsWfctlStateStore{dir: stateDir}
+	states, err := store.ListResources(t.Context())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("states = %d, want 1", len(states))
+	}
+	if states[0].ProviderID != "stub-created-loader" {
+		t.Fatalf("state ProviderID = %q, want stub-created-loader", states[0].ProviderID)
+	}
 }
 
 // TestApply_V2_LoaderSeam_DriftReportPrinted complements the
@@ -154,7 +165,7 @@ modules:
 // InputDriftReport. T3.7 wired the helper into the v2 dispatch but
 // only T3.7's mock-seam test pins the assertion; this loader-seam
 // variant proves the wiring works end-to-end without the
-// applyV2ApplyPlanFn substitution.
+// applyV2ApplyPlanWithHooksFn substitution.
 //
 // The test substitutes the wfctlhelpers.ApplyPlan dispatch only —
 // ComputePlan and the rest of the pipeline run unmodified — so the
@@ -201,11 +212,11 @@ modules:
 	driftEntries := []interfaces.DriftEntry{
 		{Name: "EXAMPLE_VAR", PlanFingerprint: "plan-fp", ApplyFingerprint: "apply-fp"},
 	}
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		return &interfaces.ApplyResult{InputDriftReport: driftEntries}, nil
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	// Capture stderr to assert printDriftReportIfAny output reached
 	// the operator. applyInfraModules writes the drift report to

--- a/cmd/wfctl/infra_apply_v2_test.go
+++ b/cmd/wfctl/infra_apply_v2_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/iac/iactest"
+	"github.com/GoCodeAlone/workflow/iac/wfctlhelpers"
 	"github.com/GoCodeAlone/workflow/interfaces"
 )
 
@@ -58,7 +59,7 @@ func TestApplyWithProviderAndStore_PassesLiveProviderToComputePlan(t *testing.T)
 // T3.7's manifest-driven dispatch: a provider whose
 // ComputePlanVersion() returns "v2" routes through
 // wfctlhelpers.ApplyPlan instead of provider.Apply. The seam is
-// applyV2ApplyPlanFn (var-indirected wfctlhelpers.ApplyPlan).
+// applyV2ApplyPlanWithHooksFn (var-indirected wfctlhelpers.ApplyPlan).
 //
 // rev2/rev3-locked: there is NO env-var. The branch is purely
 // plugin-author-controlled via plugin.json's
@@ -73,12 +74,12 @@ func TestApplyWithProviderAndStore_V2RoutesThroughWfctlhelpers(t *testing.T) {
 	var v2Called atomic.Bool
 	v2Stop := errors.New("stop after v2 ApplyPlan dispatched")
 
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		v2Called.Store(true)
 		return nil, v2Stop
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	// Force ComputePlan to emit a non-empty plan so applyWithProviderAndStore
 	// reaches the dispatch branch instead of short-circuiting on
@@ -115,12 +116,12 @@ func TestApplyWithProviderAndStore_V1FallsThroughToProviderApply(t *testing.T) {
 	v1Provider := &v1RecordingProvider{}
 
 	var v2Called atomic.Bool
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		v2Called.Store(true)
 		return nil, errors.New("v2 must not be invoked for v1 manifest")
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	origCompute := computeInfraPlan
 	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
@@ -161,11 +162,11 @@ func TestApplyWithProviderAndStore_V2PrintsDriftReport(t *testing.T) {
 		},
 	}
 
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		return driftResult, nil
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	origCompute := computeInfraPlan
 	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
@@ -206,11 +207,11 @@ func TestApplyWithProviderAndStore_V2PrintsDriftReportOnPartialFailure(t *testin
 	}
 	applyErr := errors.New("partial failure during apply")
 
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		return driftResult, applyErr
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	origCompute := computeInfraPlan
 	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
@@ -234,6 +235,337 @@ func TestApplyWithProviderAndStore_V2PrintsDriftReportOnPartialFailure(t *testin
 	}
 }
 
+func TestApplyWithProviderAndStore_V2PersistsBeforeLaterActionFailure(t *testing.T) {
+	store := &fakeStateStore{}
+	driver := &v2ImmediatePersistDriver{store: store}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		actions := make([]interfaces.PlanAction, len(specs))
+		for i, s := range specs {
+			actions[i] = interfaces.PlanAction{Action: "create", Resource: s}
+		}
+		return interfaces.IaCPlan{Actions: actions}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{
+		{Name: "first", Type: "infra.test", Config: map[string]any{"provider": "stub"}},
+		{Name: "second", Type: "infra.test", Config: map[string]any{"provider": "stub"}},
+	}
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, nil, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected second action failure")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 1 {
+		t.Fatalf("saved state count = %d, want 1; saved=%+v", len(store.saved), store.saved)
+	}
+	if store.saved[0].Name != "first" {
+		t.Fatalf("saved state = %+v, want first resource", store.saved[0])
+	}
+	if !driver.observedFirstStateBeforeSecond {
+		t.Fatal("second driver action did not observe first resource persisted")
+	}
+}
+
+func TestApplyWithProviderAndStore_V2FailedDeleteKeepsState(t *testing.T) {
+	store := &fakeStateStore{saved: []interfaces.ResourceState{{
+		Name:       "old",
+		Type:       "infra.test",
+		ProviderID: "id-old",
+	}}}
+	v2Provider := &v2DriverProvider{driver: &iactest.NoopDriver{DeleteErr: errors.New("delete failed")}}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(context.Context, interfaces.IaCProvider, []interfaces.ResourceSpec, []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "delete",
+			Resource: interfaces.ResourceSpec{Name: "old", Type: "infra.test"},
+			Current:  &interfaces.ResourceState{Name: "old", Type: "infra.test", ProviderID: "id-old"},
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", nil, store.saved, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected failed delete error")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 0 {
+		t.Fatalf("deleted state entries = %v, want none after failed cloud delete", store.deleted)
+	}
+	if len(store.saved) != 1 || store.saved[0].Name != "old" {
+		t.Fatalf("saved state = %+v, want original old state retained", store.saved)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2SuccessfulDeletePersistsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	store := &cancelAwareStateStore{fakeStateStore: fakeStateStore{saved: []interfaces.ResourceState{{
+		Name:       "old",
+		Type:       "infra.test",
+		ProviderID: "id-old",
+	}}}}
+	v2Provider := &v2DriverProvider{driver: &cancelAfterDeleteDriver{cancel: cancel}}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(context.Context, interfaces.IaCProvider, []interfaces.ResourceSpec, []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "delete",
+			Resource: interfaces.ResourceSpec{Name: "old", Type: "infra.test"},
+			Current:  &interfaces.ResourceState{Name: "old", Type: "infra.test", ProviderID: "id-old"},
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	var w bytes.Buffer
+	if err := applyWithProviderAndStore(ctx, v2Provider, "stub", nil, store.saved, store, &w, "test", "", nil); err != nil {
+		t.Fatalf("applyWithProviderAndStore: %v", err)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 1 || store.deleted[0] != "old" {
+		t.Fatalf("deleted state entries = %v, want [old]", store.deleted)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2SensitiveOutputWithoutSecretsRollsBack(t *testing.T) {
+	store := &fakeStateStore{}
+	driver := &v2SensitiveCreateDriver{}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		actions := make([]interfaces.PlanAction, len(specs))
+		for i, s := range specs {
+			actions[i] = interfaces.PlanAction{Action: "create", Resource: s}
+		}
+		return interfaces.IaCPlan{Actions: actions}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{{
+		Name:   "api-key",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "stub"},
+	}}
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, nil, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected sensitive routing failure")
+	}
+	if !strings.Contains(err.Error(), "compensating delete succeeded") {
+		t.Fatalf("error = %v, want compensating delete success", err)
+	}
+	if driver.deleteCount != 1 {
+		t.Fatalf("driver delete count = %d, want 1", driver.deleteCount)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 0 {
+		t.Fatalf("saved state = %+v, want none after routing failure", store.saved)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2InvalidProviderIDRollsBack(t *testing.T) {
+	store := &fakeStateStore{}
+	driver := &v2InvalidProviderIDDriver{}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		actions := make([]interfaces.PlanAction, len(specs))
+		for i, s := range specs {
+			actions[i] = interfaces.PlanAction{Action: "create", Resource: s}
+		}
+		return interfaces.IaCPlan{Actions: actions}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{{
+		Name:   "app",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "stub"},
+	}}
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, nil, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected ProviderID validation failure")
+	}
+	if !strings.Contains(err.Error(), "malformed ProviderID") || !strings.Contains(err.Error(), "compensating delete succeeded") {
+		t.Fatalf("error = %v, want ProviderID rejection with compensation", err)
+	}
+	if driver.deleteCount != 2 {
+		t.Fatalf("driver delete count = %d, want malformed-ID attempt plus name-only fallback", driver.deleteCount)
+	}
+	if !driver.nameOnlyDeleteSucceeded {
+		t.Fatal("ProviderID validation compensation did not fall back to name-only delete")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 0 {
+		t.Fatalf("saved state = %+v, want none after ProviderID validation failure", store.saved)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2FillsMissingOutputIdentityFromSpec(t *testing.T) {
+	store := &fakeStateStore{}
+	driver := &v2MissingIdentityDriver{}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		actions := make([]interfaces.PlanAction, len(specs))
+		for i, s := range specs {
+			actions[i] = interfaces.PlanAction{Action: "create", Resource: s}
+		}
+		return interfaces.IaCPlan{Actions: actions}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{{
+		Name:   "app",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "stub"},
+	}}
+
+	var w bytes.Buffer
+	if err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, nil, store, &w, "test", "", nil); err != nil {
+		t.Fatalf("applyWithProviderAndStore: %v", err)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 1 {
+		t.Fatalf("saved state count = %d, want 1", len(store.saved))
+	}
+	if store.saved[0].Name != "app" || store.saved[0].Type != "infra.test" {
+		t.Fatalf("saved state identity = %s/%s, want app/infra.test", store.saved[0].Name, store.saved[0].Type)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2UpdateSaveFailureDoesNotDelete(t *testing.T) {
+	current := interfaces.ResourceState{Name: "app", Type: "infra.test", ProviderID: "id-existing"}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}, saveErr: errors.New("state store down")}
+	driver := &v2UpdateFailureDriver{}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, current []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "update",
+			Resource: specs[0],
+			Current:  &current[0],
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{{
+		Name:   "app",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "stub"},
+	}}
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, []interfaces.ResourceState{current}, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected state save failure")
+	}
+	if strings.Contains(err.Error(), "compensating delete") {
+		t.Fatalf("error = %v, update path must not compensate with delete", err)
+	}
+	if driver.deleteCount != 0 {
+		t.Fatalf("driver delete count = %d, want 0 for update state-save failure", driver.deleteCount)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleted) != 0 {
+		t.Fatalf("deleted state entries = %v, want none after update state-save failure", store.deleted)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2UpdateProviderIDFailureDoesNotDelete(t *testing.T) {
+	current := interfaces.ResourceState{Name: "app", Type: "infra.test", ProviderID: "id-existing"}
+	store := &fakeStateStore{saved: []interfaces.ResourceState{current}}
+	driver := &v2UpdateInvalidProviderIDDriver{}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, current []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "update",
+			Resource: specs[0],
+			Current:  &current[0],
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{{
+		Name:   "app",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "stub"},
+	}}
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, []interfaces.ResourceState{current}, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected ProviderID validation failure")
+	}
+	if strings.Contains(err.Error(), "compensating delete") {
+		t.Fatalf("error = %v, update validation path must not compensate with delete", err)
+	}
+	if driver.deleteCount != 0 {
+		t.Fatalf("driver delete count = %d, want 0 for update validation failure", driver.deleteCount)
+	}
+}
+
+func TestApplyWithProviderAndStore_V2MismatchedOutputIdentityRollsBack(t *testing.T) {
+	store := &fakeStateStore{}
+	driver := &v2MismatchedIdentityDriver{}
+	v2Provider := &v2DriverProvider{driver: driver}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		actions := make([]interfaces.PlanAction, len(specs))
+		for i, s := range specs {
+			actions[i] = interfaces.PlanAction{Action: "create", Resource: s}
+		}
+		return interfaces.IaCPlan{Actions: actions}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	specs := []interfaces.ResourceSpec{{
+		Name:   "app",
+		Type:   "infra.test",
+		Config: map[string]any{"provider": "stub"},
+	}}
+
+	var w bytes.Buffer
+	err := applyWithProviderAndStore(t.Context(), v2Provider, "stub", specs, nil, store, &w, "test", "", nil)
+	if err == nil {
+		t.Fatal("expected output identity mismatch failure")
+	}
+	if !strings.Contains(err.Error(), "output type") || !strings.Contains(err.Error(), "compensating delete succeeded") {
+		t.Fatalf("error = %v, want output identity rejection with compensation", err)
+	}
+	if driver.deleteCount != 3 {
+		t.Fatalf("driver delete count = %d, want returned identity and desired identity delete attempts", driver.deleteCount)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.saved) != 0 {
+		t.Fatalf("saved state = %+v, want none after identity mismatch", store.saved)
+	}
+}
+
 // TestApplyWithProviderAndStore_V1Path_DeclarerReturnsEmpty pins the
 // "Path B" v1 fallback (rev3 fix for T3.7 review IMPORTANT #3): a
 // provider that DOES implement ComputePlanVersionDeclarer but
@@ -250,12 +582,12 @@ func TestApplyWithProviderAndStore_V1Path_DeclarerReturnsEmpty(t *testing.T) {
 	v1Provider := &iactest.NoopProvider{ProviderName: "v1-empty-decl", DispatchVersion: ""}
 
 	var v2Called atomic.Bool
-	origApply := applyV2ApplyPlanFn
-	applyV2ApplyPlanFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(_ context.Context, _ interfaces.IaCProvider, _ *interfaces.IaCPlan, _ wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
 		v2Called.Store(true)
 		return nil, errors.New("v2 must not be invoked when DispatchVersion is empty")
 	}
-	t.Cleanup(func() { applyV2ApplyPlanFn = origApply })
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
 
 	origCompute := computeInfraPlan
 	computeInfraPlan = func(_ context.Context, _ interfaces.IaCProvider, specs []interfaces.ResourceSpec, _ []interfaces.ResourceState) (interfaces.IaCPlan, error) {
@@ -325,3 +657,177 @@ func (p *v1RecordingProvider) BootstrapStateBackend(_ context.Context, _ map[str
 	return nil, nil
 }
 func (p *v1RecordingProvider) Close() error { return nil }
+
+type v2DriverProvider struct {
+	iactest.NoopProvider
+	driver interfaces.ResourceDriver
+}
+
+func (p *v2DriverProvider) ComputePlanVersion() string { return "v2" }
+
+func (p *v2DriverProvider) ResourceDriver(string) (interfaces.ResourceDriver, error) {
+	return p.driver, nil
+}
+
+type v2ImmediatePersistDriver struct {
+	iactest.NoopDriver
+	store                          *fakeStateStore
+	observedFirstStateBeforeSecond bool
+}
+
+func (d *v2ImmediatePersistDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	switch spec.Name {
+	case "first":
+		return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-first"}, nil
+	case "second":
+		d.store.mu.Lock()
+		for _, saved := range d.store.saved {
+			if saved.Name == "first" {
+				d.observedFirstStateBeforeSecond = true
+				break
+			}
+		}
+		d.store.mu.Unlock()
+		return nil, errors.New("second create failed")
+	default:
+		return nil, errors.New("unexpected resource")
+	}
+}
+
+type v2SensitiveCreateDriver struct {
+	iactest.NoopDriver
+	deleteCount int
+}
+
+func (d *v2SensitiveCreateDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:       spec.Name,
+		Type:       spec.Type,
+		ProviderID: "id-sensitive",
+		Outputs:    map[string]any{"token": "secret"},
+		Sensitive:  map[string]bool{"token": true},
+	}, nil
+}
+
+func (d *v2SensitiveCreateDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	d.deleteCount++
+	return d.NoopDriver.Delete(ctx, ref)
+}
+
+type v2InvalidProviderIDDriver struct {
+	iactest.NoopDriver
+	deleteCount             int
+	nameOnlyDeleteSucceeded bool
+}
+
+func (d *v2InvalidProviderIDDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatUUID
+}
+
+func (d *v2InvalidProviderIDDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:       spec.Name,
+		Type:       spec.Type,
+		ProviderID: "not-a-uuid",
+		Outputs:    map[string]any{"url": "https://example.test"},
+	}, nil
+}
+
+func (d *v2InvalidProviderIDDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	d.deleteCount++
+	if ref.ProviderID != "" {
+		return interfaces.ErrResourceNotFound
+	}
+	d.nameOnlyDeleteSucceeded = true
+	return d.NoopDriver.Delete(ctx, ref)
+}
+
+type cancelAfterDeleteDriver struct {
+	iactest.NoopDriver
+	cancel context.CancelFunc
+}
+
+func (d *cancelAfterDeleteDriver) Delete(context.Context, interfaces.ResourceRef) error {
+	d.cancel()
+	return nil
+}
+
+type cancelAwareStateStore struct {
+	fakeStateStore
+}
+
+func (s *cancelAwareStateStore) DeleteResource(ctx context.Context, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.fakeStateStore.DeleteResource(ctx, name)
+}
+
+type v2MissingIdentityDriver struct {
+	iactest.NoopDriver
+}
+
+func (d *v2MissingIdentityDriver) Create(context.Context, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		ProviderID: "id-missing-identity",
+		Outputs:    map[string]any{"url": "https://example.test"},
+	}, nil
+}
+
+type v2UpdateFailureDriver struct {
+	iactest.NoopDriver
+	deleteCount int
+}
+
+func (d *v2UpdateFailureDriver) Update(_ context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:       spec.Name,
+		Type:       spec.Type,
+		ProviderID: ref.ProviderID,
+		Outputs:    map[string]any{"url": "https://updated.example.test"},
+	}, nil
+}
+
+func (d *v2UpdateFailureDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	d.deleteCount++
+	return d.NoopDriver.Delete(ctx, ref)
+}
+
+type v2UpdateInvalidProviderIDDriver struct {
+	v2UpdateFailureDriver
+}
+
+func (d *v2UpdateInvalidProviderIDDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatUUID
+}
+
+func (d *v2UpdateInvalidProviderIDDriver) Update(_ context.Context, _ interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:       spec.Name,
+		Type:       spec.Type,
+		ProviderID: "not-a-uuid",
+		Outputs:    map[string]any{"url": "https://updated.example.test"},
+	}, nil
+}
+
+type v2MismatchedIdentityDriver struct {
+	iactest.NoopDriver
+	deleteCount int
+}
+
+func (d *v2MismatchedIdentityDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{
+		Name:       spec.Name,
+		Type:       "infra.other",
+		ProviderID: "id-mismatched-identity",
+		Outputs:    map[string]any{"url": "https://example.test"},
+	}, nil
+}
+
+func (d *v2MismatchedIdentityDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	d.deleteCount++
+	if ref.Type == "infra.other" {
+		return errors.New("reported identity not deletable")
+	}
+	return d.NoopDriver.Delete(ctx, ref)
+}

--- a/cmd/wfctl/infra_validation.go
+++ b/cmd/wfctl/infra_validation.go
@@ -53,6 +53,10 @@ func validateOutputProviderID(provider interfaces.IaCProvider, providerType stri
 	return validateProviderID(provider, providerType, r.Type, r.Name, r.ProviderID)
 }
 
+func validateOutputProviderIDWithDriver(providerType string, rd interfaces.ResourceDriver, r *interfaces.ResourceOutput) error {
+	return validateProviderIDWithDriver(providerType, rd, r.Type, r.Name, r.ProviderID)
+}
+
 func validateStateProviderID(provider interfaces.IaCProvider, providerType string, r interfaces.ResourceState) error {
 	return validateProviderID(provider, providerType, r.Type, r.Name, r.ProviderID)
 }
@@ -63,6 +67,10 @@ func validateProviderID(provider interfaces.IaCProvider, providerType, resourceT
 		log.Printf("warn: wfctl: cannot probe ResourceDriver for validation of %s %q: %v", resourceType, resourceName, err)
 		return nil
 	}
+	return validateProviderIDWithDriver(providerType, rd, resourceType, resourceName, providerID)
+}
+
+func validateProviderIDWithDriver(providerType string, rd interfaces.ResourceDriver, resourceType, resourceName, providerID string) error {
 	v, ok := rd.(interfaces.ProviderIDValidator)
 	if !ok {
 		return nil

--- a/iac/sensitive/route.go
+++ b/iac/sensitive/route.go
@@ -104,8 +104,8 @@ func IsPlaceholder(v any) bool {
 //     present in out.Outputs → error naming the resource and keys.
 //   - provider.Set returns an error → error wrapping the failed key. Set
 //     is invoked in sorted order by key for determinism; on first error
-//     the loop stops and previously-Set values are NOT cleaned up
-//     (idempotent overwrite on Apply rerun is the recovery path).
+//     the loop stops and hydrated contains values already routed so the
+//     caller can compensate partial writes.
 //
 // Out is not mutated.
 func Route(
@@ -152,11 +152,11 @@ func Route(
 	for _, k := range routableKeys {
 		val, sErr := stringifyOutput(out.Outputs[k])
 		if sErr != nil {
-			return nil, nil, fmt.Errorf("sensitive.Route: resource %q key %q: %w", resourceName, k, sErr)
+			return nil, hydrated, fmt.Errorf("sensitive.Route: resource %q key %q: %w", resourceName, k, sErr)
 		}
 		secretName := SecretKey(resourceName, k)
 		if setErr := provider.Set(ctx, secretName, val); setErr != nil {
-			return nil, nil, fmt.Errorf("sensitive.Route: provider.Set(%q): %w", secretName, setErr)
+			return nil, hydrated, fmt.Errorf("sensitive.Route: provider.Set(%q): %w", secretName, setErr)
 		}
 		sanitized[k] = Placeholder(resourceName, k)
 		hydrated[secretName] = val

--- a/iac/sensitive/route_test.go
+++ b/iac/sensitive/route_test.go
@@ -165,6 +165,27 @@ func TestRoute_ProviderSetError_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestRoute_ProviderSetErrorReturnsPartialHydrated(t *testing.T) {
+	p := newFakeProvider()
+	failKey := SecretKey("myres", "b_key")
+	p.setErr[failKey] = errors.New("boom")
+	out := &interfaces.ResourceOutput{
+		Outputs:   map[string]any{"a_key": "A", "b_key": "B"},
+		Sensitive: map[string]bool{"a_key": true, "b_key": true},
+	}
+	_, hydrated, err := Route(context.Background(), p, "myres", out)
+	if err == nil {
+		t.Fatal("expected error from second Set")
+	}
+	routedKey := SecretKey("myres", "a_key")
+	if hydrated[routedKey] != "A" {
+		t.Fatalf("hydrated = %v, want partial routed key %q", hydrated, routedKey)
+	}
+	if _, ok := hydrated[failKey]; ok {
+		t.Fatalf("hydrated contains failed key %q: %v", failKey, hydrated)
+	}
+}
+
 func TestRoute_NilProviderWithSensitive_Errors(t *testing.T) {
 	out := &interfaces.ResourceOutput{
 		Outputs:   map[string]any{"secret_key": "S"},

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -79,6 +79,20 @@ func ApplyPlan(ctx context.Context, p interfaces.IaCProvider, plan *interfaces.I
 	return applyPlanWithEnvProvider(ctx, p, plan, nil)
 }
 
+// ApplyPlanHooks are optional callbacks invoked immediately after a plan action
+// successfully mutates cloud-side state. Hooks let wfctl persist state at the
+// action boundary instead of waiting for the whole plan to finish.
+type ApplyPlanHooks struct {
+	OnResourceApplied func(context.Context, interfaces.ResourceDriver, interfaces.PlanAction, interfaces.ResourceOutput) error
+	OnResourceDeleted func(context.Context, interfaces.PlanAction) error
+}
+
+// ApplyPlanWithHooks is ApplyPlan plus action-boundary hooks for callers that
+// need durable side effects as each cloud mutation succeeds.
+func ApplyPlanWithHooks(ctx context.Context, p interfaces.IaCProvider, plan *interfaces.IaCPlan, hooks ApplyPlanHooks) (*interfaces.ApplyResult, error) {
+	return applyPlanWithEnvProviderAndHooks(ctx, p, plan, nil, hooks)
+}
+
 // applyPlanWithEnvProvider is the same-package test seam used by
 // apply_postcondition_test.go to inject a custom apply-time env provider
 // into the deferred drift postcondition (e.g., a panicky closure that
@@ -92,6 +106,17 @@ func applyPlanWithEnvProvider(
 	plan *interfaces.IaCPlan,
 	applyTimeEnv func(string) (string, bool),
 ) (*interfaces.ApplyResult, error) {
+	return applyPlanWithEnvProviderAndHooks(ctx, p, plan, applyTimeEnv, ApplyPlanHooks{})
+}
+
+func applyPlanWithEnvProviderAndHooks(
+	ctx context.Context,
+	p interfaces.IaCProvider,
+	plan *interfaces.IaCPlan,
+	applyTimeEnv func(string) (string, bool),
+	hooks ApplyPlanHooks,
+) (*interfaces.ApplyResult, error) {
+	deleteHookActive := hooks.OnResourceDeleted != nil
 	inputNames := snapshotKeys(plan.InputSnapshot)
 	result := &interfaces.ApplyResult{
 		PlanID:               plan.ID,
@@ -136,6 +161,12 @@ func applyPlanWithEnvProvider(
 	// new outputs are written per-resource on success and become visible
 	// to later actions in the same plan).
 	syncedOutputs := buildInitialSyncedOutputs(plan.Actions)
+
+	if deleteHookActive {
+		if err := preflightProviderOwnedReplaceWithDeleteHooks(p, plan); err != nil {
+			return result, err
+		}
+	}
 
 	for i := range plan.Actions {
 		action := plan.Actions[i]
@@ -182,19 +213,63 @@ func applyPlanWithEnvProvider(
 		// outputs into syncedOutputs for subsequent actions. doCreate /
 		// doUpdate / doReplace each append on success; doDelete does not.
 		preLen := len(result.Resources)
-		if err := dispatchAction(ctx, d, action, result); err != nil {
+		actionHooks := hooks
+		actionHooks.OnResourceDeleted = func(ctx context.Context, action interfaces.PlanAction) error {
+			if hooks.OnResourceDeleted != nil {
+				if err := hooks.OnResourceDeleted(ctx, action); err != nil {
+					return err
+				}
+			}
+			delete(syncedOutputs, action.Resource.Name)
+			return nil
+		}
+		if err := dispatchAction(ctx, d, action, result, actionHooks, deleteHookActive); err != nil {
+			var hookErr hookDispatchError
+			if errors.As(err, &hookErr) {
+				return result, fmt.Errorf("%s/%s: %w", action.Resource.Type, action.Resource.Name, hookErr.err)
+			}
 			result.Errors = append(result.Errors, interfaces.ActionError{
 				Resource: action.Resource.Name,
 				Action:   action.Action,
 				Error:    err.Error(),
 			})
+			continue
+		}
+		if action.Action == "delete" {
+			if err := actionHooks.OnResourceDeleted(ctx, action); err != nil {
+				return result, fmt.Errorf("%s/%s: post-delete hook: %w", action.Resource.Type, action.Resource.Name, err)
+			}
 		}
 		if len(result.Resources) > preLen {
 			out := result.Resources[len(result.Resources)-1]
+			out = fillMissingOutputIdentity(action.Resource, out)
+			result.Resources[len(result.Resources)-1] = out
+			if hooks.OnResourceApplied != nil {
+				if err := hooks.OnResourceApplied(ctx, d, action, out); err != nil {
+					return result, fmt.Errorf("%s/%s: post-apply hook: %w", action.Resource.Type, action.Resource.Name, err)
+				}
+			}
 			syncedOutputs[out.Name] = flattenOutputs(out)
 		}
 	}
 	return result, nil
+}
+
+func preflightProviderOwnedReplaceWithDeleteHooks(p interfaces.IaCProvider, plan *interfaces.IaCPlan) error {
+	for i := range plan.Actions {
+		action := plan.Actions[i]
+		if action.Action != "replace" {
+			continue
+		}
+		d, err := p.ResourceDriver(action.Resource.Type)
+		if err != nil {
+			return fmt.Errorf("%s/%s: replace preflight resolve driver: %w", action.Resource.Type, action.Resource.Name, err)
+		}
+		if _, ok := d.(interfaces.ResourceReplacer); ok {
+			return fmt.Errorf("%s/%s: replace: driver-owned ResourceReplacer is disabled while delete state hooks are active; state hooks require engine-owned delete-step visibility", action.Resource.Type, action.Resource.Name)
+		}
+	}
+	return nil
 }
 
 // buildInitialSyncedOutputs walks plan.Actions once and returns a map of
@@ -245,6 +320,16 @@ func flattenOutputs(o interfaces.ResourceOutput) map[string]any {
 	return m
 }
 
+func fillMissingOutputIdentity(spec interfaces.ResourceSpec, out interfaces.ResourceOutput) interfaces.ResourceOutput {
+	if out.Name == "" {
+		out.Name = spec.Name
+	}
+	if out.Type == "" {
+		out.Type = spec.Type
+	}
+	return out
+}
+
 // snapshotKeys returns the keys of m as an unordered slice. ComputeDrift
 // sorts its output, and Snapshot iterates in any order, so no key sort
 // is needed at this stage. Inlined helper to keep the dependency
@@ -265,14 +350,14 @@ func snapshotKeys(m map[string]string) []string {
 // An unknown action kind returns an error which ApplyPlan records on
 // result.Errors so an operator running a malformed plan sees a per-action
 // diagnostic rather than a silent skip.
-func dispatchAction(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
+func dispatchAction(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult, hooks ApplyPlanHooks, deleteHookActive bool) error {
 	switch action.Action {
 	case "create":
 		return doCreate(ctx, d, action, result)
 	case "update":
 		return doUpdate(ctx, d, action, result)
 	case "replace":
-		return doReplace(ctx, d, action, result)
+		return doReplace(ctx, d, action, result, hooks, deleteHookActive)
 	case "delete":
 		return doDelete(ctx, d, action)
 	default:
@@ -411,8 +496,17 @@ func doUpdate(ctx context.Context, d interfaces.ResourceDriver, action interface
 // Other sub-functions (doCreate non-recovery path, doUpdate, doDelete)
 // pass driver errors through unchanged.
 func DefaultReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
+	return defaultReplaceWithHooks(ctx, d, action, result, ApplyPlanHooks{})
+}
+
+func defaultReplaceWithHooks(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult, hooks ApplyPlanHooks) error {
 	if err := d.Delete(ctx, refFromAction(action)); err != nil {
 		return fmt.Errorf("replace: delete: %w", err)
+	}
+	if hooks.OnResourceDeleted != nil {
+		if err := hooks.OnResourceDeleted(ctx, action); err != nil {
+			return hookDispatchError{err: fmt.Errorf("replace: delete hook: %w", err)}
+		}
 	}
 	// Honor cancellation between Delete and Create. Without this guard
 	// a Ctrl-C / SIGTERM that arrives mid-Replace would still trigger
@@ -442,11 +536,28 @@ func DefaultReplace(ctx context.Context, d interfaces.ResourceDriver, action int
 	return nil
 }
 
+type hookDispatchError struct {
+	err error
+}
+
+func (e hookDispatchError) Error() string {
+	return e.err.Error()
+}
+
+func (e hookDispatchError) Unwrap() error {
+	return e.err
+}
+
 // doReplace is the dispatch entry point for Replace actions. It probes
 // the driver for the optional ResourceReplacer interface and routes to
 // the driver's Replace implementation when present. Drivers that do not
 // implement ResourceReplacer fall back to DefaultReplace.
-func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult) error {
+func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfaces.PlanAction, result *interfaces.ApplyResult, hooks ApplyPlanHooks, deleteHookActive bool) error {
+	if deleteHookActive {
+		if _, ok := d.(interfaces.ResourceReplacer); ok {
+			return hookDispatchError{err: fmt.Errorf("replace: driver-owned ResourceReplacer is disabled while delete state hooks are active; state hooks require engine-owned delete-step visibility")}
+		}
+	}
 	if r, ok := d.(interfaces.ResourceReplacer); ok {
 		out, err := r.Replace(ctx, refFromAction(action), action.Resource)
 		if err != nil {
@@ -454,7 +565,7 @@ func doReplace(ctx context.Context, d interfaces.ResourceDriver, action interfac
 		}
 		return finalizeReplace(out, action.Resource.Name, result)
 	}
-	return DefaultReplace(ctx, d, action, result)
+	return defaultReplaceWithHooks(ctx, d, action, result, hooks)
 }
 
 // finalizeReplace runs the post-Replace bookkeeping that DefaultReplace's

--- a/iac/wfctlhelpers/apply_hooks_test.go
+++ b/iac/wfctlhelpers/apply_hooks_test.go
@@ -1,0 +1,232 @@
+package wfctlhelpers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/iac/iactest"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+func TestApplyPlanWithHooks_PersistsBeforeLaterAction(t *testing.T) {
+	driver := &hookOrderingDriver{}
+	provider := &hookProvider{driver: driver}
+	driver.create = func(spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+		switch spec.Name {
+		case "first":
+			return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-first"}, nil
+		case "second":
+			if !driver.hookRan {
+				t.Fatal("second action ran before first action hook")
+			}
+			return nil, errors.New("second failed")
+		default:
+			t.Fatalf("unexpected resource %q", spec.Name)
+			return nil, nil
+		}
+	}
+
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{
+		{Action: "create", Resource: interfaces.ResourceSpec{Name: "first", Type: "infra.test"}},
+		{Action: "create", Resource: interfaces.ResourceSpec{Name: "second", Type: "infra.test"}},
+	}}
+
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{
+		OnResourceApplied: func(_ context.Context, _ interfaces.ResourceDriver, action interfaces.PlanAction, out interfaces.ResourceOutput) error {
+			if action.Resource.Name == "first" && out.ProviderID == "id-first" {
+				driver.hookRan = true
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPlanWithHooks returned top-level error: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("result.Errors = %d, want 1", len(result.Errors))
+	}
+	if !driver.hookRan {
+		t.Fatal("first action hook did not run")
+	}
+}
+
+func TestApplyPlanWithHooks_DefaultReplaceDeleteHookRunsBeforeCreateFailure(t *testing.T) {
+	driver := &replaceDeleteHookDriver{}
+	provider := &hookProvider{driver: driver}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "db", Type: "infra.test"},
+		Current:  &interfaces.ResourceState{Name: "db", Type: "infra.test", ProviderID: "old-id"},
+	}}}
+
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{
+		OnResourceDeleted: func(_ context.Context, action interfaces.PlanAction) error {
+			if action.Resource.Name == "db" {
+				driver.deleteHookRan = true
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPlanWithHooks returned top-level error: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("result.Errors = %d, want 1", len(result.Errors))
+	}
+	if !driver.deleteHookRan {
+		t.Fatal("replace delete hook did not run before create failure")
+	}
+}
+
+func TestApplyPlanWithHooks_DefaultReplaceDeleteHookErrorIsTopLevel(t *testing.T) {
+	driver := &replaceDeleteHookDriver{}
+	provider := &hookProvider{driver: driver}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "db", Type: "infra.test"},
+		Current:  &interfaces.ResourceState{Name: "db", Type: "infra.test", ProviderID: "old-id"},
+	}}}
+	hookErr := errors.New("state store down")
+
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{
+		OnResourceDeleted: func(context.Context, interfaces.PlanAction) error {
+			return hookErr
+		},
+	})
+	if !errors.Is(err, hookErr) {
+		t.Fatalf("error = %v, want hookErr", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("result.Errors = %+v, want no per-action driver errors for hook failure", result.Errors)
+	}
+}
+
+func TestApplyPlanWithHooks_FailedDeleteDoesNotRunDeleteHook(t *testing.T) {
+	driver := &failedDeleteHookDriver{}
+	provider := &hookProvider{driver: driver}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+		Action:   "delete",
+		Resource: interfaces.ResourceSpec{Name: "db", Type: "infra.test"},
+		Current:  &interfaces.ResourceState{Name: "db", Type: "infra.test", ProviderID: "old-id"},
+	}}}
+
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{
+		OnResourceDeleted: func(context.Context, interfaces.PlanAction) error {
+			driver.deleteHookRan = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPlanWithHooks returned top-level error: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("result.Errors = %d, want 1", len(result.Errors))
+	}
+	if driver.deleteHookRan {
+		t.Fatal("delete hook ran after failed delete")
+	}
+}
+
+func TestApplyPlanWithHooks_DeleteRemovesResourceFromLaterJIT(t *testing.T) {
+	driver := &deleteThenDependentDriver{}
+	provider := &hookProvider{driver: driver}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{
+		{
+			Action:   "delete",
+			Resource: interfaces.ResourceSpec{Name: "old", Type: "infra.test"},
+			Current: &interfaces.ResourceState{
+				Name:       "old",
+				Type:       "infra.test",
+				ProviderID: "id-old",
+			},
+		},
+		{
+			Action: "create",
+			Resource: interfaces.ResourceSpec{
+				Name:   "dependent",
+				Type:   "infra.test",
+				Config: map[string]any{"target": "${old.id}"},
+			},
+		},
+	}}
+
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{})
+	if err != nil {
+		t.Fatalf("ApplyPlanWithHooks returned top-level error: %v", err)
+	}
+	if driver.dependentCreateCalled {
+		t.Fatal("dependent create reached driver with stale deleted resource output")
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("result.Errors = %+v, want one JIT error", result.Errors)
+	}
+	if !strings.Contains(result.Errors[0].Error, "jit substitution:") || !strings.Contains(result.Errors[0].Error, "old") {
+		t.Fatalf("result error = %q, want unresolved old reference", result.Errors[0].Error)
+	}
+}
+
+type hookOrderingDriver struct {
+	iactest.NoopDriver
+	create  func(interfaces.ResourceSpec) (*interfaces.ResourceOutput, error)
+	hookRan bool
+}
+
+func (d *hookOrderingDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if d.create != nil {
+		return d.create(spec)
+	}
+	return d.NoopDriver.Create(ctx, spec)
+}
+
+type hookProvider struct {
+	iactest.NoopProvider
+	driver interfaces.ResourceDriver
+}
+
+func (p *hookProvider) ResourceDriver(string) (interfaces.ResourceDriver, error) {
+	return p.driver, nil
+}
+
+type replaceDeleteHookDriver struct {
+	iactest.NoopDriver
+	deleteHookRan bool
+}
+
+func (d *replaceDeleteHookDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	return d.NoopDriver.Delete(ctx, ref)
+}
+
+func (d *replaceDeleteHookDriver) Create(context.Context, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if !d.deleteHookRan {
+		return nil, errors.New("delete hook had not run")
+	}
+	return nil, errors.New("create failed")
+}
+
+type failedDeleteHookDriver struct {
+	iactest.NoopDriver
+	deleteHookRan bool
+}
+
+func (d *failedDeleteHookDriver) Delete(context.Context, interfaces.ResourceRef) error {
+	return errors.New("delete failed")
+}
+
+type deleteThenDependentDriver struct {
+	iactest.NoopDriver
+	dependentCreateCalled bool
+}
+
+func (d *deleteThenDependentDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	return d.NoopDriver.Delete(ctx, ref)
+}
+
+func (d *deleteThenDependentDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if spec.Name == "dependent" {
+		d.dependentCreateCalled = true
+		return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-dependent"}, nil
+	}
+	return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-" + spec.Name}, nil
+}

--- a/iac/wfctlhelpers/apply_replacer_dispatch_test.go
+++ b/iac/wfctlhelpers/apply_replacer_dispatch_test.go
@@ -37,7 +37,7 @@ func TestDoReplace_DispatchesToReplacerWhenAvailable(t *testing.T) {
 		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
 	}
 	result := &interfaces.ApplyResult{}
-	err := doReplace(context.Background(), d, action, result)
+	err := doReplace(context.Background(), d, action, result, ApplyPlanHooks{}, false)
 	if err != nil {
 		t.Fatalf("doReplace: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestDoReplace_DefaultReplaceWhenNoReplacerInterface(t *testing.T) {
 		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
 	}
 	result := &interfaces.ApplyResult{}
-	err := doReplace(context.Background(), d, action, result)
+	err := doReplace(context.Background(), d, action, result, ApplyPlanHooks{}, false)
 	if err != nil {
 		t.Fatalf("doReplace: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestDoReplace_ReplacerError_IsWrappedByBackstop(t *testing.T) {
 		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
 	}
 	result := &interfaces.ApplyResult{}
-	err := doReplace(context.Background(), d, action, result)
+	err := doReplace(context.Background(), d, action, result, ApplyPlanHooks{}, false)
 	if err == nil {
 		t.Fatal("expected error from failing Replacer")
 	}
@@ -98,4 +98,119 @@ func TestDoReplace_ReplacerError_IsWrappedByBackstop(t *testing.T) {
 	if !strings.HasPrefix(err.Error(), wantPrefix) {
 		t.Errorf("expected backstop prefix %q on non-conforming error; got: %v", wantPrefix, err)
 	}
+}
+
+func TestDoReplace_ReplacerWithoutHooksErrorsWhenStateHooksActive(t *testing.T) {
+	d := &fakeReplacerDriver{}
+	action := interfaces.PlanAction{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "x", Type: "test"},
+		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
+	}
+	result := &interfaces.ApplyResult{}
+	err := doReplace(context.Background(), d, action, result, ApplyPlanHooks{
+		OnResourceDeleted: func(context.Context, interfaces.PlanAction) error { return nil },
+	}, true)
+	if err == nil {
+		t.Fatal("expected state-hook replace requirement error")
+	}
+	if !strings.Contains(err.Error(), "driver-owned ResourceReplacer is disabled") {
+		t.Fatalf("error = %v, want ResourceReplacer rejection", err)
+	}
+	if d.replaceCalled {
+		t.Fatal("plain ResourceReplacer mutated cloud despite active state hooks")
+	}
+}
+
+func TestDoReplace_ReplacerAllowedWhenOnlyApplyHookActive(t *testing.T) {
+	d := &fakeReplacerDriver{}
+	action := interfaces.PlanAction{
+		Action:   "replace",
+		Resource: interfaces.ResourceSpec{Name: "x", Type: "test"},
+		Current:  &interfaces.ResourceState{Name: "x", ProviderID: "old-id"},
+	}
+	result := &interfaces.ApplyResult{}
+	err := doReplace(context.Background(), d, action, result, ApplyPlanHooks{
+		OnResourceApplied: func(context.Context, interfaces.ResourceDriver, interfaces.PlanAction, interfaces.ResourceOutput) error {
+			return nil
+		},
+	}, false)
+	if err != nil {
+		t.Fatalf("doReplace: %v", err)
+	}
+	if !d.replaceCalled {
+		t.Fatal("plain ResourceReplacer should be allowed when no delete hook is active")
+	}
+}
+
+func TestApplyPlanWithHooks_ReplacerGuardAbortsBeforeLaterActions(t *testing.T) {
+	replacer := &fakeReplacerDriver{}
+	provider := &hookProvider{driver: replacer}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{
+		{
+			Action:   "create",
+			Resource: interfaces.ResourceSpec{Name: "before", Type: "test"},
+		},
+		{
+			Action:   "replace",
+			Resource: interfaces.ResourceSpec{Name: "parent", Type: "test"},
+			Current:  &interfaces.ResourceState{Name: "parent", Type: "test", ProviderID: "old-id"},
+		},
+	}}
+
+	result, err := ApplyPlanWithHooks(context.Background(), provider, plan, ApplyPlanHooks{
+		OnResourceDeleted: func(context.Context, interfaces.PlanAction) error { return nil },
+	})
+	if err == nil {
+		t.Fatal("expected top-level replace guard error")
+	}
+	if !strings.Contains(err.Error(), "driver-owned ResourceReplacer is disabled") {
+		t.Fatalf("error = %v, want driver-owned replacer guard", err)
+	}
+	if replacer.replaceCalled {
+		t.Fatal("guard allowed ResourceReplacer to mutate cloud")
+	}
+	if replacer.createCount != 0 {
+		t.Fatalf("preflight guard ran after earlier mutation: createCount=%d", replacer.createCount)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("result.Errors = %+v, want top-level abort before per-action errors", result.Errors)
+	}
+}
+
+func TestApplyPlanWithHooks_ReplacerPreflightDriverErrorAbortsBeforeMutation(t *testing.T) {
+	driver := &fakeDriver{}
+	provider := &replaceDriverErrorProvider{driver: driver}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{
+		{Action: "create", Resource: interfaces.ResourceSpec{Name: "before", Type: "test"}},
+		{Action: "replace", Resource: interfaces.ResourceSpec{Name: "parent", Type: "missing"}},
+	}}
+
+	result, err := ApplyPlanWithHooks(context.Background(), provider, plan, ApplyPlanHooks{
+		OnResourceDeleted: func(context.Context, interfaces.PlanAction) error { return nil },
+	})
+	if err == nil {
+		t.Fatal("expected top-level preflight driver error")
+	}
+	if !strings.Contains(err.Error(), "replace preflight resolve driver") {
+		t.Fatalf("error = %v, want preflight driver resolution error", err)
+	}
+	if driver.createCount != 0 {
+		t.Fatalf("preflight driver error ran after earlier mutation: createCount=%d", driver.createCount)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("result.Errors = %+v, want top-level abort before per-action errors", result.Errors)
+	}
+}
+
+type replaceDriverErrorProvider struct {
+	hookProvider
+	driver interfaces.ResourceDriver
+}
+
+func (p *replaceDriverErrorProvider) ResourceDriver(typ string) (interfaces.ResourceDriver, error) {
+	if typ == "missing" {
+		return nil, errors.New("missing driver")
+	}
+	return p.driver, nil
 }


### PR DESCRIPTION
## Summary
- persist v2 IaC apply state at each successful mutation boundary via `ApplyPlanWithHooks`
- make delete-state pruning action-safe and cancellation-resistant across v2 and legacy apply paths
- compensate create/replacement persistence failures while preserving existing resources on update failures
- reject provider-owned replace before mutation when delete-state hooks need engine-owned delete visibility
- keep sensitive-output routing and ProviderID/output identity validation from leaving orphaned cloud resources or partial state

## Review notes
- No provider-specific or DigitalOcean-specific logic is added.
- Provider-owned `ResourceReplacer` remains allowed when no delete-state hook is active; with delete hooks active it aborts before any mutation because callback ordering is not enforceable generically.
- Legacy providers do not expose per-action success evidence, so any `ApplyResult.Errors` disables inferred delete-state pruning.

## Verification
- `GOWORK=off go test ./iac/wfctlhelpers ./iac/sensitive ./interfaces ./cmd/wfctl -run 'TestApplyPlanWithHooks|TestDoReplace|TestRoute_|TestApplyWithProvider_|TestApplyWithProviderAndStore_V2|TestInfraApplyPrecomputedPlan|TestApply_V2_LoaderSeamDispatch_EndToEnd|TestApplyWithProviderAndStore_ProtectedReplace_WithAllowReplace_Proceeds|TestPersistResourceWithSecretRouting|TestRequireSecretsProviderForSensitiveOutputs' -count=1`
- `git diff --check`

## Antagonistic review
Multiple adversarial review rounds were run. Final targeted review returned SHIP-IT after checking:
- legacy sensitive outputs/no secrets do not partially save state
- replace preflight/delete hooks abort before mutation
- identity validation compensation treats any successful candidate delete as success
- update paths do not compensate by deleting existing resources
- failed/partial legacy delete results do not infer delete success
- no provider-specific branches in touched runtime logic
