### PR TITLE
feat(interfaces): IsErrResourceNotFound helper + struct Is method + 11 call-site migrations

### DIFF
--- a/cmd/wfctl/deploy_providers.go
+++ b/cmd/wfctl/deploy_providers.go
@@ -705,7 +705,7 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 	case readErr == nil && readOut != nil && readOut.ProviderID != "":
 		ref.ProviderID = readOut.ProviderID
 		log.Printf("plugin deploy %q: found existing resource (id=%s)", p.resourceName, ref.ProviderID)
-	case readErr != nil && errors.Is(readErr, interfaces.ErrResourceNotFound):
+	case readErr != nil && interfaces.IsErrResourceNotFound(readErr):
 		// Resource confirmed absent — skip Update, go straight to Create.
 		return p.doCreate(ctx, driver, ref, spec, imageStr)
 	case readErr != nil:
@@ -724,7 +724,7 @@ func (p *pluginDeployProvider) Deploy(ctx context.Context, cfg DeployConfig) err
 		fmt.Printf("  plugin deploy: updated %q at %s (id=%s)\n", p.resourceName, imageStr, out.ProviderID)
 		return nil
 	}
-	if !errors.Is(updateErr, interfaces.ErrResourceNotFound) {
+	if !interfaces.IsErrResourceNotFound(updateErr) {
 		return deployOpError(p.resourceName, "update", updateErr)
 	}
 	// Resource does not exist yet — fall back to Create.

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -917,23 +917,7 @@ func driverSupportsConfigAdoption(driver interfaces.ResourceDriver) bool {
 }
 
 func isIaCNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, interfaces.ErrResourceNotFound) {
-		return true
-	}
-	var platformNotFound *platform.ResourceNotFoundError
-	if errors.As(err, &platformNotFound) {
-		return true
-	}
-	// gRPC fallback: typed adapter loses sentinel identity across the
-	// wire. The message survives as a wrapped string. Match on the
-	// literal ErrResourceNotFound.Error() value so adoption can still
-	// detect "not present yet, fall back to create" against remote
-	// plugin drivers (workflow-plugin-digitalocean v2+ database
-	// adoption is the original repro path).
-	return strings.Contains(err.Error(), interfaces.ErrResourceNotFound.Error())
+	return interfaces.IsErrResourceNotFound(err)
 }
 
 func resourceStateFromLiveOutput(spec interfaces.ResourceSpec, providerType string, live *interfaces.ResourceOutput) (interfaces.ResourceState, error) {
@@ -1268,7 +1252,7 @@ func compensateAfterValidationFailure(driver interfaces.ResourceDriver, rs inter
 	if rs.ProviderID != "" {
 		idRef := interfaces.ResourceRef{Name: rs.Name, Type: rs.Type, ProviderID: rs.ProviderID}
 		if delErr := driver.Delete(ctx, idRef); delErr != nil {
-			if !errors.Is(delErr, interfaces.ErrResourceNotFound) {
+			if !interfaces.IsErrResourceNotFound(delErr) {
 				errs = append(errs, fmt.Errorf("driver.Delete(%s): %w", rs.ProviderID, delErr))
 			}
 		} else {
@@ -1277,7 +1261,7 @@ func compensateAfterValidationFailure(driver interfaces.ResourceDriver, rs inter
 	}
 	nameRef := interfaces.ResourceRef{Name: rs.Name, Type: rs.Type}
 	if delErr := driver.Delete(ctx, nameRef); delErr != nil {
-		if !errors.Is(delErr, interfaces.ErrResourceNotFound) {
+		if !interfaces.IsErrResourceNotFound(delErr) {
 			errs = append(errs, fmt.Errorf("driver.Delete(name-only): %w", delErr))
 		}
 		return errors.Join(errs...)

--- a/iac/refreshoutputs/refresh.go
+++ b/iac/refreshoutputs/refresh.go
@@ -12,7 +12,6 @@ package refreshoutputs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -94,7 +93,7 @@ func refreshOne(ctx context.Context, p interfaces.IaCProvider, dst *interfaces.R
 	ref := interfaces.ResourceRef{Name: src.Name, Type: src.Type, ProviderID: src.ProviderID}
 	live, err := d.Read(ctx, ref)
 	if err != nil {
-		if errors.Is(err, interfaces.ErrResourceNotFound) {
+		if interfaces.IsErrResourceNotFound(err) {
 			// Ghost: cloud reports the resource does not exist. Explicitly keep
 			// dst.Outputs aligned with src so refreshOne is self-contained and
 			// does not rely on the caller having pre-copied src into dst.

--- a/interfaces/iac_resource_driver.go
+++ b/interfaces/iac_resource_driver.go
@@ -3,6 +3,7 @@ package interfaces
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -55,6 +56,25 @@ var (
 	// ErrProviderMethodUnimplemented for callers.
 	ErrProviderMethodUnimplemented = errors.New("iac: provider method unimplemented")
 )
+
+// IsErrResourceNotFound reports whether err is or wraps ErrResourceNotFound,
+// including the case where the sentinel was stringified across a gRPC plugin
+// boundary (where errors.Is fails because structpb does not preserve sentinel
+// identity). Matches the ErrImageNotInRegistry precedent above. The message
+// string of ErrResourceNotFound is load-bearing for this match; do not change
+// it without updating TestErrResourceNotFound_MessageStringStable.
+//
+// For non-gRPC callers (e.g., SQL-backed tenant lookups in module/),
+// errors.Is fires and strings.Contains is never reached.
+func IsErrResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrResourceNotFound) {
+		return true
+	}
+	return strings.Contains(err.Error(), ErrResourceNotFound.Error())
+}
 
 // ResourceDriver handles CRUD for a single resource type within a provider.
 type ResourceDriver interface {

--- a/interfaces/iac_resource_driver_test.go
+++ b/interfaces/iac_resource_driver_test.go
@@ -96,3 +96,32 @@ func TestErrImageNotInRegistry_MessageStringStable(t *testing.T) {
 		t.Fatalf("ErrImageNotInRegistry.Error() = %q; want %q (load-bearing for gRPC string-match fallback)", got, want)
 	}
 }
+
+func TestErrResourceNotFound_MessageStringStable(t *testing.T) {
+	const expected = "iac: resource not found"
+	if got := interfaces.ErrResourceNotFound.Error(); got != expected {
+		t.Fatalf("ErrResourceNotFound message changed (was %q, want %q) — load-bearing for cross-process matching", got, expected)
+	}
+}
+
+func TestIsErrResourceNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"direct", interfaces.ErrResourceNotFound, true},
+		{"wrapped with fmt.Errorf %w", fmt.Errorf("driver: %w", interfaces.ErrResourceNotFound), true},
+		{"stringified across gRPC (no sentinel)", errors.New("plugin: " + interfaces.ErrResourceNotFound.Error()), true},
+		{"unrelated NotFound", errors.New("file: not found"), false},
+		{"empty error", errors.New(""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := interfaces.IsErrResourceNotFound(tc.err); got != tc.want {
+				t.Errorf("IsErrResourceNotFound(%v) = %v; want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/module/tenant_resolver.go
+++ b/module/tenant_resolver.go
@@ -187,7 +187,7 @@ func (r *TenantContextResolver) lookup(key string) (interfaces.Tenant, error) {
 	if err == nil {
 		return t, nil
 	}
-	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+	if !interfaces.IsErrResourceNotFound(err) {
 		return interfaces.Tenant{}, fmt.Errorf("registry lookup by slug %q: %w", key, err)
 	}
 	// Fall back to domain lookup.
@@ -195,7 +195,7 @@ func (r *TenantContextResolver) lookup(key string) (interfaces.Tenant, error) {
 	if err == nil {
 		return t, nil
 	}
-	if errors.Is(err, interfaces.ErrResourceNotFound) {
+	if interfaces.IsErrResourceNotFound(err) {
 		return interfaces.Tenant{}, nil
 	}
 	return interfaces.Tenant{}, fmt.Errorf("registry lookup by domain %q: %w", key, err)

--- a/module/tenants.go
+++ b/module/tenants.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"strings"
@@ -194,7 +193,7 @@ func (r *SQLTenantRegistry) Ensure(spec interfaces.TenantSpec) (interfaces.Tenan
 	if err == nil {
 		return existing, nil
 	}
-	if !errors.Is(err, interfaces.ErrResourceNotFound) {
+	if !interfaces.IsErrResourceNotFound(err) {
 		return interfaces.Tenant{}, fmt.Errorf("ensure tenant: lookup: %w", err)
 	}
 
@@ -372,7 +371,7 @@ func (r *SQLTenantRegistry) List(filter interfaces.TenantFilter) ([]interfaces.T
 func (r *SQLTenantRegistry) Update(id string, patch interfaces.TenantPatch) (interfaces.Tenant, error) {
 	// Fetch existing so we can invalidate stale domain cache keys if domains changed.
 	existing, fetchErr := r.GetByID(id)
-	if fetchErr != nil && !errors.Is(fetchErr, interfaces.ErrResourceNotFound) {
+	if fetchErr != nil && !interfaces.IsErrResourceNotFound(fetchErr) {
 		return interfaces.Tenant{}, fmt.Errorf("update tenant: fetch existing: %w", fetchErr)
 	}
 

--- a/platform/differ.go
+++ b/platform/differ.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -384,7 +383,7 @@ func classifyCreate(ctx context.Context, p interfaces.IaCProvider, spec interfac
 	}
 	current, err := driver.Read(ctx, ref)
 	if err != nil {
-		if errors.Is(err, interfaces.ErrResourceNotFound) {
+		if interfaces.IsErrResourceNotFound(err) {
 			return create, nil
 		}
 		return nil, fmt.Errorf("provider.Read(%q/%q): %w", spec.Type, spec.Name, err)

--- a/platform/errors.go
+++ b/platform/errors.go
@@ -1,6 +1,10 @@
 package platform
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
 
 // ConstraintViolationError is returned when a capability declaration violates
 // a constraint imposed by a parent tier.
@@ -84,6 +88,13 @@ func (e *ResourceNotFoundError) Error() string {
 		return fmt.Sprintf("resource %q not found in provider %q", e.Name, e.Provider)
 	}
 	return fmt.Sprintf("resource %q not found", e.Name)
+}
+
+// Is reports whether target is interfaces.ErrResourceNotFound. Lets
+// errors.Is(err, interfaces.ErrResourceNotFound) natively match this
+// typed error without callers needing both errors.Is and errors.As.
+func (e *ResourceNotFoundError) Is(target error) bool {
+	return target == interfaces.ErrResourceNotFound
 }
 
 // PlanConflictError is returned when a plan conflicts with another plan

--- a/platform/errors_test.go
+++ b/platform/errors_test.go
@@ -1,0 +1,19 @@
+package platform_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/platform"
+)
+
+func TestResourceNotFoundError_IsErrResourceNotFound(t *testing.T) {
+	structErr := &platform.ResourceNotFoundError{Name: "alpha", Provider: "stub"}
+	if !errors.Is(structErr, interfaces.ErrResourceNotFound) {
+		t.Errorf("errors.Is(*ResourceNotFoundError, ErrResourceNotFound) = false; want true after Is method added")
+	}
+	if errors.Is(structErr, interfaces.ErrImageNotInRegistry) {
+		t.Errorf("errors.Is(*ResourceNotFoundError, ErrImageNotInRegistry) = true; want false (different sentinel)")
+	}
+}


### PR DESCRIPTION
Plugs gRPC-boundary gap where `errors.Is(err, ErrResourceNotFound)` fails on cross-wire stringified errors. Follows `ErrImageNotInRegistry` load-bearing-string precedent. No SDK changes.

## Changes

- `platform.ResourceNotFoundError.Is(target)` — makes `errors.Is(err, interfaces.ErrResourceNotFound)` catch the struct natively
- `interfaces.IsErrResourceNotFound(err)` — helper covering sentinel + struct + gRPC-stringified (via `strings.Contains` fallback on the load-bearing message string)
- 11 call sites migrated to the helper (1 helper-body collapse + 10 call-site replacements)
- Stability test pins `ErrResourceNotFound` message string
- Unit tests cover sentinel, wrapped, stringified, unrelated-NotFound, empty cases

## Call sites migrated

- `cmd/wfctl/infra_apply.go`: `isIaCNotFound` body collapsed to delegation (1) + delete-error paths (2)
- `cmd/wfctl/deploy_providers.go`: read + update error paths during deploy (2)
- `platform/differ.go`: `classifyCreate` cascade-retro gap (1)
- `iac/refreshoutputs/refresh.go`: refresh-outputs not-found (1)
- `module/tenant_resolver.go`: tenant lookup by slug + domain (2)
- `module/tenants.go`: tenant fetch + update (2)

Note: `deploy_providers.go:389` is a `fmt.Errorf("%w: ...")` WRAPPING site — not migrated per plan.

## Design

`docs/plans/2026-05-27-iac-not-found-sentinel-translation-design.md`

## Test plan

- [x] `GOWORK=off go test ./platform/...` — `TestResourceNotFoundError_IsErrResourceNotFound` green
- [x] `GOWORK=off go test ./interfaces/...` — `TestErrResourceNotFound_MessageStringStable` + `TestIsErrResourceNotFound` (6 cases) green
- [x] `GOWORK=off go test ./...` — all packages green
- [x] `GOWORK=off golangci-lint run --new-from-rev=origin/main` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)