### PR TITLE
security: strong API-key hashing + safe int conversion + workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/test-dispatch.yml
+++ b/.github/workflows/test-dispatch.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'v0.3.20'
 
+permissions:
+  contents: read
+
 jobs:
   test-dispatch:
     name: Test Repository Dispatch

--- a/schema/reflect.go
+++ b/schema/reflect.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -129,6 +130,10 @@ func parseDefault(s string) any {
 		return false
 	}
 	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		// Guard against overflow when converting int64 → int on 32-bit platforms.
+		if i < math.MinInt || i > math.MaxInt {
+			return s // out-of-range: preserve as string
+		}
 		return int(i)
 	}
 	if f, err := strconv.ParseFloat(s, 64); err == nil {

--- a/schema/reflect_test.go
+++ b/schema/reflect_test.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"math"
+	"strconv"
 	"testing"
 )
 
@@ -266,6 +268,42 @@ func TestParseDefault(t *testing.T) {
 		got := parseDefault(tc.input)
 		if got != tc.want {
 			t.Errorf("parseDefault(%q) = %v (%T), want %v (%T)", tc.input, got, got, tc.want, tc.want)
+		}
+	}
+}
+
+// TestParseDefaultIntOverflow verifies that integer values outside the range of
+// int on the current platform are never returned as int (which would silently
+// overflow on 32-bit hosts). On 64-bit hosts this exercises the guard for
+// hypothetical 32-bit deployment by directly testing the bounds.
+func TestParseDefaultIntOverflow(t *testing.T) {
+	// Values within [MinInt, MaxInt] must parse as int.
+	maxInt := strconv.FormatInt(math.MaxInt, 10)
+	gotMax := parseDefault(maxInt)
+	if _, ok := gotMax.(int); !ok {
+		t.Errorf("parseDefault(%q) should return int, got %T", maxInt, gotMax)
+	}
+	if gotMax != math.MaxInt {
+		t.Errorf("parseDefault(%q) = %v, want %v", maxInt, gotMax, math.MaxInt)
+	}
+
+	minInt := strconv.FormatInt(math.MinInt, 10)
+	gotMin := parseDefault(minInt)
+	if _, ok := gotMin.(int); !ok {
+		t.Errorf("parseDefault(%q) should return int, got %T", minInt, gotMin)
+	}
+	if gotMin != math.MinInt {
+		t.Errorf("parseDefault(%q) = %v, want %v", minInt, gotMin, math.MinInt)
+	}
+
+	// On 32-bit platforms (math.MaxInt == math.MaxInt32), values between
+	// math.MaxInt32+1 and math.MaxInt64 must NOT return as int.
+	if math.MaxInt == math.MaxInt32 {
+		overflowVal := int64(math.MaxInt32) + 1
+		overflowStr := strconv.FormatInt(overflowVal, 10)
+		got := parseDefault(overflowStr)
+		if _, ok := got.(int); ok {
+			t.Errorf("parseDefault(%q) returned int on 32-bit platform, expected non-int to avoid overflow", overflowStr)
 		}
 	}
 }

--- a/store/api_keys_test.go
+++ b/store/api_keys_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -498,5 +499,62 @@ func TestSQLiteAPIKeyStoreFromDB(t *testing.T) {
 	}
 	if validated.Name != "from-db-test" {
 		t.Errorf("Name: got %q, want %q", validated.Name, "from-db-test")
+	}
+}
+
+// TestHashKeyUsesSHA256 verifies that hashKey produces a full SHA-256 hex digest
+// (64 hex characters = 256 bits). This acts as a regression guard: if the
+// implementation were ever downgraded to MD5 (32 chars) or SHA-1 (40 chars),
+// this test would catch it immediately.
+func TestHashKeyUsesSHA256(t *testing.T) {
+	const wantHexLen = 64 // SHA-256 = 32 bytes = 64 hex chars
+
+	inputs := []string{
+		"wf_0000000000000000000000000000dead",
+		"wf_" + strings.Repeat("a", 32),
+		"",
+	}
+	for _, in := range inputs {
+		h := hashKey(in)
+		if len(h) != wantHexLen {
+			t.Errorf("hashKey(%q): got len %d, want %d (SHA-256)", in, len(h), wantHexLen)
+		}
+		if _, err := hex.DecodeString(h); err != nil {
+			t.Errorf("hashKey(%q): output is not valid hex: %v", in, err)
+		}
+	}
+
+	// Same input must always produce the same digest (deterministic).
+	const key = "wf_deterministic_key_test_value00"
+	h1, h2 := hashKey(key), hashKey(key+"") // two separate calls
+	if h1 != h2 {
+		t.Errorf("hashKey is not deterministic: %q != %q", h1, h2)
+	}
+
+	// Different inputs must produce different digests.
+	if hashKey("wf_aaa") == hashKey("wf_bbb") {
+		t.Error("hashKey collision on distinct inputs")
+	}
+}
+
+// TestConstantTimeHashCompare verifies the constant-time equality helper used
+// during API-key validation to prevent timing-oracle attacks.
+func TestConstantTimeHashCompare(t *testing.T) {
+	a := hashKey("wf_" + strings.Repeat("x", 32))
+	b := hashKey("wf_" + strings.Repeat("x", 32))
+	c := hashKey("wf_" + strings.Repeat("y", 32))
+
+	if !constantTimeHashCompare(a, b) {
+		t.Error("identical hashes should compare equal")
+	}
+	if constantTimeHashCompare(a, c) {
+		t.Error("different hashes should not compare equal")
+	}
+	// Empty strings are equal to each other and not equal to a real hash.
+	if !constantTimeHashCompare("", "") {
+		t.Error("empty strings should compare equal")
+	}
+	if constantTimeHashCompare(a, "") {
+		t.Error("hash should not equal empty string")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes three GitHub CodeQL alerts.

---

### 1. `go/weak-sensitive-data-hashing` (HIGH) — `store/api_keys.go`

**Issue:** CodeQL flagged `hashKey` for hashing a sensitive API key token.

**Finding:** The implementation already uses `crypto/sha256` (SHA-256) with `crypto/subtle.ConstantTimeCompare` for all in-memory lookups — both the correct algorithm and the correct comparison primitive for a high-entropy random token (128 bits of randomness from `crypto/rand`). SHA-256 is appropriate here because this is a **deterministic lookup hash** (the raw key is a one-time secret; the hash is stored and later used to look up the record), not a password. A slow KDF (bcrypt/argon2) would not be appropriate since it would prevent efficient index lookups.

**Fix:** Added `TestHashKeyUsesSHA256` and `TestConstantTimeHashCompare` as regression guards. Any future regression to MD5 (32-char hex output) or SHA-1 (40-char hex output) will fail immediately at CI.

**Compatibility:** No change to stored hashes. The algorithm was already SHA-256 — no migration needed.

---

### 2. `go/incorrect-integer-conversion` (HIGH) — `schema/reflect.go`

**Issue:** `parseDefault` called `strconv.ParseInt(s, 10, 64)` and then cast the `int64` result directly to `int`. On 32-bit platforms `int` is 32 bits wide, so any parsed value in the range `[math.MaxInt32+1, math.MaxInt64]` silently overflows.

**Fix:** Added a bounds check before the cast:
```go
if i < math.MinInt || i > math.MaxInt {
    return s // out-of-range: preserve as string
}
return int(i)
```
Values within `[math.MinInt, math.MaxInt]` (platform-native `int` bounds) are converted as before. Out-of-range values fall through to the string representation, which is the same behaviour the function applies to any value that fails both numeric parses.

Added `TestParseDefaultIntOverflow` covering `MaxInt`, `MinInt`, and the 32-bit overflow path.

---

### 3. `actions/missing-workflow-permissions` (MEDIUM) — `.github/workflows/test-dispatch.yml`

**Issue:** No `permissions:` block was declared, so the workflow inherited the repository default token permissions (potentially broad write access).

**Fix:** Added a top-level least-privilege `permissions: contents: read` block. The `peter-evans/repository-dispatch` step and `gh run list` call both use `REPO_DISPATCH_TOKEN` (a caller-supplied PAT) rather than `GITHUB_TOKEN`, so no `GITHUB_TOKEN` permission escalation at the job level is required.

---

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./store/... ./schema/...` — all pass
- [x] `go vet ./store/... ./schema/...` — clean
- [x] `gofmt -l` — no dirty files
- [x] `golangci-lint run ./store/... ./schema/...` — 0 issues
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on `test-dispatch.yml` — parses OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)