### PR TITLE
feat: prefer observability telemetry in wfctl templates

### DIFF
--- a/cmd/wfctl/init_test.go
+++ b/cmd/wfctl/init_test.go
@@ -54,6 +54,15 @@ func TestRunInitAPIServiceTemplate(t *testing.T) {
 	if !strings.Contains(string(yml), "my-service-server") {
 		t.Errorf("workflow.yaml missing expected module name, got: %s", string(yml))
 	}
+	if !strings.Contains(string(yml), "type: observability.telemetry") {
+		t.Errorf("workflow.yaml missing observability.telemetry, got: %s", string(yml))
+	}
+	if !strings.Contains(string(yml), "type: observability.collector") {
+		t.Errorf("workflow.yaml missing observability.collector, got: %s", string(yml))
+	}
+	if strings.Contains(string(yml), "type: metrics.collector") {
+		t.Errorf("workflow.yaml should not create metrics.collector, got: %s", string(yml))
+	}
 }
 
 func TestRunInitEventProcessorTemplate(t *testing.T) {
@@ -95,6 +104,16 @@ func TestRunInitFullStackTemplate(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(outDir, f)); os.IsNotExist(err) {
 			t.Errorf("expected %s to be created", f)
 		}
+	}
+	yml, err := os.ReadFile(filepath.Join(outDir, "workflow.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read workflow.yaml: %v", err)
+	}
+	if !strings.Contains(string(yml), "type: observability.telemetry") {
+		t.Errorf("workflow.yaml missing observability.telemetry, got: %s", string(yml))
+	}
+	if strings.Contains(string(yml), "type: metrics.collector") {
+		t.Errorf("workflow.yaml should not create metrics.collector, got: %s", string(yml))
 	}
 }
 

--- a/cmd/wfctl/templates/api-service/workflow.yaml.tmpl
+++ b/cmd/wfctl/templates/api-service/workflow.yaml.tmpl
@@ -21,10 +21,18 @@ modules:
     config:
       description: "Health check endpoint for {{.Name}}"
 
-  - name: {{.Name}}-metrics
-    type: metrics.collector
+  - name: {{.Name}}-telemetry
+    type: observability.telemetry
     config:
-      description: "Prometheus metrics for {{.Name}}"
+      serviceName: "{{.Name}}"
+      environment: "local"
+
+  - name: {{.Name}}-collector
+    type: observability.collector
+    config:
+      distribution: external
+      topology: external
+      signals: [traces, metrics, logs]
 
 workflows:
   http:

--- a/cmd/wfctl/templates/full-stack/workflow.yaml.tmpl
+++ b/cmd/wfctl/templates/full-stack/workflow.yaml.tmpl
@@ -30,10 +30,18 @@ modules:
     config:
       description: "Health check endpoint"
 
-  - name: {{.Name}}-metrics
-    type: metrics.collector
+  - name: {{.Name}}-telemetry
+    type: observability.telemetry
     config:
-      description: "Prometheus metrics"
+      serviceName: "{{.Name}}"
+      environment: "local"
+
+  - name: {{.Name}}-collector
+    type: observability.collector
+    config:
+      distribution: external
+      topology: external
+      signals: [traces, metrics, logs]
 
 workflows:
   http:

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -277,6 +277,18 @@ func KnownModuleTypes() map[string]ModuleTypeInfo {
 			Stateful:   false,
 			ConfigKeys: []string{"namespace", "subsystem", "metricsPath", "enabledMetrics"},
 		},
+		"observability.telemetry": {
+			Type:       "observability.telemetry",
+			Plugin:     "observability",
+			Stateful:   false,
+			ConfigKeys: []string{"serviceName", "environment", "resource", "metricsInterval", "otlpEndpoint"},
+		},
+		"observability.collector": {
+			Type:       "observability.collector",
+			Plugin:     "observability",
+			Stateful:   false,
+			ConfigKeys: []string{"distribution", "topology", "signals", "receivers", "processors", "exporters", "routes"},
+		},
 		"health.checker": {
 			Type:       "health.checker",
 			Plugin:     "observability",

--- a/cmd/wfctl/type_registry_test.go
+++ b/cmd/wfctl/type_registry_test.go
@@ -24,6 +24,8 @@ func TestKnownModuleTypesPopulated(t *testing.T) {
 		"messaging.broker",
 		"statemachine.engine",
 		"metrics.collector",
+		"observability.telemetry",
+		"observability.collector",
 		"health.checker",
 		"cache.redis",
 	}


### PR DESCRIPTION
## Summary\n- remove direct /metrics scaffolding from generated API/full-stack templates\n- add workflow-plugin-observability wiring so generated apps emit telemetry through the shared observability path\n- keep app-specific metric names out of generic workflow/plugin code\n\n## Dependency\n- Can merge after the observability core contracts PR lands: GoCodeAlone/workflow#775\n\n## Verification\n- GOWORK=off go test ./cmd/wfctl -run 'TestRunInit(APIService|FullStack)Template|TestKnownModuleTypesPopulated|TestRunTemplateValidate'\n- GOWORK=off go test ./cmd/wfctl