### PR TITLE
feat: workflow#640 Phase 2 — v2 hooks-over-gRPC contract (ApplyResult.Actions + ActionStatus + engine populate + decoder)

### DIFF
--- a/cmd/wfctl/iac_typed_adapter.go
+++ b/cmd/wfctl/iac_typed_adapter.go
@@ -1219,7 +1219,7 @@ func applyResultFromPB(r *pb.ApplyResult) (*interfaces.ApplyResult, error) {
 		}
 		mapped, ok := mapPBActionStatusToInterface(a.GetStatus())
 		if !ok {
-			return nil, fmt.Errorf("plugin returned unknown ActionStatus=%d at action_index=%d (wfctl version too old for this plugin? Phase 2 contract violation per ADR 0040)", int32(a.GetStatus()), a.GetActionIndex())
+			return nil, fmt.Errorf("plugin returned unknown ActionStatus=%d at action_index=%d (Phase 2 contract violation per ADR 0040; either upgrade wfctl or downgrade the plugin)", int32(a.GetStatus()), a.GetActionIndex())
 		}
 		actions = append(actions, interfaces.ActionOutcome{
 			ActionIndex: a.GetActionIndex(),

--- a/cmd/wfctl/iac_typed_adapter.go
+++ b/cmd/wfctl/iac_typed_adapter.go
@@ -1239,18 +1239,19 @@ func applyResultFromPB(r *pb.ApplyResult) (*interfaces.ApplyResult, error) {
 }
 
 // mapPBActionStatusToInterface translates the proto-side ActionStatus
-// enum to its interfaces.ActionStatus mirror. Returns (mapped, true) for
-// the four declared tags 0-3; returns (ActionStatusUnspecified, false)
-// for any unknown wire value (tags 4+ — proto3 preserves unknown enum
-// integers as-is). applyResultFromPB converts the `!ok` signal into an
-// explicit error per ADR 0040 invariant 2: a Phase 2.3+ plugin emitting
-// COMPENSATED/COMPENSATION_FAILED against an older wfctl must fail
-// loud, not silently degrade. UNSPECIFIED-sent is filtered upstream so
-// it never reaches the mapper.
+// enum to its interfaces.ActionStatus mirror. Returns (mapped, true)
+// for the three actionable tags SUCCESS / ERROR / DELETE_FAILED;
+// returns (ActionStatusUnspecified, false) for both UNSPECIFIED (a
+// plugin contract violation) AND any unknown wire value (tags 4+ —
+// proto3 preserves unknown enum integers as-is). The mapper is itself
+// fail-closed so its strict-cutover invariant doesn't rely on
+// caller-side filtering. applyResultFromPB converts the `!ok` signal
+// into an explicit error per ADR 0040 invariant 2 — a Phase 2.3+
+// plugin emitting reserved tags COMPENSATED / COMPENSATION_FAILED
+// against an older wfctl, or any plugin emitting UNSPECIFIED, must
+// fail loud and never silently degrade.
 func mapPBActionStatusToInterface(s pb.ActionStatus) (interfaces.ActionStatus, bool) {
 	switch s {
-	case pb.ActionStatus_ACTION_STATUS_UNSPECIFIED:
-		return interfaces.ActionStatusUnspecified, true
 	case pb.ActionStatus_ACTION_STATUS_SUCCESS:
 		return interfaces.ActionStatusSuccess, true
 	case pb.ActionStatus_ACTION_STATUS_ERROR:
@@ -1258,6 +1259,8 @@ func mapPBActionStatusToInterface(s pb.ActionStatus) (interfaces.ActionStatus, b
 	case pb.ActionStatus_ACTION_STATUS_DELETE_FAILED:
 		return interfaces.ActionStatusDeleteFailed, true
 	default:
+		// UNSPECIFIED (tag 0) and any unknown wire value (tags 4+)
+		// fall here. Caller surfaces the !ok as an explicit error.
 		return interfaces.ActionStatusUnspecified, false
 	}
 }

--- a/cmd/wfctl/iac_typed_adapter.go
+++ b/cmd/wfctl/iac_typed_adapter.go
@@ -1200,18 +1200,30 @@ func applyResultFromPB(r *pb.ApplyResult) (*interfaces.ApplyResult, error) {
 			ApplyFingerprint: d.GetApplyFingerprint(),
 		})
 	}
-	// Phase 2: decode per-action outcomes (workflow#640). Reject
-	// ACTION_STATUS_UNSPECIFIED at the wire boundary so a plugin that
-	// forgets to populate a status never reaches v2 hook dispatch. Per
-	// ADR 0040 invariant 2 (strict cutover, no graceful fallback).
+	// Phase 2: decode per-action outcomes (workflow#640). Two rejection
+	// paths, both enforcing ADR 0040 invariant 2 (strict cutover, no
+	// graceful fallback):
+	//   1. UNSPECIFIED-sent — a plugin that forgets to populate a status.
+	//   2. Unknown-received — a Phase 2.3+ plugin emits a tag (e.g. the
+	//      reserved 4/5 for COMPENSATED / COMPENSATION_FAILED) that this
+	//      wfctl doesn't understand. proto3 preserves unknown enum
+	//      integer values, so `reserved 4, 5;` in iac.proto only prevents
+	//      tag-reuse at compile time — it does NOT block a newer plugin
+	//      from sending them over the wire to an older wfctl.
+	// Silently degrading either case to ActionStatusUnspecified would be
+	// the graceful fallback the ADR forbids.
 	actions := make([]interfaces.ActionOutcome, 0, len(r.GetActions()))
 	for _, a := range r.GetActions() {
 		if a.GetStatus() == pb.ActionStatus_ACTION_STATUS_UNSPECIFIED {
 			return nil, fmt.Errorf("plugin returned ActionResult with UNSPECIFIED status at action_index=%d (Phase 2 contract violation per ADR 0040)", a.GetActionIndex())
 		}
+		mapped, ok := mapPBActionStatusToInterface(a.GetStatus())
+		if !ok {
+			return nil, fmt.Errorf("plugin returned unknown ActionStatus=%d at action_index=%d (wfctl version too old for this plugin? Phase 2 contract violation per ADR 0040)", int32(a.GetStatus()), a.GetActionIndex())
+		}
 		actions = append(actions, interfaces.ActionOutcome{
 			ActionIndex: a.GetActionIndex(),
-			Status:      mapPBActionStatusToInterface(a.GetStatus()),
+			Status:      mapped,
 			Error:       a.GetError(),
 		})
 	}
@@ -1227,20 +1239,26 @@ func applyResultFromPB(r *pb.ApplyResult) (*interfaces.ApplyResult, error) {
 }
 
 // mapPBActionStatusToInterface translates the proto-side ActionStatus
-// enum to its interfaces.ActionStatus mirror. UNSPECIFIED is filtered
-// upstream by applyResultFromPB; the default branch returning
-// ActionStatusUnspecified is defensive (unreachable in practice) and
-// matches the zero-value convention.
-func mapPBActionStatusToInterface(s pb.ActionStatus) interfaces.ActionStatus {
+// enum to its interfaces.ActionStatus mirror. Returns (mapped, true) for
+// the four declared tags 0-3; returns (ActionStatusUnspecified, false)
+// for any unknown wire value (tags 4+ — proto3 preserves unknown enum
+// integers as-is). applyResultFromPB converts the `!ok` signal into an
+// explicit error per ADR 0040 invariant 2: a Phase 2.3+ plugin emitting
+// COMPENSATED/COMPENSATION_FAILED against an older wfctl must fail
+// loud, not silently degrade. UNSPECIFIED-sent is filtered upstream so
+// it never reaches the mapper.
+func mapPBActionStatusToInterface(s pb.ActionStatus) (interfaces.ActionStatus, bool) {
 	switch s {
+	case pb.ActionStatus_ACTION_STATUS_UNSPECIFIED:
+		return interfaces.ActionStatusUnspecified, true
 	case pb.ActionStatus_ACTION_STATUS_SUCCESS:
-		return interfaces.ActionStatusSuccess
+		return interfaces.ActionStatusSuccess, true
 	case pb.ActionStatus_ACTION_STATUS_ERROR:
-		return interfaces.ActionStatusError
+		return interfaces.ActionStatusError, true
 	case pb.ActionStatus_ACTION_STATUS_DELETE_FAILED:
-		return interfaces.ActionStatusDeleteFailed
+		return interfaces.ActionStatusDeleteFailed, true
 	default:
-		return interfaces.ActionStatusUnspecified
+		return interfaces.ActionStatusUnspecified, false
 	}
 }
 

--- a/cmd/wfctl/iac_typed_adapter.go
+++ b/cmd/wfctl/iac_typed_adapter.go
@@ -1200,6 +1200,21 @@ func applyResultFromPB(r *pb.ApplyResult) (*interfaces.ApplyResult, error) {
 			ApplyFingerprint: d.GetApplyFingerprint(),
 		})
 	}
+	// Phase 2: decode per-action outcomes (workflow#640). Reject
+	// ACTION_STATUS_UNSPECIFIED at the wire boundary so a plugin that
+	// forgets to populate a status never reaches v2 hook dispatch. Per
+	// ADR 0040 invariant 2 (strict cutover, no graceful fallback).
+	actions := make([]interfaces.ActionOutcome, 0, len(r.GetActions()))
+	for _, a := range r.GetActions() {
+		if a.GetStatus() == pb.ActionStatus_ACTION_STATUS_UNSPECIFIED {
+			return nil, fmt.Errorf("plugin returned ActionResult with UNSPECIFIED status at action_index=%d (Phase 2 contract violation per ADR 0040)", a.GetActionIndex())
+		}
+		actions = append(actions, interfaces.ActionOutcome{
+			ActionIndex: a.GetActionIndex(),
+			Status:      mapPBActionStatusToInterface(a.GetStatus()),
+			Error:       a.GetError(),
+		})
+	}
 	return &interfaces.ApplyResult{
 		PlanID:               r.GetPlanId(),
 		Resources:            resources,
@@ -1207,7 +1222,26 @@ func applyResultFromPB(r *pb.ApplyResult) (*interfaces.ApplyResult, error) {
 		InitialInputSnapshot: copyStringMap(r.GetInitialInputSnapshot()),
 		InputDriftReport:     driftReport,
 		ReplaceIDMap:         copyStringMap(r.GetReplaceIdMap()),
+		Actions:              actions,
 	}, nil
+}
+
+// mapPBActionStatusToInterface translates the proto-side ActionStatus
+// enum to its interfaces.ActionStatus mirror. UNSPECIFIED is filtered
+// upstream by applyResultFromPB; the default branch returning
+// ActionStatusUnspecified is defensive (unreachable in practice) and
+// matches the zero-value convention.
+func mapPBActionStatusToInterface(s pb.ActionStatus) interfaces.ActionStatus {
+	switch s {
+	case pb.ActionStatus_ACTION_STATUS_SUCCESS:
+		return interfaces.ActionStatusSuccess
+	case pb.ActionStatus_ACTION_STATUS_ERROR:
+		return interfaces.ActionStatusError
+	case pb.ActionStatus_ACTION_STATUS_DELETE_FAILED:
+		return interfaces.ActionStatusDeleteFailed
+	default:
+		return interfaces.ActionStatusUnspecified
+	}
 }
 
 func destroyResultFromPB(r *pb.DestroyResult) *interfaces.DestroyResult {

--- a/cmd/wfctl/iac_typed_adapter_test.go
+++ b/cmd/wfctl/iac_typed_adapter_test.go
@@ -536,15 +536,15 @@ func TestApplyResultFromPB_RejectsUnknownStatus(t *testing.T) {
 	}
 }
 
-// TestMapPBActionStatusToInterface_KnownValues pins the four declared
-// tags 0-3 to their interfaces.ActionStatus mirrors, ok=true.
-func TestMapPBActionStatusToInterface_KnownValues(t *testing.T) {
+// TestMapPBActionStatusToInterface_ActionableValues pins the three
+// actionable tags SUCCESS / ERROR / DELETE_FAILED to their
+// interfaces.ActionStatus mirrors with ok=true.
+func TestMapPBActionStatusToInterface_ActionableValues(t *testing.T) {
 	cases := []struct {
 		name string
 		in   pb.ActionStatus
 		want interfaces.ActionStatus
 	}{
-		{"UNSPECIFIED", pb.ActionStatus_ACTION_STATUS_UNSPECIFIED, interfaces.ActionStatusUnspecified},
 		{"SUCCESS", pb.ActionStatus_ACTION_STATUS_SUCCESS, interfaces.ActionStatusSuccess},
 		{"ERROR", pb.ActionStatus_ACTION_STATUS_ERROR, interfaces.ActionStatusError},
 		{"DELETE_FAILED", pb.ActionStatus_ACTION_STATUS_DELETE_FAILED, interfaces.ActionStatusDeleteFailed},
@@ -557,6 +557,23 @@ func TestMapPBActionStatusToInterface_KnownValues(t *testing.T) {
 		if got != c.want {
 			t.Errorf("%s: got %d, want %d", c.name, got, c.want)
 		}
+	}
+}
+
+// TestMapPBActionStatusToInterface_UnspecifiedFailsClosed pins the
+// strict-cutover invariant at the mapper itself: UNSPECIFIED is a
+// declared enum tag, but per ADR 0040 invariant 2 it must never
+// translate to a valid Go-side outcome — the mapper returns
+// (Unspecified, false) and the caller surfaces the !ok as an explicit
+// contract-violation error. Discipline lives in the mapper rather
+// than relying on caller-side pre-filtering.
+func TestMapPBActionStatusToInterface_UnspecifiedFailsClosed(t *testing.T) {
+	got, ok := mapPBActionStatusToInterface(pb.ActionStatus_ACTION_STATUS_UNSPECIFIED)
+	if ok {
+		t.Errorf("ok=true for UNSPECIFIED, want false")
+	}
+	if got != interfaces.ActionStatusUnspecified {
+		t.Errorf("UNSPECIFIED mapped to %d, want ActionStatusUnspecified (0)", got)
 	}
 }
 

--- a/cmd/wfctl/iac_typed_adapter_test.go
+++ b/cmd/wfctl/iac_typed_adapter_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/iac/wfctlhelpers"
@@ -433,4 +434,75 @@ type enumeratorOnlyStub struct {
 
 func (s *enumeratorOnlyStub) EnumerateAll(_ context.Context, _ *pb.EnumerateAllRequest) (*pb.EnumerateAllResponse, error) {
 	return &pb.EnumerateAllResponse{}, nil
+}
+
+// TestApplyResultFromPB_DecodesActions verifies applyResultFromPB
+// translates pb.ActionResult entries into interfaces.ActionOutcome with
+// the correct ActionStatus mapping and Error pass-through. Per workflow#640
+// Phase 2 + ADR 0040; T3 of v2-lifecycle-phase2 plan.
+func TestApplyResultFromPB_DecodesActions(t *testing.T) {
+	pbResult := &pb.ApplyResult{
+		PlanId: "plan-1",
+		Actions: []*pb.ActionResult{
+			{ActionIndex: 0, Status: pb.ActionStatus_ACTION_STATUS_SUCCESS},
+			{ActionIndex: 1, Status: pb.ActionStatus_ACTION_STATUS_ERROR, Error: "create failed"},
+			{ActionIndex: 2, Status: pb.ActionStatus_ACTION_STATUS_DELETE_FAILED, Error: "AWS API error"},
+		},
+	}
+	got, err := applyResultFromPB(pbResult)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got.Actions) != 3 {
+		t.Fatalf("expected 3 actions, got %d", len(got.Actions))
+	}
+	if got.Actions[0].ActionIndex != 0 || got.Actions[0].Status != interfaces.ActionStatusSuccess {
+		t.Errorf("action 0: got %+v, want {0, Success}", got.Actions[0])
+	}
+	if got.Actions[1].Status != interfaces.ActionStatusError || got.Actions[1].Error != "create failed" {
+		t.Errorf("action 1: got %+v, want {1, Error, \"create failed\"}", got.Actions[1])
+	}
+	if got.Actions[2].Status != interfaces.ActionStatusDeleteFailed || got.Actions[2].Error != "AWS API error" {
+		t.Errorf("action 2: got %+v, want {2, DeleteFailed, \"AWS API error\"}", got.Actions[2])
+	}
+}
+
+// TestApplyResultFromPB_RejectsUNSPECIFIED ensures a plugin sending
+// ACTION_STATUS_UNSPECIFIED gets rejected at the decode boundary so
+// wfctl never tries to dispatch a v2 hook on a forgotten-populate
+// outcome. Per ADR 0040 invariant 2: strict cutover, no graceful
+// fallback. Error message MUST mention "UNSPECIFIED" + action_index.
+func TestApplyResultFromPB_RejectsUNSPECIFIED(t *testing.T) {
+	pbResult := &pb.ApplyResult{
+		Actions: []*pb.ActionResult{
+			{ActionIndex: 0, Status: pb.ActionStatus_ACTION_STATUS_SUCCESS},
+			{ActionIndex: 7, Status: pb.ActionStatus_ACTION_STATUS_UNSPECIFIED},
+		},
+	}
+	_, err := applyResultFromPB(pbResult)
+	if err == nil {
+		t.Fatal("expected error on UNSPECIFIED status, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "UNSPECIFIED") {
+		t.Errorf("error should mention UNSPECIFIED: %v", err)
+	}
+	if !strings.Contains(msg, "7") {
+		t.Errorf("error should mention offending action_index=7: %v", err)
+	}
+}
+
+// TestApplyResultFromPB_EmptyActionsRoundTrip confirms plugins on the
+// v1 capability shim (no Actions emitted) decode cleanly without
+// error and surface an empty/nil Actions slice — wfctl skips v2 hook
+// dispatch in that case.
+func TestApplyResultFromPB_EmptyActionsRoundTrip(t *testing.T) {
+	pbResult := &pb.ApplyResult{PlanId: "plan-empty"}
+	got, err := applyResultFromPB(pbResult)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got.Actions) != 0 {
+		t.Errorf("expected 0 actions for empty pb.Actions, got %d: %+v", len(got.Actions), got.Actions)
+	}
 }

--- a/cmd/wfctl/iac_typed_adapter_test.go
+++ b/cmd/wfctl/iac_typed_adapter_test.go
@@ -494,15 +494,81 @@ func TestApplyResultFromPB_RejectsUNSPECIFIED(t *testing.T) {
 
 // TestApplyResultFromPB_EmptyActionsRoundTrip confirms plugins on the
 // v1 capability shim (no Actions emitted) decode cleanly without
-// error and surface an empty/nil Actions slice — wfctl skips v2 hook
-// dispatch in that case.
+// error. Pins the slice contract explicitly: applyResultFromPB always
+// returns a non-nil empty slice (via make([]T, 0, ...)) to match the
+// sibling Resources/Errors fields' convention. A refactor that returns
+// nil would change downstream nil-check semantics and fails this test.
 func TestApplyResultFromPB_EmptyActionsRoundTrip(t *testing.T) {
 	pbResult := &pb.ApplyResult{PlanId: "plan-empty"}
 	got, err := applyResultFromPB(pbResult)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	if got.Actions == nil {
+		t.Errorf("expected non-nil empty Actions slice, got nil")
+	}
 	if len(got.Actions) != 0 {
 		t.Errorf("expected 0 actions for empty pb.Actions, got %d: %+v", len(got.Actions), got.Actions)
+	}
+}
+
+// TestApplyResultFromPB_RejectsUnknownStatus exercises the wire-drift
+// defense: a Phase 2.3+ plugin emitting a reserved tag (4 or 5) against
+// an older wfctl must fail loud at decode rather than silently degrade
+// to ActionStatusUnspecified. Per ADR 0040 invariant 2.
+func TestApplyResultFromPB_RejectsUnknownStatus(t *testing.T) {
+	pbResult := &pb.ApplyResult{
+		Actions: []*pb.ActionResult{
+			{ActionIndex: 0, Status: pb.ActionStatus_ACTION_STATUS_SUCCESS},
+			{ActionIndex: 3, Status: pb.ActionStatus(99)},
+		},
+	}
+	_, err := applyResultFromPB(pbResult)
+	if err == nil {
+		t.Fatal("expected error on unknown ActionStatus, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown ActionStatus=99") {
+		t.Errorf("error should name the wire value: %v", err)
+	}
+	if !strings.Contains(msg, "action_index=3") {
+		t.Errorf("error should name the offending action_index: %v", err)
+	}
+}
+
+// TestMapPBActionStatusToInterface_KnownValues pins the four declared
+// tags 0-3 to their interfaces.ActionStatus mirrors, ok=true.
+func TestMapPBActionStatusToInterface_KnownValues(t *testing.T) {
+	cases := []struct {
+		name string
+		in   pb.ActionStatus
+		want interfaces.ActionStatus
+	}{
+		{"UNSPECIFIED", pb.ActionStatus_ACTION_STATUS_UNSPECIFIED, interfaces.ActionStatusUnspecified},
+		{"SUCCESS", pb.ActionStatus_ACTION_STATUS_SUCCESS, interfaces.ActionStatusSuccess},
+		{"ERROR", pb.ActionStatus_ACTION_STATUS_ERROR, interfaces.ActionStatusError},
+		{"DELETE_FAILED", pb.ActionStatus_ACTION_STATUS_DELETE_FAILED, interfaces.ActionStatusDeleteFailed},
+	}
+	for _, c := range cases {
+		got, ok := mapPBActionStatusToInterface(c.in)
+		if !ok {
+			t.Errorf("%s: ok=false, want true", c.name)
+		}
+		if got != c.want {
+			t.Errorf("%s: got %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// TestMapPBActionStatusToInterface_UnknownValueFailsClosed pins the
+// fail-closed wire-drift defense at the helper level: any tag outside
+// 0-3 returns (Unspecified, false). Per ADR 0040 invariant 2.
+func TestMapPBActionStatusToInterface_UnknownValueFailsClosed(t *testing.T) {
+	got, ok := mapPBActionStatusToInterface(pb.ActionStatus(99))
+	if ok {
+		t.Errorf("ok=true for unknown tag, want false")
+	}
+	if got != interfaces.ActionStatusUnspecified {
+		t.Errorf("unknown tag mapped to %d, want ActionStatusUnspecified (0)", got)
 	}
 }

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -195,89 +195,161 @@ func applyPlanWithEnvProviderAndHooks(
 
 	for i := range plan.Actions {
 		action := plan.Actions[i]
-		// Honor cancellation at the loop boundary. Drivers should also
-		// check ctx internally for in-flight work, but the loop check
-		// guarantees apply stops between actions even if a driver
-		// happens to ignore ctx. The deferred postcondition still runs
-		// on early return so InputDriftReport is populated even on a
-		// canceled apply.
-		if err := ctx.Err(); err != nil {
-			return result, err
-		}
-		// Per-action JIT substitution — resolve ${VAR} / ${MODULE.field}
-		// / ${MODULE.id} in action.Resource.Config against
-		// result.ReplaceIDMap (this-apply Replace ProviderIDs) and
-		// syncedOutputs (state + this-apply prior outputs). On error,
-		// record a per-action diagnostic with the canonical "jit
-		// substitution:" prefix and SKIP dispatch — the unresolved spec
-		// must not reach the driver. The loop continues to the next
-		// action (best-effort apply contract). os.LookupEnv is the
-		// production env source; nil-safe inside ResolveSpec — refs that
-		// only need replaceIDMap / syncedOutputs still resolve.
-		resolved, err := jitsubst.ResolveSpec(action.Resource, result.ReplaceIDMap, syncedOutputs, os.LookupEnv)
-		if err != nil {
-			result.Errors = append(result.Errors, interfaces.ActionError{
-				Resource: action.Resource.Name,
-				Action:   action.Action,
-				Error:    fmt.Sprintf("jit substitution: %v", err),
-			})
-			continue
-		}
-		action.Resource = resolved
-		d, err := p.ResourceDriver(action.Resource.Type)
-		if err != nil {
-			result.Errors = append(result.Errors, interfaces.ActionError{
-				Resource: action.Resource.Name,
-				Action:   action.Action,
-				Error:    fmt.Sprintf("resolve driver: %v", err),
-			})
-			continue
-		}
-		// Capture result.Resources length pre-dispatch so we can identify
-		// the entry (if any) that this action appended and propagate its
-		// outputs into syncedOutputs for subsequent actions. doCreate /
-		// doUpdate / doReplace each append on success; doDelete does not.
-		preLen := len(result.Resources)
-		actionHooks := hooks
-		actionHooks.OnResourceDeleted = func(ctx context.Context, action interfaces.PlanAction) error {
-			if hooks.OnResourceDeleted != nil {
-				if err := hooks.OnResourceDeleted(ctx, action); err != nil {
-					return err
+		// Phase 2 (workflow#640 + ADR 0040 invariant 1): per-PlanAction
+		// ActionOutcome MUST be appended to result.Actions exactly once,
+		// regardless of which continue / fatal-return branch the iteration
+		// took. Cycle-1 plan-review C-1 caught the false-positive where
+		// jit-error / driver-resolve-error continue paths skip the append
+		// and the post-loop length-assert mis-fires. The deferred-closure
+		// pattern below records the outcome unconditionally on every exit
+		// from the inner func; the surrounding for loop then bubbles
+		// fatalErr (hook failures, ctx cancellation) to the caller.
+		var iterErr error  // best-effort error: action failed, continue
+		var fatalErr error // hook/ctx error: stop the whole apply
+
+		func() {
+			defer func() {
+				status := mapDispatchErrToStatus(iterErr, action.Action)
+				errStr := ""
+				if iterErr != nil {
+					errStr = iterErr.Error()
+				}
+				result.Actions = append(result.Actions, interfaces.ActionOutcome{
+					ActionIndex: uint32(i),
+					Status:      status,
+					Error:       errStr,
+				})
+			}()
+
+			// Honor cancellation at the loop boundary. Drivers should also
+			// check ctx internally for in-flight work, but the loop check
+			// guarantees apply stops between actions even if a driver
+			// happens to ignore ctx. The deferred postcondition still runs
+			// on early return so InputDriftReport is populated even on a
+			// canceled apply.
+			if err := ctx.Err(); err != nil {
+				iterErr = err
+				fatalErr = err
+				return
+			}
+			// Per-action JIT substitution — resolve ${VAR} / ${MODULE.field}
+			// / ${MODULE.id} in action.Resource.Config against
+			// result.ReplaceIDMap (this-apply Replace ProviderIDs) and
+			// syncedOutputs (state + this-apply prior outputs). On error,
+			// record a per-action diagnostic with the canonical "jit
+			// substitution:" prefix and SKIP dispatch — the unresolved spec
+			// must not reach the driver. The loop continues to the next
+			// action (best-effort apply contract). os.LookupEnv is the
+			// production env source; nil-safe inside ResolveSpec — refs that
+			// only need replaceIDMap / syncedOutputs still resolve.
+			resolved, err := jitsubst.ResolveSpec(action.Resource, result.ReplaceIDMap, syncedOutputs, os.LookupEnv)
+			if err != nil {
+				result.Errors = append(result.Errors, interfaces.ActionError{
+					Resource: action.Resource.Name,
+					Action:   action.Action,
+					Error:    fmt.Sprintf("jit substitution: %v", err),
+				})
+				iterErr = fmt.Errorf("jit substitution: %v", err)
+				return
+			}
+			action.Resource = resolved
+			d, err := p.ResourceDriver(action.Resource.Type)
+			if err != nil {
+				result.Errors = append(result.Errors, interfaces.ActionError{
+					Resource: action.Resource.Name,
+					Action:   action.Action,
+					Error:    fmt.Sprintf("resolve driver: %v", err),
+				})
+				iterErr = fmt.Errorf("resolve driver: %v", err)
+				return
+			}
+			// Capture result.Resources length pre-dispatch so we can identify
+			// the entry (if any) that this action appended and propagate its
+			// outputs into syncedOutputs for subsequent actions. doCreate /
+			// doUpdate / doReplace each append on success; doDelete does not.
+			preLen := len(result.Resources)
+			actionHooks := hooks
+			actionHooks.OnResourceDeleted = func(ctx context.Context, action interfaces.PlanAction) error {
+				if hooks.OnResourceDeleted != nil {
+					if err := hooks.OnResourceDeleted(ctx, action); err != nil {
+						return err
+					}
+				}
+				delete(syncedOutputs, action.Resource.Name)
+				return nil
+			}
+			if err := dispatchAction(ctx, d, action, result, actionHooks, deleteHookActive); err != nil {
+				var hookErr hookDispatchError
+				if errors.As(err, &hookErr) {
+					fatalErr = fmt.Errorf("%s/%s: %w", action.Resource.Type, action.Resource.Name, hookErr.err)
+					iterErr = hookErr.err
+					return
+				}
+				result.Errors = append(result.Errors, interfaces.ActionError{
+					Resource: action.Resource.Name,
+					Action:   action.Action,
+					Error:    err.Error(),
+				})
+				iterErr = err
+				return
+			}
+			if action.Action == "delete" {
+				if err := actionHooks.OnResourceDeleted(ctx, action); err != nil {
+					fatalErr = fmt.Errorf("%s/%s: post-delete hook: %w", action.Resource.Type, action.Resource.Name, err)
+					iterErr = err
+					return
 				}
 			}
-			delete(syncedOutputs, action.Resource.Name)
-			return nil
-		}
-		if err := dispatchAction(ctx, d, action, result, actionHooks, deleteHookActive); err != nil {
-			var hookErr hookDispatchError
-			if errors.As(err, &hookErr) {
-				return result, fmt.Errorf("%s/%s: %w", action.Resource.Type, action.Resource.Name, hookErr.err)
-			}
-			result.Errors = append(result.Errors, interfaces.ActionError{
-				Resource: action.Resource.Name,
-				Action:   action.Action,
-				Error:    err.Error(),
-			})
-			continue
-		}
-		if action.Action == "delete" {
-			if err := actionHooks.OnResourceDeleted(ctx, action); err != nil {
-				return result, fmt.Errorf("%s/%s: post-delete hook: %w", action.Resource.Type, action.Resource.Name, err)
-			}
-		}
-		if len(result.Resources) > preLen {
-			out := result.Resources[len(result.Resources)-1]
-			out = fillMissingOutputIdentity(action.Resource, out)
-			result.Resources[len(result.Resources)-1] = out
-			if hooks.OnResourceApplied != nil {
-				if err := hooks.OnResourceApplied(ctx, d, action, out); err != nil {
-					return result, fmt.Errorf("%s/%s: post-apply hook: %w", action.Resource.Type, action.Resource.Name, err)
+			if len(result.Resources) > preLen {
+				out := result.Resources[len(result.Resources)-1]
+				out = fillMissingOutputIdentity(action.Resource, out)
+				result.Resources[len(result.Resources)-1] = out
+				if hooks.OnResourceApplied != nil {
+					if err := hooks.OnResourceApplied(ctx, d, action, out); err != nil {
+						fatalErr = fmt.Errorf("%s/%s: post-apply hook: %w", action.Resource.Type, action.Resource.Name, err)
+						iterErr = err
+						return
+					}
 				}
+				syncedOutputs[out.Name] = flattenOutputs(out)
 			}
-			syncedOutputs[out.Name] = flattenOutputs(out)
+		}()
+
+		if fatalErr != nil {
+			// Early-return path: ActionOutcome for the offending action
+			// has already been appended by the deferred closure; the
+			// post-loop length-assert is skipped on fatal exits (length
+			// will be < len(plan.Actions), correctly so).
+			return result, fatalErr
 		}
 	}
+
+	// Phase 2 engine invariant (workflow#640 + ADR 0040 invariant 1): on
+	// a normally-completed loop, len(result.Actions) MUST equal
+	// len(plan.Actions). Length validation lives engine-side here, not in
+	// applyResultFromPB (which is on the v1 plugin-dispatch path).
+	if len(result.Actions) != len(plan.Actions) {
+		return result, fmt.Errorf("internal: ApplyPlanWithHooks produced %d ActionOutcomes for %d plan actions (engine invariant violation per ADR 0040)", len(result.Actions), len(plan.Actions))
+	}
+
 	return result, nil
+}
+
+// mapDispatchErrToStatus translates a per-action dispatch error into the
+// Phase 2 ActionStatus value (workflow#640). delete actions that fail map
+// to ActionStatusDeleteFailed so wfctl downstream can drop the
+// state-removal optimistic-update; all other failures map to
+// ActionStatusError. Compensation paths (Phase 2.3 — COMPENSATED /
+// COMPENSATION_FAILED) are reserved in iac.proto but not yet emitted
+// here. nil err means the dispatch (and any post-hooks) succeeded.
+func mapDispatchErrToStatus(err error, actionType string) interfaces.ActionStatus {
+	if err == nil {
+		return interfaces.ActionStatusSuccess
+	}
+	if actionType == "delete" {
+		return interfaces.ActionStatusDeleteFailed
+	}
+	return interfaces.ActionStatusError
 }
 
 func preflightProviderOwnedReplaceWithDeleteHooks(p interfaces.IaCProvider, plan *interfaces.IaCPlan) error {

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -215,6 +215,7 @@ func applyPlanWithEnvProviderAndHooks(
 					errStr = iterErr.Error()
 				}
 				result.Actions = append(result.Actions, interfaces.ActionOutcome{
+					//nolint:gosec // ActionIndex is loop counter bound by len(plan.Actions); G115 false positive.
 					ActionIndex: uint32(i),
 					Status:      status,
 					Error:       errStr,

--- a/iac/wfctlhelpers/apply_hooks_test.go
+++ b/iac/wfctlhelpers/apply_hooks_test.go
@@ -230,3 +230,73 @@ func (d *deleteThenDependentDriver) Create(_ context.Context, spec interfaces.Re
 	}
 	return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-" + spec.Name}, nil
 }
+
+// TestApplyPlanWithHooks_PopulatesActions_CleanSuccess verifies the
+// Phase 2 engine-side ActionOutcome population — every successful
+// PlanAction gets a corresponding result.Actions entry with
+// ActionStatusSuccess and ActionIndex matching loop position. Per
+// workflow#640 Phase 2 + ADR 0040 invariant 1.
+func TestApplyPlanWithHooks_PopulatesActions_CleanSuccess(t *testing.T) {
+	p := newFakeProvider()
+	plan := &interfaces.IaCPlan{
+		ID: "plan-1",
+		Actions: []interfaces.PlanAction{
+			{Action: "create", Resource: interfaces.ResourceSpec{Name: "r1", Type: "infra.test"}},
+			{Action: "create", Resource: interfaces.ResourceSpec{Name: "r2", Type: "infra.test"}},
+		},
+	}
+	result, err := ApplyPlanWithHooks(t.Context(), p, plan, ApplyPlanHooks{})
+	if err != nil {
+		t.Fatalf("top-level err: %v", err)
+	}
+	if len(result.Actions) != 2 {
+		t.Fatalf("expected 2 ActionOutcomes, got %d: %+v", len(result.Actions), result.Actions)
+	}
+	for i, a := range result.Actions {
+		if a.ActionIndex != uint32(i) {
+			t.Errorf("action %d: ActionIndex=%d, want %d", i, a.ActionIndex, i)
+		}
+		if a.Status != interfaces.ActionStatusSuccess {
+			t.Errorf("action %d: Status=%v, want Success", i, a.Status)
+		}
+		if a.Error != "" {
+			t.Errorf("action %d: Error=%q, want empty", i, a.Error)
+		}
+	}
+}
+
+// TestApplyPlanWithHooks_PopulatesActions_PreDispatchDriverError covers
+// the CRITICAL cycle-1 plan-review C-1 invariant: every continue exit
+// path (here, the driver-resolve error at apply.go:228-234) must still
+// append an ActionOutcome so the post-loop length-validation assert
+// never false-fires. Per ADR 0040.
+func TestApplyPlanWithHooks_PopulatesActions_PreDispatchDriverError(t *testing.T) {
+	p := &fakeProvider{driverErr: errors.New("driver resolution failed")}
+	plan := &interfaces.IaCPlan{
+		ID: "plan-1",
+		Actions: []interfaces.PlanAction{
+			{Action: "create", Resource: interfaces.ResourceSpec{Name: "r1", Type: "unknown.resource"}},
+		},
+	}
+	result, err := ApplyPlanWithHooks(t.Context(), p, plan, ApplyPlanHooks{})
+	if err != nil {
+		t.Fatalf("expected no top-level err on driver-resolve failure (best-effort continue), got: %v", err)
+	}
+	if len(result.Actions) != 1 {
+		t.Fatalf("expected 1 ActionOutcome (length-assert invariant), got %d: %+v", len(result.Actions), result.Actions)
+	}
+	if result.Actions[0].Status != interfaces.ActionStatusError {
+		t.Errorf("driver-resolve-error status: want Error, got %v", result.Actions[0].Status)
+	}
+	if result.Actions[0].ActionIndex != 0 {
+		t.Errorf("ActionIndex: want 0, got %d", result.Actions[0].ActionIndex)
+	}
+	if result.Actions[0].Error == "" {
+		t.Errorf("Error: want non-empty, got empty")
+	}
+	// Cross-check: existing result.Errors path also populated so the
+	// pre-Phase-2 contract is preserved.
+	if len(result.Errors) != 1 {
+		t.Errorf("expected 1 result.Errors entry (legacy contract), got %d", len(result.Errors))
+	}
+}

--- a/interfaces/iac_state.go
+++ b/interfaces/iac_state.go
@@ -141,6 +141,33 @@ type DriftEntry struct {
 	ApplyFingerprint string `json:"apply_fingerprint"`
 }
 
+// ActionStatus categorizes per-action outcomes for wfctl-side hook dispatch.
+// Mirrors pb.ActionStatus (plugin/external/proto/iac.proto) for type-safe Go
+// boundary use; constant tags 0/1/2/3 MUST stay in lockstep with the proto.
+// Per workflow#640 Phase 2 + ADR 0040 invariants 1-2. Tags 4-5 are reserved
+// in the proto for Phase 2.3 compensation (ActionStatusCompensated +
+// ActionStatusCompensationFailed) and intentionally not declared here yet.
+type ActionStatus uint8
+
+const (
+	// ActionStatusUnspecified is the zero-value; T3's applyResultFromPB
+	// REJECTS this on decode so forgotten populates surface as errors
+	// rather than silent SUCCESS misreads.
+	ActionStatusUnspecified ActionStatus = iota
+	ActionStatusSuccess
+	ActionStatusError
+	ActionStatusDeleteFailed
+)
+
+// ActionOutcome mirrors pb.ActionResult. Engine populates one entry per
+// PlanAction in ApplyResult.Actions; wfctl dispatches v2 hooks (Created /
+// Deleted) by matching ActionIndex back to the planned action slice.
+type ActionOutcome struct {
+	ActionIndex uint32       `json:"action_index"`
+	Status      ActionStatus `json:"status"`
+	Error       string       `json:"error,omitempty"`
+}
+
 // ApplyResult summarises the outcome of applying a plan.
 type ApplyResult struct {
 	PlanID    string           `json:"plan_id"`
@@ -177,6 +204,14 @@ type ApplyResult struct {
 	// the replaced resource by name in their config, so JIT substitution
 	// in W-5 translates "name → new ProviderID" via this map.
 	ReplaceIDMap map[string]string `json:"replace_id_map,omitempty"`
+
+	// Actions surfaces per-PlanAction outcomes for v2 hook dispatch in
+	// wfctl. Engine populates one entry per IaCPlan.Actions index (T4) so
+	// the length-validation assert can pair them 1:1. Empty/nil on plugins
+	// using the v1 capability shim (downstream pre-v1.2.0 cascade) —
+	// wfctl tolerates absence and skips v2-hook dispatch in that case.
+	// Per workflow#640 Phase 2 + ADR 0040 invariants 1-2.
+	Actions []ActionOutcome `json:"actions,omitempty"`
 }
 
 // DestroyResult summarises the outcome of a destroy operation.

--- a/interfaces/iac_state.go
+++ b/interfaces/iac_state.go
@@ -206,11 +206,12 @@ type ApplyResult struct {
 	ReplaceIDMap map[string]string `json:"replace_id_map,omitempty"`
 
 	// Actions surfaces per-PlanAction outcomes for v2 hook dispatch in
-	// wfctl. Engine populates one entry per IaCPlan.Actions index (T4) so
-	// the length-validation assert can pair them 1:1. Empty/nil on plugins
-	// using the v1 capability shim (downstream pre-v1.2.0 cascade) —
-	// wfctl tolerates absence and skips v2-hook dispatch in that case.
-	// Per workflow#640 Phase 2 + ADR 0040 invariants 1-2.
+	// wfctl. Always populated (one entry per IaCPlan.Actions index) when
+	// an IaC plugin declares ComputePlanVersion="v2" in
+	// CapabilitiesResponse. Per ADR 0024 + ADR 0040, plugins NOT
+	// declaring v2 are permanently incompatible with workflow v0.54.0+;
+	// there is no compat shim. Per workflow#640 Phase 2 + ADR 0040
+	// invariants 1-2.
 	Actions []ActionOutcome `json:"actions,omitempty"`
 }
 

--- a/interfaces/iac_state_test.go
+++ b/interfaces/iac_state_test.go
@@ -236,3 +236,89 @@ func TestResourceState_NewReaderTolerates_OldWriter(t *testing.T) {
 		t.Errorf("AppliedConfigSource on legacy state: got %q, want empty", out.AppliedConfigSource)
 	}
 }
+
+// TestActionStatus_ZeroValueIsUnspecified pins the zero-value semantics of
+// ActionStatus: an uninitialized status MUST be ActionStatusUnspecified so
+// T3's applyResultFromPB reject path catches forgotten populates. Per
+// workflow#640 Phase 2 + ADR 0040 invariant 2.
+func TestActionStatus_ZeroValueIsUnspecified(t *testing.T) {
+	var s ActionStatus
+	if s != ActionStatusUnspecified {
+		t.Fatalf("zero-value ActionStatus: got %d, want ActionStatusUnspecified (0)", s)
+	}
+}
+
+// TestActionStatus_ConstantValues pins the wire tags 0/1/2/3 to the four
+// declared constants. Mirrors pb.ActionStatus values; drift here would
+// cause applyResultFromPB decode (T3) to silently mis-categorize.
+func TestActionStatus_ConstantValues(t *testing.T) {
+	cases := []struct {
+		name string
+		got  ActionStatus
+		want uint8
+	}{
+		{"Unspecified", ActionStatusUnspecified, 0},
+		{"Success", ActionStatusSuccess, 1},
+		{"Error", ActionStatusError, 2},
+		{"DeleteFailed", ActionStatusDeleteFailed, 3},
+	}
+	for _, c := range cases {
+		if uint8(c.got) != c.want {
+			t.Errorf("ActionStatus%s = %d, want %d", c.name, uint8(c.got), c.want)
+		}
+	}
+}
+
+// TestActionOutcome_ZeroValueAndConstructor verifies ActionOutcome has the
+// three documented fields with the expected types and zero values. A bare
+// ActionOutcome{} has ActionIndex=0, Status=ActionStatusUnspecified, Error="".
+func TestActionOutcome_ZeroValueAndConstructor(t *testing.T) {
+	var o ActionOutcome
+	if o.ActionIndex != 0 || o.Status != ActionStatusUnspecified || o.Error != "" {
+		t.Fatalf("zero-value ActionOutcome: got %+v, want all zero", o)
+	}
+	o2 := ActionOutcome{ActionIndex: 7, Status: ActionStatusDeleteFailed, Error: "in-use"}
+	if o2.ActionIndex != 7 || o2.Status != ActionStatusDeleteFailed || o2.Error != "in-use" {
+		t.Fatalf("constructed ActionOutcome: got %+v", o2)
+	}
+}
+
+// TestApplyResult_Actions_RoundTrip verifies the new Actions field on
+// ApplyResult survives JSON marshal/unmarshal — wfctl persists ApplyResult
+// JSON in apply-state files (iac/applystate), so wire-format drift here
+// breaks resume / replay.
+func TestApplyResult_Actions_RoundTrip(t *testing.T) {
+	r := ApplyResult{Actions: []ActionOutcome{
+		{ActionIndex: 0, Status: ActionStatusSuccess},
+		{ActionIndex: 1, Status: ActionStatusError, Error: "boom"},
+	}}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ApplyResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Actions) != 2 {
+		t.Fatalf("Actions len: got %d, want 2", len(got.Actions))
+	}
+	if got.Actions[0].Status != ActionStatusSuccess || got.Actions[1].Error != "boom" {
+		t.Errorf("Actions round-trip mismatch: %+v", got.Actions)
+	}
+}
+
+// TestApplyResult_Actions_OmitemptyWhenNil ensures a nil Actions slice
+// is absent from the JSON output, matching the omitempty convention used
+// by Errors / InputDriftReport / ReplaceIDMap. Plugins on v1 capability
+// shim emit no actions; the JSON must not carry an empty array.
+func TestApplyResult_Actions_OmitemptyWhenNil(t *testing.T) {
+	r := ApplyResult{PlanID: "p"}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte(`"actions"`)) {
+		t.Errorf("nil Actions emitted in JSON: %s", data)
+	}
+}

--- a/plugin/external/proto/iac.pb.go
+++ b/plugin/external/proto/iac.pb.go
@@ -162,7 +162,7 @@ const (
 	ActionStatus_ACTION_STATUS_UNSPECIFIED   ActionStatus = 0 // wfctl REJECTS this on receipt
 	ActionStatus_ACTION_STATUS_SUCCESS       ActionStatus = 1
 	ActionStatus_ACTION_STATUS_ERROR         ActionStatus = 2
-	ActionStatus_ACTION_STATUS_DELETE_FAILED ActionStatus = 3 // 4 + 5 reserved (Phase 2.3 compensation)
+	ActionStatus_ACTION_STATUS_DELETE_FAILED ActionStatus = 3
 )
 
 // Enum value maps for ActionStatus.
@@ -5883,12 +5883,12 @@ const file_iac_proto_rawDesc = "" +
 	"\x16PlanDiagnosticSeverity\x12\x18\n" +
 	"\x14PLAN_DIAGNOSTIC_INFO\x10\x00\x12\x1b\n" +
 	"\x17PLAN_DIAGNOSTIC_WARNING\x10\x01\x12\x19\n" +
-	"\x15PLAN_DIAGNOSTIC_ERROR\x10\x02*\x82\x01\n" +
+	"\x15PLAN_DIAGNOSTIC_ERROR\x10\x02*\x8e\x01\n" +
 	"\fActionStatus\x12\x1d\n" +
 	"\x19ACTION_STATUS_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15ACTION_STATUS_SUCCESS\x10\x01\x12\x17\n" +
 	"\x13ACTION_STATUS_ERROR\x10\x02\x12\x1f\n" +
-	"\x1bACTION_STATUS_DELETE_FAILED\x10\x032\xc4\t\n" +
+	"\x1bACTION_STATUS_DELETE_FAILED\x10\x03\"\x04\b\x04\x10\x04\"\x04\b\x05\x10\x052\xc4\t\n" +
 	"\x13IaCProviderRequired\x12o\n" +
 	"\n" +
 	"Initialize\x12/.workflow.plugin.external.iac.InitializeRequest\x1a0.workflow.plugin.external.iac.InitializeResponse\x12]\n" +

--- a/plugin/external/proto/iac.pb.go
+++ b/plugin/external/proto/iac.pb.go
@@ -152,6 +152,62 @@ func (PlanDiagnosticSeverity) EnumDescriptor() ([]byte, []int) {
 	return file_iac_proto_rawDescGZIP(), []int{1}
 }
 
+// ActionStatus categorizes per-action outcomes for wfctl-side hook dispatch.
+// Per workflow#640 Phase 2 + ADR 0040 invariants 1-2. Tags 4+5 reserved
+// for Phase 2.3 ACTION_STATUS_COMPENSATED + ACTION_STATUS_COMPENSATION_FAILED
+// when engine-side compensation lands.
+type ActionStatus int32
+
+const (
+	ActionStatus_ACTION_STATUS_UNSPECIFIED   ActionStatus = 0 // wfctl REJECTS this on receipt
+	ActionStatus_ACTION_STATUS_SUCCESS       ActionStatus = 1
+	ActionStatus_ACTION_STATUS_ERROR         ActionStatus = 2
+	ActionStatus_ACTION_STATUS_DELETE_FAILED ActionStatus = 3 // 4 + 5 reserved (Phase 2.3 compensation)
+)
+
+// Enum value maps for ActionStatus.
+var (
+	ActionStatus_name = map[int32]string{
+		0: "ACTION_STATUS_UNSPECIFIED",
+		1: "ACTION_STATUS_SUCCESS",
+		2: "ACTION_STATUS_ERROR",
+		3: "ACTION_STATUS_DELETE_FAILED",
+	}
+	ActionStatus_value = map[string]int32{
+		"ACTION_STATUS_UNSPECIFIED":   0,
+		"ACTION_STATUS_SUCCESS":       1,
+		"ACTION_STATUS_ERROR":         2,
+		"ACTION_STATUS_DELETE_FAILED": 3,
+	}
+)
+
+func (x ActionStatus) Enum() *ActionStatus {
+	p := new(ActionStatus)
+	*p = x
+	return p
+}
+
+func (x ActionStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ActionStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_iac_proto_enumTypes[2].Descriptor()
+}
+
+func (ActionStatus) Type() protoreflect.EnumType {
+	return &file_iac_proto_enumTypes[2]
+}
+
+func (x ActionStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ActionStatus.Descriptor instead.
+func (ActionStatus) EnumDescriptor() ([]byte, []int) {
+	return file_iac_proto_rawDescGZIP(), []int{2}
+}
+
 // ResourceSpec mirrors interfaces.ResourceSpec.
 type ResourceSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1502,6 +1558,70 @@ func (x *ActionError) GetError() string {
 	return ""
 }
 
+// ActionResult is the per-action outcome surfacing for Phase 2 v2 hooks.
+// Per ADR 0040 invariant 1. output_keys field DROPPED per cycle-2 review
+// (hook firing only needs action_index + status; per-resource outputs
+// already in ApplyResult.resources).
+type ActionResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActionIndex   uint32                 `protobuf:"varint,1,opt,name=action_index,json=actionIndex,proto3" json:"action_index,omitempty"`
+	Status        ActionStatus           `protobuf:"varint,2,opt,name=status,proto3,enum=workflow.plugin.external.iac.ActionStatus" json:"status,omitempty"`
+	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActionResult) Reset() {
+	*x = ActionResult{}
+	mi := &file_iac_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActionResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActionResult) ProtoMessage() {}
+
+func (x *ActionResult) ProtoReflect() protoreflect.Message {
+	mi := &file_iac_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActionResult.ProtoReflect.Descriptor instead.
+func (*ActionResult) Descriptor() ([]byte, []int) {
+	return file_iac_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ActionResult) GetActionIndex() uint32 {
+	if x != nil {
+		return x.ActionIndex
+	}
+	return 0
+}
+
+func (x *ActionResult) GetStatus() ActionStatus {
+	if x != nil {
+		return x.Status
+	}
+	return ActionStatus_ACTION_STATUS_UNSPECIFIED
+}
+
+func (x *ActionResult) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 // ApplyResult mirrors interfaces.ApplyResult.
 type ApplyResult struct {
 	state                protoimpl.MessageState `protogen:"open.v1"`
@@ -1511,13 +1631,14 @@ type ApplyResult struct {
 	InitialInputSnapshot map[string]string      `protobuf:"bytes,4,rep,name=initial_input_snapshot,json=initialInputSnapshot,proto3" json:"initial_input_snapshot,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	InputDriftReport     []*DriftEntry          `protobuf:"bytes,5,rep,name=input_drift_report,json=inputDriftReport,proto3" json:"input_drift_report,omitempty"`
 	ReplaceIdMap         map[string]string      `protobuf:"bytes,6,rep,name=replace_id_map,json=replaceIdMap,proto3" json:"replace_id_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Actions              []*ActionResult        `protobuf:"bytes,7,rep,name=actions,proto3" json:"actions,omitempty"` // NEW Phase 2 (workflow#640)
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ApplyResult) Reset() {
 	*x = ApplyResult{}
-	mi := &file_iac_proto_msgTypes[18]
+	mi := &file_iac_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1529,7 +1650,7 @@ func (x *ApplyResult) String() string {
 func (*ApplyResult) ProtoMessage() {}
 
 func (x *ApplyResult) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[18]
+	mi := &file_iac_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1542,7 +1663,7 @@ func (x *ApplyResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResult.ProtoReflect.Descriptor instead.
 func (*ApplyResult) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{18}
+	return file_iac_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ApplyResult) GetPlanId() string {
@@ -1587,6 +1708,13 @@ func (x *ApplyResult) GetReplaceIdMap() map[string]string {
 	return nil
 }
 
+func (x *ApplyResult) GetActions() []*ActionResult {
+	if x != nil {
+		return x.Actions
+	}
+	return nil
+}
+
 // DestroyResult mirrors interfaces.DestroyResult.
 type DestroyResult struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1598,7 +1726,7 @@ type DestroyResult struct {
 
 func (x *DestroyResult) Reset() {
 	*x = DestroyResult{}
-	mi := &file_iac_proto_msgTypes[19]
+	mi := &file_iac_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1610,7 +1738,7 @@ func (x *DestroyResult) String() string {
 func (*DestroyResult) ProtoMessage() {}
 
 func (x *DestroyResult) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[19]
+	mi := &file_iac_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1623,7 +1751,7 @@ func (x *DestroyResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyResult.ProtoReflect.Descriptor instead.
 func (*DestroyResult) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{19}
+	return file_iac_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DestroyResult) GetDestroyed() []string {
@@ -1653,7 +1781,7 @@ type BootstrapResult struct {
 
 func (x *BootstrapResult) Reset() {
 	*x = BootstrapResult{}
-	mi := &file_iac_proto_msgTypes[20]
+	mi := &file_iac_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1665,7 +1793,7 @@ func (x *BootstrapResult) String() string {
 func (*BootstrapResult) ProtoMessage() {}
 
 func (x *BootstrapResult) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[20]
+	mi := &file_iac_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1678,7 +1806,7 @@ func (x *BootstrapResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootstrapResult.ProtoReflect.Descriptor instead.
 func (*BootstrapResult) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{20}
+	return file_iac_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *BootstrapResult) GetBucket() string {
@@ -1731,7 +1859,7 @@ type MigrationRepairRequest struct {
 
 func (x *MigrationRepairRequest) Reset() {
 	*x = MigrationRepairRequest{}
-	mi := &file_iac_proto_msgTypes[21]
+	mi := &file_iac_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1743,7 +1871,7 @@ func (x *MigrationRepairRequest) String() string {
 func (*MigrationRepairRequest) ProtoMessage() {}
 
 func (x *MigrationRepairRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[21]
+	mi := &file_iac_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1756,7 +1884,7 @@ func (x *MigrationRepairRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MigrationRepairRequest.ProtoReflect.Descriptor instead.
 func (*MigrationRepairRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{21}
+	return file_iac_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *MigrationRepairRequest) GetAppResourceName() string {
@@ -1852,7 +1980,7 @@ type MigrationRepairResult struct {
 
 func (x *MigrationRepairResult) Reset() {
 	*x = MigrationRepairResult{}
-	mi := &file_iac_proto_msgTypes[22]
+	mi := &file_iac_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1864,7 +1992,7 @@ func (x *MigrationRepairResult) String() string {
 func (*MigrationRepairResult) ProtoMessage() {}
 
 func (x *MigrationRepairResult) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[22]
+	mi := &file_iac_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1877,7 +2005,7 @@ func (x *MigrationRepairResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MigrationRepairResult.ProtoReflect.Descriptor instead.
 func (*MigrationRepairResult) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{22}
+	return file_iac_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *MigrationRepairResult) GetProviderJobId() string {
@@ -1925,7 +2053,7 @@ type InitializeRequest struct {
 
 func (x *InitializeRequest) Reset() {
 	*x = InitializeRequest{}
-	mi := &file_iac_proto_msgTypes[23]
+	mi := &file_iac_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1937,7 +2065,7 @@ func (x *InitializeRequest) String() string {
 func (*InitializeRequest) ProtoMessage() {}
 
 func (x *InitializeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[23]
+	mi := &file_iac_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1950,7 +2078,7 @@ func (x *InitializeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InitializeRequest.ProtoReflect.Descriptor instead.
 func (*InitializeRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{23}
+	return file_iac_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *InitializeRequest) GetConfigJson() []byte {
@@ -1968,7 +2096,7 @@ type InitializeResponse struct {
 
 func (x *InitializeResponse) Reset() {
 	*x = InitializeResponse{}
-	mi := &file_iac_proto_msgTypes[24]
+	mi := &file_iac_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1980,7 +2108,7 @@ func (x *InitializeResponse) String() string {
 func (*InitializeResponse) ProtoMessage() {}
 
 func (x *InitializeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[24]
+	mi := &file_iac_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1993,7 +2121,7 @@ func (x *InitializeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InitializeResponse.ProtoReflect.Descriptor instead.
 func (*InitializeResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{24}
+	return file_iac_proto_rawDescGZIP(), []int{25}
 }
 
 type NameRequest struct {
@@ -2004,7 +2132,7 @@ type NameRequest struct {
 
 func (x *NameRequest) Reset() {
 	*x = NameRequest{}
-	mi := &file_iac_proto_msgTypes[25]
+	mi := &file_iac_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2016,7 +2144,7 @@ func (x *NameRequest) String() string {
 func (*NameRequest) ProtoMessage() {}
 
 func (x *NameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[25]
+	mi := &file_iac_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2029,7 +2157,7 @@ func (x *NameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NameRequest.ProtoReflect.Descriptor instead.
 func (*NameRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{25}
+	return file_iac_proto_rawDescGZIP(), []int{26}
 }
 
 type NameResponse struct {
@@ -2041,7 +2169,7 @@ type NameResponse struct {
 
 func (x *NameResponse) Reset() {
 	*x = NameResponse{}
-	mi := &file_iac_proto_msgTypes[26]
+	mi := &file_iac_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2053,7 +2181,7 @@ func (x *NameResponse) String() string {
 func (*NameResponse) ProtoMessage() {}
 
 func (x *NameResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[26]
+	mi := &file_iac_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2066,7 +2194,7 @@ func (x *NameResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NameResponse.ProtoReflect.Descriptor instead.
 func (*NameResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{26}
+	return file_iac_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *NameResponse) GetName() string {
@@ -2084,7 +2212,7 @@ type VersionRequest struct {
 
 func (x *VersionRequest) Reset() {
 	*x = VersionRequest{}
-	mi := &file_iac_proto_msgTypes[27]
+	mi := &file_iac_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2096,7 +2224,7 @@ func (x *VersionRequest) String() string {
 func (*VersionRequest) ProtoMessage() {}
 
 func (x *VersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[27]
+	mi := &file_iac_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2109,7 +2237,7 @@ func (x *VersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionRequest.ProtoReflect.Descriptor instead.
 func (*VersionRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{27}
+	return file_iac_proto_rawDescGZIP(), []int{28}
 }
 
 type VersionResponse struct {
@@ -2121,7 +2249,7 @@ type VersionResponse struct {
 
 func (x *VersionResponse) Reset() {
 	*x = VersionResponse{}
-	mi := &file_iac_proto_msgTypes[28]
+	mi := &file_iac_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2133,7 +2261,7 @@ func (x *VersionResponse) String() string {
 func (*VersionResponse) ProtoMessage() {}
 
 func (x *VersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[28]
+	mi := &file_iac_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2146,7 +2274,7 @@ func (x *VersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionResponse.ProtoReflect.Descriptor instead.
 func (*VersionResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{28}
+	return file_iac_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *VersionResponse) GetVersion() string {
@@ -2164,7 +2292,7 @@ type CapabilitiesRequest struct {
 
 func (x *CapabilitiesRequest) Reset() {
 	*x = CapabilitiesRequest{}
-	mi := &file_iac_proto_msgTypes[29]
+	mi := &file_iac_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2176,7 +2304,7 @@ func (x *CapabilitiesRequest) String() string {
 func (*CapabilitiesRequest) ProtoMessage() {}
 
 func (x *CapabilitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[29]
+	mi := &file_iac_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2189,7 +2317,7 @@ func (x *CapabilitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilitiesRequest.ProtoReflect.Descriptor instead.
 func (*CapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{29}
+	return file_iac_proto_rawDescGZIP(), []int{30}
 }
 
 type CapabilitiesResponse struct {
@@ -2215,7 +2343,7 @@ type CapabilitiesResponse struct {
 
 func (x *CapabilitiesResponse) Reset() {
 	*x = CapabilitiesResponse{}
-	mi := &file_iac_proto_msgTypes[30]
+	mi := &file_iac_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2227,7 +2355,7 @@ func (x *CapabilitiesResponse) String() string {
 func (*CapabilitiesResponse) ProtoMessage() {}
 
 func (x *CapabilitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[30]
+	mi := &file_iac_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2240,7 +2368,7 @@ func (x *CapabilitiesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilitiesResponse.ProtoReflect.Descriptor instead.
 func (*CapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{30}
+	return file_iac_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *CapabilitiesResponse) GetCapabilities() []*IaCCapabilityDeclaration {
@@ -2274,7 +2402,7 @@ type PlanRequest struct {
 
 func (x *PlanRequest) Reset() {
 	*x = PlanRequest{}
-	mi := &file_iac_proto_msgTypes[31]
+	mi := &file_iac_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2286,7 +2414,7 @@ func (x *PlanRequest) String() string {
 func (*PlanRequest) ProtoMessage() {}
 
 func (x *PlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[31]
+	mi := &file_iac_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2299,7 +2427,7 @@ func (x *PlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanRequest.ProtoReflect.Descriptor instead.
 func (*PlanRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{31}
+	return file_iac_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *PlanRequest) GetDesired() []*ResourceSpec {
@@ -2325,7 +2453,7 @@ type PlanResponse struct {
 
 func (x *PlanResponse) Reset() {
 	*x = PlanResponse{}
-	mi := &file_iac_proto_msgTypes[32]
+	mi := &file_iac_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2337,7 +2465,7 @@ func (x *PlanResponse) String() string {
 func (*PlanResponse) ProtoMessage() {}
 
 func (x *PlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[32]
+	mi := &file_iac_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2350,7 +2478,7 @@ func (x *PlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanResponse.ProtoReflect.Descriptor instead.
 func (*PlanResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{32}
+	return file_iac_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *PlanResponse) GetPlan() *IaCPlan {
@@ -2369,7 +2497,7 @@ type ApplyRequest struct {
 
 func (x *ApplyRequest) Reset() {
 	*x = ApplyRequest{}
-	mi := &file_iac_proto_msgTypes[33]
+	mi := &file_iac_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2381,7 +2509,7 @@ func (x *ApplyRequest) String() string {
 func (*ApplyRequest) ProtoMessage() {}
 
 func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[33]
+	mi := &file_iac_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2394,7 +2522,7 @@ func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyRequest.ProtoReflect.Descriptor instead.
 func (*ApplyRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{33}
+	return file_iac_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ApplyRequest) GetPlan() *IaCPlan {
@@ -2413,7 +2541,7 @@ type ApplyResponse struct {
 
 func (x *ApplyResponse) Reset() {
 	*x = ApplyResponse{}
-	mi := &file_iac_proto_msgTypes[34]
+	mi := &file_iac_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2425,7 +2553,7 @@ func (x *ApplyResponse) String() string {
 func (*ApplyResponse) ProtoMessage() {}
 
 func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[34]
+	mi := &file_iac_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2438,7 +2566,7 @@ func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResponse.ProtoReflect.Descriptor instead.
 func (*ApplyResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{34}
+	return file_iac_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ApplyResponse) GetResult() *ApplyResult {
@@ -2457,7 +2585,7 @@ type DestroyRequest struct {
 
 func (x *DestroyRequest) Reset() {
 	*x = DestroyRequest{}
-	mi := &file_iac_proto_msgTypes[35]
+	mi := &file_iac_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2469,7 +2597,7 @@ func (x *DestroyRequest) String() string {
 func (*DestroyRequest) ProtoMessage() {}
 
 func (x *DestroyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[35]
+	mi := &file_iac_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2482,7 +2610,7 @@ func (x *DestroyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyRequest.ProtoReflect.Descriptor instead.
 func (*DestroyRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{35}
+	return file_iac_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DestroyRequest) GetRefs() []*ResourceRef {
@@ -2501,7 +2629,7 @@ type DestroyResponse struct {
 
 func (x *DestroyResponse) Reset() {
 	*x = DestroyResponse{}
-	mi := &file_iac_proto_msgTypes[36]
+	mi := &file_iac_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2513,7 +2641,7 @@ func (x *DestroyResponse) String() string {
 func (*DestroyResponse) ProtoMessage() {}
 
 func (x *DestroyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[36]
+	mi := &file_iac_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2526,7 +2654,7 @@ func (x *DestroyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyResponse.ProtoReflect.Descriptor instead.
 func (*DestroyResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{36}
+	return file_iac_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DestroyResponse) GetResult() *DestroyResult {
@@ -2545,7 +2673,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_iac_proto_msgTypes[37]
+	mi := &file_iac_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2557,7 +2685,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[37]
+	mi := &file_iac_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2570,7 +2698,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{37}
+	return file_iac_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StatusRequest) GetRefs() []*ResourceRef {
@@ -2589,7 +2717,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_iac_proto_msgTypes[38]
+	mi := &file_iac_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2601,7 +2729,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[38]
+	mi := &file_iac_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2614,7 +2742,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{38}
+	return file_iac_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StatusResponse) GetStatuses() []*ResourceStatus {
@@ -2634,7 +2762,7 @@ type ImportRequest struct {
 
 func (x *ImportRequest) Reset() {
 	*x = ImportRequest{}
-	mi := &file_iac_proto_msgTypes[39]
+	mi := &file_iac_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2646,7 +2774,7 @@ func (x *ImportRequest) String() string {
 func (*ImportRequest) ProtoMessage() {}
 
 func (x *ImportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[39]
+	mi := &file_iac_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2659,7 +2787,7 @@ func (x *ImportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportRequest.ProtoReflect.Descriptor instead.
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{39}
+	return file_iac_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ImportRequest) GetProviderId() string {
@@ -2685,7 +2813,7 @@ type ImportResponse struct {
 
 func (x *ImportResponse) Reset() {
 	*x = ImportResponse{}
-	mi := &file_iac_proto_msgTypes[40]
+	mi := &file_iac_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2697,7 +2825,7 @@ func (x *ImportResponse) String() string {
 func (*ImportResponse) ProtoMessage() {}
 
 func (x *ImportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[40]
+	mi := &file_iac_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2710,7 +2838,7 @@ func (x *ImportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportResponse.ProtoReflect.Descriptor instead.
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{40}
+	return file_iac_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ImportResponse) GetState() *ResourceState {
@@ -2731,7 +2859,7 @@ type ResolveSizingRequest struct {
 
 func (x *ResolveSizingRequest) Reset() {
 	*x = ResolveSizingRequest{}
-	mi := &file_iac_proto_msgTypes[41]
+	mi := &file_iac_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2743,7 +2871,7 @@ func (x *ResolveSizingRequest) String() string {
 func (*ResolveSizingRequest) ProtoMessage() {}
 
 func (x *ResolveSizingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[41]
+	mi := &file_iac_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2756,7 +2884,7 @@ func (x *ResolveSizingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveSizingRequest.ProtoReflect.Descriptor instead.
 func (*ResolveSizingRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{41}
+	return file_iac_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ResolveSizingRequest) GetResourceType() string {
@@ -2789,7 +2917,7 @@ type ResolveSizingResponse struct {
 
 func (x *ResolveSizingResponse) Reset() {
 	*x = ResolveSizingResponse{}
-	mi := &file_iac_proto_msgTypes[42]
+	mi := &file_iac_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2801,7 +2929,7 @@ func (x *ResolveSizingResponse) String() string {
 func (*ResolveSizingResponse) ProtoMessage() {}
 
 func (x *ResolveSizingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[42]
+	mi := &file_iac_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2814,7 +2942,7 @@ func (x *ResolveSizingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveSizingResponse.ProtoReflect.Descriptor instead.
 func (*ResolveSizingResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{42}
+	return file_iac_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ResolveSizingResponse) GetSizing() *ProviderSizing {
@@ -2834,7 +2962,7 @@ type BootstrapStateBackendRequest struct {
 
 func (x *BootstrapStateBackendRequest) Reset() {
 	*x = BootstrapStateBackendRequest{}
-	mi := &file_iac_proto_msgTypes[43]
+	mi := &file_iac_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +2974,7 @@ func (x *BootstrapStateBackendRequest) String() string {
 func (*BootstrapStateBackendRequest) ProtoMessage() {}
 
 func (x *BootstrapStateBackendRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[43]
+	mi := &file_iac_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2859,7 +2987,7 @@ func (x *BootstrapStateBackendRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootstrapStateBackendRequest.ProtoReflect.Descriptor instead.
 func (*BootstrapStateBackendRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{43}
+	return file_iac_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *BootstrapStateBackendRequest) GetConfigJson() []byte {
@@ -2878,7 +3006,7 @@ type BootstrapStateBackendResponse struct {
 
 func (x *BootstrapStateBackendResponse) Reset() {
 	*x = BootstrapStateBackendResponse{}
-	mi := &file_iac_proto_msgTypes[44]
+	mi := &file_iac_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2890,7 +3018,7 @@ func (x *BootstrapStateBackendResponse) String() string {
 func (*BootstrapStateBackendResponse) ProtoMessage() {}
 
 func (x *BootstrapStateBackendResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[44]
+	mi := &file_iac_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2903,7 +3031,7 @@ func (x *BootstrapStateBackendResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootstrapStateBackendResponse.ProtoReflect.Descriptor instead.
 func (*BootstrapStateBackendResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{44}
+	return file_iac_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *BootstrapStateBackendResponse) GetResult() *BootstrapResult {
@@ -2925,7 +3053,7 @@ type EnumerateAllRequest struct {
 
 func (x *EnumerateAllRequest) Reset() {
 	*x = EnumerateAllRequest{}
-	mi := &file_iac_proto_msgTypes[45]
+	mi := &file_iac_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2937,7 +3065,7 @@ func (x *EnumerateAllRequest) String() string {
 func (*EnumerateAllRequest) ProtoMessage() {}
 
 func (x *EnumerateAllRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[45]
+	mi := &file_iac_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2950,7 +3078,7 @@ func (x *EnumerateAllRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnumerateAllRequest.ProtoReflect.Descriptor instead.
 func (*EnumerateAllRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{45}
+	return file_iac_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *EnumerateAllRequest) GetResourceType() string {
@@ -2969,7 +3097,7 @@ type EnumerateAllResponse struct {
 
 func (x *EnumerateAllResponse) Reset() {
 	*x = EnumerateAllResponse{}
-	mi := &file_iac_proto_msgTypes[46]
+	mi := &file_iac_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2981,7 +3109,7 @@ func (x *EnumerateAllResponse) String() string {
 func (*EnumerateAllResponse) ProtoMessage() {}
 
 func (x *EnumerateAllResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[46]
+	mi := &file_iac_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2994,7 +3122,7 @@ func (x *EnumerateAllResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnumerateAllResponse.ProtoReflect.Descriptor instead.
 func (*EnumerateAllResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{46}
+	return file_iac_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *EnumerateAllResponse) GetOutputs() []*ResourceOutput {
@@ -3013,7 +3141,7 @@ type EnumerateByTagRequest struct {
 
 func (x *EnumerateByTagRequest) Reset() {
 	*x = EnumerateByTagRequest{}
-	mi := &file_iac_proto_msgTypes[47]
+	mi := &file_iac_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3025,7 +3153,7 @@ func (x *EnumerateByTagRequest) String() string {
 func (*EnumerateByTagRequest) ProtoMessage() {}
 
 func (x *EnumerateByTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[47]
+	mi := &file_iac_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3038,7 +3166,7 @@ func (x *EnumerateByTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnumerateByTagRequest.ProtoReflect.Descriptor instead.
 func (*EnumerateByTagRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{47}
+	return file_iac_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *EnumerateByTagRequest) GetTag() string {
@@ -3057,7 +3185,7 @@ type EnumerateByTagResponse struct {
 
 func (x *EnumerateByTagResponse) Reset() {
 	*x = EnumerateByTagResponse{}
-	mi := &file_iac_proto_msgTypes[48]
+	mi := &file_iac_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3069,7 +3197,7 @@ func (x *EnumerateByTagResponse) String() string {
 func (*EnumerateByTagResponse) ProtoMessage() {}
 
 func (x *EnumerateByTagResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[48]
+	mi := &file_iac_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3082,7 +3210,7 @@ func (x *EnumerateByTagResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnumerateByTagResponse.ProtoReflect.Descriptor instead.
 func (*EnumerateByTagResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{48}
+	return file_iac_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *EnumerateByTagResponse) GetRefs() []*ResourceRef {
@@ -3104,7 +3232,7 @@ type DetectDriftRequest struct {
 
 func (x *DetectDriftRequest) Reset() {
 	*x = DetectDriftRequest{}
-	mi := &file_iac_proto_msgTypes[49]
+	mi := &file_iac_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3116,7 +3244,7 @@ func (x *DetectDriftRequest) String() string {
 func (*DetectDriftRequest) ProtoMessage() {}
 
 func (x *DetectDriftRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[49]
+	mi := &file_iac_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3129,7 +3257,7 @@ func (x *DetectDriftRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftRequest.ProtoReflect.Descriptor instead.
 func (*DetectDriftRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{49}
+	return file_iac_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *DetectDriftRequest) GetRefs() []*ResourceRef {
@@ -3148,7 +3276,7 @@ type DetectDriftResponse struct {
 
 func (x *DetectDriftResponse) Reset() {
 	*x = DetectDriftResponse{}
-	mi := &file_iac_proto_msgTypes[50]
+	mi := &file_iac_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3160,7 +3288,7 @@ func (x *DetectDriftResponse) String() string {
 func (*DetectDriftResponse) ProtoMessage() {}
 
 func (x *DetectDriftResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[50]
+	mi := &file_iac_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3173,7 +3301,7 @@ func (x *DetectDriftResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftResponse.ProtoReflect.Descriptor instead.
 func (*DetectDriftResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{50}
+	return file_iac_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *DetectDriftResponse) GetDrifts() []*DriftResult {
@@ -3195,7 +3323,7 @@ type DetectDriftWithSpecsRequest struct {
 
 func (x *DetectDriftWithSpecsRequest) Reset() {
 	*x = DetectDriftWithSpecsRequest{}
-	mi := &file_iac_proto_msgTypes[51]
+	mi := &file_iac_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3207,7 +3335,7 @@ func (x *DetectDriftWithSpecsRequest) String() string {
 func (*DetectDriftWithSpecsRequest) ProtoMessage() {}
 
 func (x *DetectDriftWithSpecsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[51]
+	mi := &file_iac_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3220,7 +3348,7 @@ func (x *DetectDriftWithSpecsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftWithSpecsRequest.ProtoReflect.Descriptor instead.
 func (*DetectDriftWithSpecsRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{51}
+	return file_iac_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DetectDriftWithSpecsRequest) GetRefs() []*ResourceRef {
@@ -3246,7 +3374,7 @@ type DetectDriftWithSpecsResponse struct {
 
 func (x *DetectDriftWithSpecsResponse) Reset() {
 	*x = DetectDriftWithSpecsResponse{}
-	mi := &file_iac_proto_msgTypes[52]
+	mi := &file_iac_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3258,7 +3386,7 @@ func (x *DetectDriftWithSpecsResponse) String() string {
 func (*DetectDriftWithSpecsResponse) ProtoMessage() {}
 
 func (x *DetectDriftWithSpecsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[52]
+	mi := &file_iac_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3271,7 +3399,7 @@ func (x *DetectDriftWithSpecsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftWithSpecsResponse.ProtoReflect.Descriptor instead.
 func (*DetectDriftWithSpecsResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{52}
+	return file_iac_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *DetectDriftWithSpecsResponse) GetDrifts() []*DriftResult {
@@ -3296,7 +3424,7 @@ type RevokeProviderCredentialRequest struct {
 
 func (x *RevokeProviderCredentialRequest) Reset() {
 	*x = RevokeProviderCredentialRequest{}
-	mi := &file_iac_proto_msgTypes[53]
+	mi := &file_iac_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3308,7 +3436,7 @@ func (x *RevokeProviderCredentialRequest) String() string {
 func (*RevokeProviderCredentialRequest) ProtoMessage() {}
 
 func (x *RevokeProviderCredentialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[53]
+	mi := &file_iac_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3321,7 +3449,7 @@ func (x *RevokeProviderCredentialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeProviderCredentialRequest.ProtoReflect.Descriptor instead.
 func (*RevokeProviderCredentialRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{53}
+	return file_iac_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *RevokeProviderCredentialRequest) GetSource() string {
@@ -3346,7 +3474,7 @@ type RevokeProviderCredentialResponse struct {
 
 func (x *RevokeProviderCredentialResponse) Reset() {
 	*x = RevokeProviderCredentialResponse{}
-	mi := &file_iac_proto_msgTypes[54]
+	mi := &file_iac_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3358,7 +3486,7 @@ func (x *RevokeProviderCredentialResponse) String() string {
 func (*RevokeProviderCredentialResponse) ProtoMessage() {}
 
 func (x *RevokeProviderCredentialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[54]
+	mi := &file_iac_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3371,7 +3499,7 @@ func (x *RevokeProviderCredentialResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeProviderCredentialResponse.ProtoReflect.Descriptor instead.
 func (*RevokeProviderCredentialResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{54}
+	return file_iac_proto_rawDescGZIP(), []int{55}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3386,7 +3514,7 @@ type RepairDirtyMigrationRequest struct {
 
 func (x *RepairDirtyMigrationRequest) Reset() {
 	*x = RepairDirtyMigrationRequest{}
-	mi := &file_iac_proto_msgTypes[55]
+	mi := &file_iac_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3398,7 +3526,7 @@ func (x *RepairDirtyMigrationRequest) String() string {
 func (*RepairDirtyMigrationRequest) ProtoMessage() {}
 
 func (x *RepairDirtyMigrationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[55]
+	mi := &file_iac_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3411,7 +3539,7 @@ func (x *RepairDirtyMigrationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepairDirtyMigrationRequest.ProtoReflect.Descriptor instead.
 func (*RepairDirtyMigrationRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{55}
+	return file_iac_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *RepairDirtyMigrationRequest) GetRequest() *MigrationRepairRequest {
@@ -3430,7 +3558,7 @@ type RepairDirtyMigrationResponse struct {
 
 func (x *RepairDirtyMigrationResponse) Reset() {
 	*x = RepairDirtyMigrationResponse{}
-	mi := &file_iac_proto_msgTypes[56]
+	mi := &file_iac_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3442,7 +3570,7 @@ func (x *RepairDirtyMigrationResponse) String() string {
 func (*RepairDirtyMigrationResponse) ProtoMessage() {}
 
 func (x *RepairDirtyMigrationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[56]
+	mi := &file_iac_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3455,7 +3583,7 @@ func (x *RepairDirtyMigrationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepairDirtyMigrationResponse.ProtoReflect.Descriptor instead.
 func (*RepairDirtyMigrationResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{56}
+	return file_iac_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *RepairDirtyMigrationResponse) GetResult() *MigrationRepairResult {
@@ -3477,7 +3605,7 @@ type ValidatePlanRequest struct {
 
 func (x *ValidatePlanRequest) Reset() {
 	*x = ValidatePlanRequest{}
-	mi := &file_iac_proto_msgTypes[57]
+	mi := &file_iac_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3489,7 +3617,7 @@ func (x *ValidatePlanRequest) String() string {
 func (*ValidatePlanRequest) ProtoMessage() {}
 
 func (x *ValidatePlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[57]
+	mi := &file_iac_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3502,7 +3630,7 @@ func (x *ValidatePlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidatePlanRequest.ProtoReflect.Descriptor instead.
 func (*ValidatePlanRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{57}
+	return file_iac_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ValidatePlanRequest) GetPlan() *IaCPlan {
@@ -3521,7 +3649,7 @@ type ValidatePlanResponse struct {
 
 func (x *ValidatePlanResponse) Reset() {
 	*x = ValidatePlanResponse{}
-	mi := &file_iac_proto_msgTypes[58]
+	mi := &file_iac_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3533,7 +3661,7 @@ func (x *ValidatePlanResponse) String() string {
 func (*ValidatePlanResponse) ProtoMessage() {}
 
 func (x *ValidatePlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[58]
+	mi := &file_iac_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3546,7 +3674,7 @@ func (x *ValidatePlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidatePlanResponse.ProtoReflect.Descriptor instead.
 func (*ValidatePlanResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{58}
+	return file_iac_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ValidatePlanResponse) GetDiagnostics() []*PlanDiagnostic {
@@ -3572,7 +3700,7 @@ type DetectDriftConfigRequest struct {
 
 func (x *DetectDriftConfigRequest) Reset() {
 	*x = DetectDriftConfigRequest{}
-	mi := &file_iac_proto_msgTypes[59]
+	mi := &file_iac_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3584,7 +3712,7 @@ func (x *DetectDriftConfigRequest) String() string {
 func (*DetectDriftConfigRequest) ProtoMessage() {}
 
 func (x *DetectDriftConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[59]
+	mi := &file_iac_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3597,7 +3725,7 @@ func (x *DetectDriftConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftConfigRequest.ProtoReflect.Descriptor instead.
 func (*DetectDriftConfigRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{59}
+	return file_iac_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *DetectDriftConfigRequest) GetRefs() []*ResourceRef {
@@ -3623,7 +3751,7 @@ type DetectDriftConfigResponse struct {
 
 func (x *DetectDriftConfigResponse) Reset() {
 	*x = DetectDriftConfigResponse{}
-	mi := &file_iac_proto_msgTypes[60]
+	mi := &file_iac_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3635,7 +3763,7 @@ func (x *DetectDriftConfigResponse) String() string {
 func (*DetectDriftConfigResponse) ProtoMessage() {}
 
 func (x *DetectDriftConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[60]
+	mi := &file_iac_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3648,7 +3776,7 @@ func (x *DetectDriftConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftConfigResponse.ProtoReflect.Descriptor instead.
 func (*DetectDriftConfigResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{60}
+	return file_iac_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *DetectDriftConfigResponse) GetDrifts() []*DriftResult {
@@ -3674,7 +3802,7 @@ type ResourceCreateRequest struct {
 
 func (x *ResourceCreateRequest) Reset() {
 	*x = ResourceCreateRequest{}
-	mi := &file_iac_proto_msgTypes[61]
+	mi := &file_iac_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3686,7 +3814,7 @@ func (x *ResourceCreateRequest) String() string {
 func (*ResourceCreateRequest) ProtoMessage() {}
 
 func (x *ResourceCreateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[61]
+	mi := &file_iac_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3699,7 +3827,7 @@ func (x *ResourceCreateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceCreateRequest.ProtoReflect.Descriptor instead.
 func (*ResourceCreateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{61}
+	return file_iac_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ResourceCreateRequest) GetResourceType() string {
@@ -3725,7 +3853,7 @@ type ResourceCreateResponse struct {
 
 func (x *ResourceCreateResponse) Reset() {
 	*x = ResourceCreateResponse{}
-	mi := &file_iac_proto_msgTypes[62]
+	mi := &file_iac_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3737,7 +3865,7 @@ func (x *ResourceCreateResponse) String() string {
 func (*ResourceCreateResponse) ProtoMessage() {}
 
 func (x *ResourceCreateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[62]
+	mi := &file_iac_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3750,7 +3878,7 @@ func (x *ResourceCreateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceCreateResponse.ProtoReflect.Descriptor instead.
 func (*ResourceCreateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{62}
+	return file_iac_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ResourceCreateResponse) GetOutput() *ResourceOutput {
@@ -3770,7 +3898,7 @@ type ResourceReadRequest struct {
 
 func (x *ResourceReadRequest) Reset() {
 	*x = ResourceReadRequest{}
-	mi := &file_iac_proto_msgTypes[63]
+	mi := &file_iac_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3782,7 +3910,7 @@ func (x *ResourceReadRequest) String() string {
 func (*ResourceReadRequest) ProtoMessage() {}
 
 func (x *ResourceReadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[63]
+	mi := &file_iac_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3795,7 +3923,7 @@ func (x *ResourceReadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceReadRequest.ProtoReflect.Descriptor instead.
 func (*ResourceReadRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{63}
+	return file_iac_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ResourceReadRequest) GetResourceType() string {
@@ -3821,7 +3949,7 @@ type ResourceReadResponse struct {
 
 func (x *ResourceReadResponse) Reset() {
 	*x = ResourceReadResponse{}
-	mi := &file_iac_proto_msgTypes[64]
+	mi := &file_iac_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3833,7 +3961,7 @@ func (x *ResourceReadResponse) String() string {
 func (*ResourceReadResponse) ProtoMessage() {}
 
 func (x *ResourceReadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[64]
+	mi := &file_iac_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3846,7 +3974,7 @@ func (x *ResourceReadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceReadResponse.ProtoReflect.Descriptor instead.
 func (*ResourceReadResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{64}
+	return file_iac_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ResourceReadResponse) GetOutput() *ResourceOutput {
@@ -3867,7 +3995,7 @@ type ResourceUpdateRequest struct {
 
 func (x *ResourceUpdateRequest) Reset() {
 	*x = ResourceUpdateRequest{}
-	mi := &file_iac_proto_msgTypes[65]
+	mi := &file_iac_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3879,7 +4007,7 @@ func (x *ResourceUpdateRequest) String() string {
 func (*ResourceUpdateRequest) ProtoMessage() {}
 
 func (x *ResourceUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[65]
+	mi := &file_iac_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3892,7 +4020,7 @@ func (x *ResourceUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceUpdateRequest.ProtoReflect.Descriptor instead.
 func (*ResourceUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{65}
+	return file_iac_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ResourceUpdateRequest) GetResourceType() string {
@@ -3925,7 +4053,7 @@ type ResourceUpdateResponse struct {
 
 func (x *ResourceUpdateResponse) Reset() {
 	*x = ResourceUpdateResponse{}
-	mi := &file_iac_proto_msgTypes[66]
+	mi := &file_iac_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3937,7 +4065,7 @@ func (x *ResourceUpdateResponse) String() string {
 func (*ResourceUpdateResponse) ProtoMessage() {}
 
 func (x *ResourceUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[66]
+	mi := &file_iac_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3950,7 +4078,7 @@ func (x *ResourceUpdateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceUpdateResponse.ProtoReflect.Descriptor instead.
 func (*ResourceUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{66}
+	return file_iac_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ResourceUpdateResponse) GetOutput() *ResourceOutput {
@@ -3970,7 +4098,7 @@ type ResourceDeleteRequest struct {
 
 func (x *ResourceDeleteRequest) Reset() {
 	*x = ResourceDeleteRequest{}
-	mi := &file_iac_proto_msgTypes[67]
+	mi := &file_iac_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3982,7 +4110,7 @@ func (x *ResourceDeleteRequest) String() string {
 func (*ResourceDeleteRequest) ProtoMessage() {}
 
 func (x *ResourceDeleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[67]
+	mi := &file_iac_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3995,7 +4123,7 @@ func (x *ResourceDeleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDeleteRequest.ProtoReflect.Descriptor instead.
 func (*ResourceDeleteRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{67}
+	return file_iac_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ResourceDeleteRequest) GetResourceType() string {
@@ -4020,7 +4148,7 @@ type ResourceDeleteResponse struct {
 
 func (x *ResourceDeleteResponse) Reset() {
 	*x = ResourceDeleteResponse{}
-	mi := &file_iac_proto_msgTypes[68]
+	mi := &file_iac_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4032,7 +4160,7 @@ func (x *ResourceDeleteResponse) String() string {
 func (*ResourceDeleteResponse) ProtoMessage() {}
 
 func (x *ResourceDeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[68]
+	mi := &file_iac_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4045,7 +4173,7 @@ func (x *ResourceDeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDeleteResponse.ProtoReflect.Descriptor instead.
 func (*ResourceDeleteResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{68}
+	return file_iac_proto_rawDescGZIP(), []int{69}
 }
 
 type ResourceDiffRequest struct {
@@ -4059,7 +4187,7 @@ type ResourceDiffRequest struct {
 
 func (x *ResourceDiffRequest) Reset() {
 	*x = ResourceDiffRequest{}
-	mi := &file_iac_proto_msgTypes[69]
+	mi := &file_iac_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4071,7 +4199,7 @@ func (x *ResourceDiffRequest) String() string {
 func (*ResourceDiffRequest) ProtoMessage() {}
 
 func (x *ResourceDiffRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[69]
+	mi := &file_iac_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4084,7 +4212,7 @@ func (x *ResourceDiffRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDiffRequest.ProtoReflect.Descriptor instead.
 func (*ResourceDiffRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{69}
+	return file_iac_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ResourceDiffRequest) GetResourceType() string {
@@ -4117,7 +4245,7 @@ type ResourceDiffResponse struct {
 
 func (x *ResourceDiffResponse) Reset() {
 	*x = ResourceDiffResponse{}
-	mi := &file_iac_proto_msgTypes[70]
+	mi := &file_iac_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4129,7 +4257,7 @@ func (x *ResourceDiffResponse) String() string {
 func (*ResourceDiffResponse) ProtoMessage() {}
 
 func (x *ResourceDiffResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[70]
+	mi := &file_iac_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4142,7 +4270,7 @@ func (x *ResourceDiffResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDiffResponse.ProtoReflect.Descriptor instead.
 func (*ResourceDiffResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{70}
+	return file_iac_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *ResourceDiffResponse) GetResult() *DiffResult {
@@ -4163,7 +4291,7 @@ type ResourceScaleRequest struct {
 
 func (x *ResourceScaleRequest) Reset() {
 	*x = ResourceScaleRequest{}
-	mi := &file_iac_proto_msgTypes[71]
+	mi := &file_iac_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4175,7 +4303,7 @@ func (x *ResourceScaleRequest) String() string {
 func (*ResourceScaleRequest) ProtoMessage() {}
 
 func (x *ResourceScaleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[71]
+	mi := &file_iac_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4188,7 +4316,7 @@ func (x *ResourceScaleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceScaleRequest.ProtoReflect.Descriptor instead.
 func (*ResourceScaleRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{71}
+	return file_iac_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ResourceScaleRequest) GetResourceType() string {
@@ -4221,7 +4349,7 @@ type ResourceScaleResponse struct {
 
 func (x *ResourceScaleResponse) Reset() {
 	*x = ResourceScaleResponse{}
-	mi := &file_iac_proto_msgTypes[72]
+	mi := &file_iac_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4233,7 +4361,7 @@ func (x *ResourceScaleResponse) String() string {
 func (*ResourceScaleResponse) ProtoMessage() {}
 
 func (x *ResourceScaleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[72]
+	mi := &file_iac_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4246,7 +4374,7 @@ func (x *ResourceScaleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceScaleResponse.ProtoReflect.Descriptor instead.
 func (*ResourceScaleResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{72}
+	return file_iac_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ResourceScaleResponse) GetOutput() *ResourceOutput {
@@ -4266,7 +4394,7 @@ type ResourceHealthCheckRequest struct {
 
 func (x *ResourceHealthCheckRequest) Reset() {
 	*x = ResourceHealthCheckRequest{}
-	mi := &file_iac_proto_msgTypes[73]
+	mi := &file_iac_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4278,7 +4406,7 @@ func (x *ResourceHealthCheckRequest) String() string {
 func (*ResourceHealthCheckRequest) ProtoMessage() {}
 
 func (x *ResourceHealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[73]
+	mi := &file_iac_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4291,7 +4419,7 @@ func (x *ResourceHealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceHealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*ResourceHealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{73}
+	return file_iac_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ResourceHealthCheckRequest) GetResourceType() string {
@@ -4317,7 +4445,7 @@ type ResourceHealthCheckResponse struct {
 
 func (x *ResourceHealthCheckResponse) Reset() {
 	*x = ResourceHealthCheckResponse{}
-	mi := &file_iac_proto_msgTypes[74]
+	mi := &file_iac_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4329,7 +4457,7 @@ func (x *ResourceHealthCheckResponse) String() string {
 func (*ResourceHealthCheckResponse) ProtoMessage() {}
 
 func (x *ResourceHealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[74]
+	mi := &file_iac_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4342,7 +4470,7 @@ func (x *ResourceHealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceHealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*ResourceHealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{74}
+	return file_iac_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ResourceHealthCheckResponse) GetResult() *HealthResult {
@@ -4361,7 +4489,7 @@ type SensitiveKeysRequest struct {
 
 func (x *SensitiveKeysRequest) Reset() {
 	*x = SensitiveKeysRequest{}
-	mi := &file_iac_proto_msgTypes[75]
+	mi := &file_iac_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4373,7 +4501,7 @@ func (x *SensitiveKeysRequest) String() string {
 func (*SensitiveKeysRequest) ProtoMessage() {}
 
 func (x *SensitiveKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[75]
+	mi := &file_iac_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4386,7 +4514,7 @@ func (x *SensitiveKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SensitiveKeysRequest.ProtoReflect.Descriptor instead.
 func (*SensitiveKeysRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{75}
+	return file_iac_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SensitiveKeysRequest) GetResourceType() string {
@@ -4405,7 +4533,7 @@ type SensitiveKeysResponse struct {
 
 func (x *SensitiveKeysResponse) Reset() {
 	*x = SensitiveKeysResponse{}
-	mi := &file_iac_proto_msgTypes[76]
+	mi := &file_iac_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4417,7 +4545,7 @@ func (x *SensitiveKeysResponse) String() string {
 func (*SensitiveKeysResponse) ProtoMessage() {}
 
 func (x *SensitiveKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[76]
+	mi := &file_iac_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4430,7 +4558,7 @@ func (x *SensitiveKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SensitiveKeysResponse.ProtoReflect.Descriptor instead.
 func (*SensitiveKeysResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{76}
+	return file_iac_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *SensitiveKeysResponse) GetKeys() []string {
@@ -4451,7 +4579,7 @@ type TroubleshootRequest struct {
 
 func (x *TroubleshootRequest) Reset() {
 	*x = TroubleshootRequest{}
-	mi := &file_iac_proto_msgTypes[77]
+	mi := &file_iac_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4463,7 +4591,7 @@ func (x *TroubleshootRequest) String() string {
 func (*TroubleshootRequest) ProtoMessage() {}
 
 func (x *TroubleshootRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[77]
+	mi := &file_iac_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4476,7 +4604,7 @@ func (x *TroubleshootRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TroubleshootRequest.ProtoReflect.Descriptor instead.
 func (*TroubleshootRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{77}
+	return file_iac_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *TroubleshootRequest) GetResourceType() string {
@@ -4509,7 +4637,7 @@ type TroubleshootResponse struct {
 
 func (x *TroubleshootResponse) Reset() {
 	*x = TroubleshootResponse{}
-	mi := &file_iac_proto_msgTypes[78]
+	mi := &file_iac_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4521,7 +4649,7 @@ func (x *TroubleshootResponse) String() string {
 func (*TroubleshootResponse) ProtoMessage() {}
 
 func (x *TroubleshootResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[78]
+	mi := &file_iac_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4534,7 +4662,7 @@ func (x *TroubleshootResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TroubleshootResponse.ProtoReflect.Descriptor instead.
 func (*TroubleshootResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{78}
+	return file_iac_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *TroubleshootResponse) GetDiagnostics() []*Diagnostic {
@@ -4568,7 +4696,7 @@ type IaCState struct {
 
 func (x *IaCState) Reset() {
 	*x = IaCState{}
-	mi := &file_iac_proto_msgTypes[79]
+	mi := &file_iac_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4580,7 +4708,7 @@ func (x *IaCState) String() string {
 func (*IaCState) ProtoMessage() {}
 
 func (x *IaCState) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[79]
+	mi := &file_iac_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4593,7 +4721,7 @@ func (x *IaCState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IaCState.ProtoReflect.Descriptor instead.
 func (*IaCState) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{79}
+	return file_iac_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *IaCState) GetResourceId() string {
@@ -4701,7 +4829,7 @@ type ConfigureRequest struct {
 
 func (x *ConfigureRequest) Reset() {
 	*x = ConfigureRequest{}
-	mi := &file_iac_proto_msgTypes[80]
+	mi := &file_iac_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4713,7 +4841,7 @@ func (x *ConfigureRequest) String() string {
 func (*ConfigureRequest) ProtoMessage() {}
 
 func (x *ConfigureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[80]
+	mi := &file_iac_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4726,7 +4854,7 @@ func (x *ConfigureRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{80}
+	return file_iac_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ConfigureRequest) GetBackendName() string {
@@ -4751,7 +4879,7 @@ type ConfigureResponse struct {
 
 func (x *ConfigureResponse) Reset() {
 	*x = ConfigureResponse{}
-	mi := &file_iac_proto_msgTypes[81]
+	mi := &file_iac_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4763,7 +4891,7 @@ func (x *ConfigureResponse) String() string {
 func (*ConfigureResponse) ProtoMessage() {}
 
 func (x *ConfigureResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[81]
+	mi := &file_iac_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4776,7 +4904,7 @@ func (x *ConfigureResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{81}
+	return file_iac_proto_rawDescGZIP(), []int{82}
 }
 
 type GetStateRequest struct {
@@ -4788,7 +4916,7 @@ type GetStateRequest struct {
 
 func (x *GetStateRequest) Reset() {
 	*x = GetStateRequest{}
-	mi := &file_iac_proto_msgTypes[82]
+	mi := &file_iac_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4800,7 +4928,7 @@ func (x *GetStateRequest) String() string {
 func (*GetStateRequest) ProtoMessage() {}
 
 func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[82]
+	mi := &file_iac_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4813,7 +4941,7 @@ func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateRequest.ProtoReflect.Descriptor instead.
 func (*GetStateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{82}
+	return file_iac_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetStateRequest) GetResourceId() string {
@@ -4833,7 +4961,7 @@ type GetStateResponse struct {
 
 func (x *GetStateResponse) Reset() {
 	*x = GetStateResponse{}
-	mi := &file_iac_proto_msgTypes[83]
+	mi := &file_iac_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4845,7 +4973,7 @@ func (x *GetStateResponse) String() string {
 func (*GetStateResponse) ProtoMessage() {}
 
 func (x *GetStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[83]
+	mi := &file_iac_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4858,7 +4986,7 @@ func (x *GetStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateResponse.ProtoReflect.Descriptor instead.
 func (*GetStateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{83}
+	return file_iac_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetStateResponse) GetState() *IaCState {
@@ -4884,7 +5012,7 @@ type SaveStateRequest struct {
 
 func (x *SaveStateRequest) Reset() {
 	*x = SaveStateRequest{}
-	mi := &file_iac_proto_msgTypes[84]
+	mi := &file_iac_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4896,7 +5024,7 @@ func (x *SaveStateRequest) String() string {
 func (*SaveStateRequest) ProtoMessage() {}
 
 func (x *SaveStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[84]
+	mi := &file_iac_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4909,7 +5037,7 @@ func (x *SaveStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveStateRequest.ProtoReflect.Descriptor instead.
 func (*SaveStateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{84}
+	return file_iac_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *SaveStateRequest) GetState() *IaCState {
@@ -4927,7 +5055,7 @@ type SaveStateResponse struct {
 
 func (x *SaveStateResponse) Reset() {
 	*x = SaveStateResponse{}
-	mi := &file_iac_proto_msgTypes[85]
+	mi := &file_iac_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4939,7 +5067,7 @@ func (x *SaveStateResponse) String() string {
 func (*SaveStateResponse) ProtoMessage() {}
 
 func (x *SaveStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[85]
+	mi := &file_iac_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4952,7 +5080,7 @@ func (x *SaveStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveStateResponse.ProtoReflect.Descriptor instead.
 func (*SaveStateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{85}
+	return file_iac_proto_rawDescGZIP(), []int{86}
 }
 
 type ListStatesRequest struct {
@@ -4964,7 +5092,7 @@ type ListStatesRequest struct {
 
 func (x *ListStatesRequest) Reset() {
 	*x = ListStatesRequest{}
-	mi := &file_iac_proto_msgTypes[86]
+	mi := &file_iac_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4976,7 +5104,7 @@ func (x *ListStatesRequest) String() string {
 func (*ListStatesRequest) ProtoMessage() {}
 
 func (x *ListStatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[86]
+	mi := &file_iac_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4989,7 +5117,7 @@ func (x *ListStatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStatesRequest.ProtoReflect.Descriptor instead.
 func (*ListStatesRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{86}
+	return file_iac_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ListStatesRequest) GetFilter() map[string]string {
@@ -5008,7 +5136,7 @@ type ListStatesResponse struct {
 
 func (x *ListStatesResponse) Reset() {
 	*x = ListStatesResponse{}
-	mi := &file_iac_proto_msgTypes[87]
+	mi := &file_iac_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5020,7 +5148,7 @@ func (x *ListStatesResponse) String() string {
 func (*ListStatesResponse) ProtoMessage() {}
 
 func (x *ListStatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[87]
+	mi := &file_iac_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5033,7 +5161,7 @@ func (x *ListStatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStatesResponse.ProtoReflect.Descriptor instead.
 func (*ListStatesResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{87}
+	return file_iac_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ListStatesResponse) GetStates() []*IaCState {
@@ -5052,7 +5180,7 @@ type DeleteStateRequest struct {
 
 func (x *DeleteStateRequest) Reset() {
 	*x = DeleteStateRequest{}
-	mi := &file_iac_proto_msgTypes[88]
+	mi := &file_iac_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5064,7 +5192,7 @@ func (x *DeleteStateRequest) String() string {
 func (*DeleteStateRequest) ProtoMessage() {}
 
 func (x *DeleteStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[88]
+	mi := &file_iac_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5077,7 +5205,7 @@ func (x *DeleteStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteStateRequest.ProtoReflect.Descriptor instead.
 func (*DeleteStateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{88}
+	return file_iac_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *DeleteStateRequest) GetResourceId() string {
@@ -5095,7 +5223,7 @@ type DeleteStateResponse struct {
 
 func (x *DeleteStateResponse) Reset() {
 	*x = DeleteStateResponse{}
-	mi := &file_iac_proto_msgTypes[89]
+	mi := &file_iac_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5107,7 +5235,7 @@ func (x *DeleteStateResponse) String() string {
 func (*DeleteStateResponse) ProtoMessage() {}
 
 func (x *DeleteStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[89]
+	mi := &file_iac_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5120,7 +5248,7 @@ func (x *DeleteStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteStateResponse.ProtoReflect.Descriptor instead.
 func (*DeleteStateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{89}
+	return file_iac_proto_rawDescGZIP(), []int{90}
 }
 
 type LockRequest struct {
@@ -5132,7 +5260,7 @@ type LockRequest struct {
 
 func (x *LockRequest) Reset() {
 	*x = LockRequest{}
-	mi := &file_iac_proto_msgTypes[90]
+	mi := &file_iac_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5144,7 +5272,7 @@ func (x *LockRequest) String() string {
 func (*LockRequest) ProtoMessage() {}
 
 func (x *LockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[90]
+	mi := &file_iac_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5157,7 +5285,7 @@ func (x *LockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockRequest.ProtoReflect.Descriptor instead.
 func (*LockRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{90}
+	return file_iac_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *LockRequest) GetResourceId() string {
@@ -5175,7 +5303,7 @@ type LockResponse struct {
 
 func (x *LockResponse) Reset() {
 	*x = LockResponse{}
-	mi := &file_iac_proto_msgTypes[91]
+	mi := &file_iac_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5187,7 +5315,7 @@ func (x *LockResponse) String() string {
 func (*LockResponse) ProtoMessage() {}
 
 func (x *LockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[91]
+	mi := &file_iac_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5200,7 +5328,7 @@ func (x *LockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockResponse.ProtoReflect.Descriptor instead.
 func (*LockResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{91}
+	return file_iac_proto_rawDescGZIP(), []int{92}
 }
 
 type UnlockRequest struct {
@@ -5212,7 +5340,7 @@ type UnlockRequest struct {
 
 func (x *UnlockRequest) Reset() {
 	*x = UnlockRequest{}
-	mi := &file_iac_proto_msgTypes[92]
+	mi := &file_iac_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5224,7 +5352,7 @@ func (x *UnlockRequest) String() string {
 func (*UnlockRequest) ProtoMessage() {}
 
 func (x *UnlockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[92]
+	mi := &file_iac_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5237,7 +5365,7 @@ func (x *UnlockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockRequest.ProtoReflect.Descriptor instead.
 func (*UnlockRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{92}
+	return file_iac_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *UnlockRequest) GetResourceId() string {
@@ -5255,7 +5383,7 @@ type UnlockResponse struct {
 
 func (x *UnlockResponse) Reset() {
 	*x = UnlockResponse{}
-	mi := &file_iac_proto_msgTypes[93]
+	mi := &file_iac_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5267,7 +5395,7 @@ func (x *UnlockResponse) String() string {
 func (*UnlockResponse) ProtoMessage() {}
 
 func (x *UnlockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[93]
+	mi := &file_iac_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5280,7 +5408,7 @@ func (x *UnlockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockResponse.ProtoReflect.Descriptor instead.
 func (*UnlockResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{93}
+	return file_iac_proto_rawDescGZIP(), []int{94}
 }
 
 // ListBackendNames lets the engine ask a loaded plugin which iac.state backend
@@ -5294,7 +5422,7 @@ type ListBackendNamesRequest struct {
 
 func (x *ListBackendNamesRequest) Reset() {
 	*x = ListBackendNamesRequest{}
-	mi := &file_iac_proto_msgTypes[94]
+	mi := &file_iac_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5306,7 +5434,7 @@ func (x *ListBackendNamesRequest) String() string {
 func (*ListBackendNamesRequest) ProtoMessage() {}
 
 func (x *ListBackendNamesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[94]
+	mi := &file_iac_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5319,7 +5447,7 @@ func (x *ListBackendNamesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendNamesRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendNamesRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{94}
+	return file_iac_proto_rawDescGZIP(), []int{95}
 }
 
 type ListBackendNamesResponse struct {
@@ -5331,7 +5459,7 @@ type ListBackendNamesResponse struct {
 
 func (x *ListBackendNamesResponse) Reset() {
 	*x = ListBackendNamesResponse{}
-	mi := &file_iac_proto_msgTypes[95]
+	mi := &file_iac_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5343,7 +5471,7 @@ func (x *ListBackendNamesResponse) String() string {
 func (*ListBackendNamesResponse) ProtoMessage() {}
 
 func (x *ListBackendNamesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[95]
+	mi := &file_iac_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5356,7 +5484,7 @@ func (x *ListBackendNamesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendNamesResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendNamesResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{95}
+	return file_iac_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListBackendNamesResponse) GetBackendNames() []string {
@@ -5497,14 +5625,19 @@ const file_iac_proto_rawDesc = "" +
 	"\vActionError\x12\x1a\n" +
 	"\bresource\x18\x01 \x01(\tR\bresource\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"\xf5\x04\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\x8b\x01\n" +
+	"\fActionResult\x12!\n" +
+	"\faction_index\x18\x01 \x01(\rR\vactionIndex\x12B\n" +
+	"\x06status\x18\x02 \x01(\x0e2*.workflow.plugin.external.iac.ActionStatusR\x06status\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xbb\x05\n" +
 	"\vApplyResult\x12\x17\n" +
 	"\aplan_id\x18\x01 \x01(\tR\x06planId\x12J\n" +
 	"\tresources\x18\x02 \x03(\v2,.workflow.plugin.external.iac.ResourceOutputR\tresources\x12A\n" +
 	"\x06errors\x18\x03 \x03(\v2).workflow.plugin.external.iac.ActionErrorR\x06errors\x12y\n" +
 	"\x16initial_input_snapshot\x18\x04 \x03(\v2C.workflow.plugin.external.iac.ApplyResult.InitialInputSnapshotEntryR\x14initialInputSnapshot\x12V\n" +
 	"\x12input_drift_report\x18\x05 \x03(\v2(.workflow.plugin.external.iac.DriftEntryR\x10inputDriftReport\x12a\n" +
-	"\x0ereplace_id_map\x18\x06 \x03(\v2;.workflow.plugin.external.iac.ApplyResult.ReplaceIdMapEntryR\freplaceIdMap\x1aG\n" +
+	"\x0ereplace_id_map\x18\x06 \x03(\v2;.workflow.plugin.external.iac.ApplyResult.ReplaceIdMapEntryR\freplaceIdMap\x12D\n" +
+	"\aactions\x18\a \x03(\v2*.workflow.plugin.external.iac.ActionResultR\aactions\x1aG\n" +
 	"\x19InitialInputSnapshotEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a?\n" +
@@ -5750,7 +5883,12 @@ const file_iac_proto_rawDesc = "" +
 	"\x16PlanDiagnosticSeverity\x12\x18\n" +
 	"\x14PLAN_DIAGNOSTIC_INFO\x10\x00\x12\x1b\n" +
 	"\x17PLAN_DIAGNOSTIC_WARNING\x10\x01\x12\x19\n" +
-	"\x15PLAN_DIAGNOSTIC_ERROR\x10\x022\xc4\t\n" +
+	"\x15PLAN_DIAGNOSTIC_ERROR\x10\x02*\x82\x01\n" +
+	"\fActionStatus\x12\x1d\n" +
+	"\x19ACTION_STATUS_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15ACTION_STATUS_SUCCESS\x10\x01\x12\x17\n" +
+	"\x13ACTION_STATUS_ERROR\x10\x02\x12\x1f\n" +
+	"\x1bACTION_STATUS_DELETE_FAILED\x10\x032\xc4\t\n" +
 	"\x13IaCProviderRequired\x12o\n" +
 	"\n" +
 	"Initialize\x12/.workflow.plugin.external.iac.InitializeRequest\x1a0.workflow.plugin.external.iac.InitializeResponse\x12]\n" +
@@ -5811,271 +5949,275 @@ func file_iac_proto_rawDescGZIP() []byte {
 	return file_iac_proto_rawDescData
 }
 
-var file_iac_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_iac_proto_msgTypes = make([]protoimpl.MessageInfo, 105)
+var file_iac_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_iac_proto_msgTypes = make([]protoimpl.MessageInfo, 106)
 var file_iac_proto_goTypes = []any{
 	(DriftClass)(0),                          // 0: workflow.plugin.external.iac.DriftClass
 	(PlanDiagnosticSeverity)(0),              // 1: workflow.plugin.external.iac.PlanDiagnosticSeverity
-	(*ResourceSpec)(nil),                     // 2: workflow.plugin.external.iac.ResourceSpec
-	(*ResourceRef)(nil),                      // 3: workflow.plugin.external.iac.ResourceRef
-	(*ResourceHints)(nil),                    // 4: workflow.plugin.external.iac.ResourceHints
-	(*ProviderSizing)(nil),                   // 5: workflow.plugin.external.iac.ProviderSizing
-	(*IaCCapabilityDeclaration)(nil),         // 6: workflow.plugin.external.iac.IaCCapabilityDeclaration
-	(*ResourceState)(nil),                    // 7: workflow.plugin.external.iac.ResourceState
-	(*ResourceOutput)(nil),                   // 8: workflow.plugin.external.iac.ResourceOutput
-	(*ResourceStatus)(nil),                   // 9: workflow.plugin.external.iac.ResourceStatus
-	(*FieldChange)(nil),                      // 10: workflow.plugin.external.iac.FieldChange
-	(*DiffResult)(nil),                       // 11: workflow.plugin.external.iac.DiffResult
-	(*DriftResult)(nil),                      // 12: workflow.plugin.external.iac.DriftResult
-	(*DriftEntry)(nil),                       // 13: workflow.plugin.external.iac.DriftEntry
-	(*HealthResult)(nil),                     // 14: workflow.plugin.external.iac.HealthResult
-	(*Diagnostic)(nil),                       // 15: workflow.plugin.external.iac.Diagnostic
-	(*PlanDiagnostic)(nil),                   // 16: workflow.plugin.external.iac.PlanDiagnostic
-	(*PlanAction)(nil),                       // 17: workflow.plugin.external.iac.PlanAction
-	(*IaCPlan)(nil),                          // 18: workflow.plugin.external.iac.IaCPlan
-	(*ActionError)(nil),                      // 19: workflow.plugin.external.iac.ActionError
-	(*ApplyResult)(nil),                      // 20: workflow.plugin.external.iac.ApplyResult
-	(*DestroyResult)(nil),                    // 21: workflow.plugin.external.iac.DestroyResult
-	(*BootstrapResult)(nil),                  // 22: workflow.plugin.external.iac.BootstrapResult
-	(*MigrationRepairRequest)(nil),           // 23: workflow.plugin.external.iac.MigrationRepairRequest
-	(*MigrationRepairResult)(nil),            // 24: workflow.plugin.external.iac.MigrationRepairResult
-	(*InitializeRequest)(nil),                // 25: workflow.plugin.external.iac.InitializeRequest
-	(*InitializeResponse)(nil),               // 26: workflow.plugin.external.iac.InitializeResponse
-	(*NameRequest)(nil),                      // 27: workflow.plugin.external.iac.NameRequest
-	(*NameResponse)(nil),                     // 28: workflow.plugin.external.iac.NameResponse
-	(*VersionRequest)(nil),                   // 29: workflow.plugin.external.iac.VersionRequest
-	(*VersionResponse)(nil),                  // 30: workflow.plugin.external.iac.VersionResponse
-	(*CapabilitiesRequest)(nil),              // 31: workflow.plugin.external.iac.CapabilitiesRequest
-	(*CapabilitiesResponse)(nil),             // 32: workflow.plugin.external.iac.CapabilitiesResponse
-	(*PlanRequest)(nil),                      // 33: workflow.plugin.external.iac.PlanRequest
-	(*PlanResponse)(nil),                     // 34: workflow.plugin.external.iac.PlanResponse
-	(*ApplyRequest)(nil),                     // 35: workflow.plugin.external.iac.ApplyRequest
-	(*ApplyResponse)(nil),                    // 36: workflow.plugin.external.iac.ApplyResponse
-	(*DestroyRequest)(nil),                   // 37: workflow.plugin.external.iac.DestroyRequest
-	(*DestroyResponse)(nil),                  // 38: workflow.plugin.external.iac.DestroyResponse
-	(*StatusRequest)(nil),                    // 39: workflow.plugin.external.iac.StatusRequest
-	(*StatusResponse)(nil),                   // 40: workflow.plugin.external.iac.StatusResponse
-	(*ImportRequest)(nil),                    // 41: workflow.plugin.external.iac.ImportRequest
-	(*ImportResponse)(nil),                   // 42: workflow.plugin.external.iac.ImportResponse
-	(*ResolveSizingRequest)(nil),             // 43: workflow.plugin.external.iac.ResolveSizingRequest
-	(*ResolveSizingResponse)(nil),            // 44: workflow.plugin.external.iac.ResolveSizingResponse
-	(*BootstrapStateBackendRequest)(nil),     // 45: workflow.plugin.external.iac.BootstrapStateBackendRequest
-	(*BootstrapStateBackendResponse)(nil),    // 46: workflow.plugin.external.iac.BootstrapStateBackendResponse
-	(*EnumerateAllRequest)(nil),              // 47: workflow.plugin.external.iac.EnumerateAllRequest
-	(*EnumerateAllResponse)(nil),             // 48: workflow.plugin.external.iac.EnumerateAllResponse
-	(*EnumerateByTagRequest)(nil),            // 49: workflow.plugin.external.iac.EnumerateByTagRequest
-	(*EnumerateByTagResponse)(nil),           // 50: workflow.plugin.external.iac.EnumerateByTagResponse
-	(*DetectDriftRequest)(nil),               // 51: workflow.plugin.external.iac.DetectDriftRequest
-	(*DetectDriftResponse)(nil),              // 52: workflow.plugin.external.iac.DetectDriftResponse
-	(*DetectDriftWithSpecsRequest)(nil),      // 53: workflow.plugin.external.iac.DetectDriftWithSpecsRequest
-	(*DetectDriftWithSpecsResponse)(nil),     // 54: workflow.plugin.external.iac.DetectDriftWithSpecsResponse
-	(*RevokeProviderCredentialRequest)(nil),  // 55: workflow.plugin.external.iac.RevokeProviderCredentialRequest
-	(*RevokeProviderCredentialResponse)(nil), // 56: workflow.plugin.external.iac.RevokeProviderCredentialResponse
-	(*RepairDirtyMigrationRequest)(nil),      // 57: workflow.plugin.external.iac.RepairDirtyMigrationRequest
-	(*RepairDirtyMigrationResponse)(nil),     // 58: workflow.plugin.external.iac.RepairDirtyMigrationResponse
-	(*ValidatePlanRequest)(nil),              // 59: workflow.plugin.external.iac.ValidatePlanRequest
-	(*ValidatePlanResponse)(nil),             // 60: workflow.plugin.external.iac.ValidatePlanResponse
-	(*DetectDriftConfigRequest)(nil),         // 61: workflow.plugin.external.iac.DetectDriftConfigRequest
-	(*DetectDriftConfigResponse)(nil),        // 62: workflow.plugin.external.iac.DetectDriftConfigResponse
-	(*ResourceCreateRequest)(nil),            // 63: workflow.plugin.external.iac.ResourceCreateRequest
-	(*ResourceCreateResponse)(nil),           // 64: workflow.plugin.external.iac.ResourceCreateResponse
-	(*ResourceReadRequest)(nil),              // 65: workflow.plugin.external.iac.ResourceReadRequest
-	(*ResourceReadResponse)(nil),             // 66: workflow.plugin.external.iac.ResourceReadResponse
-	(*ResourceUpdateRequest)(nil),            // 67: workflow.plugin.external.iac.ResourceUpdateRequest
-	(*ResourceUpdateResponse)(nil),           // 68: workflow.plugin.external.iac.ResourceUpdateResponse
-	(*ResourceDeleteRequest)(nil),            // 69: workflow.plugin.external.iac.ResourceDeleteRequest
-	(*ResourceDeleteResponse)(nil),           // 70: workflow.plugin.external.iac.ResourceDeleteResponse
-	(*ResourceDiffRequest)(nil),              // 71: workflow.plugin.external.iac.ResourceDiffRequest
-	(*ResourceDiffResponse)(nil),             // 72: workflow.plugin.external.iac.ResourceDiffResponse
-	(*ResourceScaleRequest)(nil),             // 73: workflow.plugin.external.iac.ResourceScaleRequest
-	(*ResourceScaleResponse)(nil),            // 74: workflow.plugin.external.iac.ResourceScaleResponse
-	(*ResourceHealthCheckRequest)(nil),       // 75: workflow.plugin.external.iac.ResourceHealthCheckRequest
-	(*ResourceHealthCheckResponse)(nil),      // 76: workflow.plugin.external.iac.ResourceHealthCheckResponse
-	(*SensitiveKeysRequest)(nil),             // 77: workflow.plugin.external.iac.SensitiveKeysRequest
-	(*SensitiveKeysResponse)(nil),            // 78: workflow.plugin.external.iac.SensitiveKeysResponse
-	(*TroubleshootRequest)(nil),              // 79: workflow.plugin.external.iac.TroubleshootRequest
-	(*TroubleshootResponse)(nil),             // 80: workflow.plugin.external.iac.TroubleshootResponse
-	(*IaCState)(nil),                         // 81: workflow.plugin.external.iac.IaCState
-	(*ConfigureRequest)(nil),                 // 82: workflow.plugin.external.iac.ConfigureRequest
-	(*ConfigureResponse)(nil),                // 83: workflow.plugin.external.iac.ConfigureResponse
-	(*GetStateRequest)(nil),                  // 84: workflow.plugin.external.iac.GetStateRequest
-	(*GetStateResponse)(nil),                 // 85: workflow.plugin.external.iac.GetStateResponse
-	(*SaveStateRequest)(nil),                 // 86: workflow.plugin.external.iac.SaveStateRequest
-	(*SaveStateResponse)(nil),                // 87: workflow.plugin.external.iac.SaveStateResponse
-	(*ListStatesRequest)(nil),                // 88: workflow.plugin.external.iac.ListStatesRequest
-	(*ListStatesResponse)(nil),               // 89: workflow.plugin.external.iac.ListStatesResponse
-	(*DeleteStateRequest)(nil),               // 90: workflow.plugin.external.iac.DeleteStateRequest
-	(*DeleteStateResponse)(nil),              // 91: workflow.plugin.external.iac.DeleteStateResponse
-	(*LockRequest)(nil),                      // 92: workflow.plugin.external.iac.LockRequest
-	(*LockResponse)(nil),                     // 93: workflow.plugin.external.iac.LockResponse
-	(*UnlockRequest)(nil),                    // 94: workflow.plugin.external.iac.UnlockRequest
-	(*UnlockResponse)(nil),                   // 95: workflow.plugin.external.iac.UnlockResponse
-	(*ListBackendNamesRequest)(nil),          // 96: workflow.plugin.external.iac.ListBackendNamesRequest
-	(*ListBackendNamesResponse)(nil),         // 97: workflow.plugin.external.iac.ListBackendNamesResponse
-	nil,                                      // 98: workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
-	nil,                                      // 99: workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
-	nil,                                      // 100: workflow.plugin.external.iac.ApplyResult.InitialInputSnapshotEntry
-	nil,                                      // 101: workflow.plugin.external.iac.ApplyResult.ReplaceIdMapEntry
-	nil,                                      // 102: workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
-	nil,                                      // 103: workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
-	nil,                                      // 104: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
-	nil,                                      // 105: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
-	nil,                                      // 106: workflow.plugin.external.iac.ListStatesRequest.FilterEntry
-	(*timestamppb.Timestamp)(nil),            // 107: google.protobuf.Timestamp
+	(ActionStatus)(0),                        // 2: workflow.plugin.external.iac.ActionStatus
+	(*ResourceSpec)(nil),                     // 3: workflow.plugin.external.iac.ResourceSpec
+	(*ResourceRef)(nil),                      // 4: workflow.plugin.external.iac.ResourceRef
+	(*ResourceHints)(nil),                    // 5: workflow.plugin.external.iac.ResourceHints
+	(*ProviderSizing)(nil),                   // 6: workflow.plugin.external.iac.ProviderSizing
+	(*IaCCapabilityDeclaration)(nil),         // 7: workflow.plugin.external.iac.IaCCapabilityDeclaration
+	(*ResourceState)(nil),                    // 8: workflow.plugin.external.iac.ResourceState
+	(*ResourceOutput)(nil),                   // 9: workflow.plugin.external.iac.ResourceOutput
+	(*ResourceStatus)(nil),                   // 10: workflow.plugin.external.iac.ResourceStatus
+	(*FieldChange)(nil),                      // 11: workflow.plugin.external.iac.FieldChange
+	(*DiffResult)(nil),                       // 12: workflow.plugin.external.iac.DiffResult
+	(*DriftResult)(nil),                      // 13: workflow.plugin.external.iac.DriftResult
+	(*DriftEntry)(nil),                       // 14: workflow.plugin.external.iac.DriftEntry
+	(*HealthResult)(nil),                     // 15: workflow.plugin.external.iac.HealthResult
+	(*Diagnostic)(nil),                       // 16: workflow.plugin.external.iac.Diagnostic
+	(*PlanDiagnostic)(nil),                   // 17: workflow.plugin.external.iac.PlanDiagnostic
+	(*PlanAction)(nil),                       // 18: workflow.plugin.external.iac.PlanAction
+	(*IaCPlan)(nil),                          // 19: workflow.plugin.external.iac.IaCPlan
+	(*ActionError)(nil),                      // 20: workflow.plugin.external.iac.ActionError
+	(*ActionResult)(nil),                     // 21: workflow.plugin.external.iac.ActionResult
+	(*ApplyResult)(nil),                      // 22: workflow.plugin.external.iac.ApplyResult
+	(*DestroyResult)(nil),                    // 23: workflow.plugin.external.iac.DestroyResult
+	(*BootstrapResult)(nil),                  // 24: workflow.plugin.external.iac.BootstrapResult
+	(*MigrationRepairRequest)(nil),           // 25: workflow.plugin.external.iac.MigrationRepairRequest
+	(*MigrationRepairResult)(nil),            // 26: workflow.plugin.external.iac.MigrationRepairResult
+	(*InitializeRequest)(nil),                // 27: workflow.plugin.external.iac.InitializeRequest
+	(*InitializeResponse)(nil),               // 28: workflow.plugin.external.iac.InitializeResponse
+	(*NameRequest)(nil),                      // 29: workflow.plugin.external.iac.NameRequest
+	(*NameResponse)(nil),                     // 30: workflow.plugin.external.iac.NameResponse
+	(*VersionRequest)(nil),                   // 31: workflow.plugin.external.iac.VersionRequest
+	(*VersionResponse)(nil),                  // 32: workflow.plugin.external.iac.VersionResponse
+	(*CapabilitiesRequest)(nil),              // 33: workflow.plugin.external.iac.CapabilitiesRequest
+	(*CapabilitiesResponse)(nil),             // 34: workflow.plugin.external.iac.CapabilitiesResponse
+	(*PlanRequest)(nil),                      // 35: workflow.plugin.external.iac.PlanRequest
+	(*PlanResponse)(nil),                     // 36: workflow.plugin.external.iac.PlanResponse
+	(*ApplyRequest)(nil),                     // 37: workflow.plugin.external.iac.ApplyRequest
+	(*ApplyResponse)(nil),                    // 38: workflow.plugin.external.iac.ApplyResponse
+	(*DestroyRequest)(nil),                   // 39: workflow.plugin.external.iac.DestroyRequest
+	(*DestroyResponse)(nil),                  // 40: workflow.plugin.external.iac.DestroyResponse
+	(*StatusRequest)(nil),                    // 41: workflow.plugin.external.iac.StatusRequest
+	(*StatusResponse)(nil),                   // 42: workflow.plugin.external.iac.StatusResponse
+	(*ImportRequest)(nil),                    // 43: workflow.plugin.external.iac.ImportRequest
+	(*ImportResponse)(nil),                   // 44: workflow.plugin.external.iac.ImportResponse
+	(*ResolveSizingRequest)(nil),             // 45: workflow.plugin.external.iac.ResolveSizingRequest
+	(*ResolveSizingResponse)(nil),            // 46: workflow.plugin.external.iac.ResolveSizingResponse
+	(*BootstrapStateBackendRequest)(nil),     // 47: workflow.plugin.external.iac.BootstrapStateBackendRequest
+	(*BootstrapStateBackendResponse)(nil),    // 48: workflow.plugin.external.iac.BootstrapStateBackendResponse
+	(*EnumerateAllRequest)(nil),              // 49: workflow.plugin.external.iac.EnumerateAllRequest
+	(*EnumerateAllResponse)(nil),             // 50: workflow.plugin.external.iac.EnumerateAllResponse
+	(*EnumerateByTagRequest)(nil),            // 51: workflow.plugin.external.iac.EnumerateByTagRequest
+	(*EnumerateByTagResponse)(nil),           // 52: workflow.plugin.external.iac.EnumerateByTagResponse
+	(*DetectDriftRequest)(nil),               // 53: workflow.plugin.external.iac.DetectDriftRequest
+	(*DetectDriftResponse)(nil),              // 54: workflow.plugin.external.iac.DetectDriftResponse
+	(*DetectDriftWithSpecsRequest)(nil),      // 55: workflow.plugin.external.iac.DetectDriftWithSpecsRequest
+	(*DetectDriftWithSpecsResponse)(nil),     // 56: workflow.plugin.external.iac.DetectDriftWithSpecsResponse
+	(*RevokeProviderCredentialRequest)(nil),  // 57: workflow.plugin.external.iac.RevokeProviderCredentialRequest
+	(*RevokeProviderCredentialResponse)(nil), // 58: workflow.plugin.external.iac.RevokeProviderCredentialResponse
+	(*RepairDirtyMigrationRequest)(nil),      // 59: workflow.plugin.external.iac.RepairDirtyMigrationRequest
+	(*RepairDirtyMigrationResponse)(nil),     // 60: workflow.plugin.external.iac.RepairDirtyMigrationResponse
+	(*ValidatePlanRequest)(nil),              // 61: workflow.plugin.external.iac.ValidatePlanRequest
+	(*ValidatePlanResponse)(nil),             // 62: workflow.plugin.external.iac.ValidatePlanResponse
+	(*DetectDriftConfigRequest)(nil),         // 63: workflow.plugin.external.iac.DetectDriftConfigRequest
+	(*DetectDriftConfigResponse)(nil),        // 64: workflow.plugin.external.iac.DetectDriftConfigResponse
+	(*ResourceCreateRequest)(nil),            // 65: workflow.plugin.external.iac.ResourceCreateRequest
+	(*ResourceCreateResponse)(nil),           // 66: workflow.plugin.external.iac.ResourceCreateResponse
+	(*ResourceReadRequest)(nil),              // 67: workflow.plugin.external.iac.ResourceReadRequest
+	(*ResourceReadResponse)(nil),             // 68: workflow.plugin.external.iac.ResourceReadResponse
+	(*ResourceUpdateRequest)(nil),            // 69: workflow.plugin.external.iac.ResourceUpdateRequest
+	(*ResourceUpdateResponse)(nil),           // 70: workflow.plugin.external.iac.ResourceUpdateResponse
+	(*ResourceDeleteRequest)(nil),            // 71: workflow.plugin.external.iac.ResourceDeleteRequest
+	(*ResourceDeleteResponse)(nil),           // 72: workflow.plugin.external.iac.ResourceDeleteResponse
+	(*ResourceDiffRequest)(nil),              // 73: workflow.plugin.external.iac.ResourceDiffRequest
+	(*ResourceDiffResponse)(nil),             // 74: workflow.plugin.external.iac.ResourceDiffResponse
+	(*ResourceScaleRequest)(nil),             // 75: workflow.plugin.external.iac.ResourceScaleRequest
+	(*ResourceScaleResponse)(nil),            // 76: workflow.plugin.external.iac.ResourceScaleResponse
+	(*ResourceHealthCheckRequest)(nil),       // 77: workflow.plugin.external.iac.ResourceHealthCheckRequest
+	(*ResourceHealthCheckResponse)(nil),      // 78: workflow.plugin.external.iac.ResourceHealthCheckResponse
+	(*SensitiveKeysRequest)(nil),             // 79: workflow.plugin.external.iac.SensitiveKeysRequest
+	(*SensitiveKeysResponse)(nil),            // 80: workflow.plugin.external.iac.SensitiveKeysResponse
+	(*TroubleshootRequest)(nil),              // 81: workflow.plugin.external.iac.TroubleshootRequest
+	(*TroubleshootResponse)(nil),             // 82: workflow.plugin.external.iac.TroubleshootResponse
+	(*IaCState)(nil),                         // 83: workflow.plugin.external.iac.IaCState
+	(*ConfigureRequest)(nil),                 // 84: workflow.plugin.external.iac.ConfigureRequest
+	(*ConfigureResponse)(nil),                // 85: workflow.plugin.external.iac.ConfigureResponse
+	(*GetStateRequest)(nil),                  // 86: workflow.plugin.external.iac.GetStateRequest
+	(*GetStateResponse)(nil),                 // 87: workflow.plugin.external.iac.GetStateResponse
+	(*SaveStateRequest)(nil),                 // 88: workflow.plugin.external.iac.SaveStateRequest
+	(*SaveStateResponse)(nil),                // 89: workflow.plugin.external.iac.SaveStateResponse
+	(*ListStatesRequest)(nil),                // 90: workflow.plugin.external.iac.ListStatesRequest
+	(*ListStatesResponse)(nil),               // 91: workflow.plugin.external.iac.ListStatesResponse
+	(*DeleteStateRequest)(nil),               // 92: workflow.plugin.external.iac.DeleteStateRequest
+	(*DeleteStateResponse)(nil),              // 93: workflow.plugin.external.iac.DeleteStateResponse
+	(*LockRequest)(nil),                      // 94: workflow.plugin.external.iac.LockRequest
+	(*LockResponse)(nil),                     // 95: workflow.plugin.external.iac.LockResponse
+	(*UnlockRequest)(nil),                    // 96: workflow.plugin.external.iac.UnlockRequest
+	(*UnlockResponse)(nil),                   // 97: workflow.plugin.external.iac.UnlockResponse
+	(*ListBackendNamesRequest)(nil),          // 98: workflow.plugin.external.iac.ListBackendNamesRequest
+	(*ListBackendNamesResponse)(nil),         // 99: workflow.plugin.external.iac.ListBackendNamesResponse
+	nil,                                      // 100: workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
+	nil,                                      // 101: workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
+	nil,                                      // 102: workflow.plugin.external.iac.ApplyResult.InitialInputSnapshotEntry
+	nil,                                      // 103: workflow.plugin.external.iac.ApplyResult.ReplaceIdMapEntry
+	nil,                                      // 104: workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
+	nil,                                      // 105: workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
+	nil,                                      // 106: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
+	nil,                                      // 107: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
+	nil,                                      // 108: workflow.plugin.external.iac.ListStatesRequest.FilterEntry
+	(*timestamppb.Timestamp)(nil),            // 109: google.protobuf.Timestamp
 }
 var file_iac_proto_depIdxs = []int32{
-	4,   // 0: workflow.plugin.external.iac.ResourceSpec.hints:type_name -> workflow.plugin.external.iac.ResourceHints
-	107, // 1: workflow.plugin.external.iac.ResourceState.created_at:type_name -> google.protobuf.Timestamp
-	107, // 2: workflow.plugin.external.iac.ResourceState.updated_at:type_name -> google.protobuf.Timestamp
-	107, // 3: workflow.plugin.external.iac.ResourceState.last_drift_check:type_name -> google.protobuf.Timestamp
-	98,  // 4: workflow.plugin.external.iac.ResourceOutput.sensitive:type_name -> workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
-	10,  // 5: workflow.plugin.external.iac.DiffResult.changes:type_name -> workflow.plugin.external.iac.FieldChange
+	5,   // 0: workflow.plugin.external.iac.ResourceSpec.hints:type_name -> workflow.plugin.external.iac.ResourceHints
+	109, // 1: workflow.plugin.external.iac.ResourceState.created_at:type_name -> google.protobuf.Timestamp
+	109, // 2: workflow.plugin.external.iac.ResourceState.updated_at:type_name -> google.protobuf.Timestamp
+	109, // 3: workflow.plugin.external.iac.ResourceState.last_drift_check:type_name -> google.protobuf.Timestamp
+	100, // 4: workflow.plugin.external.iac.ResourceOutput.sensitive:type_name -> workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
+	11,  // 5: workflow.plugin.external.iac.DiffResult.changes:type_name -> workflow.plugin.external.iac.FieldChange
 	0,   // 6: workflow.plugin.external.iac.DriftResult.class:type_name -> workflow.plugin.external.iac.DriftClass
-	107, // 7: workflow.plugin.external.iac.Diagnostic.at:type_name -> google.protobuf.Timestamp
+	109, // 7: workflow.plugin.external.iac.Diagnostic.at:type_name -> google.protobuf.Timestamp
 	1,   // 8: workflow.plugin.external.iac.PlanDiagnostic.severity:type_name -> workflow.plugin.external.iac.PlanDiagnosticSeverity
-	2,   // 9: workflow.plugin.external.iac.PlanAction.resource:type_name -> workflow.plugin.external.iac.ResourceSpec
-	7,   // 10: workflow.plugin.external.iac.PlanAction.current:type_name -> workflow.plugin.external.iac.ResourceState
-	10,  // 11: workflow.plugin.external.iac.PlanAction.changes:type_name -> workflow.plugin.external.iac.FieldChange
-	17,  // 12: workflow.plugin.external.iac.IaCPlan.actions:type_name -> workflow.plugin.external.iac.PlanAction
-	107, // 13: workflow.plugin.external.iac.IaCPlan.created_at:type_name -> google.protobuf.Timestamp
-	99,  // 14: workflow.plugin.external.iac.IaCPlan.input_snapshot:type_name -> workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
-	8,   // 15: workflow.plugin.external.iac.ApplyResult.resources:type_name -> workflow.plugin.external.iac.ResourceOutput
-	19,  // 16: workflow.plugin.external.iac.ApplyResult.errors:type_name -> workflow.plugin.external.iac.ActionError
-	100, // 17: workflow.plugin.external.iac.ApplyResult.initial_input_snapshot:type_name -> workflow.plugin.external.iac.ApplyResult.InitialInputSnapshotEntry
-	13,  // 18: workflow.plugin.external.iac.ApplyResult.input_drift_report:type_name -> workflow.plugin.external.iac.DriftEntry
-	101, // 19: workflow.plugin.external.iac.ApplyResult.replace_id_map:type_name -> workflow.plugin.external.iac.ApplyResult.ReplaceIdMapEntry
-	19,  // 20: workflow.plugin.external.iac.DestroyResult.errors:type_name -> workflow.plugin.external.iac.ActionError
-	102, // 21: workflow.plugin.external.iac.BootstrapResult.env_vars:type_name -> workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
-	103, // 22: workflow.plugin.external.iac.MigrationRepairRequest.env:type_name -> workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
-	15,  // 23: workflow.plugin.external.iac.MigrationRepairResult.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
-	6,   // 24: workflow.plugin.external.iac.CapabilitiesResponse.capabilities:type_name -> workflow.plugin.external.iac.IaCCapabilityDeclaration
-	2,   // 25: workflow.plugin.external.iac.PlanRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
-	7,   // 26: workflow.plugin.external.iac.PlanRequest.current:type_name -> workflow.plugin.external.iac.ResourceState
-	18,  // 27: workflow.plugin.external.iac.PlanResponse.plan:type_name -> workflow.plugin.external.iac.IaCPlan
-	18,  // 28: workflow.plugin.external.iac.ApplyRequest.plan:type_name -> workflow.plugin.external.iac.IaCPlan
-	20,  // 29: workflow.plugin.external.iac.ApplyResponse.result:type_name -> workflow.plugin.external.iac.ApplyResult
-	3,   // 30: workflow.plugin.external.iac.DestroyRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	21,  // 31: workflow.plugin.external.iac.DestroyResponse.result:type_name -> workflow.plugin.external.iac.DestroyResult
-	3,   // 32: workflow.plugin.external.iac.StatusRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	9,   // 33: workflow.plugin.external.iac.StatusResponse.statuses:type_name -> workflow.plugin.external.iac.ResourceStatus
-	7,   // 34: workflow.plugin.external.iac.ImportResponse.state:type_name -> workflow.plugin.external.iac.ResourceState
-	4,   // 35: workflow.plugin.external.iac.ResolveSizingRequest.hints:type_name -> workflow.plugin.external.iac.ResourceHints
-	5,   // 36: workflow.plugin.external.iac.ResolveSizingResponse.sizing:type_name -> workflow.plugin.external.iac.ProviderSizing
-	22,  // 37: workflow.plugin.external.iac.BootstrapStateBackendResponse.result:type_name -> workflow.plugin.external.iac.BootstrapResult
-	8,   // 38: workflow.plugin.external.iac.EnumerateAllResponse.outputs:type_name -> workflow.plugin.external.iac.ResourceOutput
-	3,   // 39: workflow.plugin.external.iac.EnumerateByTagResponse.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	3,   // 40: workflow.plugin.external.iac.DetectDriftRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	12,  // 41: workflow.plugin.external.iac.DetectDriftResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
-	3,   // 42: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	104, // 43: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
-	12,  // 44: workflow.plugin.external.iac.DetectDriftWithSpecsResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
-	23,  // 45: workflow.plugin.external.iac.RepairDirtyMigrationRequest.request:type_name -> workflow.plugin.external.iac.MigrationRepairRequest
-	24,  // 46: workflow.plugin.external.iac.RepairDirtyMigrationResponse.result:type_name -> workflow.plugin.external.iac.MigrationRepairResult
-	18,  // 47: workflow.plugin.external.iac.ValidatePlanRequest.plan:type_name -> workflow.plugin.external.iac.IaCPlan
-	16,  // 48: workflow.plugin.external.iac.ValidatePlanResponse.diagnostics:type_name -> workflow.plugin.external.iac.PlanDiagnostic
-	3,   // 49: workflow.plugin.external.iac.DetectDriftConfigRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	105, // 50: workflow.plugin.external.iac.DetectDriftConfigRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
-	12,  // 51: workflow.plugin.external.iac.DetectDriftConfigResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
-	2,   // 52: workflow.plugin.external.iac.ResourceCreateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
-	8,   // 53: workflow.plugin.external.iac.ResourceCreateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	3,   // 54: workflow.plugin.external.iac.ResourceReadRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	8,   // 55: workflow.plugin.external.iac.ResourceReadResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	3,   // 56: workflow.plugin.external.iac.ResourceUpdateRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	2,   // 57: workflow.plugin.external.iac.ResourceUpdateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
-	8,   // 58: workflow.plugin.external.iac.ResourceUpdateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	3,   // 59: workflow.plugin.external.iac.ResourceDeleteRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	2,   // 60: workflow.plugin.external.iac.ResourceDiffRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
-	8,   // 61: workflow.plugin.external.iac.ResourceDiffRequest.current:type_name -> workflow.plugin.external.iac.ResourceOutput
-	11,  // 62: workflow.plugin.external.iac.ResourceDiffResponse.result:type_name -> workflow.plugin.external.iac.DiffResult
-	3,   // 63: workflow.plugin.external.iac.ResourceScaleRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	8,   // 64: workflow.plugin.external.iac.ResourceScaleResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	3,   // 65: workflow.plugin.external.iac.ResourceHealthCheckRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	14,  // 66: workflow.plugin.external.iac.ResourceHealthCheckResponse.result:type_name -> workflow.plugin.external.iac.HealthResult
-	3,   // 67: workflow.plugin.external.iac.TroubleshootRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	15,  // 68: workflow.plugin.external.iac.TroubleshootResponse.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
-	81,  // 69: workflow.plugin.external.iac.GetStateResponse.state:type_name -> workflow.plugin.external.iac.IaCState
-	81,  // 70: workflow.plugin.external.iac.SaveStateRequest.state:type_name -> workflow.plugin.external.iac.IaCState
-	106, // 71: workflow.plugin.external.iac.ListStatesRequest.filter:type_name -> workflow.plugin.external.iac.ListStatesRequest.FilterEntry
-	81,  // 72: workflow.plugin.external.iac.ListStatesResponse.states:type_name -> workflow.plugin.external.iac.IaCState
-	2,   // 73: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
-	2,   // 74: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
-	25,  // 75: workflow.plugin.external.iac.IaCProviderRequired.Initialize:input_type -> workflow.plugin.external.iac.InitializeRequest
-	27,  // 76: workflow.plugin.external.iac.IaCProviderRequired.Name:input_type -> workflow.plugin.external.iac.NameRequest
-	29,  // 77: workflow.plugin.external.iac.IaCProviderRequired.Version:input_type -> workflow.plugin.external.iac.VersionRequest
-	31,  // 78: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:input_type -> workflow.plugin.external.iac.CapabilitiesRequest
-	33,  // 79: workflow.plugin.external.iac.IaCProviderRequired.Plan:input_type -> workflow.plugin.external.iac.PlanRequest
-	35,  // 80: workflow.plugin.external.iac.IaCProviderRequired.Apply:input_type -> workflow.plugin.external.iac.ApplyRequest
-	37,  // 81: workflow.plugin.external.iac.IaCProviderRequired.Destroy:input_type -> workflow.plugin.external.iac.DestroyRequest
-	39,  // 82: workflow.plugin.external.iac.IaCProviderRequired.Status:input_type -> workflow.plugin.external.iac.StatusRequest
-	41,  // 83: workflow.plugin.external.iac.IaCProviderRequired.Import:input_type -> workflow.plugin.external.iac.ImportRequest
-	43,  // 84: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:input_type -> workflow.plugin.external.iac.ResolveSizingRequest
-	45,  // 85: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:input_type -> workflow.plugin.external.iac.BootstrapStateBackendRequest
-	47,  // 86: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:input_type -> workflow.plugin.external.iac.EnumerateAllRequest
-	49,  // 87: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:input_type -> workflow.plugin.external.iac.EnumerateByTagRequest
-	51,  // 88: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:input_type -> workflow.plugin.external.iac.DetectDriftRequest
-	53,  // 89: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:input_type -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest
-	55,  // 90: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:input_type -> workflow.plugin.external.iac.RevokeProviderCredentialRequest
-	57,  // 91: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:input_type -> workflow.plugin.external.iac.RepairDirtyMigrationRequest
-	59,  // 92: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:input_type -> workflow.plugin.external.iac.ValidatePlanRequest
-	61,  // 93: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:input_type -> workflow.plugin.external.iac.DetectDriftConfigRequest
-	63,  // 94: workflow.plugin.external.iac.ResourceDriver.Create:input_type -> workflow.plugin.external.iac.ResourceCreateRequest
-	65,  // 95: workflow.plugin.external.iac.ResourceDriver.Read:input_type -> workflow.plugin.external.iac.ResourceReadRequest
-	67,  // 96: workflow.plugin.external.iac.ResourceDriver.Update:input_type -> workflow.plugin.external.iac.ResourceUpdateRequest
-	69,  // 97: workflow.plugin.external.iac.ResourceDriver.Delete:input_type -> workflow.plugin.external.iac.ResourceDeleteRequest
-	71,  // 98: workflow.plugin.external.iac.ResourceDriver.Diff:input_type -> workflow.plugin.external.iac.ResourceDiffRequest
-	73,  // 99: workflow.plugin.external.iac.ResourceDriver.Scale:input_type -> workflow.plugin.external.iac.ResourceScaleRequest
-	75,  // 100: workflow.plugin.external.iac.ResourceDriver.HealthCheck:input_type -> workflow.plugin.external.iac.ResourceHealthCheckRequest
-	77,  // 101: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:input_type -> workflow.plugin.external.iac.SensitiveKeysRequest
-	79,  // 102: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:input_type -> workflow.plugin.external.iac.TroubleshootRequest
-	82,  // 103: workflow.plugin.external.iac.IaCStateBackend.Configure:input_type -> workflow.plugin.external.iac.ConfigureRequest
-	84,  // 104: workflow.plugin.external.iac.IaCStateBackend.GetState:input_type -> workflow.plugin.external.iac.GetStateRequest
-	86,  // 105: workflow.plugin.external.iac.IaCStateBackend.SaveState:input_type -> workflow.plugin.external.iac.SaveStateRequest
-	88,  // 106: workflow.plugin.external.iac.IaCStateBackend.ListStates:input_type -> workflow.plugin.external.iac.ListStatesRequest
-	90,  // 107: workflow.plugin.external.iac.IaCStateBackend.DeleteState:input_type -> workflow.plugin.external.iac.DeleteStateRequest
-	92,  // 108: workflow.plugin.external.iac.IaCStateBackend.Lock:input_type -> workflow.plugin.external.iac.LockRequest
-	94,  // 109: workflow.plugin.external.iac.IaCStateBackend.Unlock:input_type -> workflow.plugin.external.iac.UnlockRequest
-	96,  // 110: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:input_type -> workflow.plugin.external.iac.ListBackendNamesRequest
-	26,  // 111: workflow.plugin.external.iac.IaCProviderRequired.Initialize:output_type -> workflow.plugin.external.iac.InitializeResponse
-	28,  // 112: workflow.plugin.external.iac.IaCProviderRequired.Name:output_type -> workflow.plugin.external.iac.NameResponse
-	30,  // 113: workflow.plugin.external.iac.IaCProviderRequired.Version:output_type -> workflow.plugin.external.iac.VersionResponse
-	32,  // 114: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:output_type -> workflow.plugin.external.iac.CapabilitiesResponse
-	34,  // 115: workflow.plugin.external.iac.IaCProviderRequired.Plan:output_type -> workflow.plugin.external.iac.PlanResponse
-	36,  // 116: workflow.plugin.external.iac.IaCProviderRequired.Apply:output_type -> workflow.plugin.external.iac.ApplyResponse
-	38,  // 117: workflow.plugin.external.iac.IaCProviderRequired.Destroy:output_type -> workflow.plugin.external.iac.DestroyResponse
-	40,  // 118: workflow.plugin.external.iac.IaCProviderRequired.Status:output_type -> workflow.plugin.external.iac.StatusResponse
-	42,  // 119: workflow.plugin.external.iac.IaCProviderRequired.Import:output_type -> workflow.plugin.external.iac.ImportResponse
-	44,  // 120: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:output_type -> workflow.plugin.external.iac.ResolveSizingResponse
-	46,  // 121: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:output_type -> workflow.plugin.external.iac.BootstrapStateBackendResponse
-	48,  // 122: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:output_type -> workflow.plugin.external.iac.EnumerateAllResponse
-	50,  // 123: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:output_type -> workflow.plugin.external.iac.EnumerateByTagResponse
-	52,  // 124: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:output_type -> workflow.plugin.external.iac.DetectDriftResponse
-	54,  // 125: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:output_type -> workflow.plugin.external.iac.DetectDriftWithSpecsResponse
-	56,  // 126: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:output_type -> workflow.plugin.external.iac.RevokeProviderCredentialResponse
-	58,  // 127: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:output_type -> workflow.plugin.external.iac.RepairDirtyMigrationResponse
-	60,  // 128: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:output_type -> workflow.plugin.external.iac.ValidatePlanResponse
-	62,  // 129: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:output_type -> workflow.plugin.external.iac.DetectDriftConfigResponse
-	64,  // 130: workflow.plugin.external.iac.ResourceDriver.Create:output_type -> workflow.plugin.external.iac.ResourceCreateResponse
-	66,  // 131: workflow.plugin.external.iac.ResourceDriver.Read:output_type -> workflow.plugin.external.iac.ResourceReadResponse
-	68,  // 132: workflow.plugin.external.iac.ResourceDriver.Update:output_type -> workflow.plugin.external.iac.ResourceUpdateResponse
-	70,  // 133: workflow.plugin.external.iac.ResourceDriver.Delete:output_type -> workflow.plugin.external.iac.ResourceDeleteResponse
-	72,  // 134: workflow.plugin.external.iac.ResourceDriver.Diff:output_type -> workflow.plugin.external.iac.ResourceDiffResponse
-	74,  // 135: workflow.plugin.external.iac.ResourceDriver.Scale:output_type -> workflow.plugin.external.iac.ResourceScaleResponse
-	76,  // 136: workflow.plugin.external.iac.ResourceDriver.HealthCheck:output_type -> workflow.plugin.external.iac.ResourceHealthCheckResponse
-	78,  // 137: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:output_type -> workflow.plugin.external.iac.SensitiveKeysResponse
-	80,  // 138: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:output_type -> workflow.plugin.external.iac.TroubleshootResponse
-	83,  // 139: workflow.plugin.external.iac.IaCStateBackend.Configure:output_type -> workflow.plugin.external.iac.ConfigureResponse
-	85,  // 140: workflow.plugin.external.iac.IaCStateBackend.GetState:output_type -> workflow.plugin.external.iac.GetStateResponse
-	87,  // 141: workflow.plugin.external.iac.IaCStateBackend.SaveState:output_type -> workflow.plugin.external.iac.SaveStateResponse
-	89,  // 142: workflow.plugin.external.iac.IaCStateBackend.ListStates:output_type -> workflow.plugin.external.iac.ListStatesResponse
-	91,  // 143: workflow.plugin.external.iac.IaCStateBackend.DeleteState:output_type -> workflow.plugin.external.iac.DeleteStateResponse
-	93,  // 144: workflow.plugin.external.iac.IaCStateBackend.Lock:output_type -> workflow.plugin.external.iac.LockResponse
-	95,  // 145: workflow.plugin.external.iac.IaCStateBackend.Unlock:output_type -> workflow.plugin.external.iac.UnlockResponse
-	97,  // 146: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:output_type -> workflow.plugin.external.iac.ListBackendNamesResponse
-	111, // [111:147] is the sub-list for method output_type
-	75,  // [75:111] is the sub-list for method input_type
-	75,  // [75:75] is the sub-list for extension type_name
-	75,  // [75:75] is the sub-list for extension extendee
-	0,   // [0:75] is the sub-list for field type_name
+	3,   // 9: workflow.plugin.external.iac.PlanAction.resource:type_name -> workflow.plugin.external.iac.ResourceSpec
+	8,   // 10: workflow.plugin.external.iac.PlanAction.current:type_name -> workflow.plugin.external.iac.ResourceState
+	11,  // 11: workflow.plugin.external.iac.PlanAction.changes:type_name -> workflow.plugin.external.iac.FieldChange
+	18,  // 12: workflow.plugin.external.iac.IaCPlan.actions:type_name -> workflow.plugin.external.iac.PlanAction
+	109, // 13: workflow.plugin.external.iac.IaCPlan.created_at:type_name -> google.protobuf.Timestamp
+	101, // 14: workflow.plugin.external.iac.IaCPlan.input_snapshot:type_name -> workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
+	2,   // 15: workflow.plugin.external.iac.ActionResult.status:type_name -> workflow.plugin.external.iac.ActionStatus
+	9,   // 16: workflow.plugin.external.iac.ApplyResult.resources:type_name -> workflow.plugin.external.iac.ResourceOutput
+	20,  // 17: workflow.plugin.external.iac.ApplyResult.errors:type_name -> workflow.plugin.external.iac.ActionError
+	102, // 18: workflow.plugin.external.iac.ApplyResult.initial_input_snapshot:type_name -> workflow.plugin.external.iac.ApplyResult.InitialInputSnapshotEntry
+	14,  // 19: workflow.plugin.external.iac.ApplyResult.input_drift_report:type_name -> workflow.plugin.external.iac.DriftEntry
+	103, // 20: workflow.plugin.external.iac.ApplyResult.replace_id_map:type_name -> workflow.plugin.external.iac.ApplyResult.ReplaceIdMapEntry
+	21,  // 21: workflow.plugin.external.iac.ApplyResult.actions:type_name -> workflow.plugin.external.iac.ActionResult
+	20,  // 22: workflow.plugin.external.iac.DestroyResult.errors:type_name -> workflow.plugin.external.iac.ActionError
+	104, // 23: workflow.plugin.external.iac.BootstrapResult.env_vars:type_name -> workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
+	105, // 24: workflow.plugin.external.iac.MigrationRepairRequest.env:type_name -> workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
+	16,  // 25: workflow.plugin.external.iac.MigrationRepairResult.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
+	7,   // 26: workflow.plugin.external.iac.CapabilitiesResponse.capabilities:type_name -> workflow.plugin.external.iac.IaCCapabilityDeclaration
+	3,   // 27: workflow.plugin.external.iac.PlanRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
+	8,   // 28: workflow.plugin.external.iac.PlanRequest.current:type_name -> workflow.plugin.external.iac.ResourceState
+	19,  // 29: workflow.plugin.external.iac.PlanResponse.plan:type_name -> workflow.plugin.external.iac.IaCPlan
+	19,  // 30: workflow.plugin.external.iac.ApplyRequest.plan:type_name -> workflow.plugin.external.iac.IaCPlan
+	22,  // 31: workflow.plugin.external.iac.ApplyResponse.result:type_name -> workflow.plugin.external.iac.ApplyResult
+	4,   // 32: workflow.plugin.external.iac.DestroyRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	23,  // 33: workflow.plugin.external.iac.DestroyResponse.result:type_name -> workflow.plugin.external.iac.DestroyResult
+	4,   // 34: workflow.plugin.external.iac.StatusRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	10,  // 35: workflow.plugin.external.iac.StatusResponse.statuses:type_name -> workflow.plugin.external.iac.ResourceStatus
+	8,   // 36: workflow.plugin.external.iac.ImportResponse.state:type_name -> workflow.plugin.external.iac.ResourceState
+	5,   // 37: workflow.plugin.external.iac.ResolveSizingRequest.hints:type_name -> workflow.plugin.external.iac.ResourceHints
+	6,   // 38: workflow.plugin.external.iac.ResolveSizingResponse.sizing:type_name -> workflow.plugin.external.iac.ProviderSizing
+	24,  // 39: workflow.plugin.external.iac.BootstrapStateBackendResponse.result:type_name -> workflow.plugin.external.iac.BootstrapResult
+	9,   // 40: workflow.plugin.external.iac.EnumerateAllResponse.outputs:type_name -> workflow.plugin.external.iac.ResourceOutput
+	4,   // 41: workflow.plugin.external.iac.EnumerateByTagResponse.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	4,   // 42: workflow.plugin.external.iac.DetectDriftRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	13,  // 43: workflow.plugin.external.iac.DetectDriftResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
+	4,   // 44: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	106, // 45: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
+	13,  // 46: workflow.plugin.external.iac.DetectDriftWithSpecsResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
+	25,  // 47: workflow.plugin.external.iac.RepairDirtyMigrationRequest.request:type_name -> workflow.plugin.external.iac.MigrationRepairRequest
+	26,  // 48: workflow.plugin.external.iac.RepairDirtyMigrationResponse.result:type_name -> workflow.plugin.external.iac.MigrationRepairResult
+	19,  // 49: workflow.plugin.external.iac.ValidatePlanRequest.plan:type_name -> workflow.plugin.external.iac.IaCPlan
+	17,  // 50: workflow.plugin.external.iac.ValidatePlanResponse.diagnostics:type_name -> workflow.plugin.external.iac.PlanDiagnostic
+	4,   // 51: workflow.plugin.external.iac.DetectDriftConfigRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	107, // 52: workflow.plugin.external.iac.DetectDriftConfigRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
+	13,  // 53: workflow.plugin.external.iac.DetectDriftConfigResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
+	3,   // 54: workflow.plugin.external.iac.ResourceCreateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
+	9,   // 55: workflow.plugin.external.iac.ResourceCreateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	4,   // 56: workflow.plugin.external.iac.ResourceReadRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	9,   // 57: workflow.plugin.external.iac.ResourceReadResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	4,   // 58: workflow.plugin.external.iac.ResourceUpdateRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	3,   // 59: workflow.plugin.external.iac.ResourceUpdateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
+	9,   // 60: workflow.plugin.external.iac.ResourceUpdateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	4,   // 61: workflow.plugin.external.iac.ResourceDeleteRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	3,   // 62: workflow.plugin.external.iac.ResourceDiffRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
+	9,   // 63: workflow.plugin.external.iac.ResourceDiffRequest.current:type_name -> workflow.plugin.external.iac.ResourceOutput
+	12,  // 64: workflow.plugin.external.iac.ResourceDiffResponse.result:type_name -> workflow.plugin.external.iac.DiffResult
+	4,   // 65: workflow.plugin.external.iac.ResourceScaleRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	9,   // 66: workflow.plugin.external.iac.ResourceScaleResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	4,   // 67: workflow.plugin.external.iac.ResourceHealthCheckRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	15,  // 68: workflow.plugin.external.iac.ResourceHealthCheckResponse.result:type_name -> workflow.plugin.external.iac.HealthResult
+	4,   // 69: workflow.plugin.external.iac.TroubleshootRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	16,  // 70: workflow.plugin.external.iac.TroubleshootResponse.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
+	83,  // 71: workflow.plugin.external.iac.GetStateResponse.state:type_name -> workflow.plugin.external.iac.IaCState
+	83,  // 72: workflow.plugin.external.iac.SaveStateRequest.state:type_name -> workflow.plugin.external.iac.IaCState
+	108, // 73: workflow.plugin.external.iac.ListStatesRequest.filter:type_name -> workflow.plugin.external.iac.ListStatesRequest.FilterEntry
+	83,  // 74: workflow.plugin.external.iac.ListStatesResponse.states:type_name -> workflow.plugin.external.iac.IaCState
+	3,   // 75: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
+	3,   // 76: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
+	27,  // 77: workflow.plugin.external.iac.IaCProviderRequired.Initialize:input_type -> workflow.plugin.external.iac.InitializeRequest
+	29,  // 78: workflow.plugin.external.iac.IaCProviderRequired.Name:input_type -> workflow.plugin.external.iac.NameRequest
+	31,  // 79: workflow.plugin.external.iac.IaCProviderRequired.Version:input_type -> workflow.plugin.external.iac.VersionRequest
+	33,  // 80: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:input_type -> workflow.plugin.external.iac.CapabilitiesRequest
+	35,  // 81: workflow.plugin.external.iac.IaCProviderRequired.Plan:input_type -> workflow.plugin.external.iac.PlanRequest
+	37,  // 82: workflow.plugin.external.iac.IaCProviderRequired.Apply:input_type -> workflow.plugin.external.iac.ApplyRequest
+	39,  // 83: workflow.plugin.external.iac.IaCProviderRequired.Destroy:input_type -> workflow.plugin.external.iac.DestroyRequest
+	41,  // 84: workflow.plugin.external.iac.IaCProviderRequired.Status:input_type -> workflow.plugin.external.iac.StatusRequest
+	43,  // 85: workflow.plugin.external.iac.IaCProviderRequired.Import:input_type -> workflow.plugin.external.iac.ImportRequest
+	45,  // 86: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:input_type -> workflow.plugin.external.iac.ResolveSizingRequest
+	47,  // 87: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:input_type -> workflow.plugin.external.iac.BootstrapStateBackendRequest
+	49,  // 88: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:input_type -> workflow.plugin.external.iac.EnumerateAllRequest
+	51,  // 89: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:input_type -> workflow.plugin.external.iac.EnumerateByTagRequest
+	53,  // 90: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:input_type -> workflow.plugin.external.iac.DetectDriftRequest
+	55,  // 91: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:input_type -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest
+	57,  // 92: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:input_type -> workflow.plugin.external.iac.RevokeProviderCredentialRequest
+	59,  // 93: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:input_type -> workflow.plugin.external.iac.RepairDirtyMigrationRequest
+	61,  // 94: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:input_type -> workflow.plugin.external.iac.ValidatePlanRequest
+	63,  // 95: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:input_type -> workflow.plugin.external.iac.DetectDriftConfigRequest
+	65,  // 96: workflow.plugin.external.iac.ResourceDriver.Create:input_type -> workflow.plugin.external.iac.ResourceCreateRequest
+	67,  // 97: workflow.plugin.external.iac.ResourceDriver.Read:input_type -> workflow.plugin.external.iac.ResourceReadRequest
+	69,  // 98: workflow.plugin.external.iac.ResourceDriver.Update:input_type -> workflow.plugin.external.iac.ResourceUpdateRequest
+	71,  // 99: workflow.plugin.external.iac.ResourceDriver.Delete:input_type -> workflow.plugin.external.iac.ResourceDeleteRequest
+	73,  // 100: workflow.plugin.external.iac.ResourceDriver.Diff:input_type -> workflow.plugin.external.iac.ResourceDiffRequest
+	75,  // 101: workflow.plugin.external.iac.ResourceDriver.Scale:input_type -> workflow.plugin.external.iac.ResourceScaleRequest
+	77,  // 102: workflow.plugin.external.iac.ResourceDriver.HealthCheck:input_type -> workflow.plugin.external.iac.ResourceHealthCheckRequest
+	79,  // 103: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:input_type -> workflow.plugin.external.iac.SensitiveKeysRequest
+	81,  // 104: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:input_type -> workflow.plugin.external.iac.TroubleshootRequest
+	84,  // 105: workflow.plugin.external.iac.IaCStateBackend.Configure:input_type -> workflow.plugin.external.iac.ConfigureRequest
+	86,  // 106: workflow.plugin.external.iac.IaCStateBackend.GetState:input_type -> workflow.plugin.external.iac.GetStateRequest
+	88,  // 107: workflow.plugin.external.iac.IaCStateBackend.SaveState:input_type -> workflow.plugin.external.iac.SaveStateRequest
+	90,  // 108: workflow.plugin.external.iac.IaCStateBackend.ListStates:input_type -> workflow.plugin.external.iac.ListStatesRequest
+	92,  // 109: workflow.plugin.external.iac.IaCStateBackend.DeleteState:input_type -> workflow.plugin.external.iac.DeleteStateRequest
+	94,  // 110: workflow.plugin.external.iac.IaCStateBackend.Lock:input_type -> workflow.plugin.external.iac.LockRequest
+	96,  // 111: workflow.plugin.external.iac.IaCStateBackend.Unlock:input_type -> workflow.plugin.external.iac.UnlockRequest
+	98,  // 112: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:input_type -> workflow.plugin.external.iac.ListBackendNamesRequest
+	28,  // 113: workflow.plugin.external.iac.IaCProviderRequired.Initialize:output_type -> workflow.plugin.external.iac.InitializeResponse
+	30,  // 114: workflow.plugin.external.iac.IaCProviderRequired.Name:output_type -> workflow.plugin.external.iac.NameResponse
+	32,  // 115: workflow.plugin.external.iac.IaCProviderRequired.Version:output_type -> workflow.plugin.external.iac.VersionResponse
+	34,  // 116: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:output_type -> workflow.plugin.external.iac.CapabilitiesResponse
+	36,  // 117: workflow.plugin.external.iac.IaCProviderRequired.Plan:output_type -> workflow.plugin.external.iac.PlanResponse
+	38,  // 118: workflow.plugin.external.iac.IaCProviderRequired.Apply:output_type -> workflow.plugin.external.iac.ApplyResponse
+	40,  // 119: workflow.plugin.external.iac.IaCProviderRequired.Destroy:output_type -> workflow.plugin.external.iac.DestroyResponse
+	42,  // 120: workflow.plugin.external.iac.IaCProviderRequired.Status:output_type -> workflow.plugin.external.iac.StatusResponse
+	44,  // 121: workflow.plugin.external.iac.IaCProviderRequired.Import:output_type -> workflow.plugin.external.iac.ImportResponse
+	46,  // 122: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:output_type -> workflow.plugin.external.iac.ResolveSizingResponse
+	48,  // 123: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:output_type -> workflow.plugin.external.iac.BootstrapStateBackendResponse
+	50,  // 124: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:output_type -> workflow.plugin.external.iac.EnumerateAllResponse
+	52,  // 125: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:output_type -> workflow.plugin.external.iac.EnumerateByTagResponse
+	54,  // 126: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:output_type -> workflow.plugin.external.iac.DetectDriftResponse
+	56,  // 127: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:output_type -> workflow.plugin.external.iac.DetectDriftWithSpecsResponse
+	58,  // 128: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:output_type -> workflow.plugin.external.iac.RevokeProviderCredentialResponse
+	60,  // 129: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:output_type -> workflow.plugin.external.iac.RepairDirtyMigrationResponse
+	62,  // 130: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:output_type -> workflow.plugin.external.iac.ValidatePlanResponse
+	64,  // 131: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:output_type -> workflow.plugin.external.iac.DetectDriftConfigResponse
+	66,  // 132: workflow.plugin.external.iac.ResourceDriver.Create:output_type -> workflow.plugin.external.iac.ResourceCreateResponse
+	68,  // 133: workflow.plugin.external.iac.ResourceDriver.Read:output_type -> workflow.plugin.external.iac.ResourceReadResponse
+	70,  // 134: workflow.plugin.external.iac.ResourceDriver.Update:output_type -> workflow.plugin.external.iac.ResourceUpdateResponse
+	72,  // 135: workflow.plugin.external.iac.ResourceDriver.Delete:output_type -> workflow.plugin.external.iac.ResourceDeleteResponse
+	74,  // 136: workflow.plugin.external.iac.ResourceDriver.Diff:output_type -> workflow.plugin.external.iac.ResourceDiffResponse
+	76,  // 137: workflow.plugin.external.iac.ResourceDriver.Scale:output_type -> workflow.plugin.external.iac.ResourceScaleResponse
+	78,  // 138: workflow.plugin.external.iac.ResourceDriver.HealthCheck:output_type -> workflow.plugin.external.iac.ResourceHealthCheckResponse
+	80,  // 139: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:output_type -> workflow.plugin.external.iac.SensitiveKeysResponse
+	82,  // 140: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:output_type -> workflow.plugin.external.iac.TroubleshootResponse
+	85,  // 141: workflow.plugin.external.iac.IaCStateBackend.Configure:output_type -> workflow.plugin.external.iac.ConfigureResponse
+	87,  // 142: workflow.plugin.external.iac.IaCStateBackend.GetState:output_type -> workflow.plugin.external.iac.GetStateResponse
+	89,  // 143: workflow.plugin.external.iac.IaCStateBackend.SaveState:output_type -> workflow.plugin.external.iac.SaveStateResponse
+	91,  // 144: workflow.plugin.external.iac.IaCStateBackend.ListStates:output_type -> workflow.plugin.external.iac.ListStatesResponse
+	93,  // 145: workflow.plugin.external.iac.IaCStateBackend.DeleteState:output_type -> workflow.plugin.external.iac.DeleteStateResponse
+	95,  // 146: workflow.plugin.external.iac.IaCStateBackend.Lock:output_type -> workflow.plugin.external.iac.LockResponse
+	97,  // 147: workflow.plugin.external.iac.IaCStateBackend.Unlock:output_type -> workflow.plugin.external.iac.UnlockResponse
+	99,  // 148: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:output_type -> workflow.plugin.external.iac.ListBackendNamesResponse
+	113, // [113:149] is the sub-list for method output_type
+	77,  // [77:113] is the sub-list for method input_type
+	77,  // [77:77] is the sub-list for extension type_name
+	77,  // [77:77] is the sub-list for extension extendee
+	0,   // [0:77] is the sub-list for field type_name
 }
 
 func init() { file_iac_proto_init() }
@@ -6088,8 +6230,8 @@ func file_iac_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_iac_proto_rawDesc), len(file_iac_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   105,
+			NumEnums:      3,
+			NumMessages:   106,
 			NumExtensions: 0,
 			NumServices:   9,
 		},

--- a/plugin/external/proto/iac.proto
+++ b/plugin/external/proto/iac.proto
@@ -291,6 +291,28 @@ message ActionError {
   string error = 3;
 }
 
+// ActionStatus categorizes per-action outcomes for wfctl-side hook dispatch.
+// Per workflow#640 Phase 2 + ADR 0040 invariants 1-2. Tags 4+5 reserved
+// for Phase 2.3 ACTION_STATUS_COMPENSATED + ACTION_STATUS_COMPENSATION_FAILED
+// when engine-side compensation lands.
+enum ActionStatus {
+  ACTION_STATUS_UNSPECIFIED = 0;  // wfctl REJECTS this on receipt
+  ACTION_STATUS_SUCCESS = 1;
+  ACTION_STATUS_ERROR = 2;
+  ACTION_STATUS_DELETE_FAILED = 3;
+  // 4 + 5 reserved (Phase 2.3 compensation)
+}
+
+// ActionResult is the per-action outcome surfacing for Phase 2 v2 hooks.
+// Per ADR 0040 invariant 1. output_keys field DROPPED per cycle-2 review
+// (hook firing only needs action_index + status; per-resource outputs
+// already in ApplyResult.resources).
+message ActionResult {
+  uint32 action_index = 1;
+  ActionStatus status = 2;
+  string error = 3;
+}
+
 // ApplyResult mirrors interfaces.ApplyResult.
 message ApplyResult {
   string plan_id = 1;
@@ -299,6 +321,7 @@ message ApplyResult {
   map<string, string> initial_input_snapshot = 4;
   repeated DriftEntry input_drift_report = 5;
   map<string, string> replace_id_map = 6;
+  repeated ActionResult actions = 7;  // NEW Phase 2 (workflow#640)
 }
 
 // DestroyResult mirrors interfaces.DestroyResult.

--- a/plugin/external/proto/iac.proto
+++ b/plugin/external/proto/iac.proto
@@ -300,7 +300,7 @@ enum ActionStatus {
   ACTION_STATUS_SUCCESS = 1;
   ACTION_STATUS_ERROR = 2;
   ACTION_STATUS_DELETE_FAILED = 3;
-  // 4 + 5 reserved (Phase 2.3 compensation)
+  reserved 4, 5;  // Phase 2.3 compensation (ACTION_STATUS_COMPENSATED / COMPENSATION_FAILED)
 }
 
 // ActionResult is the per-action outcome surfacing for Phase 2 v2 hooks.

--- a/plugin/external/proto/iac_proto_test.go
+++ b/plugin/external/proto/iac_proto_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 // iacRequiredMethodsCheck is a locally-enumerated method-signature interface
@@ -93,5 +94,62 @@ func TestMigrationRepairConfirmationStringMatchesProtoComment(t *testing.T) {
 	if interfaces.MigrationRepairConfirmation != "FORCE_MIGRATION_METADATA" {
 		t.Fatalf("interfaces.MigrationRepairConfirmation drifted from proto comment in iac.proto:322-324; got %q want %q",
 			interfaces.MigrationRepairConfirmation, "FORCE_MIGRATION_METADATA")
+	}
+}
+
+// TestApplyResultActionsRoundTrip verifies the Phase 2 ActionResult+
+// ActionStatus additions to ApplyResult survive a proto marshal/unmarshal
+// round trip with identical field values. Per ADR 0040 invariants 1-2 and
+// the v2-lifecycle-phase2 plan T1. Guards against accidental field-tag
+// drift and against re-ordering action_index / status / error.
+func TestApplyResultActionsRoundTrip(t *testing.T) {
+	original := &pb.ApplyResult{
+		PlanId: "plan-phase2-roundtrip",
+		Actions: []*pb.ActionResult{
+			{ActionIndex: 0, Status: pb.ActionStatus_ACTION_STATUS_SUCCESS, Error: ""},
+			{ActionIndex: 1, Status: pb.ActionStatus_ACTION_STATUS_ERROR, Error: "boom"},
+			{ActionIndex: 2, Status: pb.ActionStatus_ACTION_STATUS_DELETE_FAILED, Error: "still in use"},
+		},
+	}
+	wire, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	decoded := &pb.ApplyResult{}
+	if err := proto.Unmarshal(wire, decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got, want := len(decoded.GetActions()), len(original.GetActions()); got != want {
+		t.Fatalf("Actions len: got %d, want %d", got, want)
+	}
+	for i, want := range original.GetActions() {
+		got := decoded.GetActions()[i]
+		if got.GetActionIndex() != want.GetActionIndex() ||
+			got.GetStatus() != want.GetStatus() ||
+			got.GetError() != want.GetError() {
+			t.Fatalf("Actions[%d]: got %+v, want %+v", i, got, want)
+		}
+	}
+}
+
+// TestActionStatusEnumValues pins the wire-tag → constant mapping for
+// ActionStatus. Per plan T1: 0=UNSPECIFIED (rejected by wfctl), 1=SUCCESS,
+// 2=ERROR, 3=DELETE_FAILED. Tags 4-5 reserved for Phase 2.3 compensation;
+// this test fails loudly if any tag is reassigned.
+func TestActionStatusEnumValues(t *testing.T) {
+	cases := []struct {
+		name string
+		val  pb.ActionStatus
+		tag  int32
+	}{
+		{"UNSPECIFIED", pb.ActionStatus_ACTION_STATUS_UNSPECIFIED, 0},
+		{"SUCCESS", pb.ActionStatus_ACTION_STATUS_SUCCESS, 1},
+		{"ERROR", pb.ActionStatus_ACTION_STATUS_ERROR, 2},
+		{"DELETE_FAILED", pb.ActionStatus_ACTION_STATUS_DELETE_FAILED, 3},
+	}
+	for _, c := range cases {
+		if int32(c.val) != c.tag {
+			t.Errorf("ActionStatus_%s = %d, want %d", c.name, int32(c.val), c.tag)
+		}
 	}
 }

--- a/plugin/external/proto/iac_proto_test.go
+++ b/plugin/external/proto/iac_proto_test.go
@@ -102,33 +102,46 @@ func TestMigrationRepairConfirmationStringMatchesProtoComment(t *testing.T) {
 // round trip with identical field values. Per ADR 0040 invariants 1-2 and
 // the v2-lifecycle-phase2 plan T1. Guards against accidental field-tag
 // drift and against re-ordering action_index / status / error.
+//
+// Uses proto.Equal for canonical comparison so adding a field to
+// ActionResult later still gets checked without changing this test.
+// Subcases include UNSPECIFIED (which T3 will REJECT on decode — wire
+// layer must still encode/decode it losslessly) and nil/empty Actions
+// (the dominant case for plugins on v1 capability shim).
 func TestApplyResultActionsRoundTrip(t *testing.T) {
-	original := &pb.ApplyResult{
-		PlanId: "plan-phase2-roundtrip",
-		Actions: []*pb.ActionResult{
+	cases := []struct {
+		name    string
+		actions []*pb.ActionResult
+	}{
+		{"nil_actions", nil},
+		{"empty_actions", []*pb.ActionResult{}},
+		{"unspecified_status", []*pb.ActionResult{
+			{ActionIndex: 0, Status: pb.ActionStatus_ACTION_STATUS_UNSPECIFIED, Error: ""},
+		}},
+		{"mixed_statuses", []*pb.ActionResult{
 			{ActionIndex: 0, Status: pb.ActionStatus_ACTION_STATUS_SUCCESS, Error: ""},
 			{ActionIndex: 1, Status: pb.ActionStatus_ACTION_STATUS_ERROR, Error: "boom"},
 			{ActionIndex: 2, Status: pb.ActionStatus_ACTION_STATUS_DELETE_FAILED, Error: "still in use"},
-		},
+		}},
 	}
-	wire, err := proto.Marshal(original)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	decoded := &pb.ApplyResult{}
-	if err := proto.Unmarshal(wire, decoded); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if got, want := len(decoded.GetActions()), len(original.GetActions()); got != want {
-		t.Fatalf("Actions len: got %d, want %d", got, want)
-	}
-	for i, want := range original.GetActions() {
-		got := decoded.GetActions()[i]
-		if got.GetActionIndex() != want.GetActionIndex() ||
-			got.GetStatus() != want.GetStatus() ||
-			got.GetError() != want.GetError() {
-			t.Fatalf("Actions[%d]: got %+v, want %+v", i, got, want)
-		}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			original := &pb.ApplyResult{
+				PlanId:  "plan-phase2-roundtrip",
+				Actions: c.actions,
+			}
+			wire, err := proto.Marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			decoded := &pb.ApplyResult{}
+			if err := proto.Unmarshal(wire, decoded); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !proto.Equal(decoded, original) {
+				t.Fatalf("round-trip mismatch:\n got: %v\nwant: %v", decoded, original)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

PR 1 of 5 in the **workflow#640 Phase 2 hard-cutover cascade** per ADR 0024 + 0040. Extends the IaC plugin gRPC contract with per-action outcome evidence so wfctl-side v2 hooks fire correctly. After this PR ships + tags `v0.54.0`, the 4 IaC plugin PRs (aws/gcp/azure/digitalocean each v1.2.0) cascade in to declare `ComputePlanVersion="v2"`.

## Changes (6 commits)

1. **`515374c2` proto extend** — `ApplyResult.actions` field at tag 7 + `ActionStatus` enum (UNSPECIFIED=0/SUCCESS=1/ERROR=2/DELETE_FAILED=3); regenerated `iac.pb.go` in same atomic commit.
2. **`b09bced1` proto guard** — `reserved 4, 5;` directive on `ActionStatus` (compile-time guard against Phase 2.3 tag reuse) + broadened round-trip subcases.
3. **`6441c6cd` Go types** — `interfaces.ActionStatus` + `ActionOutcome` struct; extend `ApplyResult.Actions`.
4. **`b57c5a90` decoder** — `cmd/wfctl/iac_typed_adapter.go::applyResultFromPB` decodes `pb.ActionResult` → `interfaces.ActionOutcome`; rejects UNSPECIFIED explicitly.
5. **`92f73de9` decoder fail-closed** — unknown ActionStatus wire values error loudly (operator message: "wfctl version too old for this plugin?") per ADR 0040 invariant 2 (no graceful fallback).
6. **`3e79c9d6` engine populate** — `iac/wfctlhelpers/apply.go::applyPlanWithEnvProviderAndHooks` populates `result.Actions` via deferred-closure pattern (covers ALL 7 dispatch-loop exit paths: ctx-cancel, jit-err, driver-resolve-err, hook-dispatch-err, dispatch-other-err, post-delete-hook-err, post-apply-hook-err, success) + post-loop length-validation invariant assert.

## ADR alignment

- **ADR 0024** (no compat shim, no graceful proto fallback): both wire-rejection paths enforce strict cutover — UNSPECIFIED-on-send + unknown-tag-on-receive both error loudly.
- **ADR 0040** invariants 1+2 (per-action evidence + failed-delete preservation): satisfied via `ActionOutcome.Status` + `DELETE_FAILED` distinct tag.

## Test plan

- [x] `GOWORK=off go test ./plugin/external/proto/... -v` — proto round-trip + reserved guard
- [x] `GOWORK=off go test ./interfaces/...` — type + JSON round-trip
- [x] `GOWORK=off go test ./cmd/wfctl/ -run 'TestApplyResultFromPB|TestMapPB' -v` — 6/6 PASS
- [x] `GOWORK=off go test ./iac/wfctlhelpers/ -race` — full package PASS race-clean

## Cascade context

After merge → tag `v0.54.0` → unblocks 4 plugin PRs (each pins workflow v0.54.0 + bumps minEngineVersion + declares `ComputePlanVersion="v2"` in `CapabilitiesResponse`).

## Rollback

If a downstream plugin reveals a contract gap after Phase 2 cascade lands: cut `v0.54.1` reverting whichever commit broke (or full revert if proto change is the issue). Per ADR 0040 matched-pair rollback.

Plan: `docs/plans/2026-05-16-v2-lifecycle-phase2.md` (locked sha256 46b795ec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)