### PR TITLE
feat(wfctl): validate iacProvider.computePlanVersion in plugin manifest (#693)

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -151,6 +151,23 @@ func findIaCPluginDir(pluginDir, providerName string) (name, computePlanVersion 
 		if m.Capabilities.IaCProvider.Name != providerName {
 			continue
 		}
+		// Per workflow#693 (Phase 2.1 follow-up to #640): validate
+		// iacProvider.computePlanVersion ∈ {"", "v1", "v2"} on the
+		// matching plugin manifest. A typo (e.g. "V2", "v2.0", "two")
+		// would silently route through the v1 dispatch path via
+		// wfctlhelpers.DispatchVersionFor's empty/unknown default,
+		// breaking the Phase 2 hard-cutover contract per ADR 0024 +
+		// ADR 0040. Hard-fail so operators see the misconfiguration
+		// loudly instead of silently dispatching to the wrong path.
+		switch m.IaCProvider.ComputePlanVersion {
+		case "", "v1", "v2":
+			// valid
+		default:
+			return "", "", false, fmt.Errorf(
+				"plugin %q manifest has invalid iacProvider.computePlanVersion %q (must be \"\", \"v1\", or \"v2\")",
+				pluginName, m.IaCProvider.ComputePlanVersion,
+			)
+		}
 		binaryPath := filepath.Join(pluginDir, pluginName, pluginName)
 		_, statErr := os.Stat(binaryPath)
 		return pluginName, m.IaCProvider.ComputePlanVersion, statErr == nil, nil

--- a/cmd/wfctl/deploy_providers_compute_plan_version_test.go
+++ b/cmd/wfctl/deploy_providers_compute_plan_version_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFindIaCPluginDir_ComputePlanVersionValidation pins the workflow#693
+// (Phase 2.1 follow-up to #640) manifest validation gate: invalid values
+// of iacProvider.computePlanVersion on the matching plugin manifest must
+// hard-fail at findIaCPluginDir so operators see misconfiguration loudly
+// instead of silently routing through the v1 dispatch fallback (which
+// would break the Phase 2 hard-cutover contract per ADR 0024 + ADR 0040).
+func TestFindIaCPluginDir_ComputePlanVersionValidation(t *testing.T) {
+	tests := []struct {
+		name              string
+		computePlanVer    string
+		wantErrSubstring  string
+		wantVersionReturn string
+	}{
+		{name: "empty defaults to v1 dispatch", computePlanVer: "", wantVersionReturn: ""},
+		{name: "v1 explicit", computePlanVer: "v1", wantVersionReturn: "v1"},
+		{name: "v2 explicit (Phase 2)", computePlanVer: "v2", wantVersionReturn: "v2"},
+		{name: "typo uppercase rejected", computePlanVer: "V2", wantErrSubstring: `invalid iacProvider.computePlanVersion "V2"`},
+		{name: "typo decimal rejected", computePlanVer: "v2.0", wantErrSubstring: `invalid iacProvider.computePlanVersion "v2.0"`},
+		{name: "typo word rejected", computePlanVer: "two", wantErrSubstring: `invalid iacProvider.computePlanVersion "two"`},
+		{name: "phase-2.3 future-tag rejected pre-introduction", computePlanVer: "v3", wantErrSubstring: `invalid iacProvider.computePlanVersion "v3"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pluginDir := t.TempDir()
+			pluginName := "workflow-plugin-test-" + tt.name
+			pluginName = strings.ReplaceAll(pluginName, " ", "-")
+			subDir := filepath.Join(pluginDir, pluginName)
+			if mkErr := os.Mkdir(subDir, 0o755); mkErr != nil {
+				t.Fatalf("mkdir: %v", mkErr)
+			}
+			manifest := `{
+				"name": "` + pluginName + `",
+				"version": "1.0.0",
+				"capabilities": {"iacProvider": {"name": "test-provider"}},
+				"iacProvider": {"computePlanVersion": "` + tt.computePlanVer + `"}
+			}`
+			if writeErr := os.WriteFile(filepath.Join(subDir, "plugin.json"), []byte(manifest), 0o644); writeErr != nil {
+				t.Fatalf("write manifest: %v", writeErr)
+			}
+
+			name, gotVer, _, err := findIaCPluginDir(pluginDir, "test-provider")
+
+			if tt.wantErrSubstring != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (name=%q ver=%q)", tt.wantErrSubstring, name, gotVer)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSubstring) {
+					t.Errorf("error mismatch:\n  got:  %v\n  want substring: %q", err, tt.wantErrSubstring)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != pluginName {
+				t.Errorf("name = %q; want %q", name, pluginName)
+			}
+			if gotVer != tt.wantVersionReturn {
+				t.Errorf("computePlanVersion = %q; want %q", gotVer, tt.wantVersionReturn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2.1 follow-up to workflow#640 Phase 2 cascade (PR #694, v0.54.0). Adds the manifest validation gate at `cmd/wfctl/deploy_providers.go::findIaCPluginDir` that was flagged as missing in the Phase 1 inventory's Assumption 8.

Without this gate, a typo in `iacProvider.computePlanVersion` (V2, v2.0, two, v3) silently routes through the v1 dispatch path via `wfctlhelpers.DispatchVersionFor`'s empty/unknown default — breaking the Phase 2 hard-cutover contract per ADR 0024 + ADR 0040.

## Design choice

Issue #693 listed 3 options:
1. Full `pluginmanifest` package (schema-driven, generic) — ~200 LOC, overkill
2. Reuse existing `schema/` JSON Schema validator — ~50 LOC, more machinery than warranted
3. **Lightweight `computePlanVersion ∈ {v1, v2}` enum check** — minimum viable, picked

Picked option 3 per YAGNI. The field's domain is a 3-element enum (`""`, `"v1"`, `"v2"`) closed by the gRPC spec; a switch statement is the right tool.

## Behavior

- Empty/missing field → permitted (defaults to v1 dispatch per `DispatchVersionFor`)
- `"v1"` / `"v2"` → permitted
- Anything else → hard-fail with `plugin %q manifest has invalid iacProvider.computePlanVersion %q (must be "", "v1", or "v2")`

Validation fires only on the matching plugin manifest (not on every plugin in the directory) — so unrelated misconfigured plugins don't block resolving the right one.

## Test plan

- [x] 7 table-driven test cases in `TestFindIaCPluginDir_ComputePlanVersionValidation`: empty, v1, v2 pass; V2 (uppercase typo), v2.0 (decimal typo), two (word typo), v3 (future Phase 2.3 tag pre-introduction) all reject with the actionable error
- [x] All pass locally: `GOWORK=off go test ./cmd/wfctl/ -run 'TestFindIaCPluginDir_ComputePlanVersionValidation' -v`

## Rollback

Revert this commit. Pre-existing v1 behavior restored (silent fallback on typo).

Closes #693.