### PR TITLE
fix: skip event recording without execution id

### DIFF
--- a/module/pipeline_event_recording_test.go
+++ b/module/pipeline_event_recording_test.go
@@ -79,6 +79,30 @@ func TestPipeline_NilEventRecorder_NoEvents(t *testing.T) {
 	}
 }
 
+func TestPipeline_EventRecorder_EmptyExecutionIDSkipsRecording(t *testing.T) {
+	recorder := &mockEventRecorder{
+		err: fmt.Errorf("parse execution ID \"\": invalid UUID length: 0"),
+	}
+
+	p := &Pipeline{
+		Name:          "inline-http",
+		Steps:         []PipelineStep{newMockStep("step1", map[string]any{"ok": true})},
+		OnError:       ErrorStrategyStop,
+		EventRecorder: recorder,
+	}
+
+	pc, err := p.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("pipeline should succeed without execution tracking: %v", err)
+	}
+	if pc.Current["ok"] != true {
+		t.Fatalf("expected step output to be merged, got %#v", pc.Current)
+	}
+	if events := recorder.getEvents(); len(events) != 0 {
+		t.Fatalf("empty ExecutionID should skip recorder calls, got %+v", events)
+	}
+}
+
 func TestPipeline_EventRecorder_SuccessfulExecution(t *testing.T) {
 	recorder := &mockEventRecorder{}
 

--- a/module/pipeline_executor.go
+++ b/module/pipeline_executor.go
@@ -61,8 +61,9 @@ type Pipeline struct {
 }
 
 // recordEvent is a nil-safe helper that records an event via EventRecorder.
-// If EventRecorder is nil, this is a no-op. Errors are logged but never
-// returned — event recording is best-effort and must not fail the pipeline.
+// If EventRecorder is nil or ExecutionID is empty, this is a no-op. Errors are
+// logged but never returned — event recording is best-effort and must not fail
+// the pipeline.
 func (p *Pipeline) recordEvent(ctx context.Context, eventType string, data map[string]any) {
 	if p.EventRecorder == nil || p.ExecutionID == "" {
 		return

--- a/module/pipeline_executor.go
+++ b/module/pipeline_executor.go
@@ -64,7 +64,7 @@ type Pipeline struct {
 // If EventRecorder is nil, this is a no-op. Errors are logged but never
 // returned — event recording is best-effort and must not fail the pipeline.
 func (p *Pipeline) recordEvent(ctx context.Context, eventType string, data map[string]any) {
-	if p.EventRecorder == nil {
+	if p.EventRecorder == nil || p.ExecutionID == "" {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- skip best-effort pipeline event recording when a recorder is wired but the pipeline has no ExecutionID
- add regression coverage for inline/untracked pipelines so they still execute successfully without recorder calls

Fixes #822

## Verification
- With fix reverted: `GOWORK=off go test ./module -run TestPipeline_EventRecorder_EmptyExecutionIDSkipsRecording -count=1` failed with recorder calls using `execution_id=""` and `parse execution ID "": invalid UUID length: 0` warnings.
- With fix restored: `GOWORK=off go test ./module -run TestPipeline_EventRecorder_EmptyExecutionIDSkipsRecording -count=1` passed.
- `GOWORK=off go test ./module -count=1`
- `git diff --check`