### PR TITLE
fix: normalize checksum asset paths

### DIFF
--- a/cmd/wfctl/plugin_checksum.go
+++ b/cmd/wfctl/plugin_checksum.go
@@ -34,6 +34,10 @@ func parseChecksumsTxt(body string) (map[string]string, error) {
 		if strings.HasPrefix(name, " ") {
 			return nil, fmt.Errorf("malformed checksums.txt line: %q (expected exactly two spaces between hash and filename)", line)
 		}
+		name = strings.TrimPrefix(name, "./")
+		if existing, ok := result[name]; ok && existing != hash {
+			return nil, fmt.Errorf("conflicting checksums.txt entries for %q", name)
+		}
 		result[name] = hash
 	}
 	return result, nil

--- a/cmd/wfctl/plugin_checksum.go
+++ b/cmd/wfctl/plugin_checksum.go
@@ -35,6 +35,9 @@ func parseChecksumsTxt(body string) (map[string]string, error) {
 			return nil, fmt.Errorf("malformed checksums.txt line: %q (expected exactly two spaces between hash and filename)", line)
 		}
 		name = strings.TrimPrefix(name, "./")
+		if name == "" {
+			return nil, fmt.Errorf("malformed checksums.txt line: %q (empty filename after normalization)", line)
+		}
 		if existing, ok := result[name]; ok && existing != hash {
 			return nil, fmt.Errorf("conflicting checksums.txt entries for %q", name)
 		}

--- a/cmd/wfctl/plugin_checksum_test.go
+++ b/cmd/wfctl/plugin_checksum_test.go
@@ -53,6 +53,16 @@ func TestParseChecksumsTxt_RejectsConflictingDotSlashAliases(t *testing.T) {
 	}
 }
 
+func TestParseChecksumsTxt_RejectsEmptyDotSlashName(t *testing.T) {
+	_, err := parseChecksumsTxt("abc123def456  ./\n")
+	if err == nil {
+		t.Fatal("expected ./ checksum entry to fail")
+	}
+	if !strings.Contains(err.Error(), "empty filename") {
+		t.Fatalf("error = %v, want empty filename error", err)
+	}
+}
+
 func TestParseChecksumsTxt_SkipsBlankLines(t *testing.T) {
 	body := "\nabc123  plugin.tar.gz\n\n"
 	got, err := parseChecksumsTxt(body)

--- a/cmd/wfctl/plugin_checksum_test.go
+++ b/cmd/wfctl/plugin_checksum_test.go
@@ -30,6 +30,29 @@ func TestParseChecksumsTxt_Valid(t *testing.T) {
 	}
 }
 
+func TestParseChecksumsTxt_NormalizesDotSlashPrefix(t *testing.T) {
+	body := "abc123def456  ./wfctl-darwin-arm64\n"
+	got, err := parseChecksumsTxt(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["wfctl-darwin-arm64"] != "abc123def456" {
+		t.Fatalf("normalized checksum = %q, want abc123def456", got["wfctl-darwin-arm64"])
+	}
+}
+
+func TestParseChecksumsTxt_RejectsConflictingDotSlashAliases(t *testing.T) {
+	body := "abc123def456  wfctl-darwin-arm64\n" +
+		"789abcdef012  ./wfctl-darwin-arm64\n"
+	_, err := parseChecksumsTxt(body)
+	if err == nil {
+		t.Fatal("expected conflicting checksum aliases to fail")
+	}
+	if !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("error = %v, want conflicting checksum error", err)
+	}
+}
+
 func TestParseChecksumsTxt_SkipsBlankLines(t *testing.T) {
 	body := "\nabc123  plugin.tar.gz\n\n"
 	got, err := parseChecksumsTxt(body)

--- a/cmd/wfctl/update_test.go
+++ b/cmd/wfctl/update_test.go
@@ -378,6 +378,23 @@ func TestVerifyAssetChecksum_Valid(t *testing.T) {
 	}
 }
 
+func TestVerifyAssetChecksum_AcceptsDotSlashAssetPrefix(t *testing.T) {
+	data := []byte("fake binary content")
+	h := sha256.Sum256(data)
+	hash := hex.EncodeToString(h[:])
+	checksumsContent := fmt.Sprintf("%s  ./wfctl-darwin-arm64\n", hash)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(checksumsContent))
+	}))
+	defer srv.Close()
+
+	checksumAsset := &githubAsset{Name: "checksums.txt", BrowserDownloadURL: srv.URL}
+	if err := verifyAssetChecksum(checksumAsset, "wfctl-darwin-arm64", data); err != nil {
+		t.Fatalf("verifyAssetChecksum: %v", err)
+	}
+}
+
 func TestVerifyAssetChecksum_Mismatch(t *testing.T) {
 	data := []byte("fake binary content")
 	checksumsContent := "deadbeef  wfctl-linux-amd64\n"


### PR DESCRIPTION
## Summary

- fixes #876 by normalizing a leading `./` in `checksums.txt` asset names before lookup
- rejects conflicting bare/`./` checksum aliases for the same normalized asset name
- adds parser and `wfctl update` regression coverage for the v0.75.0 checksum format

## Verification

- `GOWORK=off go test ./cmd/wfctl -run TestVerifyAssetChecksum_AcceptsDotSlashAssetPrefix -count=1` failed before the fix with `checksum for "wfctl-darwin-arm64" not found in checksums.txt`
- `GOWORK=off go test ./cmd/wfctl -run 'TestParseChecksumsTxt|TestLookupChecksumForURL|TestVerifyAssetChecksum' -count=1`\n- `GOWORK=off go test ./cmd/wfctl -count=1`\n- `GOWORK=off golangci-lint run --timeout=5m`\n- `git diff --check`\n