### PR TITLE
docs(templates): add GOWORK=off to CONTRIBUTING-plugin template

### DIFF
--- a/docs/templates/CONTRIBUTING-plugin.md
+++ b/docs/templates/CONTRIBUTING-plugin.md
@@ -8,11 +8,15 @@ Read the [upstream CONTRIBUTING.md](https://github.com/GoCodeAlone/workflow/blob
 
 ## Local development
 
+If you have a `go.work` file in a parent directory (common when working on
+multiple GoCodeAlone repos side-by-side), use `GOWORK=off` so the plugin
+builds against its own pinned `go.mod` rather than the workspace.
+
 ```sh
 git clone https://github.com/GoCodeAlone/workflow-plugin-<name>.git
 cd workflow-plugin-<name>
-go build ./...
-go test ./...
+GOWORK=off go build ./...
+GOWORK=off go test ./...
 ```
 
 ## Pull requests
@@ -20,7 +24,7 @@ go test ./...
 - One feature or bugfix per PR.
 - Update CHANGELOG.md with a Keep-a-Changelog entry.
 - Add tests covering new behavior.
-- Run `go vet ./...` before pushing.
+- Run `GOWORK=off go vet ./...` before pushing.
 
 ## Reporting issues
 


### PR DESCRIPTION
## Summary

- Add `GOWORK=off` prefix to `go build` / `go test` / `go vet` commands in `docs/templates/CONTRIBUTING-plugin.md` so new external contributors with a multi-repo workspace don't hit the upstream `go.work` short-circuit.
- Systemic finding from code-reviewer during the 2026-05-19 QoL sweep — per-plugin CONTRIBUTING.md files generated from this template will be updated in follow-up PRs.

## Test plan

- [x] Template renders correctly.
- [ ] Per-plugin CONTRIBUTING.md propagation follows in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)