### PR TITLE
fix(wfctl): capture logs for env resource name

### DIFF
--- a/cmd/wfctl/logs.go
+++ b/cmd/wfctl/logs.go
@@ -159,12 +159,14 @@ func resolveLogCaptureResource(cfg *config.WorkflowConfig, envName, name string)
 		if m.Name != name {
 			continue
 		}
+		resolvedName := m.Name
 		resolved := m.Config
 		if envName != "" {
 			envResolved, ok := m.ResolveForEnv(envName)
 			if !ok {
 				return interfaces.ResourceSpec{}, "", fmt.Errorf("logs capture: resource %q is disabled for environment %q", name, envName)
 			}
+			resolvedName = envResolved.Name
 			resolved = envResolved.Config
 		}
 		cfgMap := config.ExpandEnvInMapPreservingKeys(resolved, infraPreserveKeys)
@@ -172,7 +174,7 @@ func resolveLogCaptureResource(cfg *config.WorkflowConfig, envName, name string)
 		if providerRef == "" {
 			return interfaces.ResourceSpec{}, "", fmt.Errorf("logs capture: resource %q missing iac_provider/provider", name)
 		}
-		return interfaces.ResourceSpec{Name: m.Name, Type: m.Type, Config: cfgMap}, providerRef, nil
+		return interfaces.ResourceSpec{Name: resolvedName, Type: m.Type, Config: cfgMap}, providerRef, nil
 	}
 	return interfaces.ResourceSpec{}, "", fmt.Errorf("logs capture: resource %q not found", name)
 }

--- a/cmd/wfctl/logs_test.go
+++ b/cmd/wfctl/logs_test.go
@@ -199,3 +199,29 @@ func TestResolveLogCaptureResourcePreservesSecretEnvVars(t *testing.T) {
 		t.Fatalf("env_vars_secret DATABASE_URL = %v, want literal placeholder", got)
 	}
 }
+
+func TestResolveLogCaptureResourceUsesEnvResolvedName(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{{
+			Name: "web",
+			Type: "infra.container_service",
+			Config: map[string]any{
+				"provider": "do",
+			},
+			Environments: map[string]*config.InfraEnvironmentResolution{
+				"staging": {Config: map[string]any{"name": "web-staging"}},
+			},
+		}},
+	}
+
+	spec, _, err := resolveLogCaptureResource(cfg, "staging", "web")
+	if err != nil {
+		t.Fatalf("resolveLogCaptureResource: %v", err)
+	}
+	if spec.Name != "web-staging" {
+		t.Fatalf("spec.Name = %q, want env-resolved cloud name", spec.Name)
+	}
+	if got := logCaptureResourceCloudName(spec); got != "web-staging" {
+		t.Fatalf("cloud name = %q, want env-resolved cloud name", got)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve ResolveForEnv's lifted resource name when building wfctl log capture ResourceSpec
- add regression coverage for env-specific infra.container_service names

## Verification
- GOWORK=off go test ./cmd/wfctl -run 'TestResolveLogCaptureResource' -count=1
- GOWORK=off go test ./cmd/wfctl ./plugin/external/sdk ./plugin/external/proto -count=1
- git diff --check