### PR TITLE
fix: preserve wfctl release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,3 +333,17 @@ jobs:
         repository: ${{ matrix.repo }}
         event-type: workflow-release
         client-payload: '{"version": "${{ env.TAG_NAME }}"}'
+
+  notify-workflow-registry:
+    name: Notify workflow-registry
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
+    steps:
+    - name: Trigger registry manifest sync
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ secrets.repo_dispatch_token }}
+        repository: GoCodeAlone/workflow-registry
+        event-type: workflow-release
+        client-payload: '{"workflow": "${{ github.repository }}", "version": "${{ env.TAG_NAME }}"}'

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -28,7 +28,19 @@ import (
 //go:embed wfctl.yaml
 var wfctlConfigBytes []byte
 
-var version = buildVersion()
+// version is set by release builds via:
+//
+//	go build -ldflags "-X main.version=vX.Y.Z"
+//
+// Keep the declaration as a constant string initializer so the linker can
+// override it. init falls back to Go build metadata for module-installed builds.
+var version = "dev"
+
+func init() {
+	if version == "dev" {
+		version = buildVersion()
+	}
+}
 
 func buildVersion() string {
 	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {

--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -82,6 +83,25 @@ func TestBuildVersionStripsDirtyMarker(t *testing.T) {
 	v := buildVersion()
 	if strings.HasSuffix(v, "+dirty") {
 		t.Fatalf("buildVersion() = %q, must not end in +dirty", v)
+	}
+}
+
+func TestLinkedVersionOverridesBuildInfo(t *testing.T) {
+	exe := filepath.Join(t.TempDir(), "wfctl")
+	build := exec.Command("go", "build", "-o", exe, "-ldflags", "-X main.version=v9.9.9", ".")
+	build.Env = append(os.Environ(), "GOWORK=off")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build wfctl: %v\n%s", err, out)
+	}
+
+	run := exec.Command(exe, "--version")
+	run.Env = append(os.Environ(), "WFCTL_NO_UPDATE_CHECK=1", "CI=true")
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wfctl --version: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "v9.9.9" {
+		t.Fatalf("linked version = %q, want v9.9.9", got)
 	}
 }
 

--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -87,7 +88,11 @@ func TestBuildVersionStripsDirtyMarker(t *testing.T) {
 }
 
 func TestLinkedVersionOverridesBuildInfo(t *testing.T) {
-	exe := filepath.Join(t.TempDir(), "wfctl")
+	exeName := "wfctl"
+	if runtime.GOOS == "windows" {
+		exeName += ".exe"
+	}
+	exe := filepath.Join(t.TempDir(), exeName)
 	build := exec.Command("go", "build", "-o", exe, "-ldflags", "-X main.version=v9.9.9", ".")
 	build.Env = append(os.Environ(), "GOWORK=off")
 	if out, err := build.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary
- Make the wfctl `version` variable linker-overridable by release `-ldflags -X main.version=...` builds, with build metadata fallback for dev/module installs.
- Add a regression test that builds wfctl with `-X main.version=v9.9.9` and verifies `wfctl --version` reports that exact tag.
- Notify `workflow-registry` after non-prerelease workflow releases so registry core manifests and README indexes can refresh.

## Adversarial review
- Verified the root cause: linker `-X` cannot override a string variable initialized from `buildVersion()`; the new initializer is a plain string and fallback runs in `init`.
- Checked that release notification uses the existing `repo_dispatch_token` pattern and only runs after release for non-prerelease tags.
- `actionlint .github/workflows/release.yml` reports pre-existing shellcheck warnings at release.yml lines 145 and 287; the new registry notification block is not implicated.

## Test Plan
- [x] `GOWORK=off go test ./cmd/wfctl -run 'Test(BuildVersionStripsDirtyMarker|LinkedVersionOverridesBuildInfo|RunUpdate_CheckOnly|RunUpdate_AlreadyLatest|CheckForUpdateNotice_SkipsDevBuild)' -count=1 -v`
- [x] `git diff --check`
