### PR TITLE
fix(secrets): reflect.Pointer not reflect.Ptr (forward-fix main Lint)

### DIFF
--- a/secrets/reachability.go
+++ b/secrets/reachability.go
@@ -143,7 +143,7 @@ func isNilProvider(p Provider) bool {
 	}
 	v := reflect.ValueOf(p)
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
 		return v.IsNil()
 	default:
 		return false


### PR DESCRIPTION
Forward-fix: main CI Lint went red after #843 — golangci-lint v2.12.0 govet flags the deprecated `reflect.Ptr` alias (`secrets/reachability.go:146`) with "Constant reflect.Ptr should be inlined". Replaces it with the canonical `reflect.Pointer`. Local golangci v2.11.4 did not flag this (version gap). Verified: `go vet ./secrets/` clean, build + secrets tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)