### PR TITLE
fix(plugin/external): empty ConfigMessage for input-only STRICT_PROTO step contracts

### DIFF
--- a/plugin/external/adapter.go
+++ b/plugin/external/adapter.go
@@ -303,15 +303,18 @@ func createTypedConfigRequest(descriptor *pb.ContractDescriptor, cfg map[string]
 		}
 		return s, nil, nil
 	}
-	// Steps with STRICT_PROTO mode but no ConfigMessage are input-only
-	// (eventbus.ack, eventbus.publish, etc.) — they declare InputMessage +
-	// OutputMessage but no per-instance config schema. Encode cfg as legacy
-	// struct only; typed payload is nil. The plugin's typed factory reads
-	// data from the input message, not from the config.
+	// Contracts that declare a typed Mode (STRICT_PROTO or
+	// PROTO_WITH_LEGACY_STRUCT) but leave ConfigMessage empty have no
+	// per-instance config schema — primarily input-only steps like
+	// step.eventbus.ack/publish/consume where data flows through the
+	// InputMessage proto, but also applies to any contract Kind that
+	// legitimately omits a config schema. Encode cfg as legacy struct
+	// only; typed payload is nil. The plugin's typed factory reads data
+	// from the input message (or other typed payload), not from config.
 	if descriptor.ConfigMessage == "" {
 		s, err := mapToStruct(cfg)
 		if err != nil {
-			return nil, nil, fmt.Errorf("encode config as Struct (input-only typed contract): %w", err)
+			return nil, nil, fmt.Errorf("encode config as Struct (no typed config schema): %w", err)
 		}
 		return s, nil, nil
 	}

--- a/plugin/external/adapter.go
+++ b/plugin/external/adapter.go
@@ -303,6 +303,18 @@ func createTypedConfigRequest(descriptor *pb.ContractDescriptor, cfg map[string]
 		}
 		return s, nil, nil
 	}
+	// Steps with STRICT_PROTO mode but no ConfigMessage are input-only
+	// (eventbus.ack, eventbus.publish, etc.) — they declare InputMessage +
+	// OutputMessage but no per-instance config schema. Encode cfg as legacy
+	// struct only; typed payload is nil. The plugin's typed factory reads
+	// data from the input message, not from the config.
+	if descriptor.ConfigMessage == "" {
+		s, err := mapToStruct(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode config as Struct (input-only typed contract): %w", err)
+		}
+		return s, nil, nil
+	}
 	// Strip engine-internal "_"-prefix keys before proto decode. STRICT_PROTO
 	// and PROTO_WITH_LEGACY_STRUCT modules use protojson with DiscardUnknown
 	// = false (convert.go:62), which rejects engine internals like

--- a/plugin/external/adapter_test.go
+++ b/plugin/external/adapter_test.go
@@ -1022,6 +1022,33 @@ func TestCreateTypedConfigRequestStripsInternalKeysForStrictProtoStep(t *testing
 	}
 }
 
+// TestCreateTypedConfigRequestEmptyConfigMessageStrictProto covers step
+// contracts that declare STRICT_PROTO with InputMessage + OutputMessage but
+// no ConfigMessage (input-only steps like step.eventbus.ack /
+// step.eventbus.publish). The engine must encode cfg as a legacy
+// *structpb.Struct, NOT attempt to encode an unnamed typed proto.
+func TestCreateTypedConfigRequestEmptyConfigMessageStrictProto(t *testing.T) {
+	descriptor := &pb.ContractDescriptor{
+		Kind:          pb.ContractKind_CONTRACT_KIND_STEP,
+		StepType:      "step.eventbus.ack",
+		Mode:          pb.ContractMode_CONTRACT_MODE_STRICT_PROTO,
+		InputMessage:  "workflow.plugin.eventbus.v1.AckRequest",
+		OutputMessage: "workflow.plugin.eventbus.v1.AckResponse",
+		// ConfigMessage intentionally empty — step has no per-instance
+		// config schema; data flows via the input message.
+	}
+	legacy, typed, err := createTypedConfigRequest(descriptor, nil, nil)
+	if err != nil {
+		t.Fatalf("createTypedConfigRequest with empty ConfigMessage: %v", err)
+	}
+	if typed != nil {
+		t.Fatalf("expected nil typed *anypb.Any for input-only step contract; got %v", typed)
+	}
+	if legacy != nil && len(legacy.Fields) != 0 {
+		t.Fatalf("expected empty legacy struct for nil cfg; got %v", legacy.Fields)
+	}
+}
+
 // TestCreateTypedConfigRequestRetainsInternalKeysInLegacyStruct asserts the
 // legacy-struct path keeps "_"-prefix keys on its *structpb.Struct payload.
 // Legacy modules consume "_config_dir" at the plugin side to resolve filesystem-

--- a/plugin/external/adapter_test.go
+++ b/plugin/external/adapter_test.go
@@ -1022,11 +1022,13 @@ func TestCreateTypedConfigRequestStripsInternalKeysForStrictProtoStep(t *testing
 	}
 }
 
-// TestCreateTypedConfigRequestEmptyConfigMessageStrictProto covers step
+// TestCreateTypedConfigRequestEmptyConfigMessageStrictProto covers
 // contracts that declare STRICT_PROTO with InputMessage + OutputMessage but
 // no ConfigMessage (input-only steps like step.eventbus.ack /
-// step.eventbus.publish). The engine must encode cfg as a legacy
-// *structpb.Struct, NOT attempt to encode an unnamed typed proto.
+// step.eventbus.publish). The engine must NOT attempt to encode an
+// unnamed typed proto; typed payload is nil, legacy struct mirrors cfg
+// (nil cfg → nil legacy via mapToStruct(nil); non-nil cfg → populated
+// struct).
 func TestCreateTypedConfigRequestEmptyConfigMessageStrictProto(t *testing.T) {
 	descriptor := &pb.ContractDescriptor{
 		Kind:          pb.ContractKind_CONTRACT_KIND_STEP,
@@ -1037,15 +1039,28 @@ func TestCreateTypedConfigRequestEmptyConfigMessageStrictProto(t *testing.T) {
 		// ConfigMessage intentionally empty — step has no per-instance
 		// config schema; data flows via the input message.
 	}
+	// nil cfg — mapToStruct(nil) returns nil; legacy is permitted to be nil.
 	legacy, typed, err := createTypedConfigRequest(descriptor, nil, nil)
 	if err != nil {
-		t.Fatalf("createTypedConfigRequest with empty ConfigMessage: %v", err)
+		t.Fatalf("createTypedConfigRequest with nil cfg + empty ConfigMessage: %v", err)
 	}
 	if typed != nil {
 		t.Fatalf("expected nil typed *anypb.Any for input-only step contract; got %v", typed)
 	}
-	if legacy != nil && len(legacy.Fields) != 0 {
-		t.Fatalf("expected empty legacy struct for nil cfg; got %v", legacy.Fields)
+	if legacy != nil {
+		t.Fatalf("expected nil legacy struct for nil cfg; got %v", legacy.Fields)
+	}
+	// Non-nil cfg — fields populated into legacy struct; typed still nil.
+	cfg := map[string]any{"timeout_ms": float64(5000)}
+	legacy2, typed2, err := createTypedConfigRequest(descriptor, cfg, nil)
+	if err != nil {
+		t.Fatalf("createTypedConfigRequest with cfg + empty ConfigMessage: %v", err)
+	}
+	if typed2 != nil {
+		t.Fatalf("expected nil typed *anypb.Any for input-only step contract; got %v", typed2)
+	}
+	if legacy2 == nil || legacy2.Fields["timeout_ms"] == nil {
+		t.Fatalf("expected legacy struct with timeout_ms populated; got %v", legacy2)
 	}
 }
 


### PR DESCRIPTION
## Summary

Steps that declare STRICT_PROTO mode + InputMessage + OutputMessage but no ConfigMessage (input-only steps where data flows through the input proto, not a config schema) failed engine initialization with:

> STRICT_PROTO contract for config message "" cannot use legacy Struct fallback: missing protobuf message name

Engine now treats empty `ConfigMessage` as "no typed config" → encodes cfg as legacy `*structpb.Struct` only, returns nil typed payload. Plugin's typed step factory reads from the InputMessage proto as designed.

## Caught by

BMW PR #278 image-launch smoke against v0.51.3 + workflow-plugin-eventbus v0.3.0:

```
step.eventbus.ack: STRICT_PROTO contract for config message "" cannot use legacy Struct fallback: missing protobuf message name
```

Eventbus declares 3 input-only steps (ack/publish/consume); same shape applies to any plugin whose steps carry data via the input proto.

## Diff

3 lines + 1 comment in `createTypedConfigRequest` + 1 unit test.

## Test

`TestCreateTypedConfigRequestEmptyConfigMessageStrictProto` — asserts:
- empty ConfigMessage + STRICT_PROTO + nil cfg → no error
- typed payload returned is nil
- legacy *structpb.Struct returned is empty (no fields)

## Test plan

- [x] `GOWORK=off go test ./plugin/external/ -run TestCreateTypedConfigRequest -v` — all 4 PASS
- [x] No new compile errors elsewhere
- [ ] BMW PR #278 image-launch re-smoke after v0.51.4 pin bump

## Release

Tag v0.51.4 post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)