### PR TITLE
refactor(ai): relocate misfiled AI providers plugin/ai → ai/providers

### DIFF
--- a/ai/providers/anthropic/plugin.go
+++ b/ai/providers/anthropic/plugin.go
@@ -36,6 +36,10 @@ type Provider struct {
 }
 
 // New creates a new Anthropic AIProvider.
+//
+// NOTE: This provider is currently unwired. The activation site is
+// plugins/ai/plugin.go via aiRegistry.RegisterProvider(New(cfg)) —
+// do NOT wire it via initAIService.
 func New(cfg Config) (*Provider, error) {
 	apiKey := cfg.APIKey
 	if apiKey == "" {

--- a/ai/providers/generic/plugin.go
+++ b/ai/providers/generic/plugin.go
@@ -47,6 +47,10 @@ type Provider struct {
 }
 
 // New creates a new generic OpenAI-compatible provider.
+//
+// NOTE: This provider is currently unwired. The activation site is
+// plugins/ai/plugin.go via aiRegistry.RegisterProvider(New(cfg)) —
+// do NOT wire it via initAIService.
 func New(cfg Config) (*Provider, error) {
 	if cfg.Name == "" {
 		return nil, fmt.Errorf("generic: provider name is required")

--- a/ai/providers/openai/plugin.go
+++ b/ai/providers/openai/plugin.go
@@ -34,6 +34,10 @@ type Provider struct {
 }
 
 // New creates a new OpenAI AIProvider.
+//
+// NOTE: This provider is currently unwired. The activation site is
+// plugins/ai/plugin.go via aiRegistry.RegisterProvider(New(cfg)) —
+// do NOT wire it via initAIService.
 func New(cfg Config) (*Provider, error) {
 	apiKey := cfg.APIKey
 	if apiKey == "" {


### PR DESCRIPTION
## What moved

Three packages relocated from `plugin/ai/` to `ai/providers/`:

- `plugin/ai/anthropic` → `ai/providers/anthropic`
- `plugin/ai/openai` → `ai/providers/openai`
- `plugin/ai/generic` → `ai/providers/generic`

## Why

These packages implement `ai.AIProvider` (Name/Models/Complete/CompleteStream/SupportsToolUse/ToolComplete) — they are **not** plugin contracts. They belong alongside `ai/llm` and `ai/copilot` in the `ai/` tree, not under `plugin/`.

## Move-only — zero behavior change

- They had **zero importers** before this PR (confirmed by grep).
- They remain **unwired** after this PR.
- Import paths inside each file (`github.com/GoCodeAlone/workflow/ai`) are unchanged — `ai/` stayed in place.
- A short doc comment was added to each `New(...)` constructor noting the future activation site: `plugins/ai/plugin.go` via `aiRegistry.RegisterProvider(...)` (the `AIModelRegistry` owner) — not `initAIService`.

## Verification

- `go build ./...` — clean
- `go test ./ai/... ./cmd/server/...` — all pass
- `go vet ./ai/...` — clean
- `gofmt -l ai/providers/` — clean
- `golangci-lint run ./ai/providers/...` — 0 issues
- `grep -r "workflow/plugin/ai" .` — zero matches remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)