### PR TITLE
feat(wfctl): smart CI generation — cigen analyze→plan→render + ci plan/generate + MCP (PR3/7)

### DIFF
--- a/cigen/analyze.go
+++ b/cigen/analyze.go
@@ -27,6 +27,15 @@ type Options struct {
 	PhaseConfig string
 	// Project overrides the project name derived from the config file.
 	Project string
+	// ConfigPathAlias, when set, is used verbatim as the primary phase's
+	// DeployPhase.ConfigPath instead of the real (possibly temporary or
+	// absolute) filesystem path Analyze was handed. Callers that read the
+	// config from a non-repo location — e.g. the MCP server, which writes
+	// yaml_content to an os.CreateTemp file — MUST set this to a stable,
+	// repo-relative logical name (e.g. "deploy.yaml" or the project name)
+	// so generated CI steps and path filters reference a real checkout path
+	// rather than a deleted /tmp file.
+	ConfigPathAlias string
 }
 
 // Analyze reads the workflow config files in configs and derives a CIPlan.
@@ -79,10 +88,50 @@ func Analyze(configs []string, opts Options) (*CIPlan, error) {
 	// Warnings
 	plan.Warnings = deriveWarnings(cfg, plan.Migrations, plan.Secrets)
 
-	// Phases
-	plan.Phases = derivePhases(primaryPath, opts.PhaseConfig)
+	// Phases. The primary phase's config path is the stable logical alias when
+	// provided (MCP path), otherwise the real path relativized to the working
+	// directory so the generated `paths:` trigger filter and `--config` step
+	// args reference a checkout-relative path rather than an absolute or /tmp
+	// path that never matches a CI checkout.
+	primaryConfigPath := opts.ConfigPathAlias
+	if primaryConfigPath == "" {
+		primaryConfigPath = relativizeConfigPath(primaryPath)
+	}
+	phaseConfigPath := opts.PhaseConfig
+	if phaseConfigPath != "" {
+		phaseConfigPath = relativizeConfigPath(phaseConfigPath)
+	}
+	plan.Phases = derivePhases(primaryConfigPath, phaseConfigPath)
 
 	return plan, nil
+}
+
+// relativizeConfigPath converts a config path to one relative to the current
+// working directory. If the path cannot be made relative or escapes cwd
+// (resolves to a parent via ".."), it falls back to the base filename so the
+// generated CI never references an absolute or out-of-tree path.
+func relativizeConfigPath(path string) string {
+	if path == "" {
+		return path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return filepath.Base(path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Base(path)
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil {
+		return filepath.Base(path)
+	}
+	// Escapes cwd (e.g. "../sibling/deploy.yaml") — a CI checkout would not
+	// contain it at that path, so fall back to the base name.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.Base(path)
+	}
+	return rel
 }
 
 // resolveVersion returns v if non-empty, otherwise "latest".
@@ -209,7 +258,7 @@ func deriveSecrets(cfg *config.WorkflowConfig, migrations *MigrationsSpec) []Sec
 			extractVarRefs(evs, addSecret)
 		}
 		// 3. iac.provider token/spaces keys
-		if strings.HasPrefix(m.Type, "iac.provider") || m.Type == "iac.provider" {
+		if strings.HasPrefix(m.Type, "iac.provider") {
 			for _, key := range []string{"token", "spaces_access_key", "spaces_secret_key", "accessKey", "secretKey"} {
 				if val, ok := m.Config[key]; ok {
 					if s, ok := val.(string); ok {

--- a/cigen/analyze.go
+++ b/cigen/analyze.go
@@ -311,8 +311,7 @@ func extractPrimaryDomain(cfg map[string]any) string {
 	if !ok {
 		return ""
 	}
-	switch v := domains.(type) {
-	case []any:
+	if v, ok := domains.([]any); ok {
 		for _, d := range v {
 			switch dm := d.(type) {
 			case map[string]any:

--- a/cigen/analyze.go
+++ b/cigen/analyze.go
@@ -1,0 +1,376 @@
+package cigen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+// varRefPattern matches ${VAR_NAME} references in config strings.
+var varRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// Options controls the behaviour of Analyze.
+type Options struct {
+	// WfctlVersion is the version string to embed in the plan (e.g. "v0.66.0" or "latest").
+	WfctlVersion string
+	// DefaultBranch overrides the default branch (defaults to "main").
+	DefaultBranch string
+	// Runner overrides the GitHub Actions runner label (defaults to "ubuntu-latest").
+	Runner string
+	// PhaseConfig is an optional second config path that becomes a prereq DeployPhase
+	// inserted before the main phase.
+	PhaseConfig string
+	// Project overrides the project name derived from the config file.
+	Project string
+}
+
+// Analyze reads the workflow config files in configs and derives a CIPlan.
+// configs must be non-empty; the first entry is the primary config.
+// opts.PhaseConfig, if set, is loaded as a prerequisite phase.
+func Analyze(configs []string, opts Options) (*CIPlan, error) {
+	if len(configs) == 0 {
+		return nil, fmt.Errorf("cigen.Analyze: at least one config path is required")
+	}
+
+	primaryPath := configs[0]
+	cfg, err := config.LoadFromFile(primaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("cigen.Analyze: load %s: %w", primaryPath, err)
+	}
+
+	plan := &CIPlan{
+		WfctlVersion:  resolveVersion(opts.WfctlVersion),
+		DefaultBranch: resolveDefault(opts.DefaultBranch, "main"),
+		Runner:        resolveDefault(opts.Runner, "ubuntu-latest"),
+		Triggers: TriggerSpec{
+			PR:       true,
+			PushMain: true,
+			Dispatch: true,
+		},
+		Warnings: []string{},
+	}
+
+	// Project name
+	plan.Project = resolveProject(opts.Project, primaryPath)
+
+	// PluginInstall: any plugin/* or infra.* module type, or .wfctl-lock.yaml sibling
+	plan.PluginInstall = detectPluginInstall(cfg, primaryPath)
+
+	// PlanGuard: any ModuleConfig.Protected == true
+	plan.PlanGuard = detectPlanGuard(cfg)
+
+	// Migrations
+	plan.Migrations = deriveMigrations(cfg)
+
+	// Build: Dockerfile sibling
+	plan.Build = deriveBuild(primaryPath)
+
+	// Secrets
+	plan.Secrets = deriveSecrets(cfg, plan.Migrations)
+
+	// Smoke
+	plan.Smoke = deriveSmoke(cfg)
+
+	// Warnings
+	plan.Warnings = deriveWarnings(cfg, plan.Migrations, plan.Secrets)
+
+	// Phases
+	plan.Phases = derivePhases(primaryPath, opts.PhaseConfig)
+
+	return plan, nil
+}
+
+// resolveVersion returns v if non-empty, otherwise "latest".
+func resolveVersion(v string) string {
+	if v != "" {
+		return v
+	}
+	return "latest"
+}
+
+// resolveDefault returns val if non-empty, otherwise def.
+func resolveDefault(val, def string) string {
+	if val != "" {
+		return val
+	}
+	return def
+}
+
+// resolveProject derives a project name from opts.Project or the config file path.
+func resolveProject(explicit, configPath string) string {
+	if explicit != "" {
+		return explicit
+	}
+	base := filepath.Base(configPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	// Use the directory name if the file is "app" or "deploy" or similar generic names
+	if name == "app" || name == "deploy" || name == "infra" {
+		dir := filepath.Dir(configPath)
+		if dir != "." && dir != "" {
+			return filepath.Base(dir)
+		}
+	}
+	return name
+}
+
+// detectPluginInstall returns true if the config references any plugin or infra module,
+// or if a .wfctl-lock.yaml file exists in the config's directory.
+func detectPluginInstall(cfg *config.WorkflowConfig, configPath string) bool {
+	for _, m := range cfg.Modules {
+		if strings.HasPrefix(m.Type, "infra.") ||
+			strings.HasPrefix(m.Type, "iac.") ||
+			strings.HasPrefix(m.Type, "plugin.") ||
+			strings.HasPrefix(m.Type, "analytics.") {
+			return true
+		}
+	}
+	// Check for .wfctl-lock.yaml sibling
+	dir := filepath.Dir(configPath)
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	if _, err := os.Stat(lockPath); err == nil {
+		return true
+	}
+	// Check if config file has a requires.plugins section
+	if cfg.Requires != nil && len(cfg.Requires.Plugins) > 0 {
+		return true
+	}
+	return false
+}
+
+// detectPlanGuard returns true if any module has Protected == true.
+func detectPlanGuard(cfg *config.WorkflowConfig) bool {
+	for _, m := range cfg.Modules {
+		if m.Protected {
+			return true
+		}
+	}
+	return false
+}
+
+// deriveMigrations extracts migration config from the first ci.migrations entry.
+func deriveMigrations(cfg *config.WorkflowConfig) *MigrationsSpec {
+	if cfg.CI == nil || len(cfg.CI.Migrations) == 0 {
+		return nil
+	}
+	m := cfg.CI.Migrations[0]
+	spec := &MigrationsSpec{
+		DBEnv:  m.Database.Env,
+		Source: m.SourceDir,
+	}
+	if spec.DBEnv == "" {
+		return nil
+	}
+	return spec
+}
+
+// deriveBuild checks for a Dockerfile in the config directory.
+func deriveBuild(configPath string) *BuildSpec {
+	dir := filepath.Dir(configPath)
+	dockerfilePath := filepath.Join(dir, "Dockerfile")
+	if _, err := os.Stat(dockerfilePath); err == nil {
+		return &BuildSpec{Docker: true}
+	}
+	return nil
+}
+
+// deriveSecrets builds the union of all secret references.
+func deriveSecrets(cfg *config.WorkflowConfig, migrations *MigrationsSpec) []SecretRef {
+	seen := make(map[string]bool)
+	var ordered []string
+
+	addSecret := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		ordered = append(ordered, name)
+	}
+
+	// 1. secrets.entries
+	if cfg.Secrets != nil {
+		for _, entry := range cfg.Secrets.Entries {
+			addSecret(entry.Name)
+		}
+	}
+
+	// 2. ${VAR} refs from module Config["env_vars_secret"] values
+	for _, m := range cfg.Modules {
+		if m.Config == nil {
+			continue
+		}
+		if evs, ok := m.Config["env_vars_secret"]; ok {
+			extractVarRefs(evs, addSecret)
+		}
+		// 3. iac.provider token/spaces keys
+		if strings.HasPrefix(m.Type, "iac.provider") || m.Type == "iac.provider" {
+			for _, key := range []string{"token", "spaces_access_key", "spaces_secret_key", "accessKey", "secretKey"} {
+				if val, ok := m.Config[key]; ok {
+					if s, ok := val.(string); ok {
+						extractVarRefsFromString(s, addSecret)
+					}
+				}
+			}
+		}
+	}
+
+	// 4. migrations DBEnv
+	if migrations != nil && migrations.DBEnv != "" {
+		addSecret(migrations.DBEnv)
+	}
+
+	sort.Strings(ordered)
+	refs := make([]SecretRef, 0, len(ordered))
+	for _, name := range ordered {
+		refs = append(refs, SecretRef{Name: name})
+	}
+	return refs
+}
+
+// extractVarRefs navigates an interface{} that may be a map[string]any or
+// string and calls add for each ${VAR} reference found.
+func extractVarRefs(v any, add func(string)) {
+	switch val := v.(type) {
+	case string:
+		extractVarRefsFromString(val, add)
+	case map[string]any:
+		for _, mv := range val {
+			extractVarRefs(mv, add)
+		}
+	case map[any]any:
+		for _, mv := range val {
+			extractVarRefs(mv, add)
+		}
+	}
+}
+
+// extractVarRefsFromString extracts ${VAR} references from a string.
+func extractVarRefsFromString(s string, add func(string)) {
+	for _, match := range varRefPattern.FindAllStringSubmatch(s, -1) {
+		if len(match) == 2 {
+			add(match[1])
+		}
+	}
+}
+
+// deriveSmoke extracts a smoke test spec from an infra.container_service module.
+func deriveSmoke(cfg *config.WorkflowConfig) *SmokeSpec {
+	for _, m := range cfg.Modules {
+		if m.Type != "infra.container_service" {
+			continue
+		}
+		if m.Config == nil {
+			continue
+		}
+		// Get health_check http_path
+		path := extractHealthCheckPath(m.Config)
+		if path == "" {
+			path = "/healthz"
+		}
+		// Get primary domain
+		domain := extractPrimaryDomain(m.Config)
+		if domain == "" {
+			continue
+		}
+		return &SmokeSpec{
+			URL:  "https://" + domain + path,
+			Path: path,
+		}
+	}
+	return nil
+}
+
+// extractHealthCheckPath extracts the http_path from a module's health_check config.
+func extractHealthCheckPath(cfg map[string]any) string {
+	hc, ok := cfg["health_check"]
+	if !ok {
+		return ""
+	}
+	switch v := hc.(type) {
+	case map[string]any:
+		if path, ok := v["http_path"].(string); ok {
+			return path
+		}
+	case map[any]any:
+		if path, ok := v["http_path"].(string); ok {
+			return path
+		}
+	}
+	return ""
+}
+
+// extractPrimaryDomain extracts the primary domain from a module's domains config.
+func extractPrimaryDomain(cfg map[string]any) string {
+	domains, ok := cfg["domains"]
+	if !ok {
+		return ""
+	}
+	switch v := domains.(type) {
+	case []any:
+		for _, d := range v {
+			switch dm := d.(type) {
+			case map[string]any:
+				if dt, ok := dm["type"].(string); ok && strings.EqualFold(dt, "PRIMARY") {
+					if domain, ok := dm["domain"].(string); ok {
+						return domain
+					}
+				}
+			case map[any]any:
+				if dt, ok := dm["type"].(string); ok && strings.EqualFold(dt, "PRIMARY") {
+					if domain, ok := dm["domain"].(string); ok {
+						return domain
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// derivePhases builds the ordered list of deploy phases.
+func derivePhases(primaryPath, phaseConfig string) []DeployPhase {
+	var phases []DeployPhase
+	if phaseConfig != "" {
+		phases = append(phases, DeployPhase{
+			Name:       "prereq",
+			ConfigPath: phaseConfig,
+		})
+	}
+	phases = append(phases, DeployPhase{
+		Name:       "deploy",
+		ConfigPath: primaryPath,
+	})
+	return phases
+}
+
+// upperCasePattern matches valid GitHub Actions secret name pattern.
+var upperCasePattern = regexp.MustCompile(`^[A-Z0-9_]+$`)
+
+// deriveWarnings produces advisory warnings for the operator.
+func deriveWarnings(cfg *config.WorkflowConfig, migrations *MigrationsSpec, secrets []SecretRef) []string {
+	var warnings []string
+
+	// (a) state-derived warning: migrations DBEnv may be hash-suffixed in the real GitHub secret
+	if migrations != nil && migrations.DBEnv != "" {
+		warnings = append(warnings,
+			fmt.Sprintf("secret %q is populated by IaC output — the real GitHub secret name may differ (e.g. include a resource hash suffix); verify the secret name matches what wfctl infra bootstrap writes",
+				migrations.DBEnv))
+	}
+
+	// (b) case/alias warning: secret names not matching ^[A-Z0-9_]+$
+	for _, s := range secrets {
+		if !upperCasePattern.MatchString(s.Name) {
+			warnings = append(warnings,
+				fmt.Sprintf("secret %q does not match ^[A-Z0-9_]+$ — the config casing is preserved as-is; you may need a GitHub-side alias if the platform normalises secret names to upper-case",
+					s.Name))
+		}
+	}
+
+	return warnings
+}

--- a/cigen/analyze_test.go
+++ b/cigen/analyze_test.go
@@ -1,6 +1,8 @@
 package cigen_test
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/cigen"
@@ -107,5 +109,55 @@ func TestAnalyze_NoMigrationsNoMigrationsSpec(t *testing.T) {
 	}
 	if plan.Migrations != nil {
 		t.Errorf("expected Migrations=nil for config with no ci.migrations, got %+v", plan.Migrations)
+	}
+}
+
+func TestAnalyze_AbsolutePathRelativized(t *testing.T) {
+	// When given an absolute path under cwd, the resulting phase ConfigPath must
+	// be relativized (no leading slash) so the generated CI `paths:` filter and
+	// `--config` args reference a checkout-relative path.
+	abs, err := filepath.Abs("testdata/app.yaml")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if !filepath.IsAbs(abs) {
+		t.Fatalf("expected an absolute path, got %q", abs)
+	}
+
+	plan, err := cigen.Analyze([]string{abs}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(plan.Phases) != 1 {
+		t.Fatalf("expected 1 phase, got %d", len(plan.Phases))
+	}
+	got := plan.Phases[0].ConfigPath
+	if filepath.IsAbs(got) {
+		t.Errorf("expected relativized ConfigPath, got absolute %q", got)
+	}
+	if strings.HasPrefix(got, "/") {
+		t.Errorf("ConfigPath must not start with /, got %q", got)
+	}
+	if got != filepath.Join("testdata", "app.yaml") {
+		t.Errorf("expected relative path %q, got %q", filepath.Join("testdata", "app.yaml"), got)
+	}
+}
+
+func TestAnalyze_ConfigPathAliasUsedVerbatim(t *testing.T) {
+	// When ConfigPathAlias is set (the MCP path), the primary phase ConfigPath
+	// must be the alias verbatim, NOT the real (temp/absolute) path.
+	abs, err := filepath.Abs("testdata/app.yaml")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	plan, err := cigen.Analyze([]string{abs}, cigen.Options{
+		ConfigPathAlias: "deploy.yaml",
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if plan.Phases[len(plan.Phases)-1].ConfigPath != "deploy.yaml" {
+		t.Errorf("expected primary phase ConfigPath to be alias %q, got %q",
+			"deploy.yaml", plan.Phases[len(plan.Phases)-1].ConfigPath)
 	}
 }

--- a/cigen/analyze_test.go
+++ b/cigen/analyze_test.go
@@ -1,0 +1,111 @@
+package cigen_test
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/cigen"
+)
+
+func TestAnalyze_GoldenFixture(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/app.yaml"}, cigen.Options{
+		WfctlVersion: "v0.66.0",
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	// PluginInstall: infra.container_service + analytics.google_provider + iac.provider → true
+	if !plan.PluginInstall {
+		t.Error("expected PluginInstall=true (infra/analytics/iac modules present)")
+	}
+
+	// PlanGuard: infra.container_service has protected: true
+	if !plan.PlanGuard {
+		t.Error("expected PlanGuard=true (protected module present)")
+	}
+
+	// Migrations: ci.migrations[0].database.env = APP_DB_URL
+	if plan.Migrations == nil {
+		t.Fatal("expected Migrations to be non-nil")
+	}
+	if plan.Migrations.DBEnv != "APP_DB_URL" {
+		t.Errorf("Migrations.DBEnv = %q, want %q", plan.Migrations.DBEnv, "APP_DB_URL")
+	}
+	if plan.Migrations.Source != "migrations" {
+		t.Errorf("Migrations.Source = %q, want %q", plan.Migrations.Source, "migrations")
+	}
+
+	// Single phase (no PhaseConfig option provided)
+	if len(plan.Phases) != 1 {
+		t.Errorf("expected 1 phase, got %d", len(plan.Phases))
+	}
+	if plan.Phases[0].Name != "deploy" {
+		t.Errorf("expected phase name %q, got %q", "deploy", plan.Phases[0].Name)
+	}
+
+	// Triggers: default PR+PushMain+Dispatch
+	if !plan.Triggers.PR {
+		t.Error("expected Triggers.PR=true")
+	}
+	if !plan.Triggers.PushMain {
+		t.Error("expected Triggers.PushMain=true")
+	}
+	if !plan.Triggers.Dispatch {
+		t.Error("expected Triggers.Dispatch=true")
+	}
+
+	// WfctlVersion
+	if plan.WfctlVersion != "v0.66.0" {
+		t.Errorf("WfctlVersion = %q, want %q", plan.WfctlVersion, "v0.66.0")
+	}
+
+	// DefaultBranch and Runner defaults
+	if plan.DefaultBranch != "main" {
+		t.Errorf("DefaultBranch = %q, want %q", plan.DefaultBranch, "main")
+	}
+	if plan.Runner != "ubuntu-latest" {
+		t.Errorf("Runner = %q, want %q", plan.Runner, "ubuntu-latest")
+	}
+}
+
+func TestAnalyze_PhaseConfig(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/app.yaml"}, cigen.Options{
+		PhaseConfig: "testdata/prereq.yaml",
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(plan.Phases) != 2 {
+		t.Fatalf("expected 2 phases, got %d", len(plan.Phases))
+	}
+	if plan.Phases[0].Name != "prereq" {
+		t.Errorf("expected first phase %q, got %q", "prereq", plan.Phases[0].Name)
+	}
+	if plan.Phases[0].ConfigPath != "testdata/prereq.yaml" {
+		t.Errorf("expected prereq config path %q, got %q", "testdata/prereq.yaml", plan.Phases[0].ConfigPath)
+	}
+	if plan.Phases[1].Name != "deploy" {
+		t.Errorf("expected second phase %q, got %q", "deploy", plan.Phases[1].Name)
+	}
+}
+
+func TestAnalyze_DefaultWfctlVersion(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/app.yaml"}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if plan.WfctlVersion != "latest" {
+		t.Errorf("expected WfctlVersion=%q, got %q", "latest", plan.WfctlVersion)
+	}
+}
+
+func TestAnalyze_NoMigrationsNoMigrationsSpec(t *testing.T) {
+	// A minimal config with no ci.migrations should yield Migrations==nil
+	plan, err := cigen.Analyze([]string{"testdata/minimal.yaml"}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if plan.Migrations != nil {
+		t.Errorf("expected Migrations=nil for config with no ci.migrations, got %+v", plan.Migrations)
+	}
+}

--- a/cigen/plan.go
+++ b/cigen/plan.go
@@ -1,0 +1,84 @@
+// Package cigen provides an analyze → CIPlan → render pipeline for generating
+// CI/CD configuration files from workflow YAML configs.
+package cigen
+
+// CIPlan is a platform-neutral representation of a CI/CD plan derived from
+// one or more workflow config files.
+type CIPlan struct {
+	// Project is the name of the project (derived from config or directory).
+	Project string `json:"project"`
+	// WfctlVersion is the wfctl version to pin in generated CI files.
+	WfctlVersion string `json:"wfctl_version"`
+	// DefaultBranch is the branch that triggers apply jobs.
+	DefaultBranch string `json:"default_branch"`
+	// Runner is the runner label used for GitHub Actions jobs.
+	Runner string `json:"runner"`
+	// PluginInstall is true when wfctl plugin install should be run before deploy.
+	PluginInstall bool `json:"plugin_install"`
+	// Build describes the build phase, or nil when no build is needed.
+	Build *BuildSpec `json:"build,omitempty"`
+	// Secrets is the union of all secret references needed by CI.
+	Secrets []SecretRef `json:"secrets"`
+	// Phases is the ordered list of deploy phases.
+	Phases []DeployPhase `json:"phases"`
+	// Migrations describes database migration config, or nil when none.
+	Migrations *MigrationsSpec `json:"migrations,omitempty"`
+	// Smoke describes the smoke test, or nil when no smoke test can be derived.
+	Smoke *SmokeSpec `json:"smoke,omitempty"`
+	// PlanGuard is true when a protected resource requires a plan-before-apply gate.
+	PlanGuard bool `json:"plan_guard"`
+	// Triggers describes which GitHub events trigger CI jobs.
+	Triggers TriggerSpec `json:"triggers"`
+	// Warnings is a list of non-fatal advisory messages surfaced to the operator.
+	Warnings []string `json:"warnings"`
+}
+
+// BuildSpec describes the build phase.
+type BuildSpec struct {
+	// Docker is true when a Dockerfile was detected.
+	Docker bool `json:"docker"`
+	// Image is the image name to build (if derivable).
+	Image string `json:"image,omitempty"`
+}
+
+// SecretRef is a reference to a named secret required by CI.
+type SecretRef struct {
+	// Name is the secret name as it appears in the CI platform's secret store.
+	Name string `json:"name"`
+}
+
+// DeployPhase is a single phase in a potentially multi-phase deploy pipeline.
+type DeployPhase struct {
+	// Name is the human-readable phase name (e.g. "prereq", "deploy").
+	Name string `json:"name"`
+	// ConfigPath is the workflow config file for this phase.
+	ConfigPath string `json:"config_path"`
+	// Include is an optional list of module names to include in this phase.
+	Include []string `json:"include,omitempty"`
+}
+
+// MigrationsSpec describes the database migration step.
+type MigrationsSpec struct {
+	// DBEnv is the environment variable name that holds the database URL.
+	DBEnv string `json:"db_env"`
+	// Source is the migrations source directory.
+	Source string `json:"source,omitempty"`
+}
+
+// SmokeSpec describes the post-deploy smoke test.
+type SmokeSpec struct {
+	// URL is the full URL to curl for a 2xx response.
+	URL string `json:"url"`
+	// Path is the HTTP path component (e.g. "/healthz").
+	Path string `json:"path"`
+}
+
+// TriggerSpec describes which CI events should trigger each class of job.
+type TriggerSpec struct {
+	// PR triggers plan/lint jobs on pull requests.
+	PR bool `json:"pr"`
+	// PushMain triggers apply jobs on push to the default branch.
+	PushMain bool `json:"push_main"`
+	// Dispatch allows manual workflow_dispatch triggers.
+	Dispatch bool `json:"dispatch"`
+}

--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -168,7 +168,7 @@ func writePluginInstallStep(b *strings.Builder, p *CIPlan) {
 // writeApplyJob emits a single apply job.
 func writeApplyJob(b *strings.Builder, jobName string, phase DeployPhase, needs *string, p *CIPlan, runner, version, branch string) {
 	fmt.Fprintf(b, "  %s:\n", jobName)
-	fmt.Fprintf(b, "    if: \"github.event_name == 'push' && github.ref == 'refs/heads/%s' || github.event_name == 'workflow_dispatch'\"\n", branch)
+	fmt.Fprintf(b, "    if: \"(github.event_name == 'push' && github.ref == 'refs/heads/%s') || github.event_name == 'workflow_dispatch'\"\n", branch)
 	if needs != nil {
 		fmt.Fprintf(b, "    needs: %s\n", *needs)
 	}
@@ -191,10 +191,18 @@ func writeApplyJob(b *strings.Builder, jobName string, phase DeployPhase, needs 
 		fmt.Fprintf(b, "        run: wfctl plugin install --config '%s'\n", phase.ConfigPath)
 	}
 
-	// PlanGuard: grep for no-op before applying
+	// PlanGuard: a protected resource is in scope, so refuse to apply when the
+	// plan includes a replace or destroy. The plan output stays visible in the
+	// CI log (tee) and a destructive plan fails the job (exit 1) — no `|| true`.
 	if p.PlanGuard {
 		b.WriteString("      - name: Plan guard\n")
-		fmt.Fprintf(b, "        run: wfctl infra plan --config '%s' --format json | grep -q '\"changes\":0' || true\n", phase.ConfigPath)
+		b.WriteString("        run: |\n")
+		fmt.Fprintf(b, "          wfctl infra plan --config '%s' | tee plan-guard.txt\n", phase.ConfigPath)
+		b.WriteString("          if grep -Eq -- '^[[:space:]]*(- delete|-/\\+ replace)[[:space:]]' plan-guard.txt || \\\n")
+		b.WriteString("             grep -Eq -- 'Plan: .*([1-9][0-9]* to replace|[1-9][0-9]* to destroy)' plan-guard.txt; then\n")
+		b.WriteString("            echo \"::error::Refusing apply: plan includes replace or destroy of a protected resource.\" >&2\n")
+		b.WriteString("            exit 1\n")
+		b.WriteString("          fi\n")
 	}
 
 	// Migrations step (only in the last phase)

--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -60,7 +60,7 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 	var b strings.Builder
 
 	// Header + triggers
-	b.WriteString(fmt.Sprintf("name: %s\n", name))
+	fmt.Fprintf(&b, "name: %s\n", name)
 	b.WriteString("on:\n")
 	if p.Triggers.PR {
 		b.WriteString("  pull_request:\n")
@@ -68,7 +68,7 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 	}
 	if p.Triggers.PushMain {
 		b.WriteString("  push:\n")
-		b.WriteString(fmt.Sprintf("    branches: [%s]\n", branch))
+		fmt.Fprintf(&b, "    branches: [%s]\n", branch)
 		writePhasePaths(&b, p)
 	}
 	if p.Triggers.Dispatch {
@@ -83,7 +83,7 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 	// Plan job (PR only)
 	b.WriteString("  plan:\n")
 	b.WriteString("    if: github.event_name == 'pull_request'\n")
-	b.WriteString(fmt.Sprintf("    runs-on: %s\n", runner))
+	fmt.Fprintf(&b, "    runs-on: %s\n", runner)
 	b.WriteString("    steps:\n")
 	writeCheckoutStep(&b)
 	writeSetupWfctlStep(&b, version)
@@ -91,8 +91,8 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 		writePluginInstallStep(&b, p)
 	}
 	for _, phase := range p.Phases {
-		b.WriteString(fmt.Sprintf("      - name: Plan %s\n", phase.Name))
-		b.WriteString(fmt.Sprintf("        run: wfctl infra plan --config '%s' --format markdown >> plan.md\n", phase.ConfigPath))
+		fmt.Fprintf(&b, "      - name: Plan %s\n", phase.Name)
+		fmt.Fprintf(&b, "        run: wfctl infra plan --config '%s' --format markdown >> plan.md\n", phase.ConfigPath)
 	}
 	b.WriteString("      - name: Post plan comment\n")
 	b.WriteString("        uses: actions/github-script@v7\n")
@@ -132,13 +132,13 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 			lastApplyJob = fmt.Sprintf("apply-%s", lastPhase.Name)
 		}
 		b.WriteString("  smoke:\n")
-		b.WriteString(fmt.Sprintf("    needs: %s\n", lastApplyJob))
-		b.WriteString(fmt.Sprintf("    if: github.event_name == 'push' && github.ref == 'refs/heads/%s'\n", branch))
-		b.WriteString(fmt.Sprintf("    runs-on: %s\n", runner))
+		fmt.Fprintf(&b, "    needs: %s\n", lastApplyJob)
+		fmt.Fprintf(&b, "    if: github.event_name == 'push' && github.ref == 'refs/heads/%s'\n", branch)
+		fmt.Fprintf(&b, "    runs-on: %s\n", runner)
 		b.WriteString("    steps:\n")
-		b.WriteString(fmt.Sprintf("      - name: Smoke test\n"))
-		b.WriteString(fmt.Sprintf("        run: |\n"))
-		b.WriteString(fmt.Sprintf("          curl --fail --max-time 30 '%s'\n", p.Smoke.URL))
+		b.WriteString("      - name: Smoke test\n")
+		b.WriteString("        run: |\n")
+		fmt.Fprintf(&b, "          curl --fail --max-time 30 '%s'\n", p.Smoke.URL)
 	}
 
 	return b.String(), nil
@@ -154,32 +154,32 @@ func writeSetupWfctlStep(b *strings.Builder, version string) {
 	b.WriteString("      - name: Install wfctl\n")
 	b.WriteString("        uses: GoCodeAlone/setup-wfctl@v1\n")
 	b.WriteString("        with:\n")
-	b.WriteString(fmt.Sprintf("          version: '%s'\n", version))
+	fmt.Fprintf(b, "          version: '%s'\n", version)
 }
 
 // writePluginInstallStep emits a wfctl plugin install step.
 func writePluginInstallStep(b *strings.Builder, p *CIPlan) {
 	for _, phase := range p.Phases {
-		b.WriteString(fmt.Sprintf("      - name: Install plugins (%s)\n", phase.Name))
-		b.WriteString(fmt.Sprintf("        run: wfctl plugin install --config '%s'\n", phase.ConfigPath))
+		fmt.Fprintf(b, "      - name: Install plugins (%s)\n", phase.Name)
+		fmt.Fprintf(b, "        run: wfctl plugin install --config '%s'\n", phase.ConfigPath)
 	}
 }
 
 // writeApplyJob emits a single apply job.
 func writeApplyJob(b *strings.Builder, jobName string, phase DeployPhase, needs *string, p *CIPlan, runner, version, branch string) {
-	b.WriteString(fmt.Sprintf("  %s:\n", jobName))
-	b.WriteString(fmt.Sprintf("    if: \"github.event_name == 'push' && github.ref == 'refs/heads/%s' || github.event_name == 'workflow_dispatch'\"\n", branch))
+	fmt.Fprintf(b, "  %s:\n", jobName)
+	fmt.Fprintf(b, "    if: \"github.event_name == 'push' && github.ref == 'refs/heads/%s' || github.event_name == 'workflow_dispatch'\"\n", branch)
 	if needs != nil {
-		b.WriteString(fmt.Sprintf("    needs: %s\n", *needs))
+		fmt.Fprintf(b, "    needs: %s\n", *needs)
 	}
-	b.WriteString(fmt.Sprintf("    runs-on: %s\n", runner))
+	fmt.Fprintf(b, "    runs-on: %s\n", runner)
 
 	// Secrets env block
 	if len(p.Secrets) > 0 {
 		b.WriteString("    env:\n")
 		for _, s := range p.Secrets {
 			// Use ${{ secrets.NAME }} — use raw string to avoid template interpretation
-			b.WriteString(fmt.Sprintf("      %s: ${{ secrets.%s }}\n", s.Name, s.Name))
+			fmt.Fprintf(b, "      %s: ${{ secrets.%s }}\n", s.Name, s.Name)
 		}
 	}
 
@@ -187,27 +187,27 @@ func writeApplyJob(b *strings.Builder, jobName string, phase DeployPhase, needs 
 	writeCheckoutStep(b)
 	writeSetupWfctlStep(b, version)
 	if p.PluginInstall {
-		b.WriteString(fmt.Sprintf("      - name: Install plugins\n"))
-		b.WriteString(fmt.Sprintf("        run: wfctl plugin install --config '%s'\n", phase.ConfigPath))
+		b.WriteString("      - name: Install plugins\n")
+		fmt.Fprintf(b, "        run: wfctl plugin install --config '%s'\n", phase.ConfigPath)
 	}
 
 	// PlanGuard: grep for no-op before applying
 	if p.PlanGuard {
 		b.WriteString("      - name: Plan guard\n")
-		b.WriteString(fmt.Sprintf("        run: wfctl infra plan --config '%s' --format json | grep -q '\"changes\":0' || true\n", phase.ConfigPath))
+		fmt.Fprintf(b, "        run: wfctl infra plan --config '%s' --format json | grep -q '\"changes\":0' || true\n", phase.ConfigPath)
 	}
 
 	// Migrations step (only in the last phase)
 	isLastPhase := phase.Name == p.Phases[len(p.Phases)-1].Name
 	if isLastPhase && p.Migrations != nil {
 		b.WriteString("      - name: Run migrations\n")
-		b.WriteString(fmt.Sprintf("        run: wfctl ci run --config '%s' --phase migrate\n", phase.ConfigPath))
+		fmt.Fprintf(b, "        run: wfctl ci run --config '%s' --phase migrate\n", phase.ConfigPath)
 		b.WriteString("        env:\n")
-		b.WriteString(fmt.Sprintf("          %s: ${{ secrets.%s }}\n", p.Migrations.DBEnv, p.Migrations.DBEnv))
+		fmt.Fprintf(b, "          %s: ${{ secrets.%s }}\n", p.Migrations.DBEnv, p.Migrations.DBEnv)
 	}
 
-	b.WriteString(fmt.Sprintf("      - name: Apply %s\n", phase.Name))
-	b.WriteString(fmt.Sprintf("        run: wfctl infra apply --config '%s' --auto-approve\n", phase.ConfigPath))
+	fmt.Fprintf(b, "      - name: Apply %s\n", phase.Name)
+	fmt.Fprintf(b, "        run: wfctl infra apply --config '%s' --auto-approve\n", phase.ConfigPath)
 }
 
 // writePhasePaths emits the paths filter for push/pull_request triggers.
@@ -216,7 +216,7 @@ func writePhasePaths(b *strings.Builder, p *CIPlan) {
 	seen := make(map[string]bool)
 	for _, phase := range p.Phases {
 		if !seen[phase.ConfigPath] {
-			b.WriteString(fmt.Sprintf("      - '%s'\n", phase.ConfigPath))
+			fmt.Fprintf(b, "      - '%s'\n", phase.ConfigPath)
 			seen[phase.ConfigPath] = true
 		}
 	}

--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -1,0 +1,223 @@
+package cigen
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderGitHubActions generates GitHub Actions workflow YAML files from a CIPlan.
+// It returns a map of relative paths to YAML content.
+func RenderGitHubActions(p *CIPlan) (map[string]string, error) {
+	if p == nil {
+		return nil, fmt.Errorf("RenderGitHubActions: plan is nil")
+	}
+
+	name := p.Project
+	if name == "" {
+		name = "deploy"
+	}
+
+	content, err := renderGHAWorkflow(p, name)
+	if err != nil {
+		return nil, err
+	}
+
+	filename := fmt.Sprintf(".github/workflows/%s.yml", sanitizeFilename(name))
+	return map[string]string{
+		filename: content,
+	}, nil
+}
+
+// sanitizeFilename replaces characters invalid in filenames with dashes.
+func sanitizeFilename(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// renderGHAWorkflow produces the full workflow YAML content.
+func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
+	branch := p.DefaultBranch
+	if branch == "" {
+		branch = "main"
+	}
+	runner := p.Runner
+	if runner == "" {
+		runner = "ubuntu-latest"
+	}
+	version := p.WfctlVersion
+	if version == "" {
+		version = "latest"
+	}
+
+	var b strings.Builder
+
+	// Header + triggers
+	b.WriteString(fmt.Sprintf("name: %s\n", name))
+	b.WriteString("on:\n")
+	if p.Triggers.PR {
+		b.WriteString("  pull_request:\n")
+		writePhasePaths(&b, p)
+	}
+	if p.Triggers.PushMain {
+		b.WriteString("  push:\n")
+		b.WriteString(fmt.Sprintf("    branches: [%s]\n", branch))
+		writePhasePaths(&b, p)
+	}
+	if p.Triggers.Dispatch {
+		b.WriteString("  workflow_dispatch:\n")
+	}
+
+	b.WriteString("permissions:\n")
+	b.WriteString("  contents: read\n")
+	b.WriteString("  pull-requests: write\n")
+	b.WriteString("jobs:\n")
+
+	// Plan job (PR only)
+	b.WriteString("  plan:\n")
+	b.WriteString("    if: github.event_name == 'pull_request'\n")
+	b.WriteString(fmt.Sprintf("    runs-on: %s\n", runner))
+	b.WriteString("    steps:\n")
+	writeCheckoutStep(&b)
+	writeSetupWfctlStep(&b, version)
+	if p.PluginInstall {
+		writePluginInstallStep(&b, p)
+	}
+	for _, phase := range p.Phases {
+		b.WriteString(fmt.Sprintf("      - name: Plan %s\n", phase.Name))
+		b.WriteString(fmt.Sprintf("        run: wfctl infra plan --config '%s' --format markdown >> plan.md\n", phase.ConfigPath))
+	}
+	b.WriteString("      - name: Post plan comment\n")
+	b.WriteString("        uses: actions/github-script@v7\n")
+	b.WriteString("        with:\n")
+	b.WriteString("          script: |\n")
+	b.WriteString("            const fs = require('fs');\n")
+	b.WriteString("            const plan = fs.readFileSync('plan.md', 'utf8');\n")
+	b.WriteString("            github.rest.issues.createComment({\n")
+	b.WriteString("              issue_number: context.issue.number,\n")
+	b.WriteString("              owner: context.repo.owner,\n")
+	b.WriteString("              repo: context.repo.repo,\n")
+	b.WriteString("              body: plan\n")
+	b.WriteString("            });\n")
+
+	// Apply jobs
+	if len(p.Phases) == 1 {
+		writeApplyJob(&b, "apply", p.Phases[0], nil, p, runner, version, branch)
+	} else {
+		// Multi-phase: apply-prereq then apply-deploy with needs
+		prevJob := ""
+		for i, phase := range p.Phases {
+			jobName := fmt.Sprintf("apply-%s", phase.Name)
+			var needs *string
+			if i > 0 && prevJob != "" {
+				needs = &prevJob
+			}
+			writeApplyJob(&b, jobName, phase, needs, p, runner, version, branch)
+			prevJob = jobName
+		}
+	}
+
+	// Smoke job
+	if p.Smoke != nil {
+		lastApplyJob := "apply"
+		if len(p.Phases) > 1 {
+			lastPhase := p.Phases[len(p.Phases)-1]
+			lastApplyJob = fmt.Sprintf("apply-%s", lastPhase.Name)
+		}
+		b.WriteString("  smoke:\n")
+		b.WriteString(fmt.Sprintf("    needs: %s\n", lastApplyJob))
+		b.WriteString(fmt.Sprintf("    if: github.event_name == 'push' && github.ref == 'refs/heads/%s'\n", branch))
+		b.WriteString(fmt.Sprintf("    runs-on: %s\n", runner))
+		b.WriteString("    steps:\n")
+		b.WriteString(fmt.Sprintf("      - name: Smoke test\n"))
+		b.WriteString(fmt.Sprintf("        run: |\n"))
+		b.WriteString(fmt.Sprintf("          curl --fail --max-time 30 '%s'\n", p.Smoke.URL))
+	}
+
+	return b.String(), nil
+}
+
+// writeCheckoutStep emits the checkout step.
+func writeCheckoutStep(b *strings.Builder) {
+	b.WriteString("      - uses: actions/checkout@v4\n")
+}
+
+// writeSetupWfctlStep emits the setup-wfctl action step.
+func writeSetupWfctlStep(b *strings.Builder, version string) {
+	b.WriteString("      - name: Install wfctl\n")
+	b.WriteString("        uses: GoCodeAlone/setup-wfctl@v1\n")
+	b.WriteString("        with:\n")
+	b.WriteString(fmt.Sprintf("          version: '%s'\n", version))
+}
+
+// writePluginInstallStep emits a wfctl plugin install step.
+func writePluginInstallStep(b *strings.Builder, p *CIPlan) {
+	for _, phase := range p.Phases {
+		b.WriteString(fmt.Sprintf("      - name: Install plugins (%s)\n", phase.Name))
+		b.WriteString(fmt.Sprintf("        run: wfctl plugin install --config '%s'\n", phase.ConfigPath))
+	}
+}
+
+// writeApplyJob emits a single apply job.
+func writeApplyJob(b *strings.Builder, jobName string, phase DeployPhase, needs *string, p *CIPlan, runner, version, branch string) {
+	b.WriteString(fmt.Sprintf("  %s:\n", jobName))
+	b.WriteString(fmt.Sprintf("    if: \"github.event_name == 'push' && github.ref == 'refs/heads/%s' || github.event_name == 'workflow_dispatch'\"\n", branch))
+	if needs != nil {
+		b.WriteString(fmt.Sprintf("    needs: %s\n", *needs))
+	}
+	b.WriteString(fmt.Sprintf("    runs-on: %s\n", runner))
+
+	// Secrets env block
+	if len(p.Secrets) > 0 {
+		b.WriteString("    env:\n")
+		for _, s := range p.Secrets {
+			// Use ${{ secrets.NAME }} — use raw string to avoid template interpretation
+			b.WriteString(fmt.Sprintf("      %s: ${{ secrets.%s }}\n", s.Name, s.Name))
+		}
+	}
+
+	b.WriteString("    steps:\n")
+	writeCheckoutStep(b)
+	writeSetupWfctlStep(b, version)
+	if p.PluginInstall {
+		b.WriteString(fmt.Sprintf("      - name: Install plugins\n"))
+		b.WriteString(fmt.Sprintf("        run: wfctl plugin install --config '%s'\n", phase.ConfigPath))
+	}
+
+	// PlanGuard: grep for no-op before applying
+	if p.PlanGuard {
+		b.WriteString("      - name: Plan guard\n")
+		b.WriteString(fmt.Sprintf("        run: wfctl infra plan --config '%s' --format json | grep -q '\"changes\":0' || true\n", phase.ConfigPath))
+	}
+
+	// Migrations step (only in the last phase)
+	isLastPhase := phase.Name == p.Phases[len(p.Phases)-1].Name
+	if isLastPhase && p.Migrations != nil {
+		b.WriteString("      - name: Run migrations\n")
+		b.WriteString(fmt.Sprintf("        run: wfctl ci run --config '%s' --phase migrate\n", phase.ConfigPath))
+		b.WriteString("        env:\n")
+		b.WriteString(fmt.Sprintf("          %s: ${{ secrets.%s }}\n", p.Migrations.DBEnv, p.Migrations.DBEnv))
+	}
+
+	b.WriteString(fmt.Sprintf("      - name: Apply %s\n", phase.Name))
+	b.WriteString(fmt.Sprintf("        run: wfctl infra apply --config '%s' --auto-approve\n", phase.ConfigPath))
+}
+
+// writePhasePaths emits the paths filter for push/pull_request triggers.
+func writePhasePaths(b *strings.Builder, p *CIPlan) {
+	b.WriteString("    paths:\n")
+	seen := make(map[string]bool)
+	for _, phase := range p.Phases {
+		if !seen[phase.ConfigPath] {
+			b.WriteString(fmt.Sprintf("      - '%s'\n", phase.ConfigPath))
+			seen[phase.ConfigPath] = true
+		}
+	}
+}

--- a/cigen/render_gha_test.go
+++ b/cigen/render_gha_test.go
@@ -1,0 +1,165 @@
+package cigen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/cigen"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRenderGitHubActions_ValidYAML(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+
+	if len(files) == 0 {
+		t.Fatal("expected at least one file in output")
+	}
+
+	for path, content := range files {
+		if !strings.HasSuffix(path, ".yml") {
+			t.Errorf("expected .yml extension, got %q", path)
+		}
+		var parsed any
+		if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+			t.Errorf("file %q is not valid YAML: %v\ncontent:\n%s", path, err, content)
+		}
+	}
+}
+
+func TestRenderGitHubActions_TwoPhases(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	// Plan job
+	if !strings.Contains(content, "if: github.event_name == 'pull_request'") {
+		t.Error("expected plan job with pull_request condition")
+	}
+
+	// Two-phase apply jobs
+	if !strings.Contains(content, "apply-prereq:") {
+		t.Error("expected apply-prereq job for two-phase plan")
+	}
+	if !strings.Contains(content, "apply-deploy:") {
+		t.Error("expected apply-deploy job for two-phase plan")
+	}
+	// apply-deploy needs apply-prereq
+	if !strings.Contains(content, "needs: apply-prereq") {
+		t.Error("expected apply-deploy to declare needs: apply-prereq")
+	}
+}
+
+func TestRenderGitHubActions_MigrationsStep(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	if !strings.Contains(content, "migrate") {
+		t.Error("expected migrations step in output")
+	}
+}
+
+func TestRenderGitHubActions_SecretsEnv(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	for _, s := range plan.Secrets {
+		marker := "secrets." + s.Name
+		if !strings.Contains(content, marker) {
+			t.Errorf("expected ${{ secrets.%s }} in output", s.Name)
+		}
+	}
+}
+
+func TestRenderGitHubActions_SmokeJob(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	if !strings.Contains(content, "smoke:") {
+		t.Error("expected smoke job in output")
+	}
+	if !strings.Contains(content, plan.Smoke.URL) {
+		t.Errorf("expected smoke URL %q in output", plan.Smoke.URL)
+	}
+	if !strings.Contains(content, "curl") {
+		t.Error("expected curl command in smoke job")
+	}
+}
+
+func TestRenderGitHubActions_NilPlan(t *testing.T) {
+	_, err := cigen.RenderGitHubActions(nil)
+	if err == nil {
+		t.Error("expected error for nil plan")
+	}
+}
+
+// richCIPlan returns a CIPlan with 2 phases, migrations, smoke, and 3 secrets.
+func richCIPlan() *cigen.CIPlan {
+	return &cigen.CIPlan{
+		Project:       "myapp",
+		WfctlVersion:  "v0.66.0",
+		DefaultBranch: "main",
+		Runner:        "ubuntu-latest",
+		PluginInstall: true,
+		PlanGuard:     true,
+		Phases: []cigen.DeployPhase{
+			{Name: "prereq", ConfigPath: "deploy.prereq.yaml"},
+			{Name: "deploy", ConfigPath: "deploy.yaml"},
+		},
+		Migrations: &cigen.MigrationsSpec{
+			DBEnv:  "APP_DB_URL",
+			Source: "migrations",
+		},
+		Smoke: &cigen.SmokeSpec{
+			URL:  "https://myapp.example.com/healthz",
+			Path: "/healthz",
+		},
+		Secrets: []cigen.SecretRef{
+			{Name: "SECRET_ONE"},
+			{Name: "SECRET_TWO"},
+			{Name: "APP_DB_URL"},
+		},
+		Triggers: cigen.TriggerSpec{PR: true, PushMain: true, Dispatch: true},
+		Warnings: []string{},
+	}
+}

--- a/cigen/render_gha_test.go
+++ b/cigen/render_gha_test.go
@@ -133,6 +133,92 @@ func TestRenderGitHubActions_NilPlan(t *testing.T) {
 	}
 }
 
+func TestRenderGitHubActions_PlanGuardIsRealGate(t *testing.T) {
+	plan := richCIPlan() // PlanGuard: true
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	if !strings.Contains(content, "Plan guard") {
+		t.Fatal("expected a Plan guard step when PlanGuard is set")
+	}
+	// The guard must be a REAL gate, not a no-op.
+	if strings.Contains(content, "|| true") {
+		t.Error("plan guard must not contain `|| true` (would never fail the job)")
+	}
+	// It must be able to fail the job.
+	if !strings.Contains(content, "exit 1") {
+		t.Error("plan guard must contain a failing-exit path (exit 1)")
+	}
+	// It must detect replace/destroy in the plan output.
+	if !strings.Contains(content, "to replace") || !strings.Contains(content, "to destroy") {
+		t.Error("plan guard should detect replace/destroy plans")
+	}
+	// Plan output should stay visible (tee), not silenced with -q.
+	if !strings.Contains(content, "tee") {
+		t.Error("plan guard should keep plan output visible (tee)")
+	}
+}
+
+func TestRenderGitHubActions_NoPlanGuardWhenUnset(t *testing.T) {
+	plan := richCIPlan()
+	plan.PlanGuard = false
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+	if strings.Contains(content, "Plan guard") {
+		t.Error("did not expect a Plan guard step when PlanGuard is unset")
+	}
+}
+
+func TestRenderGitHubActions_RelativePathsFilter(t *testing.T) {
+	// A plan whose phase config path is already relative must render a relative
+	// `paths:` entry with no leading slash. (Analyze is responsible for
+	// relativizing absolute paths; the renderer must emit whatever it is given
+	// verbatim, and the path filter must not contain an absolute path.)
+	plan := &cigen.CIPlan{
+		Project:       "myapp",
+		WfctlVersion:  "latest",
+		DefaultBranch: "main",
+		Runner:        "ubuntu-latest",
+		Phases: []cigen.DeployPhase{
+			{Name: "deploy", ConfigPath: "deploy.yaml"},
+		},
+		Secrets:  []cigen.SecretRef{},
+		Triggers: cigen.TriggerSpec{PR: true, PushMain: true, Dispatch: true},
+		Warnings: []string{},
+	}
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	if !strings.Contains(content, "- 'deploy.yaml'") {
+		t.Errorf("expected relative paths entry `- 'deploy.yaml'`, got:\n%s", content)
+	}
+	// No absolute path leaked into the paths: filter.
+	if strings.Contains(content, "- '/") {
+		t.Error("paths: filter must not contain an absolute path")
+	}
+}
+
 // richCIPlan returns a CIPlan with 2 phases, migrations, smoke, and 3 secrets.
 func richCIPlan() *cigen.CIPlan {
 	return &cigen.CIPlan{

--- a/cigen/render_gitlab.go
+++ b/cigen/render_gitlab.go
@@ -46,13 +46,12 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 	}
 	b.WriteString("\n")
 
-	// Global variables
+	// Global variables. Project-level CI/CD variables (secrets) are already
+	// injected into every job's environment by GitLab, so we do NOT re-declare
+	// them as `NAME: $NAME` (a no-op that only obscures the pipeline). Only the
+	// wfctl version pin is a genuine pipeline variable.
 	b.WriteString("variables:\n")
 	fmt.Fprintf(&b, "  WFCTL_VERSION: %q\n", version)
-	for _, s := range p.Secrets {
-		// Secret refs in GitLab CI are just $NAME CI variables
-		fmt.Fprintf(&b, "  %s: $%s\n", s.Name, s.Name)
-	}
 	b.WriteString("\n")
 
 	// before_script

--- a/cigen/render_gitlab.go
+++ b/cigen/render_gitlab.go
@@ -42,16 +42,16 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 	}
 	b.WriteString("stages:\n")
 	for _, s := range stages {
-		b.WriteString(fmt.Sprintf("  - %s\n", s))
+		fmt.Fprintf(&b, "  - %s\n", s)
 	}
 	b.WriteString("\n")
 
 	// Global variables
 	b.WriteString("variables:\n")
-	b.WriteString(fmt.Sprintf("  WFCTL_VERSION: \"%s\"\n", version))
+	fmt.Fprintf(&b, "  WFCTL_VERSION: %q\n", version)
 	for _, s := range p.Secrets {
 		// Secret refs in GitLab CI are just $NAME CI variables
-		b.WriteString(fmt.Sprintf("  %s: $%s\n", s.Name, s.Name))
+		fmt.Fprintf(&b, "  %s: $%s\n", s.Name, s.Name)
 	}
 	b.WriteString("\n")
 
@@ -61,7 +61,7 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 	b.WriteString("  - export PATH=\"$(go env GOPATH)/bin:$PATH\"\n")
 	if p.PluginInstall {
 		for _, phase := range p.Phases {
-			b.WriteString(fmt.Sprintf("  - wfctl plugin install --config '%s'\n", phase.ConfigPath))
+			fmt.Fprintf(&b, "  - wfctl plugin install --config '%s'\n", phase.ConfigPath)
 		}
 	}
 	b.WriteString("\n")
@@ -72,10 +72,10 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 		if len(p.Phases) > 1 {
 			jobName = fmt.Sprintf("plan-%s", phase.Name)
 		}
-		b.WriteString(fmt.Sprintf("%s:\n", jobName))
+		fmt.Fprintf(&b, "%s:\n", jobName)
 		b.WriteString("  stage: plan\n")
 		b.WriteString("  script:\n")
-		b.WriteString(fmt.Sprintf("    - wfctl infra plan --config '%s' --format markdown > plan.md\n", phase.ConfigPath))
+		fmt.Fprintf(&b, "    - wfctl infra plan --config '%s' --format markdown > plan.md\n", phase.ConfigPath)
 		b.WriteString("  artifacts:\n")
 		b.WriteString("    paths:\n")
 		b.WriteString("      - plan.md\n")
@@ -83,7 +83,7 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 		b.WriteString("  rules:\n")
 		b.WriteString("    - if: $CI_PIPELINE_SOURCE == \"merge_request_event\"\n")
 		b.WriteString("      changes:\n")
-		b.WriteString(fmt.Sprintf("        - \"%s\"\n", phase.ConfigPath))
+		fmt.Fprintf(&b, "        - %q\n", phase.ConfigPath)
 		b.WriteString("\n")
 	}
 
@@ -94,23 +94,23 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 		if len(p.Phases) > 1 {
 			jobName = fmt.Sprintf("apply-%s", phase.Name)
 		}
-		b.WriteString(fmt.Sprintf("%s:\n", jobName))
+		fmt.Fprintf(&b, "%s:\n", jobName)
 		b.WriteString("  stage: apply\n")
 		if prevJob != "" {
 			b.WriteString("  needs:\n")
-			b.WriteString(fmt.Sprintf("    - job: %s\n", prevJob))
+			fmt.Fprintf(&b, "    - job: %s\n", prevJob)
 			b.WriteString("      artifacts: false\n")
 		}
 		b.WriteString("  script:\n")
 		isLastPhase := i == len(p.Phases)-1
 		if isLastPhase && p.Migrations != nil {
-			b.WriteString(fmt.Sprintf("    - wfctl ci run --config '%s' --phase migrate\n", phase.ConfigPath))
+			fmt.Fprintf(&b, "    - wfctl ci run --config '%s' --phase migrate\n", phase.ConfigPath)
 		}
-		b.WriteString(fmt.Sprintf("    - wfctl infra apply --config '%s' --auto-approve\n", phase.ConfigPath))
+		fmt.Fprintf(&b, "    - wfctl infra apply --config '%s' --auto-approve\n", phase.ConfigPath)
 		b.WriteString("  environment:\n")
 		b.WriteString("    name: production\n")
 		b.WriteString("  rules:\n")
-		b.WriteString(fmt.Sprintf("    - if: $CI_COMMIT_BRANCH == \"%s\" && $CI_PIPELINE_SOURCE == \"push\"\n", branch))
+		fmt.Fprintf(&b, "    - if: $CI_COMMIT_BRANCH == %q && $CI_PIPELINE_SOURCE == \"push\"\n", branch)
 		if p.Triggers.Dispatch {
 			b.WriteString("    - if: $CI_PIPELINE_SOURCE == \"web\"\n")
 		}
@@ -128,11 +128,11 @@ func renderGitLabWorkflow(p *CIPlan) (string, error) {
 		b.WriteString("smoke:\n")
 		b.WriteString("  stage: smoke\n")
 		b.WriteString("  needs:\n")
-		b.WriteString(fmt.Sprintf("    - job: %s\n", lastApplyJob))
+		fmt.Fprintf(&b, "    - job: %s\n", lastApplyJob)
 		b.WriteString("  script:\n")
-		b.WriteString(fmt.Sprintf("    - curl --fail --max-time 30 '%s'\n", p.Smoke.URL))
+		fmt.Fprintf(&b, "    - curl --fail --max-time 30 '%s'\n", p.Smoke.URL)
 		b.WriteString("  rules:\n")
-		b.WriteString(fmt.Sprintf("    - if: $CI_COMMIT_BRANCH == \"%s\" && $CI_PIPELINE_SOURCE == \"push\"\n", branch))
+		fmt.Fprintf(&b, "    - if: $CI_COMMIT_BRANCH == %q && $CI_PIPELINE_SOURCE == \"push\"\n", branch)
 		b.WriteString("\n")
 	}
 

--- a/cigen/render_gitlab.go
+++ b/cigen/render_gitlab.go
@@ -1,0 +1,140 @@
+package cigen
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderGitLabCI generates a GitLab CI YAML configuration from a CIPlan.
+// It returns a map with a single key ".gitlab-ci.yml".
+func RenderGitLabCI(p *CIPlan) (map[string]string, error) {
+	if p == nil {
+		return nil, fmt.Errorf("RenderGitLabCI: plan is nil")
+	}
+
+	content, err := renderGitLabWorkflow(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		".gitlab-ci.yml": content,
+	}, nil
+}
+
+// renderGitLabWorkflow produces the full .gitlab-ci.yml content.
+func renderGitLabWorkflow(p *CIPlan) (string, error) {
+	branch := p.DefaultBranch
+	if branch == "" {
+		branch = "main"
+	}
+	version := p.WfctlVersion
+	if version == "" {
+		version = "latest"
+	}
+
+	var b strings.Builder
+
+	// Stages
+	stages := []string{"plan", "apply"}
+	if p.Smoke != nil {
+		stages = append(stages, "smoke")
+	}
+	b.WriteString("stages:\n")
+	for _, s := range stages {
+		b.WriteString(fmt.Sprintf("  - %s\n", s))
+	}
+	b.WriteString("\n")
+
+	// Global variables
+	b.WriteString("variables:\n")
+	b.WriteString(fmt.Sprintf("  WFCTL_VERSION: \"%s\"\n", version))
+	for _, s := range p.Secrets {
+		// Secret refs in GitLab CI are just $NAME CI variables
+		b.WriteString(fmt.Sprintf("  %s: $%s\n", s.Name, s.Name))
+	}
+	b.WriteString("\n")
+
+	// before_script
+	b.WriteString("before_script:\n")
+	b.WriteString("  - go install \"github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION}\"\n")
+	b.WriteString("  - export PATH=\"$(go env GOPATH)/bin:$PATH\"\n")
+	if p.PluginInstall {
+		for _, phase := range p.Phases {
+			b.WriteString(fmt.Sprintf("  - wfctl plugin install --config '%s'\n", phase.ConfigPath))
+		}
+	}
+	b.WriteString("\n")
+
+	// Plan jobs
+	for _, phase := range p.Phases {
+		jobName := "plan"
+		if len(p.Phases) > 1 {
+			jobName = fmt.Sprintf("plan-%s", phase.Name)
+		}
+		b.WriteString(fmt.Sprintf("%s:\n", jobName))
+		b.WriteString("  stage: plan\n")
+		b.WriteString("  script:\n")
+		b.WriteString(fmt.Sprintf("    - wfctl infra plan --config '%s' --format markdown > plan.md\n", phase.ConfigPath))
+		b.WriteString("  artifacts:\n")
+		b.WriteString("    paths:\n")
+		b.WriteString("      - plan.md\n")
+		b.WriteString("    expire_in: 1 hour\n")
+		b.WriteString("  rules:\n")
+		b.WriteString("    - if: $CI_PIPELINE_SOURCE == \"merge_request_event\"\n")
+		b.WriteString("      changes:\n")
+		b.WriteString(fmt.Sprintf("        - \"%s\"\n", phase.ConfigPath))
+		b.WriteString("\n")
+	}
+
+	// Apply jobs
+	prevJob := ""
+	for i, phase := range p.Phases {
+		jobName := "apply"
+		if len(p.Phases) > 1 {
+			jobName = fmt.Sprintf("apply-%s", phase.Name)
+		}
+		b.WriteString(fmt.Sprintf("%s:\n", jobName))
+		b.WriteString("  stage: apply\n")
+		if prevJob != "" {
+			b.WriteString("  needs:\n")
+			b.WriteString(fmt.Sprintf("    - job: %s\n", prevJob))
+			b.WriteString("      artifacts: false\n")
+		}
+		b.WriteString("  script:\n")
+		isLastPhase := i == len(p.Phases)-1
+		if isLastPhase && p.Migrations != nil {
+			b.WriteString(fmt.Sprintf("    - wfctl ci run --config '%s' --phase migrate\n", phase.ConfigPath))
+		}
+		b.WriteString(fmt.Sprintf("    - wfctl infra apply --config '%s' --auto-approve\n", phase.ConfigPath))
+		b.WriteString("  environment:\n")
+		b.WriteString("    name: production\n")
+		b.WriteString("  rules:\n")
+		b.WriteString(fmt.Sprintf("    - if: $CI_COMMIT_BRANCH == \"%s\" && $CI_PIPELINE_SOURCE == \"push\"\n", branch))
+		if p.Triggers.Dispatch {
+			b.WriteString("    - if: $CI_PIPELINE_SOURCE == \"web\"\n")
+		}
+		b.WriteString("\n")
+		prevJob = jobName
+	}
+
+	// Smoke job
+	if p.Smoke != nil {
+		lastApplyJob := "apply"
+		if len(p.Phases) > 1 {
+			lastPhase := p.Phases[len(p.Phases)-1]
+			lastApplyJob = fmt.Sprintf("apply-%s", lastPhase.Name)
+		}
+		b.WriteString("smoke:\n")
+		b.WriteString("  stage: smoke\n")
+		b.WriteString("  needs:\n")
+		b.WriteString(fmt.Sprintf("    - job: %s\n", lastApplyJob))
+		b.WriteString("  script:\n")
+		b.WriteString(fmt.Sprintf("    - curl --fail --max-time 30 '%s'\n", p.Smoke.URL))
+		b.WriteString("  rules:\n")
+		b.WriteString(fmt.Sprintf("    - if: $CI_COMMIT_BRANCH == \"%s\" && $CI_PIPELINE_SOURCE == \"push\"\n", branch))
+		b.WriteString("\n")
+	}
+
+	return b.String(), nil
+}

--- a/cigen/render_gitlab_test.go
+++ b/cigen/render_gitlab_test.go
@@ -1,0 +1,110 @@
+package cigen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/cigen"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRenderGitLabCI_ValidYAML(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitLabCI(plan)
+	if err != nil {
+		t.Fatalf("RenderGitLabCI: %v", err)
+	}
+
+	content, ok := files[".gitlab-ci.yml"]
+	if !ok {
+		t.Fatal("expected .gitlab-ci.yml in output")
+	}
+
+	var parsed any
+	if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Errorf(".gitlab-ci.yml is not valid YAML: %v\ncontent:\n%s", err, content)
+	}
+}
+
+func TestRenderGitLabCI_Stages(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitLabCI(plan)
+	if err != nil {
+		t.Fatalf("RenderGitLabCI: %v", err)
+	}
+	content := files[".gitlab-ci.yml"]
+
+	for _, stage := range []string{"plan", "apply", "smoke"} {
+		if !strings.Contains(content, "- "+stage) {
+			t.Errorf("expected stage %q in output", stage)
+		}
+	}
+}
+
+func TestRenderGitLabCI_SecretRefs(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitLabCI(plan)
+	if err != nil {
+		t.Fatalf("RenderGitLabCI: %v", err)
+	}
+	content := files[".gitlab-ci.yml"]
+
+	for _, s := range plan.Secrets {
+		if !strings.Contains(content, "$"+s.Name) {
+			t.Errorf("expected $%s in output", s.Name)
+		}
+	}
+}
+
+func TestRenderGitLabCI_TwoPhaseNeeds(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitLabCI(plan)
+	if err != nil {
+		t.Fatalf("RenderGitLabCI: %v", err)
+	}
+	content := files[".gitlab-ci.yml"]
+
+	// Two-phase plan
+	if !strings.Contains(content, "plan-prereq:") {
+		t.Error("expected plan-prereq job")
+	}
+	if !strings.Contains(content, "plan-deploy:") {
+		t.Error("expected plan-deploy job")
+	}
+
+	// Two-phase apply with needs
+	if !strings.Contains(content, "apply-prereq:") {
+		t.Error("expected apply-prereq job")
+	}
+	if !strings.Contains(content, "apply-deploy:") {
+		t.Error("expected apply-deploy job")
+	}
+	if !strings.Contains(content, "job: apply-prereq") {
+		t.Error("expected apply-deploy to need apply-prereq")
+	}
+}
+
+func TestRenderGitLabCI_NilPlan(t *testing.T) {
+	_, err := cigen.RenderGitLabCI(nil)
+	if err == nil {
+		t.Error("expected error for nil plan")
+	}
+}
+
+func TestRenderGitLabCI_NoDeprecatedOnlySyntax(t *testing.T) {
+	plan := richCIPlan()
+
+	files, err := cigen.RenderGitLabCI(plan)
+	if err != nil {
+		t.Fatalf("RenderGitLabCI: %v", err)
+	}
+	content := files[".gitlab-ci.yml"]
+
+	if strings.Contains(content, "\nonly:") {
+		t.Error(".gitlab-ci.yml uses deprecated 'only:' syntax")
+	}
+}

--- a/cigen/render_gitlab_test.go
+++ b/cigen/render_gitlab_test.go
@@ -43,7 +43,7 @@ func TestRenderGitLabCI_Stages(t *testing.T) {
 	}
 }
 
-func TestRenderGitLabCI_SecretRefs(t *testing.T) {
+func TestRenderGitLabCI_NoRedundantSecretVars(t *testing.T) {
 	plan := richCIPlan()
 
 	files, err := cigen.RenderGitLabCI(plan)
@@ -52,10 +52,19 @@ func TestRenderGitLabCI_SecretRefs(t *testing.T) {
 	}
 	content := files[".gitlab-ci.yml"]
 
+	// Project-level CI/CD variables (secrets) are auto-injected by GitLab into
+	// every job, so the renderer must NOT re-declare them as `NAME: $NAME`
+	// no-ops in the global variables block.
 	for _, s := range plan.Secrets {
-		if !strings.Contains(content, "$"+s.Name) {
-			t.Errorf("expected $%s in output", s.Name)
+		redundant := "  " + s.Name + ": $" + s.Name
+		if strings.Contains(content, redundant) {
+			t.Errorf("expected no redundant `%s: $%s` declaration in variables block", s.Name, s.Name)
 		}
+	}
+
+	// The only declared pipeline variable should be the wfctl version pin.
+	if !strings.Contains(content, "WFCTL_VERSION:") {
+		t.Error("expected WFCTL_VERSION variable in output")
 	}
 }
 

--- a/cigen/secrets_smoke_test.go
+++ b/cigen/secrets_smoke_test.go
@@ -1,0 +1,123 @@
+package cigen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/cigen"
+)
+
+func TestAnalyze_SecretsUnion_Multisite(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/multisite.yaml"}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	secretNames := make(map[string]bool, len(plan.Secrets))
+	for _, s := range plan.Secrets {
+		secretNames[s.Name] = true
+	}
+
+	// From secrets.entries
+	wantFromEntries := []string{
+		"DIGITALOCEAN_TOKEN",
+		"RELEASES_TOKEN",
+		"GHCR_CREDENTIALS",
+		"SPACES_access_key",
+		"SPACES_secret_key",
+		"MULTISITE_DB_URL",
+	}
+	for _, name := range wantFromEntries {
+		if !secretNames[name] {
+			t.Errorf("expected secret %q from entries, not found in plan.Secrets", name)
+		}
+	}
+
+	// From env_vars_secret ${VAR} refs
+	wantFromEnvVarsSecret := []string{
+		"MULTISITE_DB_URL", // also in entries, deduplicated
+		"MULTISITE_INGEST_HMAC_SECRET",
+		"MULTISITE_JWT_SECRET",
+	}
+	for _, name := range wantFromEnvVarsSecret {
+		if !secretNames[name] {
+			t.Errorf("expected secret %q from env_vars_secret refs, not found in plan.Secrets", name)
+		}
+	}
+
+	// From iac.provider token/spaces fields
+	wantFromIaC := []string{
+		"DIGITALOCEAN_TOKEN",
+		"SPACES_access_key",
+		"SPACES_secret_key",
+	}
+	for _, name := range wantFromIaC {
+		if !secretNames[name] {
+			t.Errorf("expected secret %q from iac.provider config, not found in plan.Secrets", name)
+		}
+	}
+
+	// From migrations DBEnv
+	if !secretNames["MULTISITE_DB_URL"] {
+		t.Error("expected MULTISITE_DB_URL from migrations.DBEnv in plan.Secrets")
+	}
+
+	// No duplicates
+	if len(plan.Secrets) != len(secretNames) {
+		t.Errorf("expected no duplicates: %d unique names but %d entries", len(secretNames), len(plan.Secrets))
+	}
+}
+
+func TestAnalyze_Smoke_Multisite(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/multisite.yaml"}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	if plan.Smoke == nil {
+		t.Fatal("expected Smoke to be non-nil")
+	}
+	if plan.Smoke.URL != "https://gocodealone.tech/healthz" {
+		t.Errorf("Smoke.URL = %q, want %q", plan.Smoke.URL, "https://gocodealone.tech/healthz")
+	}
+	if plan.Smoke.Path != "/healthz" {
+		t.Errorf("Smoke.Path = %q, want %q", plan.Smoke.Path, "/healthz")
+	}
+}
+
+func TestAnalyze_Warnings_Multisite(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/multisite.yaml"}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	// Should have state-derived warning for MULTISITE_DB_URL (IaC output → migrations)
+	hasStateWarning := false
+	hasCaseWarning := false
+	for _, w := range plan.Warnings {
+		if strings.Contains(w, "MULTISITE_DB_URL") && strings.Contains(w, "IaC output") {
+			hasStateWarning = true
+		}
+		// SPACES_access_key and SPACES_secret_key don't match ^[A-Z0-9_]+$
+		if strings.Contains(w, "SPACES_access_key") || strings.Contains(w, "SPACES_secret_key") {
+			hasCaseWarning = true
+		}
+	}
+
+	if !hasStateWarning {
+		t.Errorf("expected state-derived warning for MULTISITE_DB_URL; warnings: %v", plan.Warnings)
+	}
+	if !hasCaseWarning {
+		t.Errorf("expected case-mismatch warning for SPACES_access_key/SPACES_secret_key; warnings: %v", plan.Warnings)
+	}
+}
+
+func TestAnalyze_NoSmoke_MinimalConfig(t *testing.T) {
+	plan, err := cigen.Analyze([]string{"testdata/minimal.yaml"}, cigen.Options{})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if plan.Smoke != nil {
+		t.Errorf("expected no Smoke for minimal config, got %+v", plan.Smoke)
+	}
+}

--- a/cigen/testdata/app.yaml
+++ b/cigen/testdata/app.yaml
@@ -1,0 +1,43 @@
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+      spaces_access_key: ${SPACES_access_key}
+      spaces_secret_key: ${SPACES_secret_key}
+
+  - name: my-app
+    type: infra.container_service
+    protected: true
+    config:
+      provider: do-provider
+      health_check:
+        http_path: /healthz
+      domains:
+        - domain: myapp.example.com
+          type: PRIMARY
+          zone: example.com
+      env_vars_secret:
+        APP_DB_URL: ${APP_DB_URL}
+        APP_SECRET: ${APP_SECRET}
+
+  - name: my-plugin
+    type: analytics.google_provider
+    config:
+      credentials_json: ${GOOGLE_CREDENTIALS}
+
+ci:
+  migrations:
+    - name: app
+      driver: golang-migrate
+      source_dir: migrations
+      database:
+        env: APP_DB_URL
+
+secrets:
+  entries:
+    - name: DIGITALOCEAN_TOKEN
+      description: DigitalOcean API token.
+    - name: RELEASES_TOKEN
+      description: GitHub release token.

--- a/cigen/testdata/minimal.yaml
+++ b/cigen/testdata/minimal.yaml
@@ -1,0 +1,5 @@
+modules:
+  - name: web
+    type: http.server
+    config:
+      port: 8080

--- a/cigen/testdata/multisite.yaml
+++ b/cigen/testdata/multisite.yaml
@@ -1,0 +1,75 @@
+# multisite-shaped fixture — exercises secrets-union + smoke + warnings
+
+infra:
+  auto_bootstrap: true
+
+ci:
+  migrations:
+    - name: multisite
+      plugin: workflow-plugin-migrations
+      driver: golang-migrate
+      source_dir: migrations
+      database:
+        env: MULTISITE_DB_URL
+      validation:
+        forbid_dirty: true
+
+secrets:
+  defaultStore: github-actions
+  entries:
+    - name: DIGITALOCEAN_TOKEN
+      description: DigitalOcean API token.
+    - name: RELEASES_TOKEN
+      description: GitHub token.
+    - name: GHCR_CREDENTIALS
+      description: GHCR pull cred.
+    - name: SPACES_access_key
+      description: DO Spaces access key.
+    - name: SPACES_secret_key
+      description: DO Spaces secret key.
+    - name: MULTISITE_DB_URL
+      description: Managed Postgres URL.
+
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      region: nyc3
+      token: ${DIGITALOCEAN_TOKEN}
+      spaces_access_key: ${SPACES_access_key}
+      spaces_secret_key: ${SPACES_secret_key}
+
+  - name: iac-state
+    type: iac.state
+    config:
+      backend: spaces
+      bucket: multisite-iac-state
+      prefix: prod/
+      region: nyc3
+      accessKey: ${SPACES_access_key}
+      secretKey: ${SPACES_secret_key}
+
+  - name: gocodealone-multisite
+    type: infra.container_service
+    protected: true
+    config:
+      provider: do-provider
+      region: nyc
+      image: ghcr.io/gocodealone/gocodealone-multisite:${IMAGE_SHA}
+      http_port: 8080
+      health_check:
+        http_path: /healthz
+      routes:
+        - path: /
+      domains:
+        - domain: gocodealone.tech
+          type: PRIMARY
+          zone: gocodealone.tech
+        - domain: www.gocodealone.tech
+          type: ALIAS
+          zone: gocodealone.tech
+      env_vars_secret:
+        MULTISITE_DB_URL: ${MULTISITE_DB_URL}
+        MULTISITE_INGEST_HMAC_SECRET: ${MULTISITE_INGEST_HMAC_SECRET}
+        MULTISITE_JWT_SECRET: ${MULTISITE_JWT_SECRET}

--- a/cigen/testdata/prereq.yaml
+++ b/cigen/testdata/prereq.yaml
@@ -1,0 +1,9 @@
+# Minimal prerequisite-phase fixture for TestAnalyze_PhaseConfig.
+# Analyze treats the phase config as a path string only (it does not load this
+# file), but it is checked in so the referenced path resolves to a real file.
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -9,10 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"text/template"
 
 	"github.com/GoCodeAlone/workflow/cigen"
-	"gopkg.in/yaml.v3"
 )
 
 func runCI(args []string) error {
@@ -190,10 +187,11 @@ func runCIGenerate(args []string) error {
 }
 
 // resolveOutputPath determines the final destination for a generated file.
-// For paths containing directories (e.g. .github/workflows/foo.yml), the
-// path is kept relative to cwd. For flat filenames, it is placed in outputDir.
+// When outputDir is "." (the default), paths that contain "/" are kept relative
+// to cwd (e.g. .github/workflows/foo.yml stays as-is). When outputDir is an
+// explicit non-"." directory, ALL generated paths are rooted there.
 func resolveOutputPath(relPath, outputDir string) string {
-	if strings.Contains(relPath, "/") {
+	if outputDir == "" || outputDir == "." {
 		return relPath
 	}
 	return filepath.Join(outputDir, relPath)
@@ -240,34 +238,6 @@ func resolveCIConfig(explicit string) (string, error) {
 		}
 	}
 	return "infra.yaml", nil // fall back to the conventional name even if absent
-}
-
-// detectModuleTypes parses the config YAML and returns which module categories exist.
-func detectModuleTypes(cfgFile string) map[string]bool {
-	data, err := os.ReadFile(cfgFile)
-	if err != nil {
-		return map[string]bool{}
-	}
-	var parsed struct {
-		Modules []struct {
-			Type string `yaml:"type"`
-		} `yaml:"modules"`
-	}
-	if err := yaml.Unmarshal(data, &parsed); err != nil {
-		return map[string]bool{}
-	}
-	result := map[string]bool{}
-	for _, m := range parsed.Modules {
-		switch {
-		case strings.HasPrefix(m.Type, "infra."):
-			result["infra"] = true
-		case strings.HasPrefix(m.Type, "database."):
-			result["database"] = true
-		case strings.HasPrefix(m.Type, "platform."):
-			result["platform"] = true
-		}
-	}
-	return result
 }
 
 // ciOptions is retained for backward-compatible internal use by tests.
@@ -327,19 +297,6 @@ func ciOptionsToPlan(opts ciOptions) *cigen.CIPlan {
 		Warnings: []string{},
 		Triggers: cigen.TriggerSpec{PR: true, PushMain: true, Dispatch: true},
 	}
-}
-
-// renderCITemplate is kept for callers in ci_init.go and similar.
-func renderCITemplate(name, tmplStr string, data any) (string, error) {
-	tmpl, err := template.New(name).Parse(tmplStr)
-	if err != nil {
-		return "", err
-	}
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
 }
 
 var cleanReleaseTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -27,6 +27,9 @@ func runCI(args []string) error {
 		return runCIInit(args[1:])
 	case "validate":
 		return runCIValidate(args[1:])
+	case "--help", "-h", "help":
+		_ = ciUsage()
+		return nil
 	default:
 		return ciUsage()
 	}

--- a/cmd/wfctl/ci.go
+++ b/cmd/wfctl/ci.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/GoCodeAlone/workflow/cigen"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,6 +22,8 @@ func runCI(args []string) error {
 	switch args[0] {
 	case "generate":
 		return runCIGenerate(args[1:])
+	case "plan":
+		return runCIPlan(args[1:])
 	case "run":
 		return runCIRun(args[1:])
 	case "init":
@@ -38,18 +42,27 @@ Generate CI/CD pipeline configuration files.
 
 Actions:
   generate  Generate CI config for a supported platform
+  plan      Analyze config and emit a CIPlan JSON (platform-neutral)
   run       Run CI phases (build, test, deploy) from workflow config
   init      Generate bootstrap CI YAML for GitHub Actions or GitLab CI
+  validate  Validate CI config sections
 
 Options:
-  --platform <name>   CI platform: github_actions, gitlab_ci (required)
-  --config <file>     Workflow config file (default: app.yaml or infra.yaml)
-  --output <dir>      Output directory (default: .)
-  --runner <label>    Runner label (github_actions only, default: ubuntu-latest)
+  --platform <name>     CI platform: github_actions, gitlab_ci (required for generate)
+  --config <file>       Workflow config file (default: app.yaml or infra.yaml)
+  --out <path>          Output path for generate files (directory, default: .)
+  --from-plan <file>    Skip Analyze; load a CIPlan JSON directly
+  --diff                Print unified diff vs on-disk file instead of writing
+  --exit-code           With --diff: exit 1 when files differ, 0 when identical
+  --write               Allow overwriting existing files
+  --phase-config <file> Prerequisite phase config (adds a prereq DeployPhase)
+  --runner <label>      Runner label (github_actions only, default: ubuntu-latest)
 
 Examples:
-  wfctl ci generate --platform github_actions --config infra.yaml --output .github/workflows/
-  wfctl ci generate --platform gitlab_ci --config infra.yaml --output .
+  wfctl ci plan -c deploy.yaml --out -
+  wfctl ci generate --platform github_actions --config deploy.yaml --write
+  wfctl ci generate --platform github_actions --from-plan plan.json --write
+  wfctl ci generate --platform github_actions --config deploy.yaml --diff --exit-code
 `)
 	return fmt.Errorf("missing or unknown action")
 }
@@ -58,60 +71,163 @@ func runCIGenerate(args []string) error {
 	fs := flag.NewFlagSet("ci generate", flag.ContinueOnError)
 	platform := fs.String("platform", "", "CI platform: github_actions, gitlab_ci")
 	configFile := fs.String("config", "", "Workflow config file")
+	configFileShort := fs.String("c", "", "Workflow config file (shorthand)")
 	outputDir := fs.String("output", ".", "Output directory")
+	out := fs.String("out", "", "Output directory (alias for --output)")
 	runner := fs.String("runner", "ubuntu-latest", "Runner label (github_actions only)")
+	fromPlan := fs.String("from-plan", "", "Load a CIPlan JSON file instead of analyzing")
+	diff := fs.Bool("diff", false, "Print unified diff vs on-disk file instead of writing")
+	exitCode := fs.Bool("exit-code", false, "With --diff: exit 1 when files differ")
+	write := fs.Bool("write", false, "Allow overwriting existing files")
+	phaseConfig := fs.String("phase-config", "", "Prerequisite phase config path")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// Resolve config shorthand
+	if *configFile == "" && *configFileShort != "" {
+		*configFile = *configFileShort
+	}
+	// --out as alias for --output
+	if *out != "" && *outputDir == "." {
+		*outputDir = *out
 	}
 
 	if *platform == "" {
 		return fmt.Errorf("--platform is required (github_actions, gitlab_ci)")
 	}
 
-	cfg, err := resolveCIConfig(*configFile)
-	if err != nil {
-		return err
+	// Build the plan
+	var plan *cigen.CIPlan
+	if *fromPlan != "" {
+		data, err := os.ReadFile(*fromPlan)
+		if err != nil {
+			return fmt.Errorf("ci generate: read plan: %w", err)
+		}
+		plan = &cigen.CIPlan{}
+		if err := json.Unmarshal(data, plan); err != nil {
+			return fmt.Errorf("ci generate: parse plan: %w", err)
+		}
+	} else {
+		configPath, err := resolveCIConfig(*configFile)
+		if err != nil {
+			return err
+		}
+		opts := cigen.Options{
+			WfctlVersion: ciGeneratedWfctlVersion(),
+			Runner:       *runner,
+			PhaseConfig:  *phaseConfig,
+		}
+		var analyzeErr error
+		plan, analyzeErr = cigen.Analyze([]string{configPath}, opts)
+		if analyzeErr != nil {
+			return fmt.Errorf("ci generate: analyze: %w", analyzeErr)
+		}
 	}
 
-	moduleTypes := detectModuleTypes(cfg)
-
-	opts := ciOptions{
-		Platform:    *platform,
-		InfraConfig: cfg,
-		OutputDir:   *outputDir,
-		Runner:      *runner,
-		HasInfra:    moduleTypes["infra"],
-		HasDatabase: moduleTypes["database"],
+	// Render
+	var files map[string]string
+	var renderErr error
+	switch *platform {
+	case "github_actions":
+		files, renderErr = cigen.RenderGitHubActions(plan)
+	case "gitlab_ci":
+		files, renderErr = cigen.RenderGitLabCI(plan)
+	default:
+		return fmt.Errorf("unsupported platform %q (supported: github_actions, gitlab_ci)", *platform)
+	}
+	if renderErr != nil {
+		return renderErr
 	}
 
-	files, err := generateCIFiles(opts)
-	if err != nil {
-		return err
+	// --diff mode: print diff and optionally exit 1 if different
+	if *diff {
+		hasDiff := false
+		for relPath, content := range files {
+			destPath := resolveOutputPath(relPath, *outputDir)
+			existing, err := os.ReadFile(destPath)
+			if err != nil {
+				// File doesn't exist — everything is a diff
+				fmt.Printf("--- %s (new file)\n+++ %s\n", destPath, destPath)
+				for _, line := range strings.Split(content, "\n") {
+					fmt.Printf("+ %s\n", line)
+				}
+				hasDiff = true
+				continue
+			}
+			if string(existing) != content {
+				hasDiff = true
+				fmt.Printf("--- %s\n+++ %s (generated)\n", destPath, destPath)
+				printLineDiff(string(existing), content)
+			}
+		}
+		if *exitCode && hasDiff {
+			os.Exit(1)
+		}
+		return nil
 	}
 
+	// Write mode: write files, respecting --write flag
 	if err := os.MkdirAll(*outputDir, 0o750); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
 	for relPath, content := range files {
-		dest := filepath.Join(*outputDir, filepath.Base(relPath))
-		// Preserve subdirectory structure relative to output for GHA workflows
-		if strings.Contains(relPath, "/") {
-			// relPath is already a full relative path like .github/workflows/infra.yml
-			// Write relative to cwd, not outputDir
-			dest = relPath
-			if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
-				return fmt.Errorf("create dir for %s: %w", dest, err)
-			}
+		destPath := resolveOutputPath(relPath, *outputDir)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o750); err != nil {
+			return fmt.Errorf("create dir for %s: %w", destPath, err)
 		}
-		if err := os.WriteFile(dest, []byte(content), 0o600); err != nil {
-			return fmt.Errorf("write %s: %w", dest, err)
+		if _, err := os.Stat(destPath); err == nil && !*write {
+			return fmt.Errorf("file %s already exists; use --write to overwrite", destPath)
 		}
-		fmt.Printf("wrote %s\n", dest)
+		if err := os.WriteFile(destPath, []byte(content), 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", destPath, err)
+		}
+		fmt.Printf("wrote %s\n", destPath)
 	}
 
 	return nil
 }
+
+// resolveOutputPath determines the final destination for a generated file.
+// For paths containing directories (e.g. .github/workflows/foo.yml), the
+// path is kept relative to cwd. For flat filenames, it is placed in outputDir.
+func resolveOutputPath(relPath, outputDir string) string {
+	if strings.Contains(relPath, "/") {
+		return relPath
+	}
+	return filepath.Join(outputDir, relPath)
+}
+
+// printLineDiff prints a simple +/- line-level diff.
+func printLineDiff(old, newStr string) {
+	oldLines := strings.Split(old, "\n")
+	newLines := strings.Split(newStr, "\n")
+
+	maxLen := len(oldLines)
+	if len(newLines) > maxLen {
+		maxLen = len(newLines)
+	}
+	for i := 0; i < maxLen; i++ {
+		var ov, nv string
+		if i < len(oldLines) {
+			ov = oldLines[i]
+		}
+		if i < len(newLines) {
+			nv = newLines[i]
+		}
+		if ov != nv {
+			if i < len(oldLines) {
+				fmt.Printf("- %s\n", ov)
+			}
+			if i < len(newLines) {
+				fmt.Printf("+ %s\n", nv)
+			}
+		}
+	}
+}
+
+// ── Legacy API: keep ciOptions and generateCIFiles for backward-compat tests ─
 
 // resolveCIConfig finds the config file or tries defaults.
 func resolveCIConfig(explicit string) (string, error) {
@@ -154,6 +270,7 @@ func detectModuleTypes(cfgFile string) map[string]bool {
 	return result
 }
 
+// ciOptions is retained for backward-compatible internal use by tests.
 type ciOptions struct {
 	Platform    string
 	InfraConfig string
@@ -163,6 +280,8 @@ type ciOptions struct {
 	HasDatabase bool
 }
 
+// generateCIFiles is the legacy entry point used by existing tests.
+// It builds a minimal CIPlan from ciOptions and delegates to the cigen renderers.
 func generateCIFiles(opts ciOptions) (map[string]string, error) {
 	switch opts.Platform {
 	case "github_actions":
@@ -174,212 +293,43 @@ func generateCIFiles(opts ciOptions) (map[string]string, error) {
 	}
 }
 
-// ── GitHub Actions ────────────────────────────────────────────────────────────
-
-type ghaTemplateData struct {
-	InfraConfig  string
-	Runner       string
-	Branch       string
-	WfctlVersion string
-}
-
+// generateGitHubActions builds a minimal CIPlan from opts and renders GHA files.
 func generateGitHubActions(opts ciOptions) (map[string]string, error) {
-	data := ghaTemplateData{
-		InfraConfig:  opts.InfraConfig,
-		Runner:       opts.Runner,
-		Branch:       "main",
-		WfctlVersion: ciGeneratedWfctlVersion(),
-	}
-
-	infraYAML, err := renderCITemplate("gha-infra", ghaInfraTemplate, data)
-	if err != nil {
-		return nil, fmt.Errorf("render infra.yml: %w", err)
-	}
-
-	buildYAML, err := renderCITemplate("gha-build", ghaBuildTemplate, data)
-	if err != nil {
-		return nil, fmt.Errorf("render build.yml: %w", err)
-	}
-
-	return map[string]string{
-		".github/workflows/infra.yml": infraYAML,
-		".github/workflows/build.yml": buildYAML,
-	}, nil
+	plan := ciOptionsToPlan(opts)
+	return cigen.RenderGitHubActions(plan)
 }
 
-const ghaInfraTemplate = `name: Infrastructure
-on:
-  pull_request:
-    paths:
-      - '{{.InfraConfig}}'
-      - 'infra/**'
-  push:
-    branches:
-      - {{.Branch}}
-    paths:
-      - '{{.InfraConfig}}'
-      - 'infra/**'
-permissions:
-  contents: read
-  pull-requests: write
-jobs:
-  plan:
-    if: github.event_name == 'pull_request'
-    runs-on: '{{.Runner}}'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Install wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
-        with:
-          version: '{{.WfctlVersion}}'
-      - name: Plan infrastructure
-        run: wfctl infra plan --config '{{.InfraConfig}}' --format markdown > plan.md
-      - name: Post plan comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const plan = fs.readFileSync('plan.md', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: plan
-            });
-  apply:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/{{.Branch}}'
-    runs-on: '{{.Runner}}'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Install wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
-        with:
-          version: '{{.WfctlVersion}}'
-      - name: Apply infrastructure
-        run: wfctl infra apply --config '{{.InfraConfig}}' --auto-approve
-`
-
-const ghaBuildTemplate = `name: Build
-on:
-  push:
-    branches:
-      - {{.Branch}}
-  pull_request:
-    branches:
-      - {{.Branch}}
-permissions:
-  contents: read
-  packages: write
-jobs:
-  build:
-    runs-on: '{{.Runner}}'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Install wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
-        with:
-          version: '{{.WfctlVersion}}'
-      - name: Run tests
-        env:
-          INFRA_CONFIG: '{{.InfraConfig}}'
-        run: wfctl ci run --config "$INFRA_CONFIG" --phase test
-      - name: Build without push
-        env:
-          INFRA_CONFIG: '{{.InfraConfig}}'
-        run: wfctl build --config "$INFRA_CONFIG" --no-push --tag ci --fallback-go-build
-`
-
-// ── GitLab CI ─────────────────────────────────────────────────────────────────
-
-type gitlabTemplateData struct {
-	InfraConfig  string
-	Branch       string
-	WfctlVersion string
-}
-
+// generateGitLabCI builds a minimal CIPlan from opts and renders GitLab CI.
 func generateGitLabCI(opts ciOptions) (map[string]string, error) {
-	data := gitlabTemplateData{
-		InfraConfig:  opts.InfraConfig,
-		Branch:       "main",
-		WfctlVersion: ciGeneratedWfctlVersion(),
-	}
-
-	content, err := renderCITemplate("gitlab-ci", gitlabCITemplate, data)
-	if err != nil {
-		return nil, fmt.Errorf("render .gitlab-ci.yml: %w", err)
-	}
-
-	return map[string]string{
-		".gitlab-ci.yml": content,
-	}, nil
+	plan := ciOptionsToPlan(opts)
+	return cigen.RenderGitLabCI(plan)
 }
 
-const gitlabCITemplate = `stages:
-  - plan
-  - apply
-  - build
+// ciOptionsToPlan converts legacy ciOptions to a minimal CIPlan.
+func ciOptionsToPlan(opts ciOptions) *cigen.CIPlan {
+	configPath := opts.InfraConfig
+	if configPath == "" {
+		configPath = "infra.yaml"
+	}
+	runner := opts.Runner
+	if runner == "" {
+		runner = "ubuntu-latest"
+	}
+	return &cigen.CIPlan{
+		Project:       "infra",
+		WfctlVersion:  ciGeneratedWfctlVersion(),
+		DefaultBranch: "main",
+		Runner:        runner,
+		Phases: []cigen.DeployPhase{
+			{Name: "deploy", ConfigPath: configPath},
+		},
+		Secrets:  []cigen.SecretRef{},
+		Warnings: []string{},
+		Triggers: cigen.TriggerSpec{PR: true, PushMain: true, Dispatch: true},
+	}
+}
 
-variables:
-  INFRA_CONFIG: "{{.InfraConfig}}"
-  WFCTL_VERSION: "{{.WfctlVersion}}"
-
-before_script:
-  - go install "github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION}"
-  - export PATH="$(go env GOPATH)/bin:$PATH"
-
-infra-plan:
-  stage: plan
-  script:
-    - wfctl infra plan --config "$INFRA_CONFIG" --format markdown > plan.md
-  artifacts:
-    paths:
-      - plan.md
-    expire_in: 1 hour
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-      changes:
-        - "{{.InfraConfig}}"
-        - "infra/**/*"
-
-infra-apply:
-  stage: apply
-  needs:
-    - job: infra-plan
-      artifacts: true
-  script:
-    - wfctl infra apply --config "$INFRA_CONFIG" --auto-approve
-  environment:
-    name: production
-  rules:
-    - if: $CI_COMMIT_BRANCH == "{{.Branch}}" && $CI_PIPELINE_SOURCE == "push"
-      changes:
-        - "{{.InfraConfig}}"
-        - "infra/**/*"
-
-build:
-  stage: build
-  needs: []
-  script:
-    - wfctl ci run --config "$INFRA_CONFIG" --phase test
-    - wfctl build --config "$INFRA_CONFIG" --no-push --tag ci --fallback-go-build
-  rules:
-    - if: $CI_COMMIT_BRANCH == "{{.Branch}}"
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-`
-
-// renderCITemplate executes a named text/template with data and returns the result.
+// renderCITemplate is kept for callers in ci_init.go and similar.
 func renderCITemplate(name, tmplStr string, data any) (string, error) {
 	tmpl, err := template.New(name).Parse(tmplStr)
 	if err != nil {

--- a/cmd/wfctl/ci_plan.go
+++ b/cmd/wfctl/ci_plan.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/GoCodeAlone/workflow/cigen"
@@ -13,6 +12,7 @@ import (
 func runCIPlan(args []string) error {
 	fs := flag.NewFlagSet("ci plan", flag.ContinueOnError)
 	configFile := fs.String("config", "", "Workflow config file (default: app.yaml or infra.yaml)")
+	configFileShort := fs.String("c", "", "Workflow config file (shorthand for --config)")
 	out := fs.String("out", "-", "Output file for the CIPlan JSON ('-' for stdout)")
 	phaseConfig := fs.String("phase-config", "", "Prerequisite phase config path (creates a 2-phase plan)")
 	wfctlVer := fs.String("wfctl-version", "", "Pin wfctl version in plan (default: latest)")
@@ -31,6 +31,11 @@ Options:
 	}
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// Resolve -c shorthand
+	if *configFile == "" && *configFileShort != "" {
+		*configFile = *configFileShort
 	}
 
 	configPath, err := resolveCIConfig(*configFile)
@@ -65,6 +70,6 @@ Options:
 		return fmt.Errorf("ci plan: create %s: %w", *out, err)
 	}
 	defer f.Close() //nolint:errcheck
-	_, err = io.WriteString(f, string(data)+"\n")
+	_, err = f.WriteString(string(data) + "\n")
 	return err
 }

--- a/cmd/wfctl/ci_plan.go
+++ b/cmd/wfctl/ci_plan.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/GoCodeAlone/workflow/cigen"
+)
+
+func runCIPlan(args []string) error {
+	fs := flag.NewFlagSet("ci plan", flag.ContinueOnError)
+	configFile := fs.String("config", "", "Workflow config file (default: app.yaml or infra.yaml)")
+	out := fs.String("out", "-", "Output file for the CIPlan JSON ('-' for stdout)")
+	phaseConfig := fs.String("phase-config", "", "Prerequisite phase config path (creates a 2-phase plan)")
+	wfctlVer := fs.String("wfctl-version", "", "Pin wfctl version in plan (default: latest)")
+	branch := fs.String("branch", "", "Default branch name (default: main)")
+	runner := fs.String("runner", "", "GitHub Actions runner label (default: ubuntu-latest)")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage: wfctl ci plan [options]
+
+Analyze a workflow config and emit a platform-neutral CIPlan as JSON.
+The plan can be passed to 'wfctl ci generate --from-plan' to render
+CI files without re-analyzing.
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	configPath, err := resolveCIConfig(*configFile)
+	if err != nil {
+		return err
+	}
+
+	opts := cigen.Options{
+		WfctlVersion:  *wfctlVer,
+		DefaultBranch: *branch,
+		Runner:        *runner,
+		PhaseConfig:   *phaseConfig,
+	}
+
+	plan, err := cigen.Analyze([]string{configPath}, opts)
+	if err != nil {
+		return fmt.Errorf("ci plan: %w", err)
+	}
+
+	data, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return fmt.Errorf("ci plan: marshal: %w", err)
+	}
+
+	if *out == "-" {
+		_, err = fmt.Fprintln(os.Stdout, string(data))
+		return err
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("ci plan: create %s: %w", *out, err)
+	}
+	defer f.Close() //nolint:errcheck
+	_, err = io.WriteString(f, string(data)+"\n")
+	return err
+}

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,46 +20,42 @@ func TestGenerateGitHubActions(t *testing.T) {
 		t.Fatalf("generateCIFiles: %v", err)
 	}
 
-	infraYML, ok := files[".github/workflows/infra.yml"]
-	if !ok {
-		t.Fatal("expected .github/workflows/infra.yml in output")
+	if len(files) == 0 {
+		t.Fatal("expected at least one file in output")
+	}
+
+	// Find the main workflow file (the cigen renderer produces a single named file)
+	var workflowYML string
+	for path, content := range files {
+		if strings.HasSuffix(path, ".yml") && strings.Contains(path, ".github/workflows/") {
+			workflowYML = content
+			break
+		}
+	}
+	if workflowYML == "" {
+		t.Fatalf("expected a .github/workflows/*.yml file in output, got keys: %v", fileKeys(files))
 	}
 
 	markers := []string{
 		"actions/checkout@v4",
-		"actions/setup-go@v5",
 		"GoCodeAlone/setup-wfctl@v1",
 		"wfctl infra plan",
 		"permissions",
-		"actions/github-script@v7",
 	}
 	for _, m := range markers {
-		if !strings.Contains(infraYML, m) {
-			t.Errorf("infra.yml missing marker %q", m)
+		if !strings.Contains(workflowYML, m) {
+			t.Errorf("workflow YAML missing marker %q", m)
 		}
 	}
 
-	buildYML, ok := files[".github/workflows/build.yml"]
-	if !ok {
-		t.Fatal("expected .github/workflows/build.yml in output")
+	// Plan job must be PR-gated
+	if !strings.Contains(workflowYML, "github.event_name == 'pull_request'") {
+		t.Error("expected plan job to be gated on pull_request")
 	}
-	if !strings.Contains(buildYML, "actions/checkout@v4") {
-		t.Error("build.yml missing actions/checkout@v4")
-	}
-	if !strings.Contains(buildYML, "actions/setup-go@v5") {
-		t.Error("build.yml missing actions/setup-go@v5")
-	}
-	if !strings.Contains(buildYML, "GoCodeAlone/setup-wfctl@v1") {
-		t.Error("build.yml missing setup-wfctl action")
-	}
-	if !strings.Contains(buildYML, "wfctl ci run --config \"$INFRA_CONFIG\" --phase test") {
-		t.Error("build.yml missing wfctl ci run test phase")
-	}
-	if !strings.Contains(buildYML, "wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci --fallback-go-build") {
-		t.Error("build.yml missing wfctl build")
-	}
-	if strings.Contains(buildYML, "go build ./...") {
-		t.Error("build.yml should use wfctl build instead of raw go build")
+
+	// Apply job must exist
+	if !strings.Contains(workflowYML, "wfctl infra apply") {
+		t.Error("expected apply step using wfctl infra apply")
 	}
 }
 
@@ -80,14 +77,11 @@ func TestGenerateGitLabCI(t *testing.T) {
 
 	markers := []string{
 		"rules:",
-		"needs:",
 		"before_script:",
-		"WFCTL_VERSION: \"latest\"",
-		"go install \"github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION}\"",
-		"export PATH=\"$(go env GOPATH)/bin:$PATH\"",
+		`WFCTL_VERSION: "latest"`,
+		`go install "github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION}"`,
+		`export PATH="$(go env GOPATH)/bin:$PATH"`,
 		"wfctl infra plan",
-		"wfctl ci run --config \"$INFRA_CONFIG\" --phase test",
-		"wfctl build --config \"$INFRA_CONFIG\" --no-push --tag ci --fallback-go-build",
 		"environment:",
 	}
 	for _, m := range markers {
@@ -115,8 +109,13 @@ func TestCIGeneratePinsCurrentWfctlVersionWhenReleased(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate GitHub Actions: %v", err)
 	}
-	if !strings.Contains(ghaFiles[".github/workflows/build.yml"], "version: 'v9.9.9'") {
-		t.Fatal("GitHub Actions build workflow should pin the generated wfctl version")
+	var ghaContent string
+	for _, c := range ghaFiles {
+		ghaContent = c
+		break
+	}
+	if !strings.Contains(ghaContent, "version: 'v9.9.9'") {
+		t.Fatal("GitHub Actions workflow should pin the generated wfctl version")
 	}
 
 	gitlabFiles, err := generateCIFiles(ciOptions{
@@ -214,10 +213,23 @@ func TestResolveCIConfigPicksAppYaml(t *testing.T) {
 func TestCIGenerateWritesFiles(t *testing.T) {
 	dir := t.TempDir()
 
+	// Write a minimal config so runCIGenerate can analyze it
+	cfgPath := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(cfgPath, []byte("modules:\n  - name: web\n    type: http.server\n    config:\n      port: 8080\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+
 	err := runCIGenerate([]string{
 		"--platform", "gitlab_ci",
 		"--config", "infra.yaml",
 		"--output", dir,
+		"--write",
 	})
 	if err != nil {
 		t.Fatalf("runCIGenerate: %v", err)
@@ -230,5 +242,178 @@ func TestCIGenerateWritesFiles(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "rules:") {
 		t.Error("generated .gitlab-ci.yml missing 'rules:'")
+	}
+}
+
+// fileKeys returns sorted keys from the files map for debugging.
+func fileKeys(files map[string]string) []string {
+	keys := make([]string, 0, len(files))
+	for k := range files {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// ─── New ci plan + ci generate extended tests ────────────────────────────────
+
+func TestRunCIPlan_StdoutJSON(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(cfgPath, []byte("modules:\n  - name: web\n    type: http.server\n    config:\n      port: 8080\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+
+	outPath := filepath.Join(dir, "plan.json")
+	err := runCIPlan([]string{"--config", "app.yaml", "--out", outPath})
+	if err != nil {
+		t.Fatalf("runCIPlan: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read plan.json: %v", err)
+	}
+
+	var plan map[string]any
+	if err := json.Unmarshal(data, &plan); err != nil {
+		t.Fatalf("plan.json is not valid JSON: %v", err)
+	}
+
+	if _, ok := plan["warnings"]; !ok {
+		t.Error("expected 'warnings' field in CIPlan JSON")
+	}
+	if _, ok := plan["phases"]; !ok {
+		t.Error("expected 'phases' field in CIPlan JSON")
+	}
+}
+
+func TestRunCIGenerate_FromPlan(t *testing.T) {
+	dir := t.TempDir()
+
+	planJSON := `{
+  "project": "test",
+  "wfctl_version": "latest",
+  "default_branch": "main",
+  "runner": "ubuntu-latest",
+  "plugin_install": false,
+  "phases": [{"name":"deploy","config_path":"app.yaml"}],
+  "secrets": [],
+  "plan_guard": false,
+  "triggers": {"pr":true,"push_main":true,"dispatch":true},
+  "warnings": []
+}`
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(planPath, []byte(planJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+
+	err := runCIGenerate([]string{
+		"--platform", "gitlab_ci",
+		"--from-plan", planPath,
+		"--output", outDir,
+		"--write",
+	})
+	if err != nil {
+		t.Fatalf("runCIGenerate --from-plan: %v", err)
+	}
+
+	dest := filepath.Join(outDir, ".gitlab-ci.yml")
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %v", dest, err)
+	}
+	if !strings.Contains(string(data), "rules:") {
+		t.Error("expected 'rules:' in generated gitlab-ci.yml")
+	}
+}
+
+func TestRunCIGenerate_DiffExitCode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(cfgPath, []byte("modules:\n  - name: web\n    type: http.server\n    config:\n      port: 8080\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+
+	// First write the files
+	err := runCIGenerate([]string{
+		"--platform", "gitlab_ci",
+		"--config", "app.yaml",
+		"--output", dir,
+		"--write",
+	})
+	if err != nil {
+		t.Fatalf("initial generate: %v", err)
+	}
+
+	// Now run --diff against the same output — no diff, so exit code 0 (no os.Exit called)
+	// We can't test os.Exit directly, but we can test the function doesn't error.
+	// We test --diff without --exit-code to avoid os.Exit being called.
+	err = runCIGenerate([]string{
+		"--platform", "gitlab_ci",
+		"--config", "app.yaml",
+		"--output", dir,
+		"--diff",
+	})
+	if err != nil {
+		t.Fatalf("--diff should not return error when files match: %v", err)
+	}
+}
+
+func TestRunCIGenerate_NoOverwriteWithoutWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(cfgPath, []byte("modules:\n  - name: web\n    type: http.server\n    config:\n      port: 8080\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create the output file
+	destDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, ".gitlab-ci.yml"), []byte("old content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+
+	err := runCIGenerate([]string{
+		"--platform", "gitlab_ci",
+		"--config", "app.yaml",
+		"--output", destDir,
+		// no --write
+	})
+	if err == nil {
+		t.Fatal("expected error when target file exists and --write is not set")
+	}
+	if !strings.Contains(err.Error(), "--write") {
+		t.Errorf("expected error to mention --write, got: %v", err)
 	}
 }

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -1678,55 +1678,6 @@ func mcpDetectFeatures(cfg *config.WorkflowConfig) *mcpProjectFeatures {
 	return features
 }
 
-func mcpGenerateCIWorkflow(features *mcpProjectFeatures) string {
-	var b strings.Builder
-
-	b.WriteString("name: CI\n")
-	b.WriteString("on:\n")
-	b.WriteString("  pull_request:\n")
-	b.WriteString("    branches: [main]\n")
-	b.WriteString("  push:\n")
-	b.WriteString("    branches: [main]\n")
-	b.WriteString("\n")
-	b.WriteString("jobs:\n")
-	b.WriteString("  validate:\n")
-	b.WriteString("    runs-on: ubuntu-latest\n")
-	b.WriteString("    steps:\n")
-	b.WriteString("      - uses: actions/checkout@v4\n")
-	b.WriteString("      - uses: actions/setup-go@v5\n")
-	b.WriteString("        with:\n")
-	b.WriteString("          go-version: '1.22'\n")
-	b.WriteString("      - name: Install wfctl\n")
-	b.WriteString("        run: go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest\n")
-	b.WriteString("      - name: Validate config\n")
-	b.WriteString("        run: wfctl validate config.yaml\n")
-	b.WriteString("      - name: Inspect config\n")
-	b.WriteString("        run: wfctl inspect config.yaml\n")
-
-	if features.HasUI {
-		b.WriteString("      - uses: actions/setup-node@v4\n")
-		b.WriteString("        with:\n")
-		b.WriteString("          node-version: '22'\n")
-		b.WriteString("      - name: Build UI\n")
-		b.WriteString("        run: wfctl build-ui --ui-dir ui\n")
-	}
-
-	if features.HasAuth {
-		b.WriteString("      - name: Verify secrets setup\n")
-		b.WriteString("        run: echo \"Secrets configured for auth modules\"\n")
-		b.WriteString("        env:\n")
-		b.WriteString("          JWT_SECRET: ${{ secrets.JWT_SECRET }}\n")
-	}
-
-	if features.HasDatabase {
-		b.WriteString("      - name: Run migrations\n")
-		b.WriteString("        run: wfctl migrate --config config.yaml\n")
-		b.WriteString("        continue-on-error: true\n")
-	}
-
-	return b.String()
-}
-
 func mcpGenerateCDWorkflow(features *mcpProjectFeatures, registry, platforms string) string {
 	var b strings.Builder
 

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -476,8 +476,23 @@ func (s *Server) handleCIPlan(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	return marshalToolResult(plan)
 }
 
-// mcpAnalyzeFromYAML writes YAML content to temp files, calls cigen.Analyze, and
-// returns the CIPlan. phaseConfigYAML may be empty (single-phase plan).
+// Logical, repo-relative config-path names the MCP path hands to cigen.Analyze.
+// The real config bytes live in os.CreateTemp files that are deleted before the
+// CIPlan is returned, so the plan's DeployPhase.ConfigPath (and every generated
+// `--config '...'` step + `paths:` filter) MUST reference these stable names
+// rather than the temp paths. Callers regenerate the config at these paths in
+// their repo checkout.
+const (
+	mcpLogicalConfigPath = "deploy.yaml"
+	mcpLogicalPrereqPath = "deploy.prereq.yaml"
+)
+
+// mcpAnalyzeFromYAML writes YAML content to a temp file, calls cigen.Analyze,
+// and returns the CIPlan. The plan's phase config paths are stable logical
+// names (see mcpLogicalConfigPath) rather than the temp filesystem path, so the
+// generated CI references a real checkout path. phaseConfigYAML may be empty
+// (single-phase plan); when set, the prereq config bytes are parsed via temp
+// file but the plan references mcpLogicalPrereqPath.
 func mcpAnalyzeFromYAML(yamlContent, phaseConfigYAML, wfctlVersion string) (*cigen.CIPlan, error) {
 	// Write primary config to a temp file
 	primaryFile, err := os.CreateTemp("", "wfctl-mcp-config-*.yaml")
@@ -493,21 +508,16 @@ func mcpAnalyzeFromYAML(yamlContent, phaseConfigYAML, wfctlVersion string) (*cig
 
 	opts := cigen.Options{
 		WfctlVersion: wfctlVersion,
+		// Use a stable logical path so the generated CI does not point at the
+		// temp file deleted by the defer above.
+		ConfigPathAlias: mcpLogicalConfigPath,
 	}
 
-	// Write phase config if provided
+	// The prereq phase config is only used as a path string by Analyze (its
+	// contents are never read), so we pass the logical name directly without a
+	// temp file.
 	if phaseConfigYAML != "" {
-		prereqFile, err := os.CreateTemp("", "wfctl-mcp-prereq-*.yaml")
-		if err != nil {
-			return nil, fmt.Errorf("create prereq temp file: %w", err)
-		}
-		defer os.Remove(prereqFile.Name()) //nolint:errcheck
-		if _, err := prereqFile.WriteString(phaseConfigYAML); err != nil {
-			prereqFile.Close() //nolint:errcheck
-			return nil, fmt.Errorf("write prereq temp file: %w", err)
-		}
-		prereqFile.Close() //nolint:errcheck
-		opts.PhaseConfig = prereqFile.Name()
+		opts.PhaseConfig = mcpLogicalPrereqPath
 	}
 
 	return cigen.Analyze([]string{primaryFile.Name()}, opts)

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoCodeAlone/workflow/cigen"
 	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/manifest"
 	"github.com/GoCodeAlone/workflow/modernize"
@@ -147,6 +148,27 @@ func (s *Server) registerWfctlTools() {
 			mcp.WithReadOnlyHintAnnotation(true),
 		),
 		s.handleGenerateGithubActions,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("ci_plan",
+			mcp.WithDescription("Analyze a workflow YAML config and emit a platform-neutral CIPlan JSON. "+
+				"The plan describes project name, wfctl version, deploy phases, secrets union, "+
+				"migrations spec, smoke test URL, plan guard, and warnings. "+
+				"Pass the returned JSON to 'wfctl ci generate --from-plan' to render CI files."),
+			mcp.WithString("yaml_content",
+				mcp.Required(),
+				mcp.Description("The YAML content of the workflow configuration"),
+			),
+			mcp.WithString("phase_config_yaml",
+				mcp.Description("Optional YAML content of a prerequisite phase config (creates a 2-phase plan)"),
+			),
+			mcp.WithString("wfctl_version",
+				mcp.Description("wfctl version to pin in the plan (default: latest)"),
+			),
+			mcp.WithReadOnlyHintAnnotation(true),
+		),
+		s.handleCIPlan,
 	)
 
 	s.mcpServer.AddTool(
@@ -391,29 +413,104 @@ func (s *Server) handleGenerateGithubActions(_ context.Context, req mcp.CallTool
 		return mcp.NewToolResultError("yaml_content is required"), nil
 	}
 
-	cfg, err := config.LoadFromString(yamlContent)
+	// Route through cigen.Analyze + RenderGitHubActions for plan-derived output.
+	plan, err := mcpAnalyzeFromYAML(yamlContent, mcp.ParseString(req, "phase_config_yaml", ""), mcp.ParseString(req, "wfctl_version", ""))
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("YAML parse error: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("analyze error: %v", err)), nil
+	}
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("render error: %v", err)), nil
+	}
+
+	// Also run legacy feature detection for backward-compat result shape.
+	cfg, cfgErr := config.LoadFromString(yamlContent)
+	var features *mcpProjectFeatures
+	if cfgErr == nil {
+		features = mcpDetectFeatures(cfg)
 	}
 
 	registry := mcp.ParseString(req, "registry", "ghcr.io")
 	platforms := mcp.ParseString(req, "platforms", "linux/amd64,linux/arm64")
 
-	features := mcpDetectFeatures(cfg)
-	ciYAML := mcpGenerateCIWorkflow(features)
-	cdYAML := mcpGenerateCDWorkflow(features, registry, platforms)
-
-	result := map[string]any{
-		"features": features,
-		"ci_yaml":  ciYAML,
-		"cd_yaml":  cdYAML,
+	// Collect ci_yaml from the first generated file for backward compat.
+	var ciYAML string
+	for _, content := range files {
+		ciYAML = content
+		break
 	}
 
-	if features.HasPlugin {
-		result["release_yaml"] = mcpGenerateReleaseWorkflow()
+	result := map[string]any{
+		"plan":     plan,
+		"files":    files,
+		"ci_yaml":  ciYAML,
+		"features": features,
+	}
+
+	if features != nil {
+		cdYAML := mcpGenerateCDWorkflow(features, registry, platforms)
+		result["cd_yaml"] = cdYAML
+		if features.HasPlugin {
+			result["release_yaml"] = mcpGenerateReleaseWorkflow()
+		}
 	}
 
 	return marshalToolResult(result)
+}
+
+// handleCIPlan is the MCP handler for the ci_plan tool.
+func (s *Server) handleCIPlan(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	yamlContent := mcp.ParseString(req, "yaml_content", "")
+	if yamlContent == "" {
+		return mcp.NewToolResultError("yaml_content is required"), nil
+	}
+
+	phaseConfigYAML := mcp.ParseString(req, "phase_config_yaml", "")
+	wfctlVersion := mcp.ParseString(req, "wfctl_version", "")
+
+	plan, err := mcpAnalyzeFromYAML(yamlContent, phaseConfigYAML, wfctlVersion)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("ci_plan error: %v", err)), nil
+	}
+
+	return marshalToolResult(plan)
+}
+
+// mcpAnalyzeFromYAML writes YAML content to temp files, calls cigen.Analyze, and
+// returns the CIPlan. phaseConfigYAML may be empty (single-phase plan).
+func mcpAnalyzeFromYAML(yamlContent, phaseConfigYAML, wfctlVersion string) (*cigen.CIPlan, error) {
+	// Write primary config to a temp file
+	primaryFile, err := os.CreateTemp("", "wfctl-mcp-config-*.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(primaryFile.Name()) //nolint:errcheck
+	if _, err := primaryFile.WriteString(yamlContent); err != nil {
+		primaryFile.Close() //nolint:errcheck
+		return nil, fmt.Errorf("write temp file: %w", err)
+	}
+	primaryFile.Close() //nolint:errcheck
+
+	opts := cigen.Options{
+		WfctlVersion: wfctlVersion,
+	}
+
+	// Write phase config if provided
+	if phaseConfigYAML != "" {
+		prereqFile, err := os.CreateTemp("", "wfctl-mcp-prereq-*.yaml")
+		if err != nil {
+			return nil, fmt.Errorf("create prereq temp file: %w", err)
+		}
+		defer os.Remove(prereqFile.Name()) //nolint:errcheck
+		if _, err := prereqFile.WriteString(phaseConfigYAML); err != nil {
+			prereqFile.Close() //nolint:errcheck
+			return nil, fmt.Errorf("write prereq temp file: %w", err)
+		}
+		prereqFile.Close() //nolint:errcheck
+		opts.PhaseConfig = prereqFile.Name()
+	}
+
+	return cigen.Analyze([]string{primaryFile.Name()}, opts)
 }
 
 func (s *Server) handleDetectProjectFeatures(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/mcp/wfctl_tools_test.go
+++ b/mcp/wfctl_tools_test.go
@@ -804,12 +804,14 @@ func TestGenerateGithubActions(t *testing.T) {
 		t.Fatalf("failed to parse result: %v", err)
 	}
 
+	// ci_yaml now contains cigen-rendered GitHub Actions workflow
 	ciYAML, _ := data["ci_yaml"].(string)
 	if ciYAML == "" {
 		t.Error("expected ci_yaml in result")
 	}
-	if !contains(ciYAML, "name: CI") {
-		t.Error("CI workflow should have name")
+	// cigen emits wfctl infra plan in the plan job
+	if !contains(ciYAML, "wfctl infra plan") {
+		t.Error("CI workflow should contain wfctl infra plan step")
 	}
 
 	cdYAML, _ := data["cd_yaml"].(string)
@@ -833,6 +835,11 @@ func TestGenerateGithubActions(t *testing.T) {
 	if features["hasAuth"] != true {
 		t.Error("expected hasAuth=true")
 	}
+
+	// plan should be present (new cigen-derived field)
+	if _, hasPlan := data["plan"]; !hasPlan {
+		t.Error("expected 'plan' field in result (cigen CIPlan)")
+	}
 }
 
 func TestGenerateGithubActions_WithAuth(t *testing.T) {
@@ -852,9 +859,15 @@ func TestGenerateGithubActions_WithAuth(t *testing.T) {
 		t.Fatalf("failed to parse result: %v", err)
 	}
 
+	// cigen-rendered ci_yaml: the result should parse as valid YAML
 	ciYAML, _ := data["ci_yaml"].(string)
-	if !contains(ciYAML, "JWT_SECRET") {
-		t.Error("CI workflow should include JWT_SECRET for auth projects")
+	if ciYAML == "" {
+		t.Error("expected ci_yaml in result")
+	}
+	// testConfigYAML uses auth.jwt with a plain config secret (not a ${VAR} ref),
+	// so cigen won't derive it as a secret ref; verify the YAML at least contains the plan job.
+	if !contains(ciYAML, "wfctl infra plan") {
+		t.Error("CI workflow should contain wfctl infra plan step")
 	}
 }
 
@@ -875,9 +888,10 @@ func TestGenerateGithubActions_WithDatabase(t *testing.T) {
 		t.Fatalf("failed to parse result: %v", err)
 	}
 
+	// cigen-rendered ci_yaml: should contain the apply step
 	ciYAML, _ := data["ci_yaml"].(string)
-	if !contains(ciYAML, "migrations") {
-		t.Error("CI workflow should include migration step for database projects")
+	if !contains(ciYAML, "wfctl infra apply") {
+		t.Error("CI workflow should contain wfctl infra apply step")
 	}
 }
 
@@ -919,6 +933,96 @@ func TestGenerateGithubActions_MissingContent(t *testing.T) {
 	text := extractText(t, result)
 	if !contains(text, "yaml_content is required") {
 		t.Errorf("expected error, got %q", text)
+	}
+}
+
+// --- ci_plan MCP Tool Tests ---
+
+func TestCIPlan_BasicConfig(t *testing.T) {
+	srv := NewServer("")
+	req := makeCallToolRequest(map[string]any{
+		"yaml_content": testConfigYAML,
+	})
+
+	result, err := srv.handleCIPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractText(t, result)
+	var plan map[string]any
+	if err := json.Unmarshal([]byte(text), &plan); err != nil {
+		t.Fatalf("expected valid JSON CIPlan, got: %v\ntext: %s", err, text)
+	}
+
+	if _, ok := plan["warnings"]; !ok {
+		t.Error("expected 'warnings' field in CIPlan JSON")
+	}
+	if _, ok := plan["phases"]; !ok {
+		t.Error("expected 'phases' field in CIPlan JSON")
+	}
+	if _, ok := plan["triggers"]; !ok {
+		t.Error("expected 'triggers' field in CIPlan JSON")
+	}
+}
+
+func TestCIPlan_MissingContent(t *testing.T) {
+	srv := NewServer("")
+	req := makeCallToolRequest(map[string]any{})
+
+	result, err := srv.handleCIPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractText(t, result)
+	if !contains(text, "yaml_content is required") {
+		t.Errorf("expected error for missing yaml_content, got: %s", text)
+	}
+}
+
+func TestCIPlan_WithMigrationsConfig(t *testing.T) {
+	srv := NewServer("")
+	req := makeCallToolRequest(map[string]any{
+		"yaml_content": `
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+ci:
+  migrations:
+    - name: app
+      driver: golang-migrate
+      source_dir: migrations
+      database:
+        env: APP_DB_URL
+`,
+	})
+
+	result, err := srv.handleCIPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractText(t, result)
+	var plan map[string]any
+	if err := json.Unmarshal([]byte(text), &plan); err != nil {
+		t.Fatalf("expected valid JSON CIPlan: %v\n%s", err, text)
+	}
+
+	migrations, _ := plan["migrations"].(map[string]any)
+	if migrations == nil {
+		t.Fatal("expected migrations field in plan")
+	}
+	if migrations["db_env"] != "APP_DB_URL" {
+		t.Errorf("expected migrations.db_env=APP_DB_URL, got %v", migrations["db_env"])
+	}
+
+	// iac.provider → PluginInstall should be true
+	if plan["plugin_install"] != true {
+		t.Error("expected plugin_install=true for iac.provider module")
 	}
 }
 

--- a/mcp/wfctl_tools_test.go
+++ b/mcp/wfctl_tools_test.go
@@ -981,6 +981,72 @@ func TestCIPlan_MissingContent(t *testing.T) {
 	}
 }
 
+func TestCIPlan_ConfigPathIsLogicalNotTemp(t *testing.T) {
+	// The MCP path writes yaml_content to an os.CreateTemp file that is deleted
+	// before the plan is returned. The plan's phase config_path MUST be a stable
+	// logical name (deploy.yaml), never the deleted /tmp path.
+	srv := NewServer("")
+	req := makeCallToolRequest(map[string]any{
+		"yaml_content": testConfigYAML,
+	})
+
+	result, err := srv.handleCIPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractText(t, result)
+	var plan map[string]any
+	if err := json.Unmarshal([]byte(text), &plan); err != nil {
+		t.Fatalf("expected valid JSON CIPlan: %v\n%s", err, text)
+	}
+
+	phases, ok := plan["phases"].([]any)
+	if !ok || len(phases) == 0 {
+		t.Fatalf("expected phases in plan, got %v", plan["phases"])
+	}
+	phase, _ := phases[0].(map[string]any)
+	cfgPath, _ := phase["config_path"].(string)
+	if cfgPath != "deploy.yaml" {
+		t.Errorf("expected logical config_path 'deploy.yaml', got %q", cfgPath)
+	}
+	if contains(cfgPath, "wfctl-mcp-config") || contains(cfgPath, "/tmp") || contains(cfgPath, "/var/folders") {
+		t.Errorf("config_path must not be a temp filesystem path, got %q", cfgPath)
+	}
+}
+
+func TestCIPlan_TwoPhaseLogicalPaths(t *testing.T) {
+	srv := NewServer("")
+	req := makeCallToolRequest(map[string]any{
+		"yaml_content":      testConfigYAML,
+		"phase_config_yaml": testConfigYAML,
+	})
+
+	result, err := srv.handleCIPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractText(t, result)
+	var plan map[string]any
+	if err := json.Unmarshal([]byte(text), &plan); err != nil {
+		t.Fatalf("expected valid JSON CIPlan: %v\n%s", err, text)
+	}
+
+	phases, ok := plan["phases"].([]any)
+	if !ok || len(phases) != 2 {
+		t.Fatalf("expected 2 phases, got %v", plan["phases"])
+	}
+	prereq, _ := phases[0].(map[string]any)
+	if cp, _ := prereq["config_path"].(string); cp != "deploy.prereq.yaml" {
+		t.Errorf("expected prereq config_path 'deploy.prereq.yaml', got %q", cp)
+	}
+	deploy, _ := phases[1].(map[string]any)
+	if cp, _ := deploy["config_path"].(string); cp != "deploy.yaml" {
+		t.Errorf("expected deploy config_path 'deploy.yaml', got %q", cp)
+	}
+}
+
 func TestCIPlan_WithMigrationsConfig(t *testing.T) {
 	srv := NewServer("")
 	req := makeCallToolRequest(map[string]any{


### PR DESCRIPTION
## What

PR3 of the **wfctl secrets wizard + smart CI generation** cascade (design+plan in `workspace:docs/plans/2026-05-30-wfctl-secrets-wizard-and-smart-ci{-design,}.md`, adversarial PASS, scope-locked). Replaces template-stamped CI generation with a **config-derived** `analyze → CIPlan → render` engine. Independent of PR2; depends only on PR1 (merged).

### Tasks (11–16)
- **`cigen` package** (new, exported): `Analyze(configs, opts) (*CIPlan, error)` derives a platform-neutral plan from the real `config.WorkflowConfig` — `PluginInstall` (plugin/infra module or `.wfctl-lock.yaml`), `PlanGuard` (`Protected` modules), `Migrations` (`ci.migrations`), `Build.Docker` (Dockerfile), deploy phases (`--phase-config`), triggers.
- **Secrets union + smoke + Warnings**: unions `secrets.entries` ∪ `${VAR}` in `env_vars_secret` ∪ iac token/spaces ∪ migrations DB env (deduped); smoke from `health_check.http_path` + PRIMARY domain; `Warnings[]` for **state-derived** secret names (e.g. hash-suffixed DB URL — unknowable pre-apply) and **case/alias** mismatches (non-`UPPER_SNAKE`). Raw-map navigation is panic-safe on missing/wrong-type keys.
- **Renderers**: `RenderGitHubActions` (plan / apply[-prereq→-deploy w/ `needs`] / migrations / smoke jobs, `${{ secrets.NAME }}` refs, real plan-guard that fails on replace/destroy, relative `paths:` filters) and `RenderGitLabCI`. Output is valid YAML (parse-back tested).
- **CLI**: `wfctl ci plan` (emits `CIPlan` JSON for AI-stepping) + smart `wfctl ci generate` (`--from-plan` / `--diff` / `--exit-code` / `--phase-config`; no silent overwrite). Template consts/funcs removed.
- **MCP**: new `ci_plan` tool + `generate_github_actions` routed through `cigen`. `scaffold_ci` left untouched (it generates a `ci:` section from a description — the inverse of cigen's role).

### Review findings fixed (adversarial + code review)
- Critical: MCP `ci_plan` no longer embeds a deleted temp path — `Options.ConfigPathAlias` gives a stable logical config name.
- Important: plan-guard is now a **real gate** (was a no-op `|| true`); `paths:` filters are checkout-relative (was leaking absolute paths → triggers never fired).

## Verification
- `GOWORK=off go test ./cigen/ ./mcp/ ./cmd/wfctl/` → all `ok`; `golangci-lint` → `0 issues`.
- Binary smoke: `ci plan` config_path is logical (`deploy.yaml`, not `/tmp/...`); generated GHA parses as YAML; plan-guard has no `|| true`; `paths:` relative.
- New tests: plan-guard-real-gate, relative-paths, config-path-alias, logical-not-temp, two-phase.

## Notes
- Smart Jenkins/CircleCI deferred (the ci-generator plugin keeps template renderers for those; PR5 routes GHA/GitLab through cigen).
- Copilot review not requested (service down per operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)