### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,9 @@ baseline-bench.txt
 current-bench.txt
 benchmark-results.txt
 benchstat-output.txt
-.worktrees
+# Local agent/dev worktrees
+_worktrees/
+.worktrees/
 cmd/wfctl/.wfctl.yaml
 cmd/wfctl/.wfctl-lock.yaml
 


### PR DESCRIPTION
## Summary
- ignore project-local `_worktrees/` and `.worktrees/` directories
- keep agent/dev worktree directories out of deny-list git status noise

## Verification
- `git check-ignore -v _worktrees/ .worktrees/ .claude/worktrees/`
- `git diff --check`
