### PR TITLE
ci: pin GitHub Actions refs and move Node to 24

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,18 +29,18 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -59,7 +59,7 @@ jobs:
     - name: Restore baseline
       if: github.event_name == 'pull_request'
       id: restore-baseline
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: baseline-bench.txt
         key: go-benchmark-${{ github.event.pull_request.base.ref }}-never
@@ -95,7 +95,7 @@ jobs:
 
     - name: Comment PR with results
       if: github.event_name == 'pull_request' && steps.restore-baseline.outputs.cache-matched-key != ''
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const fs = require('fs');
@@ -160,14 +160,14 @@ jobs:
 
     - name: Save baseline
       if: github.event_name == 'push'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: baseline-bench.txt
         key: go-benchmark-${{ github.ref_name }}-${{ github.sha }}
 
     - name: Upload benchmark results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: benchmark-results
         path: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/ci-wfctl.yml.example
+++ b/.github/workflows/ci-wfctl.yml.example
@@ -50,8 +50,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'   # bumped from generated 1.22 to match repo standard
       - name: Install wfctl
@@ -78,23 +78,23 @@ jobs:
 #       contents: read
 #       packages: write
 #     steps:
-#       - uses: actions/checkout@v6
-#       - uses: actions/setup-go@v5
+#       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+#       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
 #         with:
 #           go-version: '1.26'
 #       - name: Build binary
 #         run: |
 #           GOOS=linux GOARCH=amd64 go build -o bin/server ./cmd/server/
 #       - name: Log in to registry
-#         uses: docker/login-action@v3
+#         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
 #         with:
 #           registry: ${{ env.REGISTRY }}
 #           username: ${{ github.actor }}
 #           password: ${{ secrets.GITHUB_TOKEN }}
 #       - name: Set up Docker Buildx
-#         uses: docker/setup-buildx-action@v3
+#         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 #       - name: Build and push Docker image
-#         uses: docker/build-push-action@v5
+#         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
 #         with:
 #           context: .
 #           push: true

--- a/.github/workflows/ci-wfctl.yml.example
+++ b/.github/workflows/ci-wfctl.yml.example
@@ -50,7 +50,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'   # bumped from generated 1.22 to match repo standard
@@ -78,7 +78,7 @@ jobs:
 #       contents: read
 #       packages: write
 #     steps:
-#       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+#       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
 #         with:
 #           go-version: '1.26'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -95,7 +95,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -118,7 +118,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
       with:
         version: v2.12.0
         args: --timeout=10m
@@ -133,7 +133,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -178,7 +178,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -201,7 +201,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -210,7 +210,7 @@ jobs:
         cache: true
 
     - name: Run golangci-lint on examples
-      uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
       with:
         version: v2.12.0
         args: --timeout=10m
@@ -225,7 +225,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -272,7 +272,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -307,7 +307,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -381,7 +381,7 @@ jobs:
     name: Verify godo is not imported (issue #617)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Grep gate — *.go files must not import godo
         run: |
           ! grep -rn --include="*.go" \
@@ -398,7 +398,7 @@ jobs:
     name: Cloud-SDK inventory + k8s-backend init() partition + asymmetric graph audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
@@ -448,7 +448,7 @@ jobs:
     name: Verify removed AWS SDK packages are not imported (issue #653)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Grep gate — no *.go file (repo-wide) may import fully-removed AWS service packages
         # Scans the whole repo. service/eks is allowed only in provider/ (ECS/EKS deploy pipeline).
         # platform/providers/aws/ was deleted in Phase 3; provider/aws/ (deploy pipeline) is kept.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,18 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -78,7 +78,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
       if: always() && steps.codecov-token.outputs.available == 'true'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -95,18 +95,18 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -118,7 +118,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
       with:
         version: v2.12.0
         args: --timeout=10m
@@ -133,18 +133,18 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -162,7 +162,7 @@ jobs:
       run: go build -v ./...
 
     - name: Upload UI build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: admin-ui-dist
         path: ui/dist/
@@ -178,10 +178,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
@@ -201,16 +201,16 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Run golangci-lint on examples
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
       with:
         version: v2.12.0
         args: --timeout=10m
@@ -225,12 +225,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
@@ -272,12 +272,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -307,18 +307,18 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -381,7 +381,7 @@ jobs:
     name: Verify godo is not imported (issue #617)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Grep gate — *.go files must not import godo
         run: |
           ! grep -rn --include="*.go" \
@@ -398,8 +398,8 @@ jobs:
     name: Cloud-SDK inventory + k8s-backend init() partition + asymmetric graph audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -448,7 +448,7 @@ jobs:
     name: Verify removed AWS SDK packages are not imported (issue #653)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Grep gate — no *.go file (repo-wide) may import fully-removed AWS service packages
         # Scans the whole repo. service/eks is allowed only in provider/ (ECS/EKS deploy pipeline).
         # platform/providers/aws/ was deleted in Phase 3; provider/aws/ (deploy pipeline) is kept.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       if: matrix.language == 'go'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,20 +39,20 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
       if: matrix.language == 'go'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
       if: matrix.language == 'go'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -64,12 +64,12 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         category: "/language:${{ matrix.language }}"

--- a/.github/workflows/conformance-budget-check.yml
+++ b/.github/workflows/conformance-budget-check.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out workflow repo
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Compute the hour-bucket as a step output so the cache step
       # can reference it. Hourly TTL: same PR series re-checking

--- a/.github/workflows/conformance-budget-check.yml
+++ b/.github/workflows/conformance-budget-check.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out workflow repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       # Compute the hour-bucket as a step output so the cache step
       # can reference it. Hourly TTL: same PR series re-checking
@@ -46,13 +46,13 @@ jobs:
         id: hour
         run: echo "value=$(date -u +%Y%m%d%H)" >> "$GITHUB_OUTPUT"
 
-      # actions/cache@v4 does post-step write-back automatically:
+      # actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 does post-step write-back automatically:
       # if cache-hit is false, the action records the path's contents
       # at job-end and uploads under this key for the next run on the
       # same key. No explicit upload-cache step is needed.
       - name: Restore budget result cache
         id: budget-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: budget-${{ github.event.pull_request.base.sha || github.sha }}-${{ steps.hour.outputs.value }}
           path: /tmp/budget-result.json

--- a/.github/workflows/conformance-leak-scrubber.yml
+++ b/.github/workflows/conformance-leak-scrubber.yml
@@ -46,7 +46,7 @@ jobs:
       DAILY_SCRUB_THRESHOLD: 3     # > 3 scrub events / day → file budget incident too
     steps:
       - name: Check out workflow repo
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Detect unconfigured secret. The cron fires on a fixed
       # schedule regardless of secret provisioning state; if the

--- a/.github/workflows/conformance-leak-scrubber.yml
+++ b/.github/workflows/conformance-leak-scrubber.yml
@@ -46,7 +46,7 @@ jobs:
       DAILY_SCRUB_THRESHOLD: 3     # > 3 scrub events / day → file budget incident too
     steps:
       - name: Check out workflow repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       # Detect unconfigured secret. The cron fires on a fixed
       # schedule regardless of secret provisioning state; if the

--- a/.github/workflows/conformance-smoke.yml
+++ b/.github/workflows/conformance-smoke.yml
@@ -72,10 +72,10 @@ jobs:
       CONFORMANCE_TAG: conformance-pr-${{ github.event.pull_request.number }}
     steps:
       - name: Check out workflow repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
           cache: true

--- a/.github/workflows/conformance-smoke.yml
+++ b/.github/workflows/conformance-smoke.yml
@@ -72,7 +72,7 @@ jobs:
       CONFORMANCE_TAG: conformance-pr-${{ github.event.pull_request.number }}
     steps:
       - name: Check out workflow repo
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Setup Go environment for development and testing
       - name: Setup Go
@@ -52,7 +52,7 @@ jobs:
 
       # Install golangci-lint for Go code linting
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         continue-on-error: true
         with:
           version: latest

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,11 +26,11 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       # Setup Go environment for development and testing
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '^1.24.2'
           cache-dependency-path: go.sum
@@ -42,7 +42,7 @@ jobs:
 
       # Setup Docker for containerized development
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Install Go dependencies and development tools
       - name: Install Go dependencies and tools
@@ -52,7 +52,7 @@ jobs:
 
       # Install golangci-lint for Go code linting
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         continue-on-error: true
         with:
           version: latest

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '^1.24.2'
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       # Configure Go for private repository access

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: true
           cache-dependency-path: go.sum
 
       # Configure Go for private repository access

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
           printf '%s\n' "${{ steps.next_version.outputs.tag }}" > release-metadata/release-tag.txt
 
       - name: Upload release metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-metadata
           path: release-metadata/release-tag.txt

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cross-plugin-build-test.yml
+++ b/.github/workflows/cross-plugin-build-test.yml
@@ -52,13 +52,13 @@ jobs:
       matrix:
         plugin: [workflow-plugin-aws, workflow-plugin-gcp, workflow-plugin-azure]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with: { path: workflow }
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: GoCodeAlone/${{ matrix.plugin }}
           path: ${{ matrix.plugin }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: workflow/go.mod }
       # The replace directive points the plugin's go.mod at THIS PR's checkout
       # of workflow (../workflow), NOT at workflow main. The gate exercises
@@ -93,8 +93,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
       - name: Typed-IaC E2E test (in-process gRPC roundtrip)
         run: GOWORK=off go test -tags=integration ./plugin/external/sdk/... -run TestIaC_EndToEnd -count=1 -v

--- a/.github/workflows/cross-plugin-build-test.yml
+++ b/.github/workflows/cross-plugin-build-test.yml
@@ -59,7 +59,7 @@ jobs:
           repository: GoCodeAlone/${{ matrix.plugin }}
           path: ${{ matrix.plugin }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with: { go-version: '1.26' }
+        with: { go-version-file: workflow/go.mod }
       # The replace directive points the plugin's go.mod at THIS PR's checkout
       # of workflow (../workflow), NOT at workflow main. The gate exercises
       # whether the PR's interface changes break AWS/GCP/Azure compilation —

--- a/.github/workflows/cross-plugin-build-test.yml
+++ b/.github/workflows/cross-plugin-build-test.yml
@@ -59,7 +59,7 @@ jobs:
           repository: GoCodeAlone/${{ matrix.plugin }}
           path: ${{ matrix.plugin }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with: { go-version-file: workflow/go.mod }
+        with: { go-version: '1.26' }
       # The replace directive points the plugin's go.mod at THIS PR's checkout
       # of workflow (../workflow), NOT at workflow main. The gate exercises
       # whether the PR's interface changes break AWS/GCP/Azure compilation —

--- a/.github/workflows/cross-plugin-build-test.yml
+++ b/.github/workflows/cross-plugin-build-test.yml
@@ -52,9 +52,9 @@ jobs:
       matrix:
         plugin: [workflow-plugin-aws, workflow-plugin-gcp, workflow-plugin-azure]
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { path: workflow }
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: GoCodeAlone/${{ matrix.plugin }}
           path: ${{ matrix.plugin }}
@@ -93,7 +93,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
       - name: Typed-IaC E2E test (in-process gRPC roundtrip)

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -23,12 +23,12 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24'
         cache: true
@@ -50,7 +50,7 @@ jobs:
         cd example && go build ./...
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: 'chore: update Go dependencies'

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       with:
         version: 'v3.16.0'
 

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Helm
       uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 
@@ -153,7 +153,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,18 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -58,20 +58,20 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -153,16 +153,16 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up ko
-      uses: ko-build/setup-ko@v0.9
+      uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
     - name: Log in to GitHub Container Registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | ko login ghcr.io --username ${{ github.actor }} --password-stdin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -65,7 +65,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -106,7 +106,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 
@@ -188,7 +188,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -244,7 +244,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -65,12 +65,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -90,7 +90,7 @@ jobs:
         echo "UI_TARBALL=workflow-admin-ui-${VERSION}.tar.gz" >> "$GITHUB_ENV"
 
     - name: Upload UI artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: admin-ui
         path: workflow-admin-ui-*.tar.gz
@@ -106,20 +106,20 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -132,7 +132,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up ko
-      uses: ko-build/setup-ko@v0.9
+      uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
     - name: Log in to GitHub Container Registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | ko login ghcr.io --username ${{ github.actor }} --password-stdin
@@ -188,19 +188,19 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Set up Node.js
       if: matrix.build_ui
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
         cache-dependency-path: ui/package-lock.json
@@ -231,7 +231,7 @@ jobs:
         done
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: binaries-${{ matrix.name }}
         path: dist/*
@@ -244,25 +244,25 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         fetch-depth: 0
 
     - name: Download all binary artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         pattern: binaries-*
         path: dist
         merge-multiple: true
 
     - name: Download admin UI artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: admin-ui
         path: dist
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26'
         cache: true
@@ -294,7 +294,7 @@ jobs:
         sha256sum * > checksums.txt
 
     - name: Create Release (draft during asset upload)
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
       with:
         tag_name: ${{ env.TAG_NAME }}
         files: |
@@ -315,7 +315,7 @@ jobs:
     if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
     steps:
     - name: Update wfctl formula in homebrew-tap
-      uses: peter-evans/repository-dispatch@v4
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
       with:
         token: ${{ secrets.repo_dispatch_token }}
         repository: GoCodeAlone/homebrew-tap
@@ -332,7 +332,7 @@ jobs:
         repo: ['GoCodeAlone/workflow-editor']
     steps:
     - name: Trigger IDE update for ${{ matrix.repo }}
-      uses: peter-evans/repository-dispatch@v4
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
       with:
         token: ${{ secrets.repo_dispatch_token }}
         repository: ${{ matrix.repo }}
@@ -346,7 +346,7 @@ jobs:
     if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
     steps:
     - name: Trigger registry manifest sync
-      uses: peter-evans/repository-dispatch@v4
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
       with:
         token: ${{ secrets.repo_dispatch_token }}
         repository: GoCodeAlone/workflow-registry
@@ -360,7 +360,7 @@ jobs:
     if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
     steps:
     - name: Trigger workflow-scenarios bump
-      uses: peter-evans/repository-dispatch@v4
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
       with:
         token: ${{ secrets.repo_dispatch_token }}
         repository: GoCodeAlone/workflow-scenarios

--- a/.github/workflows/test-dispatch.yml
+++ b/.github/workflows/test-dispatch.yml
@@ -25,7 +25,7 @@ jobs:
         echo "REPO_DISPATCH_TOKEN is set"
 
     - name: Dispatch to workflow-editor
-      uses: peter-evans/repository-dispatch@v4
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
       with:
         token: ${{ secrets.REPO_DISPATCH_TOKEN }}
         repository: GoCodeAlone/workflow-editor

--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	githubActionsCheckoutRef   = "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3"
+	githubActionsCheckoutRef   = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
 	githubActionsScriptRef     = "actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7"
 	githubActionsSetupWfctlRef = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
 )

--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+const (
+	githubActionsCheckoutRef   = "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3"
+	githubActionsScriptRef     = "actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7"
+	githubActionsSetupWfctlRef = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+)
+
 // RenderGitHubActions generates GitHub Actions workflow YAML files from a CIPlan.
 // It returns a map of relative paths to YAML content.
 func RenderGitHubActions(p *CIPlan) (map[string]string, error) {
@@ -95,7 +101,7 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 		fmt.Fprintf(&b, "        run: wfctl infra plan --config '%s' --format markdown >> plan.md\n", phase.ConfigPath)
 	}
 	b.WriteString("      - name: Post plan comment\n")
-	b.WriteString("        uses: actions/github-script@v7\n")
+	fmt.Fprintf(&b, "        uses: %s\n", githubActionsScriptRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          script: |\n")
 	b.WriteString("            const fs = require('fs');\n")
@@ -146,13 +152,13 @@ func renderGHAWorkflow(p *CIPlan, name string) (string, error) {
 
 // writeCheckoutStep emits the checkout step.
 func writeCheckoutStep(b *strings.Builder) {
-	b.WriteString("      - uses: actions/checkout@v6\n")
+	fmt.Fprintf(b, "      - uses: %s\n", githubActionsCheckoutRef)
 }
 
 // writeSetupWfctlStep emits the setup-wfctl action step.
 func writeSetupWfctlStep(b *strings.Builder, version string) {
 	b.WriteString("      - name: Install wfctl\n")
-	b.WriteString("        uses: GoCodeAlone/setup-wfctl@v1\n")
+	fmt.Fprintf(b, "        uses: %s\n", githubActionsSetupWfctlRef)
 	b.WriteString("        with:\n")
 	fmt.Fprintf(b, "          version: '%s'\n", version)
 }

--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	githubActionsCheckoutRef   = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
-	githubActionsScriptRef     = "actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7"
+	githubActionsCheckoutRef = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
+	githubActionsScriptRef   = "actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7"
+	// #nosec G101 -- action commit SHA, not a credential.
 	githubActionsSetupWfctlRef = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
 )
 

--- a/cigen/render_gha_test.go
+++ b/cigen/render_gha_test.go
@@ -63,6 +63,38 @@ func TestRenderGitHubActions_TwoPhases(t *testing.T) {
 	}
 }
 
+func TestRenderGitHubActions_PinsActionSHAs(t *testing.T) {
+	plan := richCIPlan()
+	files, err := cigen.RenderGitHubActions(plan)
+	if err != nil {
+		t.Fatalf("RenderGitHubActions: %v", err)
+	}
+	var content string
+	for _, c := range files {
+		content = c
+		break
+	}
+
+	for _, want := range []string{
+		"actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3",
+		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
+		"actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("generated GitHub Actions workflow missing pinned action %q:\n%s", want, content)
+		}
+	}
+	for _, moving := range []string{
+		"actions/checkout@" + "v6",
+		"GoCodeAlone/setup-wfctl@" + "v1",
+		"actions/github-script@" + "v7",
+	} {
+		if strings.Contains(content, moving) {
+			t.Fatalf("generated GitHub Actions workflow contains moving action ref %q:\n%s", moving, content)
+		}
+	}
+}
+
 func TestRenderGitHubActions_MigrationsStep(t *testing.T) {
 	plan := richCIPlan()
 

--- a/cigen/render_gha_test.go
+++ b/cigen/render_gha_test.go
@@ -76,7 +76,7 @@ func TestRenderGitHubActions_PinsActionSHAs(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3",
+		"actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
 		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
 		"actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7",
 	} {

--- a/cigen/testdata/multisite/GAP.md
+++ b/cigen/testdata/multisite/GAP.md
@@ -241,7 +241,7 @@ The hand-written workflow pins actions by SHA:
 ```yaml
 - uses: GoCodeAlone/setup-wfctl@362fe9aaf4792e5adffa2b406ee39dcad31f54a9
 ```
-and adds `actions/setup-go@v6` with `go-version-file: go.mod`.
+and adds `actions/setup-go` pinned to v6.4.0 with `go-version-file: go.mod`.
 
 The generator uses tag references (`@v4`, `@v1`) without SHA pinning and
 does not emit a Go setup step. Not derivable from config.

--- a/cigen/testdata/multisite/generated-infra.yml
+++ b/cigen/testdata/multisite/generated-infra.yml
@@ -18,9 +18,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Install wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
+        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
           version: 'latest'
       - name: Install plugins (prereq)
@@ -32,7 +32,7 @@ jobs:
       - name: Plan deploy
         run: wfctl infra plan --config 'deploy.yaml' --format markdown >> plan.md
       - name: Post plan comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -58,9 +58,9 @@ jobs:
       SPACES_access_key: ${{ secrets.SPACES_access_key }}
       SPACES_secret_key: ${{ secrets.SPACES_secret_key }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Install wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
+        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
           version: 'latest'
       - name: Install plugins
@@ -97,9 +97,9 @@ jobs:
       SPACES_access_key: ${{ secrets.SPACES_access_key }}
       SPACES_secret_key: ${{ secrets.SPACES_secret_key }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Install wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
+        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
           version: 'latest'
       - name: Install plugins

--- a/cigen/testdata/multisite/generated-infra.yml
+++ b/cigen/testdata/multisite/generated-infra.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
@@ -58,7 +58,7 @@ jobs:
       SPACES_access_key: ${{ secrets.SPACES_access_key }}
       SPACES_secret_key: ${{ secrets.SPACES_secret_key }}
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
@@ -97,7 +97,7 @@ jobs:
       SPACES_access_key: ${{ secrets.SPACES_access_key }}
       SPACES_secret_key: ${{ secrets.SPACES_secret_key }}
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:

--- a/cigen/validate_test.go
+++ b/cigen/validate_test.go
@@ -54,7 +54,7 @@ jobs:
   plan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         run: echo invalid
 `,
 	}

--- a/cigen/validate_test.go
+++ b/cigen/validate_test.go
@@ -54,7 +54,7 @@ jobs:
   plan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         run: echo invalid
 `,
 	}

--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -190,7 +190,7 @@ func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, 
 		// Verify a non-default builder is active; the default "docker" driver rejects --provenance.
 		if err := exec.Command("docker", "buildx", "inspect", "--bootstrap").Run(); err != nil {
 			return fmt.Errorf("hardened build requires docker buildx: run 'docker buildx create --use' "+
-				"or add a SHA-pinned docker/setup-buildx-action v3 step to your CI workflow (%w)", err)
+				"or add '%s' to your CI workflow (%w)", githubActionsDockerSetupBuildxRef, err)
 		}
 	}
 

--- a/cmd/wfctl/build_image.go
+++ b/cmd/wfctl/build_image.go
@@ -190,7 +190,7 @@ func buildWithDockerfile(ctr config.CIContainerTarget, tag string, dryRun bool, 
 		// Verify a non-default builder is active; the default "docker" driver rejects --provenance.
 		if err := exec.Command("docker", "buildx", "inspect", "--bootstrap").Run(); err != nil {
 			return fmt.Errorf("hardened build requires docker buildx: run 'docker buildx create --use' "+
-				"or add 'docker/setup-buildx-action@v3' to your CI workflow (%w)", err)
+				"or add a SHA-pinned docker/setup-buildx-action v3 step to your CI workflow (%w)", err)
 		}
 	}
 

--- a/cmd/wfctl/ci_init.go
+++ b/cmd/wfctl/ci_init.go
@@ -122,8 +122,8 @@ func generateGHABootstrap(cfg *config.WorkflowConfig) string {
 	sb.WriteString("  build-test:\n")
 	sb.WriteString("    runs-on: ubuntu-latest\n")
 	sb.WriteString("    steps:\n")
-	sb.WriteString("      - uses: actions/checkout@v6\n")
-	sb.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+	fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsCheckoutRef)
+	fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsSetupWfctlRef)
 	sb.WriteString("      - run: wfctl ci run --phase build,test\n")
 
 	// Emit one deploy job per environment in ci.deploy.environments.
@@ -145,8 +145,8 @@ func generateGHABootstrap(cfg *config.WorkflowConfig) string {
 				sb.WriteString("    environment: " + envName + "\n")
 			}
 			sb.WriteString("    steps:\n")
-			sb.WriteString("      - uses: actions/checkout@v6\n")
-			sb.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+			fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsCheckoutRef)
+			fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsSetupWfctlRef)
 			if configHasMigrations(cfg) {
 				sb.WriteString("      - run: mkdir -p .wfctl\n")
 				sb.WriteString("      - run: wfctl migrations validate --env " + envName + " --commit ${{ github.sha }} --result-file .wfctl/migrations-result.json --format json\n")
@@ -270,10 +270,10 @@ func generateGHADeploy(cfg *config.WorkflowConfig) string {
 	sb.WriteString("    if: github.event.workflow_run.conclusion == 'success'\n")
 	sb.WriteString("    runs-on: ubuntu-latest\n")
 	sb.WriteString("    steps:\n")
-	sb.WriteString("      - uses: actions/checkout@v6\n")
+	fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsCheckoutRef)
 	sb.WriteString("        with:\n")
 	sb.WriteString("          ref: " + sha + "\n")
-	sb.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+	fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsSetupWfctlRef)
 	sb.WriteString("      - id: build\n")
 	sb.WriteString("        run: wfctl build --push --format json\n")
 	if len(regEnvVars) > 0 {
@@ -299,10 +299,10 @@ func generateGHADeploy(cfg *config.WorkflowConfig) string {
 				sb.WriteString("    environment: " + envName + "\n")
 			}
 			sb.WriteString("    steps:\n")
-			sb.WriteString("      - uses: actions/checkout@v6\n")
+			fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsCheckoutRef)
 			sb.WriteString("        with:\n")
 			sb.WriteString("          ref: " + sha + "\n")
-			sb.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+			fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsSetupWfctlRef)
 			if configHasMigrations(cfg) {
 				sb.WriteString("      - run: mkdir -p .wfctl && wfctl migrations validate --env " + envName + " --commit " + sha + " --result-file .wfctl/migrations-result.json --format json\n")
 			}
@@ -358,8 +358,8 @@ func generateRetentionYML(cfg *config.WorkflowConfig) string {
 	sb.WriteString("  prune:\n")
 	sb.WriteString("    runs-on: ubuntu-latest\n")
 	sb.WriteString("    steps:\n")
-	sb.WriteString("      - uses: actions/checkout@v6\n")
-	sb.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+	fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsCheckoutRef)
+	fmt.Fprintf(&sb, "      - uses: %s\n", githubActionsSetupWfctlRef)
 	for _, e := range entries {
 		sb.WriteString("      - run: wfctl registry prune --registry " + e.name + "\n")
 		if e.envVar != "" {

--- a/cmd/wfctl/ci_init_test.go
+++ b/cmd/wfctl/ci_init_test.go
@@ -15,8 +15,8 @@ func TestGenerateGHABootstrap_NoConfig(t *testing.T) {
 	if !strings.Contains(content, "wfctl ci run --phase build,test") {
 		t.Error("expected wfctl ci run --phase build,test in output")
 	}
-	if !strings.Contains(content, "GoCodeAlone/setup-wfctl@v1") {
-		t.Error("expected setup-wfctl action in output")
+	if !strings.Contains(content, "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1") {
+		t.Error("expected SHA-pinned setup-wfctl action in output")
 	}
 }
 

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -39,7 +39,7 @@ func TestGenerateGitHubActions(t *testing.T) {
 	}
 
 	markers := []string{
-		"actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3",
+		"actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
 		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
 		"wfctl infra plan",
 		"permissions",

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -39,8 +39,8 @@ func TestGenerateGitHubActions(t *testing.T) {
 	}
 
 	markers := []string{
-		"actions/checkout@v6",
-		"GoCodeAlone/setup-wfctl@v1",
+		"actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3",
+		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
 		"wfctl infra plan",
 		"permissions",
 	}

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -47,6 +47,16 @@ type projectFeatures struct {
 	configFile  string
 }
 
+const (
+	githubActionsCheckoutRef        = "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3"
+	githubActionsSetupGoRef         = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
+	githubActionsSetupNodeRef       = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	githubActionsSetupWfctlRef      = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+	githubActionsDockerLoginRef     = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
+	githubActionsDockerSetupBuildx  = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"
+	githubActionsDockerBuildPushRef = "docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6"
+)
+
 func runGenerateGithubActions(args []string) error {
 	fs := flag.NewFlagSet("generate github-actions", flag.ContinueOnError)
 	output := fs.String("output", ".github/workflows/", "Output directory for generated workflow files")
@@ -163,8 +173,8 @@ func writeCIWorkflow(path string, features *projectFeatures) error {
 	b.WriteString("  validate:\n")
 	b.WriteString("    runs-on: ubuntu-latest\n")
 	b.WriteString("    steps:\n")
-	b.WriteString("      - uses: actions/checkout@v6\n")
-	b.WriteString("      - uses: actions/setup-go@v5\n")
+	fmt.Fprintf(&b, "      - uses: %s\n", githubActionsCheckoutRef)
+	fmt.Fprintf(&b, "      - uses: %s\n", githubActionsSetupGoRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          go-version: '1.22'\n")
 	b.WriteString("      - name: Install wfctl\n")
@@ -175,9 +185,9 @@ func writeCIWorkflow(path string, features *projectFeatures) error {
 	fmt.Fprintf(&b, "        run: wfctl inspect %s\n", features.configFile)
 
 	if features.hasUI {
-		b.WriteString("      - uses: actions/setup-node@v4\n")
+		fmt.Fprintf(&b, "      - uses: %s\n", githubActionsSetupNodeRef)
 		b.WriteString("        with:\n")
-		b.WriteString("          node-version: '22'\n")
+		b.WriteString("          node-version: '24'\n")
 		b.WriteString("      - name: Build UI\n")
 		b.WriteString("        run: wfctl build-ui --ui-dir ui\n")
 	}
@@ -216,15 +226,15 @@ func writeCDWorkflow(path string, features *projectFeatures, registry, platforms
 	b.WriteString("      contents: read\n")
 	b.WriteString("      packages: write\n")
 	b.WriteString("    steps:\n")
-	b.WriteString("      - uses: actions/checkout@v6\n")
-	b.WriteString("      - uses: actions/setup-go@v5\n")
+	fmt.Fprintf(&b, "      - uses: %s\n", githubActionsCheckoutRef)
+	fmt.Fprintf(&b, "      - uses: %s\n", githubActionsSetupGoRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          go-version: '1.22'\n")
 
 	if features.hasUI {
-		b.WriteString("      - uses: actions/setup-node@v4\n")
+		fmt.Fprintf(&b, "      - uses: %s\n", githubActionsSetupNodeRef)
 		b.WriteString("        with:\n")
-		b.WriteString("          node-version: '22'\n")
+		b.WriteString("          node-version: '24'\n")
 		b.WriteString("      - name: Build UI\n")
 		b.WriteString("        run: |\n")
 		b.WriteString("          cd ui && npm ci && npm run build && cd ..\n")
@@ -234,15 +244,15 @@ func writeCDWorkflow(path string, features *projectFeatures, registry, platforms
 	b.WriteString("        run: |\n")
 	b.WriteString("          GOOS=linux GOARCH=amd64 go build -o bin/server ./cmd/server/\n")
 	b.WriteString("      - name: Log in to registry\n")
-	b.WriteString("        uses: docker/login-action@v3\n")
+	fmt.Fprintf(&b, "        uses: %s\n", githubActionsDockerLoginRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          registry: ${{ env.REGISTRY }}\n")
 	b.WriteString("          username: ${{ github.actor }}\n")
 	b.WriteString("          password: ${{ secrets.GITHUB_TOKEN }}\n")
 	b.WriteString("      - name: Set up Docker Buildx\n")
-	b.WriteString("        uses: docker/setup-buildx-action@v3\n")
+	fmt.Fprintf(&b, "        uses: %s\n", githubActionsDockerSetupBuildx)
 	b.WriteString("      - name: Build and push Docker image\n")
-	b.WriteString("        uses: docker/build-push-action@v5\n")
+	fmt.Fprintf(&b, "        uses: %s\n", githubActionsDockerBuildPushRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          context: .\n")
 	b.WriteString("          push: true\n")
@@ -266,8 +276,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
       - name: Build plugin binaries
@@ -279,7 +289,7 @@ jobs:
             done
           done
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: dist/*
 `

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -52,10 +52,10 @@ const (
 	githubActionsSetupGoRef   = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
 	githubActionsSetupNodeRef = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
 	// #nosec G101 -- action commit SHA, not a credential.
-	githubActionsSetupWfctlRef      = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
-	githubActionsDockerLoginRef     = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
-	githubActionsDockerSetupBuildx  = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"
-	githubActionsDockerBuildPushRef = "docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6"
+	githubActionsSetupWfctlRef        = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+	githubActionsDockerLoginRef       = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
+	githubActionsDockerSetupBuildxRef = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"
+	githubActionsDockerBuildPushRef   = "docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6"
 )
 
 func runGenerateGithubActions(args []string) error {
@@ -251,7 +251,7 @@ func writeCDWorkflow(path string, features *projectFeatures, registry, platforms
 	b.WriteString("          username: ${{ github.actor }}\n")
 	b.WriteString("          password: ${{ secrets.GITHUB_TOKEN }}\n")
 	b.WriteString("      - name: Set up Docker Buildx\n")
-	fmt.Fprintf(&b, "        uses: %s\n", githubActionsDockerSetupBuildx)
+	fmt.Fprintf(&b, "        uses: %s\n", githubActionsDockerSetupBuildxRef)
 	b.WriteString("      - name: Build and push Docker image\n")
 	fmt.Fprintf(&b, "        uses: %s\n", githubActionsDockerBuildPushRef)
 	b.WriteString("        with:\n")

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -48,7 +48,7 @@ type projectFeatures struct {
 }
 
 const (
-	githubActionsCheckoutRef        = "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3"
+	githubActionsCheckoutRef        = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
 	githubActionsSetupGoRef         = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
 	githubActionsSetupNodeRef       = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
 	githubActionsSetupWfctlRef      = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
@@ -276,7 +276,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -48,9 +48,10 @@ type projectFeatures struct {
 }
 
 const (
-	githubActionsCheckoutRef        = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
-	githubActionsSetupGoRef         = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
-	githubActionsSetupNodeRef       = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	githubActionsCheckoutRef  = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
+	githubActionsSetupGoRef   = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
+	githubActionsSetupNodeRef = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	// #nosec G101 -- action commit SHA, not a credential.
 	githubActionsSetupWfctlRef      = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
 	githubActionsDockerLoginRef     = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
 	githubActionsDockerSetupBuildx  = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"

--- a/cmd/wfctl/generate_test.go
+++ b/cmd/wfctl/generate_test.go
@@ -397,7 +397,7 @@ func TestCIWorkflowContent(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3") {
+	if !strings.Contains(content, "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3") {
 		t.Error("ci.yml should use SHA-pinned actions/checkout v6.0.3")
 	}
 	if !strings.Contains(content, "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0") {

--- a/cmd/wfctl/generate_test.go
+++ b/cmd/wfctl/generate_test.go
@@ -397,11 +397,11 @@ func TestCIWorkflowContent(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "actions/checkout@v6") {
-		t.Error("ci.yml should use actions/checkout@v6")
+	if !strings.Contains(content, "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3") {
+		t.Error("ci.yml should use SHA-pinned actions/checkout v6.0.3")
 	}
-	if !strings.Contains(content, "actions/setup-go@v5") {
-		t.Error("ci.yml should use actions/setup-go@v5")
+	if !strings.Contains(content, "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0") {
+		t.Error("ci.yml should use SHA-pinned actions/setup-go v6.4.0")
 	}
 	if !strings.Contains(content, "wfctl validate") {
 		t.Error("ci.yml should include wfctl validate step")

--- a/cmd/wfctl/templates/api-service/.github/workflows/ci.yml.tmpl
+++ b/cmd/wfctl/templates/api-service/.github/workflows/ci.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/cmd/wfctl/templates/api-service/.github/workflows/ci.yml.tmpl
+++ b/cmd/wfctl/templates/api-service/.github/workflows/ci.yml.tmpl
@@ -9,8 +9,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
       - name: Install wfctl

--- a/cmd/wfctl/templates/event-processor/.github/workflows/ci.yml.tmpl
+++ b/cmd/wfctl/templates/event-processor/.github/workflows/ci.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/cmd/wfctl/templates/event-processor/.github/workflows/ci.yml.tmpl
+++ b/cmd/wfctl/templates/event-processor/.github/workflows/ci.yml.tmpl
@@ -9,8 +9,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
       - name: Install wfctl

--- a/cmd/wfctl/templates/full-stack/.github/workflows/ci.yml.tmpl
+++ b/cmd/wfctl/templates/full-stack/.github/workflows/ci.yml.tmpl
@@ -9,13 +9,13 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
       - name: Install wfctl
         run: go install github.com/GoCodeAlone/workflow/cmd/wfctl@latest
       - name: Validate config

--- a/cmd/wfctl/templates/full-stack/.github/workflows/ci.yml.tmpl
+++ b/cmd/wfctl/templates/full-stack/.github/workflows/ci.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
@@ -9,8 +9,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
       - name: Build plugin binaries
@@ -22,6 +22,6 @@ jobs:
             done
           done
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: dist/*

--- a/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
@@ -9,13 +9,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
       - name: Build UI
         run: |
           cd ui && npm ci && npm run build && cd ..
@@ -28,6 +28,6 @@ jobs:
             done
           done
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: dist/*

--- a/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/cmd/wfctl/testdata/verify_capabilities/good/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/good/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/good
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.62.0
 

--- a/cmd/wfctl/testdata/verify_capabilities/iac-extra-service/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/iac-extra-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/iac-extra-service
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.63.2
 

--- a/cmd/wfctl/testdata/verify_capabilities/iac-good/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/iac-good/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/iac-good
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.63.2
 

--- a/cmd/wfctl/testdata/verify_capabilities/iac-missing-service/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/iac-missing-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/iac-missing-service
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.63.2
 

--- a/cmd/wfctl/testdata/verify_capabilities/missing-ldflag/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/missing-ldflag/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/missing-ldflag
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.62.0
 

--- a/cmd/wfctl/testdata/verify_capabilities/name-drift/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/name-drift/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/name-drift
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.62.0
 

--- a/cmd/wfctl/testdata/verify_capabilities/release-good/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/release-good/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/release-good
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.62.0
 

--- a/cmd/wfctl/testdata/verify_capabilities/version-drift/go.mod
+++ b/cmd/wfctl/testdata/verify_capabilities/version-drift/go.mod
@@ -1,6 +1,6 @@
 module github.com/test/version-drift
 
-go 1.26.0
+go 1.26.1
 
 require github.com/GoCodeAlone/workflow v0.62.0
 

--- a/cmd/wfctl/validate_test.go
+++ b/cmd/wfctl/validate_test.go
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 `
 	ciPath := filepath.Join(dir, "ci.yml")
 	if err := os.WriteFile(ciPath, []byte(ciYAML), 0644); err != nil {

--- a/cmd/wfctl/validate_test.go
+++ b/cmd/wfctl/validate_test.go
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 `
 	ciPath := filepath.Join(dir, "ci.yml")
 	if err := os.WriteFile(ciPath, []byte(ciYAML), 0644); err != nil {

--- a/docs/PLUGIN_RELEASE_GATES.md
+++ b/docs/PLUGIN_RELEASE_GATES.md
@@ -63,7 +63,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { fetch-depth: 0 }
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }

--- a/docs/PLUGIN_RELEASE_GATES.md
+++ b/docs/PLUGIN_RELEASE_GATES.md
@@ -63,11 +63,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with: { fetch-depth: 0 }
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with: { version: v0.61.0 }
 
       # 1. Pre-build gate: static contract + tag format
@@ -75,7 +75,7 @@ jobs:
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
 
       # 2. Build (goreleaser mutates plugin.json or writes .release/plugin.json)
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2728,7 +2728,7 @@ Plugin CI should generate evidence with the released artifact, then update the r
 
 ```yaml
 steps:
-  - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+  - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
     with:
       version: v0.51.2

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2728,8 +2728,8 @@ Plugin CI should generate evidence with the released artifact, then update the r
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
-  - uses: GoCodeAlone/workflow/.github/actions/setup-wfctl@main
+  - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+  - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
     with:
       version: v0.51.2
   - run: wfctl plugin conformance --mode typed-iac --artifact dist/plugin.tar.gz --engine-version v0.51.2 --format json --output evidence.json

--- a/docs/manual/build-deploy/03-ci-deploy-environments.md
+++ b/docs/manual/build-deploy/03-ci-deploy-environments.md
@@ -73,10 +73,10 @@ deploy-staging:
   needs: [build-image]
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-    - uses: GoCodeAlone/setup-wfctl@v1
+    - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
     - run: wfctl ci run --phase deploy --env staging
 ```
 
@@ -96,8 +96,8 @@ repair-staging-migrations:
   environment: staging
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v6
-    - uses: GoCodeAlone/setup-wfctl@v1
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+    - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
     - run: |
         wfctl migrate repair-dirty --config infra.yaml --env staging \
           --database app-db \

--- a/docs/manual/build-deploy/03-ci-deploy-environments.md
+++ b/docs/manual/build-deploy/03-ci-deploy-environments.md
@@ -73,7 +73,7 @@ deploy-staging:
   needs: [build-image]
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
@@ -96,7 +96,7 @@ repair-staging-migrations:
   environment: staging
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
     - run: |
         wfctl migrate repair-dirty --config infra.yaml --env staging \

--- a/docs/tutorials/deploy-pipeline.md
+++ b/docs/tutorials/deploy-pipeline.md
@@ -355,21 +355,21 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase build,test
   deploy-staging:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env staging
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env prod
 ```
@@ -389,7 +389,7 @@ Insert a `build-image` job between `build-test` and the deploy jobs. This compil
     outputs:
       sha: ${{ steps.meta.outputs.sha }}
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
@@ -413,7 +413,7 @@ Reference the SHA in your deploy jobs via the `IMAGE_SHA` environment variable (
   deploy-staging:
     needs: [build-image]
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env staging
         env:
@@ -453,7 +453,7 @@ Change `deploy-prod.needs` from `[build-test]` to `[deploy-staging]`. This makes
     runs-on: ubuntu-latest
     needs: [build-image]           # waits for image push
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env staging
         env:
@@ -464,7 +464,7 @@ Change `deploy-prod.needs` from `[build-test]` to `[deploy-staging]`. This makes
     runs-on: ubuntu-latest
     needs: [deploy-staging]        # auto-promotes after staging succeeds
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env prod
         env:
@@ -508,7 +508,7 @@ When `requireApproval: true`, `wfctl ci init` emits `environment: prod` in the g
     needs: [deploy-staging]
     environment: prod              # GitHub waits for environment protection approval
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env prod
 ```

--- a/docs/tutorials/deploy-pipeline.md
+++ b/docs/tutorials/deploy-pipeline.md
@@ -355,22 +355,22 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase build,test
   deploy-staging:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env staging
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env prod
 ```
 
@@ -389,11 +389,11 @@ Insert a `build-image` job between `build-test` and the deploy jobs. This compil
     outputs:
       sha: ${{ steps.meta.outputs.sha }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
-      - uses: digitalocean/action-doctl@v2
+      - uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_TOKEN }}
       - name: Build binary
@@ -413,8 +413,8 @@ Reference the SHA in your deploy jobs via the `IMAGE_SHA` environment variable (
   deploy-staging:
     needs: [build-image]
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env staging
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
@@ -453,8 +453,8 @@ Change `deploy-prod.needs` from `[build-test]` to `[deploy-staging]`. This makes
     runs-on: ubuntu-latest
     needs: [build-image]           # waits for image push
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env staging
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
@@ -464,8 +464,8 @@ Change `deploy-prod.needs` from `[build-test]` to `[deploy-staging]`. This makes
     runs-on: ubuntu-latest
     needs: [deploy-staging]        # auto-promotes after staging succeeds
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env prod
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
@@ -508,8 +508,8 @@ When `requireApproval: true`, `wfctl ci init` emits `environment: prod` in the g
     needs: [deploy-staging]
     environment: prod              # GitHub waits for environment protection approval
     steps:
-      - uses: actions/checkout@v6
-      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
       - run: wfctl ci run --phase deploy --env prod
 ```
 

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,6 @@
 module example
 
-go 1.26.0
+go 1.26.1
 
 replace github.com/GoCodeAlone/workflow => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoCodeAlone/workflow
 
-go 1.26.0
+go 1.26.1
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/mcp/github_actions_refs.go
+++ b/mcp/github_actions_refs.go
@@ -1,9 +1,10 @@
 package mcp
 
 const (
-	mcpGithubActionsCheckoutRef          = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
-	mcpGithubActionsSetupGoRef           = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
-	mcpGithubActionsSetupNodeRef         = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	mcpGithubActionsCheckoutRef  = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
+	mcpGithubActionsSetupGoRef   = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
+	mcpGithubActionsSetupNodeRef = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	// #nosec G101 -- action commit SHA, not a credential.
 	mcpGithubActionsSetupWfctlRef        = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
 	mcpGithubActionsDockerLoginRef       = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
 	mcpGithubActionsDockerSetupBuildxRef = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"

--- a/mcp/github_actions_refs.go
+++ b/mcp/github_actions_refs.go
@@ -1,0 +1,11 @@
+package mcp
+
+const (
+	mcpGithubActionsCheckoutRef        = "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3"
+	mcpGithubActionsSetupGoRef         = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
+	mcpGithubActionsSetupNodeRef       = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	mcpGithubActionsSetupWfctlRef      = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+	mcpGithubActionsDockerLoginRef     = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
+	mcpGithubActionsDockerSetupBuildx  = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"
+	mcpGithubActionsDockerBuildPushRef = "docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6"
+)

--- a/mcp/github_actions_refs.go
+++ b/mcp/github_actions_refs.go
@@ -1,11 +1,11 @@
 package mcp
 
 const (
-	mcpGithubActionsCheckoutRef        = "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3"
-	mcpGithubActionsSetupGoRef         = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
-	mcpGithubActionsSetupNodeRef       = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
-	mcpGithubActionsSetupWfctlRef      = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
-	mcpGithubActionsDockerLoginRef     = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
-	mcpGithubActionsDockerSetupBuildx  = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"
-	mcpGithubActionsDockerBuildPushRef = "docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6"
+	mcpGithubActionsCheckoutRef          = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
+	mcpGithubActionsSetupGoRef           = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
+	mcpGithubActionsSetupNodeRef         = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+	mcpGithubActionsSetupWfctlRef        = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+	mcpGithubActionsDockerLoginRef       = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
+	mcpGithubActionsDockerSetupBuildxRef = "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3"
+	mcpGithubActionsDockerBuildPushRef   = "docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6"
 )

--- a/mcp/scaffold_tools.go
+++ b/mcp/scaffold_tools.go
@@ -721,8 +721,8 @@ func generateGitHubActionsBootstrap(cfg *config.WorkflowConfig) string {
 	b.WriteString("  build-test:\n")
 	b.WriteString("    runs-on: ubuntu-latest\n")
 	b.WriteString("    steps:\n")
-	b.WriteString("      - uses: actions/checkout@v6\n")
-	b.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+	fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsCheckoutRef)
+	fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsSetupWfctlRef)
 	b.WriteString("      - run: wfctl ci run --phase build,test\n")
 
 	if cfg.CI != nil && cfg.CI.Deploy != nil {
@@ -737,8 +737,8 @@ func generateGitHubActionsBootstrap(cfg *config.WorkflowConfig) string {
 			}
 			b.WriteString("    if: github.ref == 'refs/heads/main'\n")
 			b.WriteString("    steps:\n")
-			b.WriteString("      - uses: actions/checkout@v6\n")
-			b.WriteString("      - uses: GoCodeAlone/setup-wfctl@v1\n")
+			fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsCheckoutRef)
+			fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsSetupWfctlRef)
 			fmt.Fprintf(&b, "      - run: wfctl ci run --phase deploy --env %s\n", envName)
 		}
 	}

--- a/mcp/scaffold_tools_test.go
+++ b/mcp/scaffold_tools_test.go
@@ -211,8 +211,8 @@ ci:
 	if !strings.Contains(text, "wfctl ci run") {
 		t.Error("expected wfctl ci run call")
 	}
-	if !strings.Contains(text, "actions/checkout@v6") {
-		t.Error("expected checkout action")
+	if !strings.Contains(text, "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3") {
+		t.Error("expected SHA-pinned checkout action")
 	}
 }
 

--- a/mcp/scaffold_tools_test.go
+++ b/mcp/scaffold_tools_test.go
@@ -211,7 +211,7 @@ ci:
 	if !strings.Contains(text, "wfctl ci run") {
 		t.Error("expected wfctl ci run call")
 	}
-	if !strings.Contains(text, "actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3") {
+	if !strings.Contains(text, "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3") {
 		t.Error("expected SHA-pinned checkout action")
 	}
 }

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -1735,7 +1735,7 @@ func mcpGenerateCDWorkflow(features *mcpProjectFeatures, registry, platforms str
 	b.WriteString("          username: ${{ github.actor }}\n")
 	b.WriteString("          password: ${{ secrets.GITHUB_TOKEN }}\n")
 	b.WriteString("      - name: Set up Docker Buildx\n")
-	fmt.Fprintf(&b, "        uses: %s\n", mcpGithubActionsDockerSetupBuildx)
+	fmt.Fprintf(&b, "        uses: %s\n", mcpGithubActionsDockerSetupBuildxRef)
 	b.WriteString("      - name: Build and push Docker image\n")
 	fmt.Fprintf(&b, "        uses: %s\n", mcpGithubActionsDockerBuildPushRef)
 	b.WriteString("        with:\n")
@@ -1914,7 +1914,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -1711,15 +1711,15 @@ func mcpGenerateCDWorkflow(features *mcpProjectFeatures, registry, platforms str
 	b.WriteString("      contents: read\n")
 	b.WriteString("      packages: write\n")
 	b.WriteString("    steps:\n")
-	b.WriteString("      - uses: actions/checkout@v6\n")
-	b.WriteString("      - uses: actions/setup-go@v5\n")
+	fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsCheckoutRef)
+	fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsSetupGoRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          go-version: '1.22'\n")
 
 	if features.HasUI {
-		b.WriteString("      - uses: actions/setup-node@v4\n")
+		fmt.Fprintf(&b, "      - uses: %s\n", mcpGithubActionsSetupNodeRef)
 		b.WriteString("        with:\n")
-		b.WriteString("          node-version: '22'\n")
+		b.WriteString("          node-version: '24'\n")
 		b.WriteString("      - name: Build UI\n")
 		b.WriteString("        run: |\n")
 		b.WriteString("          cd ui && npm ci && npm run build && cd ..\n")
@@ -1729,15 +1729,15 @@ func mcpGenerateCDWorkflow(features *mcpProjectFeatures, registry, platforms str
 	b.WriteString("        run: |\n")
 	b.WriteString("          GOOS=linux GOARCH=amd64 go build -o bin/server ./cmd/server/\n")
 	b.WriteString("      - name: Log in to registry\n")
-	b.WriteString("        uses: docker/login-action@v3\n")
+	fmt.Fprintf(&b, "        uses: %s\n", mcpGithubActionsDockerLoginRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          registry: ${{ env.REGISTRY }}\n")
 	b.WriteString("          username: ${{ github.actor }}\n")
 	b.WriteString("          password: ${{ secrets.GITHUB_TOKEN }}\n")
 	b.WriteString("      - name: Set up Docker Buildx\n")
-	b.WriteString("        uses: docker/setup-buildx-action@v3\n")
+	fmt.Fprintf(&b, "        uses: %s\n", mcpGithubActionsDockerSetupBuildx)
 	b.WriteString("      - name: Build and push Docker image\n")
-	b.WriteString("        uses: docker/build-push-action@v5\n")
+	fmt.Fprintf(&b, "        uses: %s\n", mcpGithubActionsDockerBuildPushRef)
 	b.WriteString("        with:\n")
 	b.WriteString("          context: .\n")
 	b.WriteString("          push: true\n")
@@ -1914,8 +1914,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
       - name: Build plugin binaries
@@ -1927,7 +1927,7 @@ jobs:
             done
           done
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: dist/*
 `

--- a/plugin/sdk/generator.go
+++ b/plugin/sdk/generator.go
@@ -589,8 +589,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '%s'
       - name: Test
@@ -612,14 +612,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '%s'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: '~> v2'
           args: release --clean
@@ -633,7 +633,7 @@ jobs:
     steps:
       - name: Notify workflow-registry
         if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.REGISTRY_PAT }}
           repository: GoCodeAlone/workflow-registry

--- a/plugin/sdk/generator.go
+++ b/plugin/sdk/generator.go
@@ -589,7 +589,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '%s'
@@ -612,7 +612,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
Closes #868

## Summary
- Pin active GitHub workflow actions to full commit SHAs with version comments.
- Move GitHub workflow and generated Node setup from 20/22 to Node 24 LTS.
- Make cigen, wfctl generator, MCP generator/scaffolds, SDK templates, fixtures, and docs emit SHA-pinned action refs by default.

## Version checks
- actions/checkout v6.0.3 -> df4cb1c069e1874edd31b4311f1884172cec0e10
- actions/setup-go v6.4.0 -> 4a3601121dd01d1626a1e23e37211e3254c1c06c
- actions/setup-node v6.4.0 -> 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
- golangci/golangci-lint-action v9.2.1 -> 82606bf257cbaff209d206a39f5134f0cfbfd2ee
- Additional workflow helpers were resolved through GitHub refs and pinned with version comments.

## Verification
- GOWORK=off go test -race ./...
- GOWORK=off go test ./cigen ./mcp ./plugin/sdk -timeout=2m
- GOWORK=off go test ./cmd/wfctl -run 'TestVerifyCapabilities|TestGenerateGitHubActions|TestCIWorkflowContent|TestCDWorkflowContent|TestReleaseWorkflowContent|TestRunGenerateGithubActionsWithUI|TestGenerateGHABootstrap_NoConfig|TestGenerateGHABootstrap_WithEnvironments|TestValidateSkipsNonWorkflowYAML' -count=1 -timeout=3m
- GOWORK=off golangci-lint run ./cigen ./mcp ./plugin/sdk ./cmd/wfctl --timeout=10m
- actionlint -ignore 'shellcheck reported issue' .github/workflows/*.yml
- git diff --check

## Notes
- Node.js release metadata currently lists v24 as Latest LTS and v26 as Latest Release.
- CI provider coverage passed for workflow-plugin-aws, workflow-plugin-azure, and workflow-plugin-gcp.