### PR TITLE
Notify workflow-scenarios on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,3 +347,17 @@ jobs:
         repository: GoCodeAlone/workflow-registry
         event-type: workflow-release
         client-payload: '{"workflow": "${{ github.repository }}", "version": "${{ env.TAG_NAME }}"}'
+
+  notify-workflow-scenarios:
+    name: Notify workflow-scenarios
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
+    steps:
+    - name: Trigger workflow-scenarios bump
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ secrets.repo_dispatch_token }}
+        repository: GoCodeAlone/workflow-scenarios
+        event-type: workflow-release
+        client-payload: '{"workflow": "${{ github.repository }}", "tag": "${{ env.TAG_NAME }}"}'


### PR DESCRIPTION
## Summary
- notify `workflow-scenarios` after stable Workflow releases
- dispatch `workflow-release` with the released tag so scenarios can open dependency bump PRs immediately

## Verification
- YAML parse check for `.github/workflows/release.yml`
- `git diff --check`
