### PR TITLE
feat(iac): add provider region lister contract

### DIFF
--- a/cmd/wfctl/iac_typed_adapter.go
+++ b/cmd/wfctl/iac_typed_adapter.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -53,6 +54,7 @@ const (
 	iacServiceEnumerator        = "workflow.plugin.external.iac.IaCProviderEnumerator"
 	iacServiceDriftDetector     = "workflow.plugin.external.iac.IaCProviderDriftDetector"
 	iacServiceCredentialRevoker = "workflow.plugin.external.iac.IaCProviderCredentialRevoker"
+	iacServiceRegionLister      = "workflow.plugin.external.iac.IaCProviderRegionLister"
 	iacServiceMigrationRepairer = "workflow.plugin.external.iac.IaCProviderMigrationRepairer"
 	iacServiceValidator         = "workflow.plugin.external.iac.IaCProviderValidator"
 	iacServiceDriftConfigDetect = "workflow.plugin.external.iac.IaCProviderDriftConfigDetector"
@@ -80,6 +82,7 @@ type typedIaCAdapter struct {
 	enumerator   pb.IaCProviderEnumeratorClient
 	drift        pb.IaCProviderDriftDetectorClient
 	revoker      pb.IaCProviderCredentialRevokerClient
+	regionLister pb.IaCProviderRegionListerClient
 	repairer     pb.IaCProviderMigrationRepairerClient
 	validator    pb.IaCProviderValidatorClient
 	driftCfg     pb.IaCProviderDriftConfigDetectorClient
@@ -114,6 +117,9 @@ func newTypedIaCAdapter(conn *grpc.ClientConn, registered map[string]bool) *type
 	}
 	if registered[iacServiceCredentialRevoker] {
 		a.revoker = pb.NewIaCProviderCredentialRevokerClient(conn)
+	}
+	if registered[iacServiceRegionLister] {
+		a.regionLister = pb.NewIaCProviderRegionListerClient(conn)
 	}
 	if registered[iacServiceMigrationRepairer] {
 		a.repairer = pb.NewIaCProviderMigrationRepairerClient(conn)
@@ -219,6 +225,37 @@ func (a *typedIaCAdapter) LogCapture() pb.IaCProviderLogCaptureClient {
 // provider credential after the new one is minted (ADR 0012).
 func (a *typedIaCAdapter) CredentialRevoker() pb.IaCProviderCredentialRevokerClient {
 	return a.revoker
+}
+
+// RegionLister returns the typed pb.IaCProviderRegionListerClient or nil
+// when the plugin did not register IaCProviderRegionLister. Used by
+// infra-admin provider metadata to prefer provider-sourced region lists
+// over the host's local catalog.
+func (a *typedIaCAdapter) RegionLister() pb.IaCProviderRegionListerClient {
+	return a.regionLister
+}
+
+// ListProviderRegions queries the optional region lister and returns sorted
+// provider region identifiers. The display name is intentionally ignored here
+// because infra-admin's current response shape carries region IDs only.
+func (a *typedIaCAdapter) ListProviderRegions(ctx context.Context, envName string) ([]string, error) {
+	if a.regionLister == nil {
+		return nil, fmt.Errorf("ListProviderRegions: %w", interfaces.ErrProviderMethodUnimplemented)
+	}
+	resp, err := a.regionLister.ListRegions(ctx, &pb.ListRegionsRequest{EnvName: envName})
+	if err != nil {
+		return nil, translateRPCErr(err)
+	}
+	regions := make([]string, 0, len(resp.GetRegions()))
+	for _, region := range resp.GetRegions() {
+		name := strings.TrimSpace(region.GetName())
+		if name == "" {
+			continue
+		}
+		regions = append(regions, name)
+	}
+	sort.Strings(regions)
+	return regions, nil
 }
 
 // MigrationRepairer returns the typed

--- a/cmd/wfctl/iac_typed_adapter.go
+++ b/cmd/wfctl/iac_typed_adapter.go
@@ -240,7 +240,7 @@ func (a *typedIaCAdapter) RegionLister() pb.IaCProviderRegionListerClient {
 // because infra-admin's current response shape carries region IDs only.
 func (a *typedIaCAdapter) ListProviderRegions(ctx context.Context, envName string) ([]string, error) {
 	if a.regionLister == nil {
-		return nil, fmt.Errorf("ListProviderRegions: %w", interfaces.ErrProviderMethodUnimplemented)
+		return nil, unimplementedOptional(iacServiceRegionLister)
 	}
 	resp, err := a.regionLister.ListRegions(ctx, &pb.ListRegionsRequest{EnvName: envName})
 	if err != nil {

--- a/cmd/wfctl/iac_typed_adapter_test.go
+++ b/cmd/wfctl/iac_typed_adapter_test.go
@@ -94,6 +94,10 @@ func TestTypedAdapter_OptionalReturnsUnimplementedSentinel(t *testing.T) {
 		{"RevokeProviderCredential", func() error {
 			return a.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "key-1")
 		}},
+		{"ListProviderRegions", func() error {
+			_, err := a.ListProviderRegions(context.Background(), "staging")
+			return err
+		}},
 		{"RepairDirtyMigration", func() error {
 			_, err := a.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{})
 			return err
@@ -394,6 +398,61 @@ func TestTypedAdapter_Finalizer_NilWhenNotRegistered(t *testing.T) {
 	if adapter.Finalizer() != nil {
 		t.Error("Finalizer() returned non-nil when IaCProviderFinalizer not registered")
 	}
+}
+
+func TestTypedAdapter_RegionLister_PopulatedWhenRegistered(t *testing.T) {
+	conn := dialLazyConn(t)
+	adapter := newTypedIaCAdapter(conn, map[string]bool{
+		iacServiceRegionLister: true,
+	})
+	if adapter.RegionLister() == nil {
+		t.Error("RegionLister() returned nil when IaCProviderRegionLister is in registered set")
+	}
+}
+
+func TestTypedAdapter_RegionLister_NilWhenNotRegistered(t *testing.T) {
+	conn := dialLazyConn(t)
+	adapter := newTypedIaCAdapter(conn, map[string]bool{
+		iacServiceEnumerator: true,
+	})
+	if adapter.RegionLister() != nil {
+		t.Error("RegionLister() returned non-nil when IaCProviderRegionLister not registered")
+	}
+}
+
+func TestTypedAdapter_ListProviderRegions(t *testing.T) {
+	adapter := fixtureTypedAdapter{
+		RegionLister: regionListerStub{},
+	}.build(t)
+
+	got, err := adapter.ListProviderRegions(context.Background(), "staging")
+	if err != nil {
+		t.Fatalf("ListProviderRegions: %v", err)
+	}
+	want := []string{"nyc3", "sfo3"}
+	if len(got) != len(want) {
+		t.Fatalf("regions = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("regions = %v, want %v", got, want)
+		}
+	}
+}
+
+type regionListerStub struct {
+	pb.UnimplementedIaCProviderRegionListerServer
+}
+
+func (regionListerStub) ListRegions(ctx context.Context, req *pb.ListRegionsRequest) (*pb.ListRegionsResponse, error) {
+	if req.GetEnvName() != "staging" {
+		return nil, status.Errorf(codes.InvalidArgument, "env = %q, want staging", req.GetEnvName())
+	}
+	return &pb.ListRegionsResponse{Regions: []*pb.ProviderRegion{
+		{Name: "sfo3"},
+		{Name: "nyc3"},
+		{Name: ""},
+	}}, nil
 }
 
 // dialLazyConn returns a real *grpc.ClientConn pointing at an in-process

--- a/cmd/wfctl/iac_typed_fixture_test.go
+++ b/cmd/wfctl/iac_typed_fixture_test.go
@@ -93,6 +93,7 @@ type fixtureTypedAdapter struct {
 	Enumerator        pb.IaCProviderEnumeratorServer
 	DriftDetector     pb.IaCProviderDriftDetectorServer
 	CredentialRevoker pb.IaCProviderCredentialRevokerServer
+	RegionLister      pb.IaCProviderRegionListerServer
 	MigrationRepairer pb.IaCProviderMigrationRepairerServer
 	Validator         pb.IaCProviderValidatorServer
 	DriftConfigDetect pb.IaCProviderDriftConfigDetectorServer
@@ -130,6 +131,10 @@ func (f fixtureTypedAdapter) build(t *testing.T) *typedIaCAdapter {
 	if f.CredentialRevoker != nil {
 		pb.RegisterIaCProviderCredentialRevokerServer(server, f.CredentialRevoker)
 		registered[iacServiceCredentialRevoker] = true
+	}
+	if f.RegionLister != nil {
+		pb.RegisterIaCProviderRegionListerServer(server, f.RegionLister)
+		registered[iacServiceRegionLister] = true
 	}
 	if f.MigrationRepairer != nil {
 		pb.RegisterIaCProviderMigrationRepairerServer(server, f.MigrationRepairer)

--- a/docs/plans/2026-06-01-iac-provider-region-lister.md
+++ b/docs/plans/2026-06-01-iac-provider-region-lister.md
@@ -1,0 +1,122 @@
+# IaC Provider Region Lister Implementation Plan
+
+> **For the implementing agent:** REQUIRED SUB-SKILL: Use autodev:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the optional `IaCProviderRegionLister` gRPC contract and make infra-admin use provider-sourced regions when advertised, falling back to the local catalog otherwise.
+
+**Architecture:** Follow the existing optional IaC service pattern: additive proto service, SDK auto-registration by Go type assertion, typed wfctl adapter gated by ContractRegistry, and infra-admin handler probing an optional host-side interface. Absence or failure of the optional service keeps the current `local-catalog` behavior.
+
+**Tech Stack:** Go 1.26, protobuf/gRPC via `buf generate`, Workflow plugin SDK, `wfctl` typed IaC adapter, infra-admin handler.
+
+**Base branch:** main
+
+---
+
+## Scope Manifest
+
+**PR Count:** 1
+**Tasks:** 4
+**Estimated Lines of Change:** ~600 including generated protobuf files
+
+**Out of scope:**
+- Cloud provider plugin implementations; they need a follow-up cascade after this core contract PR lands.
+- Changes to `workflow-plugin-infra`; it does not own cloud credentials or the engine/plugin contract.
+- New UI fields beyond existing `supported_regions` and `regions_source`.
+
+**PR Grouping:**
+
+| PR # | Title | Tasks | Branch |
+|------|-------|-------|--------|
+| 1 | Add IaCProviderRegionLister contract and infra-admin consumer | Task 1, Task 2, Task 3, Task 4 | feat/813-iac-provider-region-lister |
+
+**Status:** Draft
+
+## Global Design Guidance
+
+Source: `AGENTS.md`, `docs/AGENT_GUIDE.md`, `docs/REPO_LAYOUT.md`, `decisions/0025-iac-optional-method-typed-services-not-bool.md`
+
+| Guidance | Plan response |
+|---|---|
+| Core owns shared contracts; plugins own provider-specific runtime integrations. | Add the shared proto/SDK/adapter contract in workflow only; defer cloud SDK implementations to provider repos. |
+| Optional IaC capabilities are advertised by ContractRegistry; absence is the negative signal. | Region lister is an optional service registered only when providers implement it. |
+| Use `GOWORK=off` and focused tests first. | Verification starts with proto/SDK/adapter/handler tests, then broadens to package tests and lint. |
+| Do not add scratch example/test directories. | No new root directories; only source, tests, generated proto, and this plan. |
+
+## Task 1: Proto Contract
+
+**Files:**
+- Modify: `plugin/external/proto/iac.proto`
+- Regenerate: `plugin/external/proto/iac.pb.go`
+- Regenerate: `plugin/external/proto/iac_grpc.pb.go`
+- Test: `plugin/external/proto/iac_proto_test.go`
+
+**Steps:**
+1. Add optional service `IaCProviderRegionLister` with `ListRegions(ListRegionsRequest) returns (ListRegionsResponse)`.
+2. Add strict typed messages with scalar fields only: `ListRegionsRequest { string env_name = 1; }`, `ProviderRegion { string name = 1; string display_name = 2; }`, and `ListRegionsResponse { repeated ProviderRegion regions = 1; }`.
+3. Run `buf generate` from repo root.
+4. Add/extend compile-time tests proving the service exists and remains optional.
+
+**Verification:**
+- `GOWORK=off go test ./plugin/external/proto -run 'TestIaCProto|TestRegion' -count=1`
+- Expected: package passes and generated Go exposes `pb.IaCProviderRegionListerServer`.
+
+**Rollback:** Revert the proto + generated files; provider plugins keep using local catalog fallback.
+
+## Task 2: SDK Registration and Contract Advertisement
+
+**Files:**
+- Modify: `plugin/external/sdk/iacserver.go`
+- Modify: `plugin/external/sdk/contracts_iac_test.go`
+- Modify as needed: `plugin/external/sdk/iacserver_test.go`
+
+**Steps:**
+1. Add `pb.IaCProviderRegionListerServer` to the optional service list in SDK docs/comments.
+2. Register it in `registerIaCServicesOnly` via the existing type-assertion pattern.
+3. Add a contract registry test proving the service is advertised when implemented and absent when not implemented.
+
+**Verification:**
+- `GOWORK=off go test ./plugin/external/sdk -run 'TestBuildContractRegistry|TestRegisterAllIaCProviderServices' -count=1`
+- Expected: service descriptor includes `workflow.plugin.external.iac.IaCProviderRegionLister` only for implementing providers.
+
+**Rollback:** Revert SDK registration; plugins can still compile with the proto but the host will not discover the service.
+
+## Task 3: wfctl Typed Adapter
+
+**Files:**
+- Modify: `cmd/wfctl/iac_typed_adapter.go`
+- Modify: `cmd/wfctl/iac_typed_adapter_test.go`
+
+**Steps:**
+1. Add `iacServiceRegionLister` constant and gated client construction in `newTypedIaCAdapter`.
+2. Add `RegionLister()` accessor and a small `ListProviderRegions(ctx, envName)` helper returning sorted region names or `interfaces.ErrProviderMethodUnimplemented` when not advertised.
+3. Add tests for advertised and absent region lister behavior.
+
+**Verification:**
+- `GOWORK=off go test ./cmd/wfctl -run 'TestTypedIaCAdapter.*Region|TestNewTypedIaCAdapter' -count=1`
+- Expected: advertised service returns provider regions; absent service returns the existing unimplemented sentinel.
+
+**Rollback:** Revert adapter changes; infra-admin falls back to local catalog.
+
+## Task 4: Infra-Admin Consumer
+
+**Files:**
+- Modify: `iac/admin/handler/list_providers.go`
+- Modify: `iac/admin/handler/list_providers_test.go`
+- Modify: `iac/admin/proto/infra_admin.proto`
+- Regenerate if proto comments or fields change: `iac/admin/proto/infra_admin.pb.go`
+- Modify docs if needed: `docs/WFCTL.md`
+
+**Steps:**
+1. Add a narrow handler-local interface for providers that can list regions.
+2. In `ListProviders`, call the optional lister when available. On nil error, use provider regions and set `regions_source = "provider-lister"`; on absence or error, keep existing `local-catalog` fallback.
+3. Update tests for provider-sourced regions, error fallback, and existing local-catalog behavior.
+4. Update comments/docs to remove the “future v1.1” wording.
+
+**Verification:**
+- `GOWORK=off go test ./iac/admin/handler -run 'TestListProviders' -count=1`
+- `GOWORK=off go test ./cmd/wfctl -run 'TestInfraAdminCLI_ListProvidersOutput_RoundTrip' -count=1`
+- `GOWORK=off go test ./plugin/external/proto ./plugin/external/sdk ./iac/admin/handler ./cmd/wfctl -count=1`
+- `GOWORK=off golangci-lint run ./plugin/external/... ./iac/admin/... ./cmd/wfctl`
+- Expected: all tests/lint pass; local catalog behavior remains unchanged when the optional service is absent.
+
+**Rollback:** Revert handler + docs; infra-admin returns to host local catalog without schema migration.

--- a/iac/admin/handler/list_providers.go
+++ b/iac/admin/handler/list_providers.go
@@ -3,11 +3,16 @@ package handler
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/GoCodeAlone/workflow/iac/admin/catalog"
 	adminpb "github.com/GoCodeAlone/workflow/iac/admin/proto"
 	"github.com/GoCodeAlone/workflow/interfaces"
 )
+
+type providerRegionLister interface {
+	ListProviderRegions(context.Context, string) ([]string, error)
+}
 
 // ListProviders implements InfraAdminService.ListProviders by
 // walking the provided `providers` map (keyed by host YAML module
@@ -44,9 +49,9 @@ import (
 // fix requires providerTypeByModule. Final shape is 7 params;
 // design line 233 was underspecified.
 //
-// regions_source is the literal "local-catalog" per design §FieldSpec
-// Catalog so consumers can distinguish v1's local lookup from a
-// future v1.1 IaCProviderRegionLister gRPC service.
+// regions_source is "provider-lister" when the provider advertises and
+// successfully serves IaCProviderRegionLister; otherwise it remains the
+// literal "local-catalog" fallback.
 //
 // Per design §Authz: default-deny via the shared authz guard.
 func ListProviders(
@@ -81,15 +86,38 @@ func ListProviders(
 	out := &adminpb.AdminListProvidersOutput{}
 	for _, modName := range moduleNames {
 		providerType := providerTypeByModule[modName] // may be "" if Init didn't populate
+		supportedRegions := regionCat.For(providerType)
+		regionsSource := "local-catalog"
+		if lister, ok := providers[modName].(providerRegionLister); ok {
+			if regions, err := lister.ListProviderRegions(ctx, in.GetEnvName()); err == nil {
+				supportedRegions = normalizeProviderRegions(regions)
+				regionsSource = "provider-lister"
+			}
+		}
 		summary := &adminpb.AdminProviderSummary{
 			ModuleName:       modName,
 			ProviderType:     providerType,
-			SupportedRegions: regionCat.For(providerType),
+			SupportedRegions: supportedRegions,
 			SupportedEngines: engineCat.For(providerType),
 			SupportedTypes:   append([]string(nil), allTypes...),
-			RegionsSource:    "local-catalog",
+			RegionsSource:    regionsSource,
 		}
 		out.Providers = append(out.Providers, summary)
 	}
 	return out, nil
+}
+
+func normalizeProviderRegions(regions []string) []string {
+	out := make([]string, 0, len(regions))
+	seen := make(map[string]bool, len(regions))
+	for _, region := range regions {
+		region = strings.TrimSpace(region)
+		if region == "" || seen[region] {
+			continue
+		}
+		seen[region] = true
+		out = append(out, region)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/iac/admin/handler/list_providers_test.go
+++ b/iac/admin/handler/list_providers_test.go
@@ -49,6 +49,16 @@ func (p *nameableProvider) BootstrapStateBackend(_ context.Context, _ map[string
 }
 func (p *nameableProvider) Close() error { return nil }
 
+type regionListingProvider struct {
+	*nameableProvider
+	regions []string
+	err     error
+}
+
+func (p *regionListingProvider) ListProviderRegions(_ context.Context, _ string) ([]string, error) {
+	return append([]string(nil), p.regions...), p.err
+}
+
 // providersFixture returns the providers map + a parallel
 // providerTypeByModule map captured "as if" at module Init from the
 // host YAML config. Per spec-reviewer T6 F1: the test fixture must
@@ -132,6 +142,67 @@ func TestListProviders_PopulatesRegionsAndEnginesAndTypes(t *testing.T) {
 	// of the catalog treats every type as cross-provider.
 	if len(doProv.SupportedTypes) < 13 {
 		t.Errorf("SupportedTypes count = %d, want >= 13 (full catalog)", len(doProv.SupportedTypes))
+	}
+}
+
+func TestListProviders_UsesProviderRegionListerWhenAvailable(t *testing.T) {
+	providers := map[string]interfaces.IaCProvider{
+		"do-prod": &regionListingProvider{
+			nameableProvider: &nameableProvider{name: "DigitalOcean Provider"},
+			regions:          []string{"sfo3", "nyc3"},
+		},
+	}
+	providerTypeByModule := map[string]string{"do-prod": "digitalocean"}
+	in := &adminpb.AdminListProvidersInput{EnvName: "staging", Evidence: authzOK()}
+	out, _ := handler.ListProviders(
+		context.Background(),
+		providers,
+		providerTypeByModule,
+		catalog.New(),
+		catalog.NewRegionCatalog(),
+		catalog.NewEngineCatalog(),
+		in,
+	)
+	if len(out.Providers) != 1 {
+		t.Fatalf("got %d providers, want 1", len(out.Providers))
+	}
+	got := out.Providers[0]
+	if got.RegionsSource != "provider-lister" {
+		t.Fatalf("RegionsSource = %q, want provider-lister", got.RegionsSource)
+	}
+	want := []string{"nyc3", "sfo3"}
+	if !equalStrings(got.SupportedRegions, want) {
+		t.Fatalf("SupportedRegions = %v, want provider lister regions %v", got.SupportedRegions, want)
+	}
+}
+
+func TestListProviders_RegionListerErrorFallsBackToLocalCatalog(t *testing.T) {
+	providers := map[string]interfaces.IaCProvider{
+		"do-prod": &regionListingProvider{
+			nameableProvider: &nameableProvider{name: "DigitalOcean Provider"},
+			err:              errors.New("credentials unavailable"),
+		},
+	}
+	providerTypeByModule := map[string]string{"do-prod": "digitalocean"}
+	in := &adminpb.AdminListProvidersInput{Evidence: authzOK()}
+	out, _ := handler.ListProviders(
+		context.Background(),
+		providers,
+		providerTypeByModule,
+		catalog.New(),
+		catalog.NewRegionCatalog(),
+		catalog.NewEngineCatalog(),
+		in,
+	)
+	if len(out.Providers) != 1 {
+		t.Fatalf("got %d providers, want 1", len(out.Providers))
+	}
+	got := out.Providers[0]
+	if got.RegionsSource != "local-catalog" {
+		t.Fatalf("RegionsSource = %q, want local-catalog fallback", got.RegionsSource)
+	}
+	if !contains(got.SupportedRegions, "nyc3") {
+		t.Fatalf("SupportedRegions = %v, want local catalog fallback including nyc3", got.SupportedRegions)
 	}
 }
 
@@ -291,4 +362,16 @@ func contains(slice []string, v string) bool {
 		}
 	}
 	return false
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/iac/admin/proto/infra_admin.pb.go
+++ b/iac/admin/proto/infra_admin.pb.go
@@ -919,12 +919,11 @@ func (x *AdminListResourceTypesOutput) GetError() string {
 	return ""
 }
 
-// AdminProviderSummary is the ListProviders response row. v1
-// populates supported_regions / supported_types / supported_engines
-// from the host-side catalog (regions.go + engines.go + fields.go);
-// regions_source is the literal string "local-catalog" so consumers
-// can distinguish v1's local lookup from a future v1.1
-// IaCProviderRegionLister gRPC service.
+// AdminProviderSummary is the ListProviders response row. supported_regions
+// comes from IaCProviderRegionLister when the provider advertises it and the
+// call succeeds; otherwise it falls back to the host-side catalog
+// (regions.go). supported_types / supported_engines remain host catalogued.
+// regions_source is "provider-lister" or "local-catalog".
 type AdminProviderSummary struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	ModuleName       string                 `protobuf:"bytes,1,opt,name=module_name,json=moduleName,proto3" json:"module_name,omitempty"`
@@ -933,7 +932,7 @@ type AdminProviderSummary struct {
 	SupportedRegions []string               `protobuf:"bytes,4,rep,name=supported_regions,json=supportedRegions,proto3" json:"supported_regions,omitempty"`
 	SupportedTypes   []string               `protobuf:"bytes,5,rep,name=supported_types,json=supportedTypes,proto3" json:"supported_types,omitempty"`
 	SupportedEngines []string               `protobuf:"bytes,6,rep,name=supported_engines,json=supportedEngines,proto3" json:"supported_engines,omitempty"`
-	RegionsSource    string                 `protobuf:"bytes,7,opt,name=regions_source,json=regionsSource,proto3" json:"regions_source,omitempty"` // "local-catalog" for v1
+	RegionsSource    string                 `protobuf:"bytes,7,opt,name=regions_source,json=regionsSource,proto3" json:"regions_source,omitempty"` // "provider-lister" or "local-catalog"
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }

--- a/iac/admin/proto/infra_admin.proto
+++ b/iac/admin/proto/infra_admin.proto
@@ -179,12 +179,11 @@ message AdminListResourceTypesOutput {
   reserved 2 to 99, 101 to 199;
 }
 
-// AdminProviderSummary is the ListProviders response row. v1
-// populates supported_regions / supported_types / supported_engines
-// from the host-side catalog (regions.go + engines.go + fields.go);
-// regions_source is the literal string "local-catalog" so consumers
-// can distinguish v1's local lookup from a future v1.1
-// IaCProviderRegionLister gRPC service.
+// AdminProviderSummary is the ListProviders response row. supported_regions
+// comes from IaCProviderRegionLister when the provider advertises it and the
+// call succeeds; otherwise it falls back to the host-side catalog
+// (regions.go). supported_types / supported_engines remain host catalogued.
+// regions_source is "provider-lister" or "local-catalog".
 message AdminProviderSummary {
   string module_name              = 1;
   string provider_type            = 2;
@@ -192,7 +191,7 @@ message AdminProviderSummary {
   repeated string supported_regions = 4;
   repeated string supported_types = 5;
   repeated string supported_engines = 6;
-  string regions_source           = 7;  // "local-catalog" for v1
+  string regions_source           = 7;  // "provider-lister" or "local-catalog"
 }
 
 // AdminListProvidersInput is the request shape for the ListProviders

--- a/plugin/external/proto/iac.pb.go
+++ b/plugin/external/proto/iac.pb.go
@@ -4,7 +4,7 @@
 // Plan:   docs/plans/2026-05-10-strict-contracts-force-cutover.md (Task 3)
 //
 // Hard invariants (per cycle 4 §Acceptance criteria):
-//   - NO google.protobuf.Struct, NO google.protobuf.Any used in any message.
+//   - NO loose Struct/Any wrapper types used in any message.
 //   - Free-form per-resource Config / Outputs payloads cross the wire as
 //     bytes <name>_json, JSON-encoded by the plugin/host. The plugin owns
 //     the serialization shape; the proto layer carries opaque bytes.
@@ -4305,6 +4305,152 @@ func (*RevokeProviderCredentialResponse) Descriptor() ([]byte, []int) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// IaCProviderRegionLister messages.
+// ─────────────────────────────────────────────────────────────────────────────
+type ListRegionsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// env_name is the optional Workflow environment selected by the caller.
+	EnvName       string `protobuf:"bytes,1,opt,name=env_name,json=envName,proto3" json:"env_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRegionsRequest) Reset() {
+	*x = ListRegionsRequest{}
+	mi := &file_iac_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRegionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRegionsRequest) ProtoMessage() {}
+
+func (x *ListRegionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_iac_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRegionsRequest.ProtoReflect.Descriptor instead.
+func (*ListRegionsRequest) Descriptor() ([]byte, []int) {
+	return file_iac_proto_rawDescGZIP(), []int{62}
+}
+
+func (x *ListRegionsRequest) GetEnvName() string {
+	if x != nil {
+		return x.EnvName
+	}
+	return ""
+}
+
+type ProviderRegion struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name is the provider-specific region identifier used in Workflow config.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// display_name is optional UI text. Empty means consumers should show name.
+	DisplayName   string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProviderRegion) Reset() {
+	*x = ProviderRegion{}
+	mi := &file_iac_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProviderRegion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProviderRegion) ProtoMessage() {}
+
+func (x *ProviderRegion) ProtoReflect() protoreflect.Message {
+	mi := &file_iac_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProviderRegion.ProtoReflect.Descriptor instead.
+func (*ProviderRegion) Descriptor() ([]byte, []int) {
+	return file_iac_proto_rawDescGZIP(), []int{63}
+}
+
+func (x *ProviderRegion) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ProviderRegion) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+type ListRegionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Regions       []*ProviderRegion      `protobuf:"bytes,1,rep,name=regions,proto3" json:"regions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRegionsResponse) Reset() {
+	*x = ListRegionsResponse{}
+	mi := &file_iac_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRegionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRegionsResponse) ProtoMessage() {}
+
+func (x *ListRegionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_iac_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRegionsResponse.ProtoReflect.Descriptor instead.
+func (*ListRegionsResponse) Descriptor() ([]byte, []int) {
+	return file_iac_proto_rawDescGZIP(), []int{64}
+}
+
+func (x *ListRegionsResponse) GetRegions() []*ProviderRegion {
+	if x != nil {
+		return x.Regions
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // IaCProviderFinalizer messages.
 // ─────────────────────────────────────────────────────────────────────────────
 type FinalizeApplyRequest struct {
@@ -4318,7 +4464,7 @@ type FinalizeApplyRequest struct {
 
 func (x *FinalizeApplyRequest) Reset() {
 	*x = FinalizeApplyRequest{}
-	mi := &file_iac_proto_msgTypes[62]
+	mi := &file_iac_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4330,7 +4476,7 @@ func (x *FinalizeApplyRequest) String() string {
 func (*FinalizeApplyRequest) ProtoMessage() {}
 
 func (x *FinalizeApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[62]
+	mi := &file_iac_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4343,7 +4489,7 @@ func (x *FinalizeApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizeApplyRequest.ProtoReflect.Descriptor instead.
 func (*FinalizeApplyRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{62}
+	return file_iac_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *FinalizeApplyRequest) GetPlanId() string {
@@ -4378,7 +4524,7 @@ type FinalizeApplyResponse struct {
 
 func (x *FinalizeApplyResponse) Reset() {
 	*x = FinalizeApplyResponse{}
-	mi := &file_iac_proto_msgTypes[63]
+	mi := &file_iac_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4390,7 +4536,7 @@ func (x *FinalizeApplyResponse) String() string {
 func (*FinalizeApplyResponse) ProtoMessage() {}
 
 func (x *FinalizeApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[63]
+	mi := &file_iac_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4403,7 +4549,7 @@ func (x *FinalizeApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizeApplyResponse.ProtoReflect.Descriptor instead.
 func (*FinalizeApplyResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{63}
+	return file_iac_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *FinalizeApplyResponse) GetErrors() []*ActionError {
@@ -4425,7 +4571,7 @@ type RepairDirtyMigrationRequest struct {
 
 func (x *RepairDirtyMigrationRequest) Reset() {
 	*x = RepairDirtyMigrationRequest{}
-	mi := &file_iac_proto_msgTypes[64]
+	mi := &file_iac_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4437,7 +4583,7 @@ func (x *RepairDirtyMigrationRequest) String() string {
 func (*RepairDirtyMigrationRequest) ProtoMessage() {}
 
 func (x *RepairDirtyMigrationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[64]
+	mi := &file_iac_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4450,7 +4596,7 @@ func (x *RepairDirtyMigrationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepairDirtyMigrationRequest.ProtoReflect.Descriptor instead.
 func (*RepairDirtyMigrationRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{64}
+	return file_iac_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *RepairDirtyMigrationRequest) GetRequest() *MigrationRepairRequest {
@@ -4469,7 +4615,7 @@ type RepairDirtyMigrationResponse struct {
 
 func (x *RepairDirtyMigrationResponse) Reset() {
 	*x = RepairDirtyMigrationResponse{}
-	mi := &file_iac_proto_msgTypes[65]
+	mi := &file_iac_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4481,7 +4627,7 @@ func (x *RepairDirtyMigrationResponse) String() string {
 func (*RepairDirtyMigrationResponse) ProtoMessage() {}
 
 func (x *RepairDirtyMigrationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[65]
+	mi := &file_iac_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4494,7 +4640,7 @@ func (x *RepairDirtyMigrationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepairDirtyMigrationResponse.ProtoReflect.Descriptor instead.
 func (*RepairDirtyMigrationResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{65}
+	return file_iac_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RepairDirtyMigrationResponse) GetResult() *MigrationRepairResult {
@@ -4516,7 +4662,7 @@ type ValidatePlanRequest struct {
 
 func (x *ValidatePlanRequest) Reset() {
 	*x = ValidatePlanRequest{}
-	mi := &file_iac_proto_msgTypes[66]
+	mi := &file_iac_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4528,7 +4674,7 @@ func (x *ValidatePlanRequest) String() string {
 func (*ValidatePlanRequest) ProtoMessage() {}
 
 func (x *ValidatePlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[66]
+	mi := &file_iac_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4541,7 +4687,7 @@ func (x *ValidatePlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidatePlanRequest.ProtoReflect.Descriptor instead.
 func (*ValidatePlanRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{66}
+	return file_iac_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ValidatePlanRequest) GetPlan() *IaCPlan {
@@ -4560,7 +4706,7 @@ type ValidatePlanResponse struct {
 
 func (x *ValidatePlanResponse) Reset() {
 	*x = ValidatePlanResponse{}
-	mi := &file_iac_proto_msgTypes[67]
+	mi := &file_iac_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4572,7 +4718,7 @@ func (x *ValidatePlanResponse) String() string {
 func (*ValidatePlanResponse) ProtoMessage() {}
 
 func (x *ValidatePlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[67]
+	mi := &file_iac_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4585,7 +4731,7 @@ func (x *ValidatePlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidatePlanResponse.ProtoReflect.Descriptor instead.
 func (*ValidatePlanResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{67}
+	return file_iac_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ValidatePlanResponse) GetDiagnostics() []*PlanDiagnostic {
@@ -4611,7 +4757,7 @@ type DetectDriftConfigRequest struct {
 
 func (x *DetectDriftConfigRequest) Reset() {
 	*x = DetectDriftConfigRequest{}
-	mi := &file_iac_proto_msgTypes[68]
+	mi := &file_iac_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4623,7 +4769,7 @@ func (x *DetectDriftConfigRequest) String() string {
 func (*DetectDriftConfigRequest) ProtoMessage() {}
 
 func (x *DetectDriftConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[68]
+	mi := &file_iac_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4636,7 +4782,7 @@ func (x *DetectDriftConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftConfigRequest.ProtoReflect.Descriptor instead.
 func (*DetectDriftConfigRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{68}
+	return file_iac_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *DetectDriftConfigRequest) GetRefs() []*ResourceRef {
@@ -4662,7 +4808,7 @@ type DetectDriftConfigResponse struct {
 
 func (x *DetectDriftConfigResponse) Reset() {
 	*x = DetectDriftConfigResponse{}
-	mi := &file_iac_proto_msgTypes[69]
+	mi := &file_iac_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4674,7 +4820,7 @@ func (x *DetectDriftConfigResponse) String() string {
 func (*DetectDriftConfigResponse) ProtoMessage() {}
 
 func (x *DetectDriftConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[69]
+	mi := &file_iac_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4687,7 +4833,7 @@ func (x *DetectDriftConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetectDriftConfigResponse.ProtoReflect.Descriptor instead.
 func (*DetectDriftConfigResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{69}
+	return file_iac_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *DetectDriftConfigResponse) GetDrifts() []*DriftResult {
@@ -4714,7 +4860,7 @@ type CaptureLogsRequest struct {
 
 func (x *CaptureLogsRequest) Reset() {
 	*x = CaptureLogsRequest{}
-	mi := &file_iac_proto_msgTypes[70]
+	mi := &file_iac_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4726,7 +4872,7 @@ func (x *CaptureLogsRequest) String() string {
 func (*CaptureLogsRequest) ProtoMessage() {}
 
 func (x *CaptureLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[70]
+	mi := &file_iac_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4739,7 +4885,7 @@ func (x *CaptureLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CaptureLogsRequest.ProtoReflect.Descriptor instead.
 func (*CaptureLogsRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{70}
+	return file_iac_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *CaptureLogsRequest) GetResourceName() string {
@@ -4816,7 +4962,7 @@ type LogChunk struct {
 
 func (x *LogChunk) Reset() {
 	*x = LogChunk{}
-	mi := &file_iac_proto_msgTypes[71]
+	mi := &file_iac_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4828,7 +4974,7 @@ func (x *LogChunk) String() string {
 func (*LogChunk) ProtoMessage() {}
 
 func (x *LogChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[71]
+	mi := &file_iac_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4841,7 +4987,7 @@ func (x *LogChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogChunk.ProtoReflect.Descriptor instead.
 func (*LogChunk) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{71}
+	return file_iac_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *LogChunk) GetData() []byte {
@@ -4881,7 +5027,7 @@ type ResourceCreateRequest struct {
 
 func (x *ResourceCreateRequest) Reset() {
 	*x = ResourceCreateRequest{}
-	mi := &file_iac_proto_msgTypes[72]
+	mi := &file_iac_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4893,7 +5039,7 @@ func (x *ResourceCreateRequest) String() string {
 func (*ResourceCreateRequest) ProtoMessage() {}
 
 func (x *ResourceCreateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[72]
+	mi := &file_iac_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4906,7 +5052,7 @@ func (x *ResourceCreateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceCreateRequest.ProtoReflect.Descriptor instead.
 func (*ResourceCreateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{72}
+	return file_iac_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ResourceCreateRequest) GetResourceType() string {
@@ -4932,7 +5078,7 @@ type ResourceCreateResponse struct {
 
 func (x *ResourceCreateResponse) Reset() {
 	*x = ResourceCreateResponse{}
-	mi := &file_iac_proto_msgTypes[73]
+	mi := &file_iac_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4944,7 +5090,7 @@ func (x *ResourceCreateResponse) String() string {
 func (*ResourceCreateResponse) ProtoMessage() {}
 
 func (x *ResourceCreateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[73]
+	mi := &file_iac_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4957,7 +5103,7 @@ func (x *ResourceCreateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceCreateResponse.ProtoReflect.Descriptor instead.
 func (*ResourceCreateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{73}
+	return file_iac_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *ResourceCreateResponse) GetOutput() *ResourceOutput {
@@ -4977,7 +5123,7 @@ type ResourceReadRequest struct {
 
 func (x *ResourceReadRequest) Reset() {
 	*x = ResourceReadRequest{}
-	mi := &file_iac_proto_msgTypes[74]
+	mi := &file_iac_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4989,7 +5135,7 @@ func (x *ResourceReadRequest) String() string {
 func (*ResourceReadRequest) ProtoMessage() {}
 
 func (x *ResourceReadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[74]
+	mi := &file_iac_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5002,7 +5148,7 @@ func (x *ResourceReadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceReadRequest.ProtoReflect.Descriptor instead.
 func (*ResourceReadRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{74}
+	return file_iac_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ResourceReadRequest) GetResourceType() string {
@@ -5028,7 +5174,7 @@ type ResourceReadResponse struct {
 
 func (x *ResourceReadResponse) Reset() {
 	*x = ResourceReadResponse{}
-	mi := &file_iac_proto_msgTypes[75]
+	mi := &file_iac_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5040,7 +5186,7 @@ func (x *ResourceReadResponse) String() string {
 func (*ResourceReadResponse) ProtoMessage() {}
 
 func (x *ResourceReadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[75]
+	mi := &file_iac_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5053,7 +5199,7 @@ func (x *ResourceReadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceReadResponse.ProtoReflect.Descriptor instead.
 func (*ResourceReadResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{75}
+	return file_iac_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ResourceReadResponse) GetOutput() *ResourceOutput {
@@ -5074,7 +5220,7 @@ type ResourceUpdateRequest struct {
 
 func (x *ResourceUpdateRequest) Reset() {
 	*x = ResourceUpdateRequest{}
-	mi := &file_iac_proto_msgTypes[76]
+	mi := &file_iac_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5086,7 +5232,7 @@ func (x *ResourceUpdateRequest) String() string {
 func (*ResourceUpdateRequest) ProtoMessage() {}
 
 func (x *ResourceUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[76]
+	mi := &file_iac_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5099,7 +5245,7 @@ func (x *ResourceUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceUpdateRequest.ProtoReflect.Descriptor instead.
 func (*ResourceUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{76}
+	return file_iac_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ResourceUpdateRequest) GetResourceType() string {
@@ -5132,7 +5278,7 @@ type ResourceUpdateResponse struct {
 
 func (x *ResourceUpdateResponse) Reset() {
 	*x = ResourceUpdateResponse{}
-	mi := &file_iac_proto_msgTypes[77]
+	mi := &file_iac_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5144,7 +5290,7 @@ func (x *ResourceUpdateResponse) String() string {
 func (*ResourceUpdateResponse) ProtoMessage() {}
 
 func (x *ResourceUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[77]
+	mi := &file_iac_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5157,7 +5303,7 @@ func (x *ResourceUpdateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceUpdateResponse.ProtoReflect.Descriptor instead.
 func (*ResourceUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{77}
+	return file_iac_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ResourceUpdateResponse) GetOutput() *ResourceOutput {
@@ -5177,7 +5323,7 @@ type ResourceDeleteRequest struct {
 
 func (x *ResourceDeleteRequest) Reset() {
 	*x = ResourceDeleteRequest{}
-	mi := &file_iac_proto_msgTypes[78]
+	mi := &file_iac_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5189,7 +5335,7 @@ func (x *ResourceDeleteRequest) String() string {
 func (*ResourceDeleteRequest) ProtoMessage() {}
 
 func (x *ResourceDeleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[78]
+	mi := &file_iac_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5202,7 +5348,7 @@ func (x *ResourceDeleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDeleteRequest.ProtoReflect.Descriptor instead.
 func (*ResourceDeleteRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{78}
+	return file_iac_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ResourceDeleteRequest) GetResourceType() string {
@@ -5227,7 +5373,7 @@ type ResourceDeleteResponse struct {
 
 func (x *ResourceDeleteResponse) Reset() {
 	*x = ResourceDeleteResponse{}
-	mi := &file_iac_proto_msgTypes[79]
+	mi := &file_iac_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5239,7 +5385,7 @@ func (x *ResourceDeleteResponse) String() string {
 func (*ResourceDeleteResponse) ProtoMessage() {}
 
 func (x *ResourceDeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[79]
+	mi := &file_iac_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5252,7 +5398,7 @@ func (x *ResourceDeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDeleteResponse.ProtoReflect.Descriptor instead.
 func (*ResourceDeleteResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{79}
+	return file_iac_proto_rawDescGZIP(), []int{82}
 }
 
 type ResourceDiffRequest struct {
@@ -5266,7 +5412,7 @@ type ResourceDiffRequest struct {
 
 func (x *ResourceDiffRequest) Reset() {
 	*x = ResourceDiffRequest{}
-	mi := &file_iac_proto_msgTypes[80]
+	mi := &file_iac_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5278,7 +5424,7 @@ func (x *ResourceDiffRequest) String() string {
 func (*ResourceDiffRequest) ProtoMessage() {}
 
 func (x *ResourceDiffRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[80]
+	mi := &file_iac_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5291,7 +5437,7 @@ func (x *ResourceDiffRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDiffRequest.ProtoReflect.Descriptor instead.
 func (*ResourceDiffRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{80}
+	return file_iac_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ResourceDiffRequest) GetResourceType() string {
@@ -5324,7 +5470,7 @@ type ResourceDiffResponse struct {
 
 func (x *ResourceDiffResponse) Reset() {
 	*x = ResourceDiffResponse{}
-	mi := &file_iac_proto_msgTypes[81]
+	mi := &file_iac_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5336,7 +5482,7 @@ func (x *ResourceDiffResponse) String() string {
 func (*ResourceDiffResponse) ProtoMessage() {}
 
 func (x *ResourceDiffResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[81]
+	mi := &file_iac_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5349,7 +5495,7 @@ func (x *ResourceDiffResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDiffResponse.ProtoReflect.Descriptor instead.
 func (*ResourceDiffResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{81}
+	return file_iac_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ResourceDiffResponse) GetResult() *DiffResult {
@@ -5370,7 +5516,7 @@ type ResourceScaleRequest struct {
 
 func (x *ResourceScaleRequest) Reset() {
 	*x = ResourceScaleRequest{}
-	mi := &file_iac_proto_msgTypes[82]
+	mi := &file_iac_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5382,7 +5528,7 @@ func (x *ResourceScaleRequest) String() string {
 func (*ResourceScaleRequest) ProtoMessage() {}
 
 func (x *ResourceScaleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[82]
+	mi := &file_iac_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5395,7 +5541,7 @@ func (x *ResourceScaleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceScaleRequest.ProtoReflect.Descriptor instead.
 func (*ResourceScaleRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{82}
+	return file_iac_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ResourceScaleRequest) GetResourceType() string {
@@ -5428,7 +5574,7 @@ type ResourceScaleResponse struct {
 
 func (x *ResourceScaleResponse) Reset() {
 	*x = ResourceScaleResponse{}
-	mi := &file_iac_proto_msgTypes[83]
+	mi := &file_iac_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5440,7 +5586,7 @@ func (x *ResourceScaleResponse) String() string {
 func (*ResourceScaleResponse) ProtoMessage() {}
 
 func (x *ResourceScaleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[83]
+	mi := &file_iac_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5453,7 +5599,7 @@ func (x *ResourceScaleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceScaleResponse.ProtoReflect.Descriptor instead.
 func (*ResourceScaleResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{83}
+	return file_iac_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ResourceScaleResponse) GetOutput() *ResourceOutput {
@@ -5473,7 +5619,7 @@ type ResourceHealthCheckRequest struct {
 
 func (x *ResourceHealthCheckRequest) Reset() {
 	*x = ResourceHealthCheckRequest{}
-	mi := &file_iac_proto_msgTypes[84]
+	mi := &file_iac_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5485,7 +5631,7 @@ func (x *ResourceHealthCheckRequest) String() string {
 func (*ResourceHealthCheckRequest) ProtoMessage() {}
 
 func (x *ResourceHealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[84]
+	mi := &file_iac_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5498,7 +5644,7 @@ func (x *ResourceHealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceHealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*ResourceHealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{84}
+	return file_iac_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ResourceHealthCheckRequest) GetResourceType() string {
@@ -5524,7 +5670,7 @@ type ResourceHealthCheckResponse struct {
 
 func (x *ResourceHealthCheckResponse) Reset() {
 	*x = ResourceHealthCheckResponse{}
-	mi := &file_iac_proto_msgTypes[85]
+	mi := &file_iac_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5536,7 +5682,7 @@ func (x *ResourceHealthCheckResponse) String() string {
 func (*ResourceHealthCheckResponse) ProtoMessage() {}
 
 func (x *ResourceHealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[85]
+	mi := &file_iac_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5549,7 +5695,7 @@ func (x *ResourceHealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceHealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*ResourceHealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{85}
+	return file_iac_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ResourceHealthCheckResponse) GetResult() *HealthResult {
@@ -5568,7 +5714,7 @@ type SensitiveKeysRequest struct {
 
 func (x *SensitiveKeysRequest) Reset() {
 	*x = SensitiveKeysRequest{}
-	mi := &file_iac_proto_msgTypes[86]
+	mi := &file_iac_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5580,7 +5726,7 @@ func (x *SensitiveKeysRequest) String() string {
 func (*SensitiveKeysRequest) ProtoMessage() {}
 
 func (x *SensitiveKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[86]
+	mi := &file_iac_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5593,7 +5739,7 @@ func (x *SensitiveKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SensitiveKeysRequest.ProtoReflect.Descriptor instead.
 func (*SensitiveKeysRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{86}
+	return file_iac_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *SensitiveKeysRequest) GetResourceType() string {
@@ -5612,7 +5758,7 @@ type SensitiveKeysResponse struct {
 
 func (x *SensitiveKeysResponse) Reset() {
 	*x = SensitiveKeysResponse{}
-	mi := &file_iac_proto_msgTypes[87]
+	mi := &file_iac_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5624,7 +5770,7 @@ func (x *SensitiveKeysResponse) String() string {
 func (*SensitiveKeysResponse) ProtoMessage() {}
 
 func (x *SensitiveKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[87]
+	mi := &file_iac_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5637,7 +5783,7 @@ func (x *SensitiveKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SensitiveKeysResponse.ProtoReflect.Descriptor instead.
 func (*SensitiveKeysResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{87}
+	return file_iac_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *SensitiveKeysResponse) GetKeys() []string {
@@ -5658,7 +5804,7 @@ type TroubleshootRequest struct {
 
 func (x *TroubleshootRequest) Reset() {
 	*x = TroubleshootRequest{}
-	mi := &file_iac_proto_msgTypes[88]
+	mi := &file_iac_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5670,7 +5816,7 @@ func (x *TroubleshootRequest) String() string {
 func (*TroubleshootRequest) ProtoMessage() {}
 
 func (x *TroubleshootRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[88]
+	mi := &file_iac_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5683,7 +5829,7 @@ func (x *TroubleshootRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TroubleshootRequest.ProtoReflect.Descriptor instead.
 func (*TroubleshootRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{88}
+	return file_iac_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *TroubleshootRequest) GetResourceType() string {
@@ -5716,7 +5862,7 @@ type TroubleshootResponse struct {
 
 func (x *TroubleshootResponse) Reset() {
 	*x = TroubleshootResponse{}
-	mi := &file_iac_proto_msgTypes[89]
+	mi := &file_iac_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5728,7 +5874,7 @@ func (x *TroubleshootResponse) String() string {
 func (*TroubleshootResponse) ProtoMessage() {}
 
 func (x *TroubleshootResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[89]
+	mi := &file_iac_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5741,7 +5887,7 @@ func (x *TroubleshootResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TroubleshootResponse.ProtoReflect.Descriptor instead.
 func (*TroubleshootResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{89}
+	return file_iac_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *TroubleshootResponse) GetDiagnostics() []*Diagnostic {
@@ -5775,7 +5921,7 @@ type IaCState struct {
 
 func (x *IaCState) Reset() {
 	*x = IaCState{}
-	mi := &file_iac_proto_msgTypes[90]
+	mi := &file_iac_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5787,7 +5933,7 @@ func (x *IaCState) String() string {
 func (*IaCState) ProtoMessage() {}
 
 func (x *IaCState) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[90]
+	mi := &file_iac_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5800,7 +5946,7 @@ func (x *IaCState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IaCState.ProtoReflect.Descriptor instead.
 func (*IaCState) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{90}
+	return file_iac_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *IaCState) GetResourceId() string {
@@ -5908,7 +6054,7 @@ type ConfigureRequest struct {
 
 func (x *ConfigureRequest) Reset() {
 	*x = ConfigureRequest{}
-	mi := &file_iac_proto_msgTypes[91]
+	mi := &file_iac_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5920,7 +6066,7 @@ func (x *ConfigureRequest) String() string {
 func (*ConfigureRequest) ProtoMessage() {}
 
 func (x *ConfigureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[91]
+	mi := &file_iac_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5933,7 +6079,7 @@ func (x *ConfigureRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{91}
+	return file_iac_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ConfigureRequest) GetBackendName() string {
@@ -5958,7 +6104,7 @@ type ConfigureResponse struct {
 
 func (x *ConfigureResponse) Reset() {
 	*x = ConfigureResponse{}
-	mi := &file_iac_proto_msgTypes[92]
+	mi := &file_iac_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5970,7 +6116,7 @@ func (x *ConfigureResponse) String() string {
 func (*ConfigureResponse) ProtoMessage() {}
 
 func (x *ConfigureResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[92]
+	mi := &file_iac_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5983,7 +6129,7 @@ func (x *ConfigureResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{92}
+	return file_iac_proto_rawDescGZIP(), []int{95}
 }
 
 type GetStateRequest struct {
@@ -5995,7 +6141,7 @@ type GetStateRequest struct {
 
 func (x *GetStateRequest) Reset() {
 	*x = GetStateRequest{}
-	mi := &file_iac_proto_msgTypes[93]
+	mi := &file_iac_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6007,7 +6153,7 @@ func (x *GetStateRequest) String() string {
 func (*GetStateRequest) ProtoMessage() {}
 
 func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[93]
+	mi := &file_iac_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6020,7 +6166,7 @@ func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateRequest.ProtoReflect.Descriptor instead.
 func (*GetStateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{93}
+	return file_iac_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetStateRequest) GetResourceId() string {
@@ -6040,7 +6186,7 @@ type GetStateResponse struct {
 
 func (x *GetStateResponse) Reset() {
 	*x = GetStateResponse{}
-	mi := &file_iac_proto_msgTypes[94]
+	mi := &file_iac_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6052,7 +6198,7 @@ func (x *GetStateResponse) String() string {
 func (*GetStateResponse) ProtoMessage() {}
 
 func (x *GetStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[94]
+	mi := &file_iac_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6065,7 +6211,7 @@ func (x *GetStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateResponse.ProtoReflect.Descriptor instead.
 func (*GetStateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{94}
+	return file_iac_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *GetStateResponse) GetState() *IaCState {
@@ -6091,7 +6237,7 @@ type SaveStateRequest struct {
 
 func (x *SaveStateRequest) Reset() {
 	*x = SaveStateRequest{}
-	mi := &file_iac_proto_msgTypes[95]
+	mi := &file_iac_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6103,7 +6249,7 @@ func (x *SaveStateRequest) String() string {
 func (*SaveStateRequest) ProtoMessage() {}
 
 func (x *SaveStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[95]
+	mi := &file_iac_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6116,7 +6262,7 @@ func (x *SaveStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveStateRequest.ProtoReflect.Descriptor instead.
 func (*SaveStateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{95}
+	return file_iac_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *SaveStateRequest) GetState() *IaCState {
@@ -6134,7 +6280,7 @@ type SaveStateResponse struct {
 
 func (x *SaveStateResponse) Reset() {
 	*x = SaveStateResponse{}
-	mi := &file_iac_proto_msgTypes[96]
+	mi := &file_iac_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6146,7 +6292,7 @@ func (x *SaveStateResponse) String() string {
 func (*SaveStateResponse) ProtoMessage() {}
 
 func (x *SaveStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[96]
+	mi := &file_iac_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6159,7 +6305,7 @@ func (x *SaveStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveStateResponse.ProtoReflect.Descriptor instead.
 func (*SaveStateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{96}
+	return file_iac_proto_rawDescGZIP(), []int{99}
 }
 
 type ListStatesRequest struct {
@@ -6171,7 +6317,7 @@ type ListStatesRequest struct {
 
 func (x *ListStatesRequest) Reset() {
 	*x = ListStatesRequest{}
-	mi := &file_iac_proto_msgTypes[97]
+	mi := &file_iac_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6183,7 +6329,7 @@ func (x *ListStatesRequest) String() string {
 func (*ListStatesRequest) ProtoMessage() {}
 
 func (x *ListStatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[97]
+	mi := &file_iac_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6196,7 +6342,7 @@ func (x *ListStatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStatesRequest.ProtoReflect.Descriptor instead.
 func (*ListStatesRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{97}
+	return file_iac_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ListStatesRequest) GetFilter() map[string]string {
@@ -6215,7 +6361,7 @@ type ListStatesResponse struct {
 
 func (x *ListStatesResponse) Reset() {
 	*x = ListStatesResponse{}
-	mi := &file_iac_proto_msgTypes[98]
+	mi := &file_iac_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6227,7 +6373,7 @@ func (x *ListStatesResponse) String() string {
 func (*ListStatesResponse) ProtoMessage() {}
 
 func (x *ListStatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[98]
+	mi := &file_iac_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6240,7 +6386,7 @@ func (x *ListStatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStatesResponse.ProtoReflect.Descriptor instead.
 func (*ListStatesResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{98}
+	return file_iac_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ListStatesResponse) GetStates() []*IaCState {
@@ -6259,7 +6405,7 @@ type DeleteStateRequest struct {
 
 func (x *DeleteStateRequest) Reset() {
 	*x = DeleteStateRequest{}
-	mi := &file_iac_proto_msgTypes[99]
+	mi := &file_iac_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6271,7 +6417,7 @@ func (x *DeleteStateRequest) String() string {
 func (*DeleteStateRequest) ProtoMessage() {}
 
 func (x *DeleteStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[99]
+	mi := &file_iac_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6284,7 +6430,7 @@ func (x *DeleteStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteStateRequest.ProtoReflect.Descriptor instead.
 func (*DeleteStateRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{99}
+	return file_iac_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *DeleteStateRequest) GetResourceId() string {
@@ -6302,7 +6448,7 @@ type DeleteStateResponse struct {
 
 func (x *DeleteStateResponse) Reset() {
 	*x = DeleteStateResponse{}
-	mi := &file_iac_proto_msgTypes[100]
+	mi := &file_iac_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6314,7 +6460,7 @@ func (x *DeleteStateResponse) String() string {
 func (*DeleteStateResponse) ProtoMessage() {}
 
 func (x *DeleteStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[100]
+	mi := &file_iac_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6327,7 +6473,7 @@ func (x *DeleteStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteStateResponse.ProtoReflect.Descriptor instead.
 func (*DeleteStateResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{100}
+	return file_iac_proto_rawDescGZIP(), []int{103}
 }
 
 type LockRequest struct {
@@ -6339,7 +6485,7 @@ type LockRequest struct {
 
 func (x *LockRequest) Reset() {
 	*x = LockRequest{}
-	mi := &file_iac_proto_msgTypes[101]
+	mi := &file_iac_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6351,7 +6497,7 @@ func (x *LockRequest) String() string {
 func (*LockRequest) ProtoMessage() {}
 
 func (x *LockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[101]
+	mi := &file_iac_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6364,7 +6510,7 @@ func (x *LockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockRequest.ProtoReflect.Descriptor instead.
 func (*LockRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{101}
+	return file_iac_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *LockRequest) GetResourceId() string {
@@ -6382,7 +6528,7 @@ type LockResponse struct {
 
 func (x *LockResponse) Reset() {
 	*x = LockResponse{}
-	mi := &file_iac_proto_msgTypes[102]
+	mi := &file_iac_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6394,7 +6540,7 @@ func (x *LockResponse) String() string {
 func (*LockResponse) ProtoMessage() {}
 
 func (x *LockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[102]
+	mi := &file_iac_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6407,7 +6553,7 @@ func (x *LockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockResponse.ProtoReflect.Descriptor instead.
 func (*LockResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{102}
+	return file_iac_proto_rawDescGZIP(), []int{105}
 }
 
 type UnlockRequest struct {
@@ -6419,7 +6565,7 @@ type UnlockRequest struct {
 
 func (x *UnlockRequest) Reset() {
 	*x = UnlockRequest{}
-	mi := &file_iac_proto_msgTypes[103]
+	mi := &file_iac_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6431,7 +6577,7 @@ func (x *UnlockRequest) String() string {
 func (*UnlockRequest) ProtoMessage() {}
 
 func (x *UnlockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[103]
+	mi := &file_iac_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6444,7 +6590,7 @@ func (x *UnlockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockRequest.ProtoReflect.Descriptor instead.
 func (*UnlockRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{103}
+	return file_iac_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *UnlockRequest) GetResourceId() string {
@@ -6462,7 +6608,7 @@ type UnlockResponse struct {
 
 func (x *UnlockResponse) Reset() {
 	*x = UnlockResponse{}
-	mi := &file_iac_proto_msgTypes[104]
+	mi := &file_iac_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6474,7 +6620,7 @@ func (x *UnlockResponse) String() string {
 func (*UnlockResponse) ProtoMessage() {}
 
 func (x *UnlockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[104]
+	mi := &file_iac_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6487,7 +6633,7 @@ func (x *UnlockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockResponse.ProtoReflect.Descriptor instead.
 func (*UnlockResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{104}
+	return file_iac_proto_rawDescGZIP(), []int{107}
 }
 
 // ListBackendNames lets the engine ask a loaded plugin which iac.state backend
@@ -6501,7 +6647,7 @@ type ListBackendNamesRequest struct {
 
 func (x *ListBackendNamesRequest) Reset() {
 	*x = ListBackendNamesRequest{}
-	mi := &file_iac_proto_msgTypes[105]
+	mi := &file_iac_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6513,7 +6659,7 @@ func (x *ListBackendNamesRequest) String() string {
 func (*ListBackendNamesRequest) ProtoMessage() {}
 
 func (x *ListBackendNamesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[105]
+	mi := &file_iac_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6526,7 +6672,7 @@ func (x *ListBackendNamesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendNamesRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendNamesRequest) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{105}
+	return file_iac_proto_rawDescGZIP(), []int{108}
 }
 
 type ListBackendNamesResponse struct {
@@ -6538,7 +6684,7 @@ type ListBackendNamesResponse struct {
 
 func (x *ListBackendNamesResponse) Reset() {
 	*x = ListBackendNamesResponse{}
-	mi := &file_iac_proto_msgTypes[106]
+	mi := &file_iac_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6550,7 +6696,7 @@ func (x *ListBackendNamesResponse) String() string {
 func (*ListBackendNamesResponse) ProtoMessage() {}
 
 func (x *ListBackendNamesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_iac_proto_msgTypes[106]
+	mi := &file_iac_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6563,7 +6709,7 @@ func (x *ListBackendNamesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendNamesResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendNamesResponse) Descriptor() ([]byte, []int) {
-	return file_iac_proto_rawDescGZIP(), []int{106}
+	return file_iac_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ListBackendNamesResponse) GetBackendNames() []string {
@@ -6863,6 +7009,13 @@ const file_iac_proto_rawDesc = "" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12#\n" +
 	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\"\"\n" +
 	" RevokeProviderCredentialResponse\"/\n" +
+	"\x12ListRegionsRequest\x12\x19\n" +
+	"\benv_name\x18\x01 \x01(\tR\aenvName\"G\n" +
+	"\x0eProviderRegion\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\"]\n" +
+	"\x13ListRegionsResponse\x12F\n" +
+	"\aregions\x18\x01 \x03(\v2,.workflow.plugin.external.iac.ProviderRegionR\aregions\"/\n" +
 	"\x14FinalizeApplyRequest\x12\x17\n" +
 	"\aplan_id\x18\x01 \x01(\tR\x06planId\"`\n" +
 	"\x15FinalizeApplyResponse\x12A\n" +
@@ -7081,7 +7234,9 @@ const file_iac_proto_rawDesc = "" +
 	"\vDetectDrift\x120.workflow.plugin.external.iac.DetectDriftRequest\x1a1.workflow.plugin.external.iac.DetectDriftResponse\x12\x8d\x01\n" +
 	"\x14DetectDriftWithSpecs\x129.workflow.plugin.external.iac.DetectDriftWithSpecsRequest\x1a:.workflow.plugin.external.iac.DetectDriftWithSpecsResponse2\xba\x01\n" +
 	"\x1cIaCProviderCredentialRevoker\x12\x99\x01\n" +
-	"\x18RevokeProviderCredential\x12=.workflow.plugin.external.iac.RevokeProviderCredentialRequest\x1a>.workflow.plugin.external.iac.RevokeProviderCredentialResponse2\x90\x01\n" +
+	"\x18RevokeProviderCredential\x12=.workflow.plugin.external.iac.RevokeProviderCredentialRequest\x1a>.workflow.plugin.external.iac.RevokeProviderCredentialResponse2\x8d\x01\n" +
+	"\x17IaCProviderRegionLister\x12r\n" +
+	"\vListRegions\x120.workflow.plugin.external.iac.ListRegionsRequest\x1a1.workflow.plugin.external.iac.ListRegionsResponse2\x90\x01\n" +
 	"\x14IaCProviderFinalizer\x12x\n" +
 	"\rFinalizeApply\x122.workflow.plugin.external.iac.FinalizeApplyRequest\x1a3.workflow.plugin.external.iac.FinalizeApplyResponse2\xae\x01\n" +
 	"\x1cIaCProviderMigrationRepairer\x12\x8d\x01\n" +
@@ -7130,7 +7285,7 @@ func file_iac_proto_rawDescGZIP() []byte {
 }
 
 var file_iac_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_iac_proto_msgTypes = make([]protoimpl.MessageInfo, 114)
+var file_iac_proto_msgTypes = make([]protoimpl.MessageInfo, 117)
 var file_iac_proto_goTypes = []any{
 	(DriftClass)(0),                          // 0: workflow.plugin.external.iac.DriftClass
 	(RequirementKind)(0),                     // 1: workflow.plugin.external.iac.RequirementKind
@@ -7203,66 +7358,69 @@ var file_iac_proto_goTypes = []any{
 	(*DetectDriftWithSpecsResponse)(nil),     // 68: workflow.plugin.external.iac.DetectDriftWithSpecsResponse
 	(*RevokeProviderCredentialRequest)(nil),  // 69: workflow.plugin.external.iac.RevokeProviderCredentialRequest
 	(*RevokeProviderCredentialResponse)(nil), // 70: workflow.plugin.external.iac.RevokeProviderCredentialResponse
-	(*FinalizeApplyRequest)(nil),             // 71: workflow.plugin.external.iac.FinalizeApplyRequest
-	(*FinalizeApplyResponse)(nil),            // 72: workflow.plugin.external.iac.FinalizeApplyResponse
-	(*RepairDirtyMigrationRequest)(nil),      // 73: workflow.plugin.external.iac.RepairDirtyMigrationRequest
-	(*RepairDirtyMigrationResponse)(nil),     // 74: workflow.plugin.external.iac.RepairDirtyMigrationResponse
-	(*ValidatePlanRequest)(nil),              // 75: workflow.plugin.external.iac.ValidatePlanRequest
-	(*ValidatePlanResponse)(nil),             // 76: workflow.plugin.external.iac.ValidatePlanResponse
-	(*DetectDriftConfigRequest)(nil),         // 77: workflow.plugin.external.iac.DetectDriftConfigRequest
-	(*DetectDriftConfigResponse)(nil),        // 78: workflow.plugin.external.iac.DetectDriftConfigResponse
-	(*CaptureLogsRequest)(nil),               // 79: workflow.plugin.external.iac.CaptureLogsRequest
-	(*LogChunk)(nil),                         // 80: workflow.plugin.external.iac.LogChunk
-	(*ResourceCreateRequest)(nil),            // 81: workflow.plugin.external.iac.ResourceCreateRequest
-	(*ResourceCreateResponse)(nil),           // 82: workflow.plugin.external.iac.ResourceCreateResponse
-	(*ResourceReadRequest)(nil),              // 83: workflow.plugin.external.iac.ResourceReadRequest
-	(*ResourceReadResponse)(nil),             // 84: workflow.plugin.external.iac.ResourceReadResponse
-	(*ResourceUpdateRequest)(nil),            // 85: workflow.plugin.external.iac.ResourceUpdateRequest
-	(*ResourceUpdateResponse)(nil),           // 86: workflow.plugin.external.iac.ResourceUpdateResponse
-	(*ResourceDeleteRequest)(nil),            // 87: workflow.plugin.external.iac.ResourceDeleteRequest
-	(*ResourceDeleteResponse)(nil),           // 88: workflow.plugin.external.iac.ResourceDeleteResponse
-	(*ResourceDiffRequest)(nil),              // 89: workflow.plugin.external.iac.ResourceDiffRequest
-	(*ResourceDiffResponse)(nil),             // 90: workflow.plugin.external.iac.ResourceDiffResponse
-	(*ResourceScaleRequest)(nil),             // 91: workflow.plugin.external.iac.ResourceScaleRequest
-	(*ResourceScaleResponse)(nil),            // 92: workflow.plugin.external.iac.ResourceScaleResponse
-	(*ResourceHealthCheckRequest)(nil),       // 93: workflow.plugin.external.iac.ResourceHealthCheckRequest
-	(*ResourceHealthCheckResponse)(nil),      // 94: workflow.plugin.external.iac.ResourceHealthCheckResponse
-	(*SensitiveKeysRequest)(nil),             // 95: workflow.plugin.external.iac.SensitiveKeysRequest
-	(*SensitiveKeysResponse)(nil),            // 96: workflow.plugin.external.iac.SensitiveKeysResponse
-	(*TroubleshootRequest)(nil),              // 97: workflow.plugin.external.iac.TroubleshootRequest
-	(*TroubleshootResponse)(nil),             // 98: workflow.plugin.external.iac.TroubleshootResponse
-	(*IaCState)(nil),                         // 99: workflow.plugin.external.iac.IaCState
-	(*ConfigureRequest)(nil),                 // 100: workflow.plugin.external.iac.ConfigureRequest
-	(*ConfigureResponse)(nil),                // 101: workflow.plugin.external.iac.ConfigureResponse
-	(*GetStateRequest)(nil),                  // 102: workflow.plugin.external.iac.GetStateRequest
-	(*GetStateResponse)(nil),                 // 103: workflow.plugin.external.iac.GetStateResponse
-	(*SaveStateRequest)(nil),                 // 104: workflow.plugin.external.iac.SaveStateRequest
-	(*SaveStateResponse)(nil),                // 105: workflow.plugin.external.iac.SaveStateResponse
-	(*ListStatesRequest)(nil),                // 106: workflow.plugin.external.iac.ListStatesRequest
-	(*ListStatesResponse)(nil),               // 107: workflow.plugin.external.iac.ListStatesResponse
-	(*DeleteStateRequest)(nil),               // 108: workflow.plugin.external.iac.DeleteStateRequest
-	(*DeleteStateResponse)(nil),              // 109: workflow.plugin.external.iac.DeleteStateResponse
-	(*LockRequest)(nil),                      // 110: workflow.plugin.external.iac.LockRequest
-	(*LockResponse)(nil),                     // 111: workflow.plugin.external.iac.LockResponse
-	(*UnlockRequest)(nil),                    // 112: workflow.plugin.external.iac.UnlockRequest
-	(*UnlockResponse)(nil),                   // 113: workflow.plugin.external.iac.UnlockResponse
-	(*ListBackendNamesRequest)(nil),          // 114: workflow.plugin.external.iac.ListBackendNamesRequest
-	(*ListBackendNamesResponse)(nil),         // 115: workflow.plugin.external.iac.ListBackendNamesResponse
-	nil,                                      // 116: workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
-	nil,                                      // 117: workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
-	nil,                                      // 118: workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
-	nil,                                      // 119: workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
-	nil,                                      // 120: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
-	nil,                                      // 121: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
-	nil,                                      // 122: workflow.plugin.external.iac.ListStatesRequest.FilterEntry
-	(*timestamppb.Timestamp)(nil),            // 123: google.protobuf.Timestamp
+	(*ListRegionsRequest)(nil),               // 71: workflow.plugin.external.iac.ListRegionsRequest
+	(*ProviderRegion)(nil),                   // 72: workflow.plugin.external.iac.ProviderRegion
+	(*ListRegionsResponse)(nil),              // 73: workflow.plugin.external.iac.ListRegionsResponse
+	(*FinalizeApplyRequest)(nil),             // 74: workflow.plugin.external.iac.FinalizeApplyRequest
+	(*FinalizeApplyResponse)(nil),            // 75: workflow.plugin.external.iac.FinalizeApplyResponse
+	(*RepairDirtyMigrationRequest)(nil),      // 76: workflow.plugin.external.iac.RepairDirtyMigrationRequest
+	(*RepairDirtyMigrationResponse)(nil),     // 77: workflow.plugin.external.iac.RepairDirtyMigrationResponse
+	(*ValidatePlanRequest)(nil),              // 78: workflow.plugin.external.iac.ValidatePlanRequest
+	(*ValidatePlanResponse)(nil),             // 79: workflow.plugin.external.iac.ValidatePlanResponse
+	(*DetectDriftConfigRequest)(nil),         // 80: workflow.plugin.external.iac.DetectDriftConfigRequest
+	(*DetectDriftConfigResponse)(nil),        // 81: workflow.plugin.external.iac.DetectDriftConfigResponse
+	(*CaptureLogsRequest)(nil),               // 82: workflow.plugin.external.iac.CaptureLogsRequest
+	(*LogChunk)(nil),                         // 83: workflow.plugin.external.iac.LogChunk
+	(*ResourceCreateRequest)(nil),            // 84: workflow.plugin.external.iac.ResourceCreateRequest
+	(*ResourceCreateResponse)(nil),           // 85: workflow.plugin.external.iac.ResourceCreateResponse
+	(*ResourceReadRequest)(nil),              // 86: workflow.plugin.external.iac.ResourceReadRequest
+	(*ResourceReadResponse)(nil),             // 87: workflow.plugin.external.iac.ResourceReadResponse
+	(*ResourceUpdateRequest)(nil),            // 88: workflow.plugin.external.iac.ResourceUpdateRequest
+	(*ResourceUpdateResponse)(nil),           // 89: workflow.plugin.external.iac.ResourceUpdateResponse
+	(*ResourceDeleteRequest)(nil),            // 90: workflow.plugin.external.iac.ResourceDeleteRequest
+	(*ResourceDeleteResponse)(nil),           // 91: workflow.plugin.external.iac.ResourceDeleteResponse
+	(*ResourceDiffRequest)(nil),              // 92: workflow.plugin.external.iac.ResourceDiffRequest
+	(*ResourceDiffResponse)(nil),             // 93: workflow.plugin.external.iac.ResourceDiffResponse
+	(*ResourceScaleRequest)(nil),             // 94: workflow.plugin.external.iac.ResourceScaleRequest
+	(*ResourceScaleResponse)(nil),            // 95: workflow.plugin.external.iac.ResourceScaleResponse
+	(*ResourceHealthCheckRequest)(nil),       // 96: workflow.plugin.external.iac.ResourceHealthCheckRequest
+	(*ResourceHealthCheckResponse)(nil),      // 97: workflow.plugin.external.iac.ResourceHealthCheckResponse
+	(*SensitiveKeysRequest)(nil),             // 98: workflow.plugin.external.iac.SensitiveKeysRequest
+	(*SensitiveKeysResponse)(nil),            // 99: workflow.plugin.external.iac.SensitiveKeysResponse
+	(*TroubleshootRequest)(nil),              // 100: workflow.plugin.external.iac.TroubleshootRequest
+	(*TroubleshootResponse)(nil),             // 101: workflow.plugin.external.iac.TroubleshootResponse
+	(*IaCState)(nil),                         // 102: workflow.plugin.external.iac.IaCState
+	(*ConfigureRequest)(nil),                 // 103: workflow.plugin.external.iac.ConfigureRequest
+	(*ConfigureResponse)(nil),                // 104: workflow.plugin.external.iac.ConfigureResponse
+	(*GetStateRequest)(nil),                  // 105: workflow.plugin.external.iac.GetStateRequest
+	(*GetStateResponse)(nil),                 // 106: workflow.plugin.external.iac.GetStateResponse
+	(*SaveStateRequest)(nil),                 // 107: workflow.plugin.external.iac.SaveStateRequest
+	(*SaveStateResponse)(nil),                // 108: workflow.plugin.external.iac.SaveStateResponse
+	(*ListStatesRequest)(nil),                // 109: workflow.plugin.external.iac.ListStatesRequest
+	(*ListStatesResponse)(nil),               // 110: workflow.plugin.external.iac.ListStatesResponse
+	(*DeleteStateRequest)(nil),               // 111: workflow.plugin.external.iac.DeleteStateRequest
+	(*DeleteStateResponse)(nil),              // 112: workflow.plugin.external.iac.DeleteStateResponse
+	(*LockRequest)(nil),                      // 113: workflow.plugin.external.iac.LockRequest
+	(*LockResponse)(nil),                     // 114: workflow.plugin.external.iac.LockResponse
+	(*UnlockRequest)(nil),                    // 115: workflow.plugin.external.iac.UnlockRequest
+	(*UnlockResponse)(nil),                   // 116: workflow.plugin.external.iac.UnlockResponse
+	(*ListBackendNamesRequest)(nil),          // 117: workflow.plugin.external.iac.ListBackendNamesRequest
+	(*ListBackendNamesResponse)(nil),         // 118: workflow.plugin.external.iac.ListBackendNamesResponse
+	nil,                                      // 119: workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
+	nil,                                      // 120: workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
+	nil,                                      // 121: workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
+	nil,                                      // 122: workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
+	nil,                                      // 123: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
+	nil,                                      // 124: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
+	nil,                                      // 125: workflow.plugin.external.iac.ListStatesRequest.FilterEntry
+	(*timestamppb.Timestamp)(nil),            // 126: google.protobuf.Timestamp
 }
 var file_iac_proto_depIdxs = []int32{
 	11,  // 0: workflow.plugin.external.iac.ResourceSpec.hints:type_name -> workflow.plugin.external.iac.ResourceHints
-	123, // 1: workflow.plugin.external.iac.ResourceState.created_at:type_name -> google.protobuf.Timestamp
-	123, // 2: workflow.plugin.external.iac.ResourceState.updated_at:type_name -> google.protobuf.Timestamp
-	123, // 3: workflow.plugin.external.iac.ResourceState.last_drift_check:type_name -> google.protobuf.Timestamp
-	116, // 4: workflow.plugin.external.iac.ResourceOutput.sensitive:type_name -> workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
+	126, // 1: workflow.plugin.external.iac.ResourceState.created_at:type_name -> google.protobuf.Timestamp
+	126, // 2: workflow.plugin.external.iac.ResourceState.updated_at:type_name -> google.protobuf.Timestamp
+	126, // 3: workflow.plugin.external.iac.ResourceState.last_drift_check:type_name -> google.protobuf.Timestamp
+	119, // 4: workflow.plugin.external.iac.ResourceOutput.sensitive:type_name -> workflow.plugin.external.iac.ResourceOutput.SensitiveEntry
 	17,  // 5: workflow.plugin.external.iac.DiffResult.changes:type_name -> workflow.plugin.external.iac.FieldChange
 	1,   // 6: workflow.plugin.external.iac.IaCRequirement.kind:type_name -> workflow.plugin.external.iac.RequirementKind
 	2,   // 7: workflow.plugin.external.iac.IaCRequirement.runtimes:type_name -> workflow.plugin.external.iac.RequirementRuntime
@@ -7278,17 +7436,17 @@ var file_iac_proto_depIdxs = []int32{
 	25,  // 17: workflow.plugin.external.iac.MapRequirementsResponse.modules:type_name -> workflow.plugin.external.iac.DerivedModuleSpec
 	27,  // 18: workflow.plugin.external.iac.MapRequirementsResponse.notes:type_name -> workflow.plugin.external.iac.RequirementNote
 	0,   // 19: workflow.plugin.external.iac.DriftResult.class:type_name -> workflow.plugin.external.iac.DriftClass
-	123, // 20: workflow.plugin.external.iac.Diagnostic.at:type_name -> google.protobuf.Timestamp
+	126, // 20: workflow.plugin.external.iac.Diagnostic.at:type_name -> google.protobuf.Timestamp
 	6,   // 21: workflow.plugin.external.iac.PlanDiagnostic.severity:type_name -> workflow.plugin.external.iac.PlanDiagnosticSeverity
 	9,   // 22: workflow.plugin.external.iac.PlanAction.resource:type_name -> workflow.plugin.external.iac.ResourceSpec
 	14,  // 23: workflow.plugin.external.iac.PlanAction.current:type_name -> workflow.plugin.external.iac.ResourceState
 	17,  // 24: workflow.plugin.external.iac.PlanAction.changes:type_name -> workflow.plugin.external.iac.FieldChange
 	34,  // 25: workflow.plugin.external.iac.IaCPlan.actions:type_name -> workflow.plugin.external.iac.PlanAction
-	123, // 26: workflow.plugin.external.iac.IaCPlan.created_at:type_name -> google.protobuf.Timestamp
-	117, // 27: workflow.plugin.external.iac.IaCPlan.input_snapshot:type_name -> workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
+	126, // 26: workflow.plugin.external.iac.IaCPlan.created_at:type_name -> google.protobuf.Timestamp
+	120, // 27: workflow.plugin.external.iac.IaCPlan.input_snapshot:type_name -> workflow.plugin.external.iac.IaCPlan.InputSnapshotEntry
 	36,  // 28: workflow.plugin.external.iac.DestroyResult.errors:type_name -> workflow.plugin.external.iac.ActionError
-	118, // 29: workflow.plugin.external.iac.BootstrapResult.env_vars:type_name -> workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
-	119, // 30: workflow.plugin.external.iac.MigrationRepairRequest.env:type_name -> workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
+	121, // 29: workflow.plugin.external.iac.BootstrapResult.env_vars:type_name -> workflow.plugin.external.iac.BootstrapResult.EnvVarsEntry
+	122, // 30: workflow.plugin.external.iac.MigrationRepairRequest.env:type_name -> workflow.plugin.external.iac.MigrationRepairRequest.EnvEntry
 	32,  // 31: workflow.plugin.external.iac.MigrationRepairResult.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
 	13,  // 32: workflow.plugin.external.iac.CapabilitiesResponse.capabilities:type_name -> workflow.plugin.external.iac.IaCCapabilityDeclaration
 	9,   // 33: workflow.plugin.external.iac.PlanRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
@@ -7307,123 +7465,126 @@ var file_iac_proto_depIdxs = []int32{
 	10,  // 46: workflow.plugin.external.iac.DetectDriftRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
 	29,  // 47: workflow.plugin.external.iac.DetectDriftResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
 	10,  // 48: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	120, // 49: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
+	123, // 49: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry
 	29,  // 50: workflow.plugin.external.iac.DetectDriftWithSpecsResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
-	36,  // 51: workflow.plugin.external.iac.FinalizeApplyResponse.errors:type_name -> workflow.plugin.external.iac.ActionError
-	39,  // 52: workflow.plugin.external.iac.RepairDirtyMigrationRequest.request:type_name -> workflow.plugin.external.iac.MigrationRepairRequest
-	40,  // 53: workflow.plugin.external.iac.RepairDirtyMigrationResponse.result:type_name -> workflow.plugin.external.iac.MigrationRepairResult
-	35,  // 54: workflow.plugin.external.iac.ValidatePlanRequest.plan:type_name -> workflow.plugin.external.iac.IaCPlan
-	33,  // 55: workflow.plugin.external.iac.ValidatePlanResponse.diagnostics:type_name -> workflow.plugin.external.iac.PlanDiagnostic
-	10,  // 56: workflow.plugin.external.iac.DetectDriftConfigRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
-	121, // 57: workflow.plugin.external.iac.DetectDriftConfigRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
-	29,  // 58: workflow.plugin.external.iac.DetectDriftConfigResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
-	8,   // 59: workflow.plugin.external.iac.CaptureLogsRequest.log_type:type_name -> workflow.plugin.external.iac.LogCaptureType
-	9,   // 60: workflow.plugin.external.iac.ResourceCreateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
-	15,  // 61: workflow.plugin.external.iac.ResourceCreateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	10,  // 62: workflow.plugin.external.iac.ResourceReadRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	15,  // 63: workflow.plugin.external.iac.ResourceReadResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	10,  // 64: workflow.plugin.external.iac.ResourceUpdateRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	9,   // 65: workflow.plugin.external.iac.ResourceUpdateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
-	15,  // 66: workflow.plugin.external.iac.ResourceUpdateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	10,  // 67: workflow.plugin.external.iac.ResourceDeleteRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	9,   // 68: workflow.plugin.external.iac.ResourceDiffRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
-	15,  // 69: workflow.plugin.external.iac.ResourceDiffRequest.current:type_name -> workflow.plugin.external.iac.ResourceOutput
-	18,  // 70: workflow.plugin.external.iac.ResourceDiffResponse.result:type_name -> workflow.plugin.external.iac.DiffResult
-	10,  // 71: workflow.plugin.external.iac.ResourceScaleRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	15,  // 72: workflow.plugin.external.iac.ResourceScaleResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
-	10,  // 73: workflow.plugin.external.iac.ResourceHealthCheckRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	31,  // 74: workflow.plugin.external.iac.ResourceHealthCheckResponse.result:type_name -> workflow.plugin.external.iac.HealthResult
-	10,  // 75: workflow.plugin.external.iac.TroubleshootRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
-	32,  // 76: workflow.plugin.external.iac.TroubleshootResponse.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
-	99,  // 77: workflow.plugin.external.iac.GetStateResponse.state:type_name -> workflow.plugin.external.iac.IaCState
-	99,  // 78: workflow.plugin.external.iac.SaveStateRequest.state:type_name -> workflow.plugin.external.iac.IaCState
-	122, // 79: workflow.plugin.external.iac.ListStatesRequest.filter:type_name -> workflow.plugin.external.iac.ListStatesRequest.FilterEntry
-	99,  // 80: workflow.plugin.external.iac.ListStatesResponse.states:type_name -> workflow.plugin.external.iac.IaCState
-	9,   // 81: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
-	9,   // 82: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
-	41,  // 83: workflow.plugin.external.iac.IaCProviderRequired.Initialize:input_type -> workflow.plugin.external.iac.InitializeRequest
-	43,  // 84: workflow.plugin.external.iac.IaCProviderRequired.Name:input_type -> workflow.plugin.external.iac.NameRequest
-	45,  // 85: workflow.plugin.external.iac.IaCProviderRequired.Version:input_type -> workflow.plugin.external.iac.VersionRequest
-	47,  // 86: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:input_type -> workflow.plugin.external.iac.CapabilitiesRequest
-	49,  // 87: workflow.plugin.external.iac.IaCProviderRequired.Plan:input_type -> workflow.plugin.external.iac.PlanRequest
-	51,  // 88: workflow.plugin.external.iac.IaCProviderRequired.Destroy:input_type -> workflow.plugin.external.iac.DestroyRequest
-	53,  // 89: workflow.plugin.external.iac.IaCProviderRequired.Status:input_type -> workflow.plugin.external.iac.StatusRequest
-	55,  // 90: workflow.plugin.external.iac.IaCProviderRequired.Import:input_type -> workflow.plugin.external.iac.ImportRequest
-	57,  // 91: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:input_type -> workflow.plugin.external.iac.ResolveSizingRequest
-	59,  // 92: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:input_type -> workflow.plugin.external.iac.BootstrapStateBackendRequest
-	61,  // 93: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:input_type -> workflow.plugin.external.iac.EnumerateAllRequest
-	63,  // 94: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:input_type -> workflow.plugin.external.iac.EnumerateByTagRequest
-	65,  // 95: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:input_type -> workflow.plugin.external.iac.DetectDriftRequest
-	67,  // 96: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:input_type -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest
-	69,  // 97: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:input_type -> workflow.plugin.external.iac.RevokeProviderCredentialRequest
-	71,  // 98: workflow.plugin.external.iac.IaCProviderFinalizer.FinalizeApply:input_type -> workflow.plugin.external.iac.FinalizeApplyRequest
-	73,  // 99: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:input_type -> workflow.plugin.external.iac.RepairDirtyMigrationRequest
-	75,  // 100: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:input_type -> workflow.plugin.external.iac.ValidatePlanRequest
-	77,  // 101: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:input_type -> workflow.plugin.external.iac.DetectDriftConfigRequest
-	79,  // 102: workflow.plugin.external.iac.IaCProviderLogCapture.CaptureLogs:input_type -> workflow.plugin.external.iac.CaptureLogsRequest
-	20,  // 103: workflow.plugin.external.iac.IaCRequirementDiscovery.DiscoverRequirements:input_type -> workflow.plugin.external.iac.DiscoverRequirementsRequest
-	24,  // 104: workflow.plugin.external.iac.IaCProviderRequirementMapper.MapRequirements:input_type -> workflow.plugin.external.iac.MapRequirementsRequest
-	81,  // 105: workflow.plugin.external.iac.ResourceDriver.Create:input_type -> workflow.plugin.external.iac.ResourceCreateRequest
-	83,  // 106: workflow.plugin.external.iac.ResourceDriver.Read:input_type -> workflow.plugin.external.iac.ResourceReadRequest
-	85,  // 107: workflow.plugin.external.iac.ResourceDriver.Update:input_type -> workflow.plugin.external.iac.ResourceUpdateRequest
-	87,  // 108: workflow.plugin.external.iac.ResourceDriver.Delete:input_type -> workflow.plugin.external.iac.ResourceDeleteRequest
-	89,  // 109: workflow.plugin.external.iac.ResourceDriver.Diff:input_type -> workflow.plugin.external.iac.ResourceDiffRequest
-	91,  // 110: workflow.plugin.external.iac.ResourceDriver.Scale:input_type -> workflow.plugin.external.iac.ResourceScaleRequest
-	93,  // 111: workflow.plugin.external.iac.ResourceDriver.HealthCheck:input_type -> workflow.plugin.external.iac.ResourceHealthCheckRequest
-	95,  // 112: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:input_type -> workflow.plugin.external.iac.SensitiveKeysRequest
-	97,  // 113: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:input_type -> workflow.plugin.external.iac.TroubleshootRequest
-	100, // 114: workflow.plugin.external.iac.IaCStateBackend.Configure:input_type -> workflow.plugin.external.iac.ConfigureRequest
-	102, // 115: workflow.plugin.external.iac.IaCStateBackend.GetState:input_type -> workflow.plugin.external.iac.GetStateRequest
-	104, // 116: workflow.plugin.external.iac.IaCStateBackend.SaveState:input_type -> workflow.plugin.external.iac.SaveStateRequest
-	106, // 117: workflow.plugin.external.iac.IaCStateBackend.ListStates:input_type -> workflow.plugin.external.iac.ListStatesRequest
-	108, // 118: workflow.plugin.external.iac.IaCStateBackend.DeleteState:input_type -> workflow.plugin.external.iac.DeleteStateRequest
-	110, // 119: workflow.plugin.external.iac.IaCStateBackend.Lock:input_type -> workflow.plugin.external.iac.LockRequest
-	112, // 120: workflow.plugin.external.iac.IaCStateBackend.Unlock:input_type -> workflow.plugin.external.iac.UnlockRequest
-	114, // 121: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:input_type -> workflow.plugin.external.iac.ListBackendNamesRequest
-	42,  // 122: workflow.plugin.external.iac.IaCProviderRequired.Initialize:output_type -> workflow.plugin.external.iac.InitializeResponse
-	44,  // 123: workflow.plugin.external.iac.IaCProviderRequired.Name:output_type -> workflow.plugin.external.iac.NameResponse
-	46,  // 124: workflow.plugin.external.iac.IaCProviderRequired.Version:output_type -> workflow.plugin.external.iac.VersionResponse
-	48,  // 125: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:output_type -> workflow.plugin.external.iac.CapabilitiesResponse
-	50,  // 126: workflow.plugin.external.iac.IaCProviderRequired.Plan:output_type -> workflow.plugin.external.iac.PlanResponse
-	52,  // 127: workflow.plugin.external.iac.IaCProviderRequired.Destroy:output_type -> workflow.plugin.external.iac.DestroyResponse
-	54,  // 128: workflow.plugin.external.iac.IaCProviderRequired.Status:output_type -> workflow.plugin.external.iac.StatusResponse
-	56,  // 129: workflow.plugin.external.iac.IaCProviderRequired.Import:output_type -> workflow.plugin.external.iac.ImportResponse
-	58,  // 130: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:output_type -> workflow.plugin.external.iac.ResolveSizingResponse
-	60,  // 131: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:output_type -> workflow.plugin.external.iac.BootstrapStateBackendResponse
-	62,  // 132: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:output_type -> workflow.plugin.external.iac.EnumerateAllResponse
-	64,  // 133: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:output_type -> workflow.plugin.external.iac.EnumerateByTagResponse
-	66,  // 134: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:output_type -> workflow.plugin.external.iac.DetectDriftResponse
-	68,  // 135: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:output_type -> workflow.plugin.external.iac.DetectDriftWithSpecsResponse
-	70,  // 136: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:output_type -> workflow.plugin.external.iac.RevokeProviderCredentialResponse
-	72,  // 137: workflow.plugin.external.iac.IaCProviderFinalizer.FinalizeApply:output_type -> workflow.plugin.external.iac.FinalizeApplyResponse
-	74,  // 138: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:output_type -> workflow.plugin.external.iac.RepairDirtyMigrationResponse
-	76,  // 139: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:output_type -> workflow.plugin.external.iac.ValidatePlanResponse
-	78,  // 140: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:output_type -> workflow.plugin.external.iac.DetectDriftConfigResponse
-	80,  // 141: workflow.plugin.external.iac.IaCProviderLogCapture.CaptureLogs:output_type -> workflow.plugin.external.iac.LogChunk
-	23,  // 142: workflow.plugin.external.iac.IaCRequirementDiscovery.DiscoverRequirements:output_type -> workflow.plugin.external.iac.DiscoverRequirementsResponse
-	28,  // 143: workflow.plugin.external.iac.IaCProviderRequirementMapper.MapRequirements:output_type -> workflow.plugin.external.iac.MapRequirementsResponse
-	82,  // 144: workflow.plugin.external.iac.ResourceDriver.Create:output_type -> workflow.plugin.external.iac.ResourceCreateResponse
-	84,  // 145: workflow.plugin.external.iac.ResourceDriver.Read:output_type -> workflow.plugin.external.iac.ResourceReadResponse
-	86,  // 146: workflow.plugin.external.iac.ResourceDriver.Update:output_type -> workflow.plugin.external.iac.ResourceUpdateResponse
-	88,  // 147: workflow.plugin.external.iac.ResourceDriver.Delete:output_type -> workflow.plugin.external.iac.ResourceDeleteResponse
-	90,  // 148: workflow.plugin.external.iac.ResourceDriver.Diff:output_type -> workflow.plugin.external.iac.ResourceDiffResponse
-	92,  // 149: workflow.plugin.external.iac.ResourceDriver.Scale:output_type -> workflow.plugin.external.iac.ResourceScaleResponse
-	94,  // 150: workflow.plugin.external.iac.ResourceDriver.HealthCheck:output_type -> workflow.plugin.external.iac.ResourceHealthCheckResponse
-	96,  // 151: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:output_type -> workflow.plugin.external.iac.SensitiveKeysResponse
-	98,  // 152: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:output_type -> workflow.plugin.external.iac.TroubleshootResponse
-	101, // 153: workflow.plugin.external.iac.IaCStateBackend.Configure:output_type -> workflow.plugin.external.iac.ConfigureResponse
-	103, // 154: workflow.plugin.external.iac.IaCStateBackend.GetState:output_type -> workflow.plugin.external.iac.GetStateResponse
-	105, // 155: workflow.plugin.external.iac.IaCStateBackend.SaveState:output_type -> workflow.plugin.external.iac.SaveStateResponse
-	107, // 156: workflow.plugin.external.iac.IaCStateBackend.ListStates:output_type -> workflow.plugin.external.iac.ListStatesResponse
-	109, // 157: workflow.plugin.external.iac.IaCStateBackend.DeleteState:output_type -> workflow.plugin.external.iac.DeleteStateResponse
-	111, // 158: workflow.plugin.external.iac.IaCStateBackend.Lock:output_type -> workflow.plugin.external.iac.LockResponse
-	113, // 159: workflow.plugin.external.iac.IaCStateBackend.Unlock:output_type -> workflow.plugin.external.iac.UnlockResponse
-	115, // 160: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:output_type -> workflow.plugin.external.iac.ListBackendNamesResponse
-	122, // [122:161] is the sub-list for method output_type
-	83,  // [83:122] is the sub-list for method input_type
-	83,  // [83:83] is the sub-list for extension type_name
-	83,  // [83:83] is the sub-list for extension extendee
-	0,   // [0:83] is the sub-list for field type_name
+	72,  // 51: workflow.plugin.external.iac.ListRegionsResponse.regions:type_name -> workflow.plugin.external.iac.ProviderRegion
+	36,  // 52: workflow.plugin.external.iac.FinalizeApplyResponse.errors:type_name -> workflow.plugin.external.iac.ActionError
+	39,  // 53: workflow.plugin.external.iac.RepairDirtyMigrationRequest.request:type_name -> workflow.plugin.external.iac.MigrationRepairRequest
+	40,  // 54: workflow.plugin.external.iac.RepairDirtyMigrationResponse.result:type_name -> workflow.plugin.external.iac.MigrationRepairResult
+	35,  // 55: workflow.plugin.external.iac.ValidatePlanRequest.plan:type_name -> workflow.plugin.external.iac.IaCPlan
+	33,  // 56: workflow.plugin.external.iac.ValidatePlanResponse.diagnostics:type_name -> workflow.plugin.external.iac.PlanDiagnostic
+	10,  // 57: workflow.plugin.external.iac.DetectDriftConfigRequest.refs:type_name -> workflow.plugin.external.iac.ResourceRef
+	124, // 58: workflow.plugin.external.iac.DetectDriftConfigRequest.specs:type_name -> workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry
+	29,  // 59: workflow.plugin.external.iac.DetectDriftConfigResponse.drifts:type_name -> workflow.plugin.external.iac.DriftResult
+	8,   // 60: workflow.plugin.external.iac.CaptureLogsRequest.log_type:type_name -> workflow.plugin.external.iac.LogCaptureType
+	9,   // 61: workflow.plugin.external.iac.ResourceCreateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
+	15,  // 62: workflow.plugin.external.iac.ResourceCreateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	10,  // 63: workflow.plugin.external.iac.ResourceReadRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	15,  // 64: workflow.plugin.external.iac.ResourceReadResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	10,  // 65: workflow.plugin.external.iac.ResourceUpdateRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	9,   // 66: workflow.plugin.external.iac.ResourceUpdateRequest.spec:type_name -> workflow.plugin.external.iac.ResourceSpec
+	15,  // 67: workflow.plugin.external.iac.ResourceUpdateResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	10,  // 68: workflow.plugin.external.iac.ResourceDeleteRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	9,   // 69: workflow.plugin.external.iac.ResourceDiffRequest.desired:type_name -> workflow.plugin.external.iac.ResourceSpec
+	15,  // 70: workflow.plugin.external.iac.ResourceDiffRequest.current:type_name -> workflow.plugin.external.iac.ResourceOutput
+	18,  // 71: workflow.plugin.external.iac.ResourceDiffResponse.result:type_name -> workflow.plugin.external.iac.DiffResult
+	10,  // 72: workflow.plugin.external.iac.ResourceScaleRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	15,  // 73: workflow.plugin.external.iac.ResourceScaleResponse.output:type_name -> workflow.plugin.external.iac.ResourceOutput
+	10,  // 74: workflow.plugin.external.iac.ResourceHealthCheckRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	31,  // 75: workflow.plugin.external.iac.ResourceHealthCheckResponse.result:type_name -> workflow.plugin.external.iac.HealthResult
+	10,  // 76: workflow.plugin.external.iac.TroubleshootRequest.ref:type_name -> workflow.plugin.external.iac.ResourceRef
+	32,  // 77: workflow.plugin.external.iac.TroubleshootResponse.diagnostics:type_name -> workflow.plugin.external.iac.Diagnostic
+	102, // 78: workflow.plugin.external.iac.GetStateResponse.state:type_name -> workflow.plugin.external.iac.IaCState
+	102, // 79: workflow.plugin.external.iac.SaveStateRequest.state:type_name -> workflow.plugin.external.iac.IaCState
+	125, // 80: workflow.plugin.external.iac.ListStatesRequest.filter:type_name -> workflow.plugin.external.iac.ListStatesRequest.FilterEntry
+	102, // 81: workflow.plugin.external.iac.ListStatesResponse.states:type_name -> workflow.plugin.external.iac.IaCState
+	9,   // 82: workflow.plugin.external.iac.DetectDriftWithSpecsRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
+	9,   // 83: workflow.plugin.external.iac.DetectDriftConfigRequest.SpecsEntry.value:type_name -> workflow.plugin.external.iac.ResourceSpec
+	41,  // 84: workflow.plugin.external.iac.IaCProviderRequired.Initialize:input_type -> workflow.plugin.external.iac.InitializeRequest
+	43,  // 85: workflow.plugin.external.iac.IaCProviderRequired.Name:input_type -> workflow.plugin.external.iac.NameRequest
+	45,  // 86: workflow.plugin.external.iac.IaCProviderRequired.Version:input_type -> workflow.plugin.external.iac.VersionRequest
+	47,  // 87: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:input_type -> workflow.plugin.external.iac.CapabilitiesRequest
+	49,  // 88: workflow.plugin.external.iac.IaCProviderRequired.Plan:input_type -> workflow.plugin.external.iac.PlanRequest
+	51,  // 89: workflow.plugin.external.iac.IaCProviderRequired.Destroy:input_type -> workflow.plugin.external.iac.DestroyRequest
+	53,  // 90: workflow.plugin.external.iac.IaCProviderRequired.Status:input_type -> workflow.plugin.external.iac.StatusRequest
+	55,  // 91: workflow.plugin.external.iac.IaCProviderRequired.Import:input_type -> workflow.plugin.external.iac.ImportRequest
+	57,  // 92: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:input_type -> workflow.plugin.external.iac.ResolveSizingRequest
+	59,  // 93: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:input_type -> workflow.plugin.external.iac.BootstrapStateBackendRequest
+	61,  // 94: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:input_type -> workflow.plugin.external.iac.EnumerateAllRequest
+	63,  // 95: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:input_type -> workflow.plugin.external.iac.EnumerateByTagRequest
+	65,  // 96: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:input_type -> workflow.plugin.external.iac.DetectDriftRequest
+	67,  // 97: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:input_type -> workflow.plugin.external.iac.DetectDriftWithSpecsRequest
+	69,  // 98: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:input_type -> workflow.plugin.external.iac.RevokeProviderCredentialRequest
+	71,  // 99: workflow.plugin.external.iac.IaCProviderRegionLister.ListRegions:input_type -> workflow.plugin.external.iac.ListRegionsRequest
+	74,  // 100: workflow.plugin.external.iac.IaCProviderFinalizer.FinalizeApply:input_type -> workflow.plugin.external.iac.FinalizeApplyRequest
+	76,  // 101: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:input_type -> workflow.plugin.external.iac.RepairDirtyMigrationRequest
+	78,  // 102: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:input_type -> workflow.plugin.external.iac.ValidatePlanRequest
+	80,  // 103: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:input_type -> workflow.plugin.external.iac.DetectDriftConfigRequest
+	82,  // 104: workflow.plugin.external.iac.IaCProviderLogCapture.CaptureLogs:input_type -> workflow.plugin.external.iac.CaptureLogsRequest
+	20,  // 105: workflow.plugin.external.iac.IaCRequirementDiscovery.DiscoverRequirements:input_type -> workflow.plugin.external.iac.DiscoverRequirementsRequest
+	24,  // 106: workflow.plugin.external.iac.IaCProviderRequirementMapper.MapRequirements:input_type -> workflow.plugin.external.iac.MapRequirementsRequest
+	84,  // 107: workflow.plugin.external.iac.ResourceDriver.Create:input_type -> workflow.plugin.external.iac.ResourceCreateRequest
+	86,  // 108: workflow.plugin.external.iac.ResourceDriver.Read:input_type -> workflow.plugin.external.iac.ResourceReadRequest
+	88,  // 109: workflow.plugin.external.iac.ResourceDriver.Update:input_type -> workflow.plugin.external.iac.ResourceUpdateRequest
+	90,  // 110: workflow.plugin.external.iac.ResourceDriver.Delete:input_type -> workflow.plugin.external.iac.ResourceDeleteRequest
+	92,  // 111: workflow.plugin.external.iac.ResourceDriver.Diff:input_type -> workflow.plugin.external.iac.ResourceDiffRequest
+	94,  // 112: workflow.plugin.external.iac.ResourceDriver.Scale:input_type -> workflow.plugin.external.iac.ResourceScaleRequest
+	96,  // 113: workflow.plugin.external.iac.ResourceDriver.HealthCheck:input_type -> workflow.plugin.external.iac.ResourceHealthCheckRequest
+	98,  // 114: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:input_type -> workflow.plugin.external.iac.SensitiveKeysRequest
+	100, // 115: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:input_type -> workflow.plugin.external.iac.TroubleshootRequest
+	103, // 116: workflow.plugin.external.iac.IaCStateBackend.Configure:input_type -> workflow.plugin.external.iac.ConfigureRequest
+	105, // 117: workflow.plugin.external.iac.IaCStateBackend.GetState:input_type -> workflow.plugin.external.iac.GetStateRequest
+	107, // 118: workflow.plugin.external.iac.IaCStateBackend.SaveState:input_type -> workflow.plugin.external.iac.SaveStateRequest
+	109, // 119: workflow.plugin.external.iac.IaCStateBackend.ListStates:input_type -> workflow.plugin.external.iac.ListStatesRequest
+	111, // 120: workflow.plugin.external.iac.IaCStateBackend.DeleteState:input_type -> workflow.plugin.external.iac.DeleteStateRequest
+	113, // 121: workflow.plugin.external.iac.IaCStateBackend.Lock:input_type -> workflow.plugin.external.iac.LockRequest
+	115, // 122: workflow.plugin.external.iac.IaCStateBackend.Unlock:input_type -> workflow.plugin.external.iac.UnlockRequest
+	117, // 123: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:input_type -> workflow.plugin.external.iac.ListBackendNamesRequest
+	42,  // 124: workflow.plugin.external.iac.IaCProviderRequired.Initialize:output_type -> workflow.plugin.external.iac.InitializeResponse
+	44,  // 125: workflow.plugin.external.iac.IaCProviderRequired.Name:output_type -> workflow.plugin.external.iac.NameResponse
+	46,  // 126: workflow.plugin.external.iac.IaCProviderRequired.Version:output_type -> workflow.plugin.external.iac.VersionResponse
+	48,  // 127: workflow.plugin.external.iac.IaCProviderRequired.Capabilities:output_type -> workflow.plugin.external.iac.CapabilitiesResponse
+	50,  // 128: workflow.plugin.external.iac.IaCProviderRequired.Plan:output_type -> workflow.plugin.external.iac.PlanResponse
+	52,  // 129: workflow.plugin.external.iac.IaCProviderRequired.Destroy:output_type -> workflow.plugin.external.iac.DestroyResponse
+	54,  // 130: workflow.plugin.external.iac.IaCProviderRequired.Status:output_type -> workflow.plugin.external.iac.StatusResponse
+	56,  // 131: workflow.plugin.external.iac.IaCProviderRequired.Import:output_type -> workflow.plugin.external.iac.ImportResponse
+	58,  // 132: workflow.plugin.external.iac.IaCProviderRequired.ResolveSizing:output_type -> workflow.plugin.external.iac.ResolveSizingResponse
+	60,  // 133: workflow.plugin.external.iac.IaCProviderRequired.BootstrapStateBackend:output_type -> workflow.plugin.external.iac.BootstrapStateBackendResponse
+	62,  // 134: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateAll:output_type -> workflow.plugin.external.iac.EnumerateAllResponse
+	64,  // 135: workflow.plugin.external.iac.IaCProviderEnumerator.EnumerateByTag:output_type -> workflow.plugin.external.iac.EnumerateByTagResponse
+	66,  // 136: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDrift:output_type -> workflow.plugin.external.iac.DetectDriftResponse
+	68,  // 137: workflow.plugin.external.iac.IaCProviderDriftDetector.DetectDriftWithSpecs:output_type -> workflow.plugin.external.iac.DetectDriftWithSpecsResponse
+	70,  // 138: workflow.plugin.external.iac.IaCProviderCredentialRevoker.RevokeProviderCredential:output_type -> workflow.plugin.external.iac.RevokeProviderCredentialResponse
+	73,  // 139: workflow.plugin.external.iac.IaCProviderRegionLister.ListRegions:output_type -> workflow.plugin.external.iac.ListRegionsResponse
+	75,  // 140: workflow.plugin.external.iac.IaCProviderFinalizer.FinalizeApply:output_type -> workflow.plugin.external.iac.FinalizeApplyResponse
+	77,  // 141: workflow.plugin.external.iac.IaCProviderMigrationRepairer.RepairDirtyMigration:output_type -> workflow.plugin.external.iac.RepairDirtyMigrationResponse
+	79,  // 142: workflow.plugin.external.iac.IaCProviderValidator.ValidatePlan:output_type -> workflow.plugin.external.iac.ValidatePlanResponse
+	81,  // 143: workflow.plugin.external.iac.IaCProviderDriftConfigDetector.DetectDriftConfig:output_type -> workflow.plugin.external.iac.DetectDriftConfigResponse
+	83,  // 144: workflow.plugin.external.iac.IaCProviderLogCapture.CaptureLogs:output_type -> workflow.plugin.external.iac.LogChunk
+	23,  // 145: workflow.plugin.external.iac.IaCRequirementDiscovery.DiscoverRequirements:output_type -> workflow.plugin.external.iac.DiscoverRequirementsResponse
+	28,  // 146: workflow.plugin.external.iac.IaCProviderRequirementMapper.MapRequirements:output_type -> workflow.plugin.external.iac.MapRequirementsResponse
+	85,  // 147: workflow.plugin.external.iac.ResourceDriver.Create:output_type -> workflow.plugin.external.iac.ResourceCreateResponse
+	87,  // 148: workflow.plugin.external.iac.ResourceDriver.Read:output_type -> workflow.plugin.external.iac.ResourceReadResponse
+	89,  // 149: workflow.plugin.external.iac.ResourceDriver.Update:output_type -> workflow.plugin.external.iac.ResourceUpdateResponse
+	91,  // 150: workflow.plugin.external.iac.ResourceDriver.Delete:output_type -> workflow.plugin.external.iac.ResourceDeleteResponse
+	93,  // 151: workflow.plugin.external.iac.ResourceDriver.Diff:output_type -> workflow.plugin.external.iac.ResourceDiffResponse
+	95,  // 152: workflow.plugin.external.iac.ResourceDriver.Scale:output_type -> workflow.plugin.external.iac.ResourceScaleResponse
+	97,  // 153: workflow.plugin.external.iac.ResourceDriver.HealthCheck:output_type -> workflow.plugin.external.iac.ResourceHealthCheckResponse
+	99,  // 154: workflow.plugin.external.iac.ResourceDriver.SensitiveKeys:output_type -> workflow.plugin.external.iac.SensitiveKeysResponse
+	101, // 155: workflow.plugin.external.iac.ResourceDriver.Troubleshoot:output_type -> workflow.plugin.external.iac.TroubleshootResponse
+	104, // 156: workflow.plugin.external.iac.IaCStateBackend.Configure:output_type -> workflow.plugin.external.iac.ConfigureResponse
+	106, // 157: workflow.plugin.external.iac.IaCStateBackend.GetState:output_type -> workflow.plugin.external.iac.GetStateResponse
+	108, // 158: workflow.plugin.external.iac.IaCStateBackend.SaveState:output_type -> workflow.plugin.external.iac.SaveStateResponse
+	110, // 159: workflow.plugin.external.iac.IaCStateBackend.ListStates:output_type -> workflow.plugin.external.iac.ListStatesResponse
+	112, // 160: workflow.plugin.external.iac.IaCStateBackend.DeleteState:output_type -> workflow.plugin.external.iac.DeleteStateResponse
+	114, // 161: workflow.plugin.external.iac.IaCStateBackend.Lock:output_type -> workflow.plugin.external.iac.LockResponse
+	116, // 162: workflow.plugin.external.iac.IaCStateBackend.Unlock:output_type -> workflow.plugin.external.iac.UnlockResponse
+	118, // 163: workflow.plugin.external.iac.IaCStateBackend.ListBackendNames:output_type -> workflow.plugin.external.iac.ListBackendNamesResponse
+	124, // [124:164] is the sub-list for method output_type
+	84,  // [84:124] is the sub-list for method input_type
+	84,  // [84:84] is the sub-list for extension type_name
+	84,  // [84:84] is the sub-list for extension extendee
+	0,   // [0:84] is the sub-list for field type_name
 }
 
 func init() { file_iac_proto_init() }
@@ -7437,9 +7598,9 @@ func file_iac_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_iac_proto_rawDesc), len(file_iac_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   114,
+			NumMessages:   117,
 			NumExtensions: 0,
-			NumServices:   13,
+			NumServices:   14,
 		},
 		GoTypes:           file_iac_proto_goTypes,
 		DependencyIndexes: file_iac_proto_depIdxs,

--- a/plugin/external/proto/iac.proto
+++ b/plugin/external/proto/iac.proto
@@ -61,6 +61,10 @@ service IaCProviderCredentialRevoker {
   rpc RevokeProviderCredential(RevokeProviderCredentialRequest) returns (RevokeProviderCredentialResponse);
 }
 
+service IaCProviderRegionLister {
+  rpc ListRegions(ListRegionsRequest) returns (ListRegionsResponse);
+}
+
 // IaCProviderFinalizer is the optional service plugins implement when
 // they need a post-apply-loop finalizer hook under v2 dispatch.
 // Use case: DigitalOcean plugin's database trusted_sources deferred-flush
@@ -646,6 +650,25 @@ message RevokeProviderCredentialRequest {
   string credential_id = 2;
 }
 message RevokeProviderCredentialResponse {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IaCProviderRegionLister messages.
+// ─────────────────────────────────────────────────────────────────────────────
+message ListRegionsRequest {
+  // env_name is the optional Workflow environment selected by the caller.
+  string env_name = 1;
+}
+
+message ProviderRegion {
+  // name is the provider-specific region identifier used in Workflow config.
+  string name = 1;
+  // display_name is optional UI text. Empty means consumers should show name.
+  string display_name = 2;
+}
+
+message ListRegionsResponse {
+  repeated ProviderRegion regions = 1;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // IaCProviderFinalizer messages.

--- a/plugin/external/proto/iac_grpc.pb.go
+++ b/plugin/external/proto/iac_grpc.pb.go
@@ -4,7 +4,7 @@
 // Plan:   docs/plans/2026-05-10-strict-contracts-force-cutover.md (Task 3)
 //
 // Hard invariants (per cycle 4 §Acceptance criteria):
-//   - NO google.protobuf.Struct, NO google.protobuf.Any used in any message.
+//   - NO loose Struct/Any wrapper types used in any message.
 //   - Free-form per-resource Config / Outputs payloads cross the wire as
 //     bytes <name>_json, JSON-encoded by the plugin/host. The plugin owns
 //     the serialization shape; the proto layer carries opaque bytes.
@@ -880,6 +880,109 @@ var IaCProviderCredentialRevoker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RevokeProviderCredential",
 			Handler:    _IaCProviderCredentialRevoker_RevokeProviderCredential_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "iac.proto",
+}
+
+const (
+	IaCProviderRegionLister_ListRegions_FullMethodName = "/workflow.plugin.external.iac.IaCProviderRegionLister/ListRegions"
+)
+
+// IaCProviderRegionListerClient is the client API for IaCProviderRegionLister service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+type IaCProviderRegionListerClient interface {
+	ListRegions(ctx context.Context, in *ListRegionsRequest, opts ...grpc.CallOption) (*ListRegionsResponse, error)
+}
+
+type iaCProviderRegionListerClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewIaCProviderRegionListerClient(cc grpc.ClientConnInterface) IaCProviderRegionListerClient {
+	return &iaCProviderRegionListerClient{cc}
+}
+
+func (c *iaCProviderRegionListerClient) ListRegions(ctx context.Context, in *ListRegionsRequest, opts ...grpc.CallOption) (*ListRegionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRegionsResponse)
+	err := c.cc.Invoke(ctx, IaCProviderRegionLister_ListRegions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// IaCProviderRegionListerServer is the server API for IaCProviderRegionLister service.
+// All implementations must embed UnimplementedIaCProviderRegionListerServer
+// for forward compatibility.
+type IaCProviderRegionListerServer interface {
+	ListRegions(context.Context, *ListRegionsRequest) (*ListRegionsResponse, error)
+	mustEmbedUnimplementedIaCProviderRegionListerServer()
+}
+
+// UnimplementedIaCProviderRegionListerServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedIaCProviderRegionListerServer struct{}
+
+func (UnimplementedIaCProviderRegionListerServer) ListRegions(context.Context, *ListRegionsRequest) (*ListRegionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListRegions not implemented")
+}
+func (UnimplementedIaCProviderRegionListerServer) mustEmbedUnimplementedIaCProviderRegionListerServer() {
+}
+func (UnimplementedIaCProviderRegionListerServer) testEmbeddedByValue() {}
+
+// UnsafeIaCProviderRegionListerServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to IaCProviderRegionListerServer will
+// result in compilation errors.
+type UnsafeIaCProviderRegionListerServer interface {
+	mustEmbedUnimplementedIaCProviderRegionListerServer()
+}
+
+func RegisterIaCProviderRegionListerServer(s grpc.ServiceRegistrar, srv IaCProviderRegionListerServer) {
+	// If the following call panics, it indicates UnimplementedIaCProviderRegionListerServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&IaCProviderRegionLister_ServiceDesc, srv)
+}
+
+func _IaCProviderRegionLister_ListRegions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRegionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(IaCProviderRegionListerServer).ListRegions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: IaCProviderRegionLister_ListRegions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(IaCProviderRegionListerServer).ListRegions(ctx, req.(*ListRegionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// IaCProviderRegionLister_ServiceDesc is the grpc.ServiceDesc for IaCProviderRegionLister service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var IaCProviderRegionLister_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "workflow.plugin.external.iac.IaCProviderRegionLister",
+	HandlerType: (*IaCProviderRegionListerServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ListRegions",
+			Handler:    _IaCProviderRegionLister_ListRegions_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/plugin/external/proto/iac_proto_test.go
+++ b/plugin/external/proto/iac_proto_test.go
@@ -71,6 +71,7 @@ func TestOptionalServicesHaveDistinctInterfaces(t *testing.T) {
 		pb.IaCProviderEnumeratorServer
 		pb.IaCProviderDriftDetectorServer
 		pb.IaCProviderCredentialRevokerServer
+		pb.IaCProviderRegionListerServer
 		pb.IaCProviderMigrationRepairerServer
 		pb.IaCProviderValidatorServer
 		pb.IaCProviderDriftConfigDetectorServer
@@ -83,6 +84,7 @@ type allOptionalStub struct {
 	pb.UnimplementedIaCProviderEnumeratorServer
 	pb.UnimplementedIaCProviderDriftDetectorServer
 	pb.UnimplementedIaCProviderCredentialRevokerServer
+	pb.UnimplementedIaCProviderRegionListerServer
 	pb.UnimplementedIaCProviderMigrationRepairerServer
 	pb.UnimplementedIaCProviderValidatorServer
 	pb.UnimplementedIaCProviderDriftConfigDetectorServer

--- a/plugin/external/sdk/contracts_iac_test.go
+++ b/plugin/external/sdk/contracts_iac_test.go
@@ -34,6 +34,7 @@ func TestBuildContractRegistry_AdvertisesRegisteredIaCServices(t *testing.T) {
 		"workflow.plugin.external.iac.IaCProviderRequired",
 		"workflow.plugin.external.iac.IaCProviderEnumerator",
 		"workflow.plugin.external.iac.IaCProviderDriftDetector",
+		"workflow.plugin.external.iac.IaCProviderRegionLister",
 	}
 	for _, name := range want {
 		if !services[name] {
@@ -132,6 +133,7 @@ type iacContractProviderStub struct {
 	pb.UnimplementedIaCProviderRequiredServer
 	pb.UnimplementedIaCProviderEnumeratorServer
 	pb.UnimplementedIaCProviderDriftDetectorServer
+	pb.UnimplementedIaCProviderRegionListerServer
 }
 
 type iacRequirementContractProviderStub struct {

--- a/plugin/external/sdk/iacserver.go
+++ b/plugin/external/sdk/iacserver.go
@@ -34,6 +34,7 @@ import (
 //	pb.IaCProviderEnumeratorServer
 //	pb.IaCProviderDriftDetectorServer
 //	pb.IaCProviderCredentialRevokerServer
+//	pb.IaCProviderRegionListerServer
 //	pb.IaCProviderMigrationRepairerServer
 //	pb.IaCProviderValidatorServer
 //	pb.IaCProviderDriftConfigDetectorServer
@@ -158,6 +159,9 @@ func registerIaCServicesOnly(s *grpc.Server, provider any) error {
 	}
 	if v, ok := provider.(pb.IaCProviderCredentialRevokerServer); ok {
 		pb.RegisterIaCProviderCredentialRevokerServer(s, v)
+	}
+	if v, ok := provider.(pb.IaCProviderRegionListerServer); ok {
+		pb.RegisterIaCProviderRegionListerServer(s, v)
 	}
 	if v, ok := provider.(pb.IaCProviderMigrationRepairerServer); ok {
 		pb.RegisterIaCProviderMigrationRepairerServer(s, v)

--- a/wftest/bdd/strict_iac.go
+++ b/wftest/bdd/strict_iac.go
@@ -89,6 +89,10 @@ var iacServiceChecks = []iacServiceCheck{
 		_, ok := p.(pb.IaCProviderRequirementMapperServer)
 		return ok
 	}},
+	{"workflow.plugin.external.iac.IaCProviderRegionLister", func(p any) bool {
+		_, ok := p.(pb.IaCProviderRegionListerServer)
+		return ok
+	}},
 }
 
 // AssertProviderCapabilitiesMatchRegistration asserts that every typed


### PR DESCRIPTION
## Summary
- add optional `IaCProviderRegionLister` gRPC service and generated bindings
- auto-register/advertise the optional service through the plugin SDK and ContractRegistry
- wire wfctl typed adapter support and let infra-admin prefer provider-sourced regions with local-catalog fallback

Closes part of #813. Provider plugin implementations will cascade after this core contract PR lands.

## Verification
- `GOWORK=off go test ./plugin/external/proto -run TestOptionalServicesHaveDistinctInterfaces -count=1`
- `GOWORK=off go test ./plugin/external/sdk -run TestBuildContractRegistry_AdvertisesRegisteredIaCServices -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestTypedAdapter_(OptionalReturnsUnimplementedSentinel|RegionLister|ListProviderRegions)' -count=1`\n- `GOWORK=off go test ./iac/admin/handler -run 'TestListProviders_(UsesProviderRegionListerWhenAvailable|RegionListerErrorFallsBackToLocalCatalog|PopulatesRegionsAndEnginesAndTypes)' -count=1`\n- `GOWORK=off go test ./plugin/external/... ./iac/admin/... -count=1`\n- `GOWORK=off go test ./cmd/wfctl -run 'TestTypedAdapter|TestInfraAdminCLI_ListProvidersOutput_RoundTrip' -count=1`\n- `GOWORK=off golangci-lint run ./plugin/external/... ./iac/admin/... ./cmd/wfctl`\n- `GOWORK=off go build -o /tmp/wfctl-813 ./cmd/wfctl`\n- `GOWORK=off go test ./cmd/wfctl -count=1 -timeout 300s`\n- `git diff --check`\n\n## Notes\n- `buf lint` still fails on existing repo-wide proto lint drift (package/version/service-name conventions); the new service intentionally follows existing IaC service naming.