### PR TITLE
fix(wfctl): match GitHub secrets case-insensitively

### DIFF
--- a/cmd/wfctl/infra_bootstrap.go
+++ b/cmd/wfctl/infra_bootstrap.go
@@ -563,6 +563,7 @@ var bootstrapSecrets = func(ctx context.Context, provider secrets.Provider, cfg 
 	// the provider once and subsequent lookups are O(1). Resolved lazily on
 	// the first write-only Get.
 	var listSet map[string]struct{}
+	var githubListFoldSet map[string]struct{}
 	var listErr error
 	var listDone bool
 	lookupViaList := func(key string) (bool, error) {
@@ -571,8 +572,14 @@ var bootstrapSecrets = func(ctx context.Context, provider secrets.Provider, cfg 
 			listErr = err
 			if err == nil {
 				listSet = make(map[string]struct{}, len(names))
+				if provider.Name() == "github" {
+					githubListFoldSet = make(map[string]struct{}, len(names))
+				}
 				for _, n := range names {
 					listSet[n] = struct{}{}
+					if githubListFoldSet != nil {
+						githubListFoldSet[strings.ToUpper(n)] = struct{}{}
+					}
 				}
 			}
 			listDone = true
@@ -580,8 +587,17 @@ var bootstrapSecrets = func(ctx context.Context, provider secrets.Provider, cfg 
 		if listErr != nil && !errors.Is(listErr, secrets.ErrUnsupported) {
 			return false, fmt.Errorf("list secrets to check %q: %w", key, listErr)
 		}
-		_, ok := listSet[key]
-		return ok, nil
+		if _, ok := listSet[key]; ok {
+			return true, nil
+		}
+		// GitHub Actions secret names are case-insensitive and are commonly
+		// reported uppercased by the API. Generated subkeys such as
+		// SPACES_access_key must still match SPACES_ACCESS_KEY.
+		if githubListFoldSet != nil {
+			_, ok := githubListFoldSet[strings.ToUpper(key)]
+			return ok, nil
+		}
+		return false, nil
 	}
 	secretExists := func(key string) (bool, error) {
 		_, err := provider.Get(ctx, key)
@@ -667,6 +683,7 @@ var bootstrapSecrets = func(ctx context.Context, provider secrets.Provider, cfg 
 			// write-only providers (GitHub Actions) where Get is unsupported.
 			listDone = false
 			listSet = nil
+			githubListFoldSet = nil
 		} else {
 			// Normal path: check that EVERY expected stored key is already present
 			// before skipping. provider_credential writes multiple sub-keys; if a

--- a/cmd/wfctl/infra_bootstrap_secrets_test.go
+++ b/cmd/wfctl/infra_bootstrap_secrets_test.go
@@ -16,9 +16,15 @@ type writeOnlyProvider struct {
 	getCalls  int
 	listCalls int
 	listOK    bool
+	name      string
 }
 
-func (p *writeOnlyProvider) Name() string { return "write-only-fake" }
+func (p *writeOnlyProvider) Name() string {
+	if p.name != "" {
+		return p.name
+	}
+	return "write-only-fake"
+}
 
 func (p *writeOnlyProvider) Get(_ context.Context, _ string) (string, error) {
 	p.getCalls++
@@ -78,6 +84,35 @@ func TestBootstrapSecrets_WriteOnlyProviderSkipsExisting(t *testing.T) {
 	}
 	if p.listCalls != 1 {
 		t.Fatalf("List called %d times, want 1 (should be cached)", p.listCalls)
+	}
+}
+
+// TestBootstrapSecrets_GitHubProviderCredentialMatchesUppercaseList verifies
+// GitHub's write-only secret list can satisfy mixed-case generated key probes.
+// GitHub Actions secret names are case-insensitive, and the API reports common
+// subkey names as uppercase (SPACES_ACCESS_KEY / SPACES_SECRET_KEY). Without
+// this, auto-bootstrap attempts to recreate an existing upstream provider
+// credential and DigitalOcean refuses the duplicate name.
+func TestBootstrapSecrets_GitHubProviderCredentialMatchesUppercaseList(t *testing.T) {
+	withStubGenerator(t, func(_ context.Context, _ string, _ map[string]any) (string, error) {
+		t.Fatal("generator must not be called when GitHub-listed sub-keys already exist")
+		return "", nil
+	})
+	p := &writeOnlyProvider{
+		name:     "github",
+		existing: []string{"SPACES_ACCESS_KEY", "SPACES_SECRET_KEY"},
+		listOK:   true,
+	}
+	cfg := &SecretsConfig{
+		Generate: []SecretGen{
+			{Key: "SPACES", Type: "provider_credential", Source: "digitalocean.spaces"},
+		},
+	}
+	if _, _, err := bootstrapSecrets(context.Background(), p, cfg, nil); err != nil {
+		t.Fatalf("bootstrapSecrets: %v", err)
+	}
+	if len(p.stored) != 0 {
+		t.Fatalf("stored = %v, want empty (GitHub-listed secrets already exist)", p.stored)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- treat GitHub Actions secret names as case-insensitive when wfctl auto-bootstrap checks write-only List() results\n- add regression coverage for generated DO Spaces provider credentials listed as SPACES_ACCESS_KEY / SPACES_SECRET_KEY\n\n## Verification\n- GOWORK=off go test ./cmd/wfctl -run 'TestBootstrapSecrets_(WriteOnlyProviderSkipsExisting|GitHubProviderCredentialMatchesUppercaseList|ProviderCredentialAllSubKeysPresent|ProviderCredentialPartialRegenerates)'\n- GOWORK=off go test ./cmd/wfctl ./secrets