### PR TITLE
fix(module/infra_admin): populate provider types in Start, not Init (live config-section ordering bug)

### DIFF
--- a/module/infra_admin.go
+++ b/module/infra_admin.go
@@ -397,13 +397,15 @@ func (m *InfraAdmin) Init(app modular.Application) error {
 		m.providerMu[pm] = &sync.Mutex{}
 	}
 
-	// Populate providerTypeByModule from the loaded WorkflowConfig
-	// per spec-reviewer T6 F1 + design cycle-5/6: handler.
-	// ListProviders needs the YAML-config `provider:` string, NOT
-	// the plugin's display name from provider.Name().
-	if err := m.populateProviderTypes(app); err != nil {
-		return fmt.Errorf("infra.admin: populate provider types: %w", err)
-	}
+	// NOTE: providerTypeByModule / wfCfg / desiredSpecs are populated in
+	// Start(), NOT here. engine.BuildFromConfig registers the "workflow"
+	// config section AFTER app.Init() (engine.go: app.Init() then
+	// RegisterConfigSection("workflow")), so app.GetConfigSection("workflow")
+	// returns "not found" during Init and would silently degrade
+	// provider_type, supported_regions, and the mutation desiredSpecs to
+	// empty. Start() runs after BuildFromConfig completes, when the section
+	// is present. (Surfaced by scenario-92 live boot; unit tests pre-register
+	// the section via withConfigSectionApp so they did not catch it.)
 
 	// In-process catalogs.
 	m.fieldCatalog = catalog.New()
@@ -561,6 +563,14 @@ func (m *InfraAdmin) Start(ctx context.Context) error {
 	}
 	if err := m.app.GetService("workflowEngine", &m.engine); err != nil {
 		return fmt.Errorf("infra.admin: workflowEngine: %w", err)
+	}
+
+	// Populate providerTypeByModule + wfCfg + desiredSpecs from the loaded
+	// WorkflowConfig. MUST run here (Start), not Init: the engine registers
+	// the "workflow" config section after app.Init(), so this would silently
+	// degrade to empty during Init. Runs before routes serve any request.
+	if err := m.populateProviderTypes(m.app); err != nil {
+		return fmt.Errorf("infra.admin: populate provider types: %w", err)
 	}
 
 	if m.router == nil {

--- a/module/infra_admin_test.go
+++ b/module/infra_admin_test.go
@@ -200,6 +200,13 @@ func TestInfraAdmin_Init_ResolvesAllServices(t *testing.T) {
 	if len(m.providers) != 1 || m.providers["do-provider"] == nil {
 		t.Errorf("providers = %v, want one do-provider entry", m.providers)
 	}
+	// providerTypeByModule is populated in Start() now, not Init() — the
+	// engine registers the "workflow" config section after app.Init(), so
+	// Init-time GetConfigSection would fail. Drive populateProviderTypes
+	// explicitly to assert the F1 contract (the function is unchanged).
+	if err := m.populateProviderTypes(app); err != nil {
+		t.Fatalf("populateProviderTypes: %v", err)
+	}
 	if m.providerTypeByModule["do-provider"] != "digitalocean" {
 		t.Errorf("providerTypeByModule[do-provider] = %q, want digitalocean (F1 contract)", m.providerTypeByModule["do-provider"])
 	}


### PR DESCRIPTION
## Bug

`infra.admin.Init` called `populateProviderTypes(app)` which reads `app.GetConfigSection("workflow")`. But `engine.BuildFromConfig` registers that section **after** `app.Init()`:

```
engine.go BuildFromConfig:  ... app.Init() (≈671) ... RegisterConfigSection("workflow") (≈684)
```

So during `infra.admin.Init`, `GetConfigSection("workflow")` returns `config section not found: workflow` → silent graceful-degradation → **empty `provider_type`, empty `supported_regions`, and empty `wfCfg`/`desiredSpecs`** (the last degrades the actual mutation Plan/Apply path, not just the form's region dropdown).

## Why it was never caught

The v1 infra-admin scenario never booted as a live stack (it referenced an `iac.provider` type no plugin registered). Unit tests pre-register the section via `withConfigSectionApp`, so the live ordering was never exercised. The **scenario-92 v1.1 live boot** surfaced it: region dropdown empty + `curl /api/infra-admin/providers` returned no `provider_type`/`supported_regions`. Debug logging confirmed `section_nil=true err="config section not found: workflow"` at Init.

## Fix

Move the `populateProviderTypes` call from `Init` to `Start` (which runs after `BuildFromConfig` completes, when the section exists, and before any route serves a request). One-line move + a comment; `TestInfraAdmin_Init_ResolvesAllServices` updated to drive `populateProviderTypes` explicitly.

## Verification

`go test -race ./module/ ./iac/admin/...` green; `golangci-lint --new-from-rev=origin/main` 0. **Live-proven:** scenario-92 stack boots, `providers` now returns `provider_type:"stub"` + `supported_regions:[test-region-1,test-region-2]`, and the full scenario-92 Playwright suite goes **20/20** (region depends_on provider + generate-config now pass; RBAC viewer→403, CSRF→401, apply→200 all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)