### PR TITLE
fix: publish bare checksum names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
     - name: Create checksums
       run: |
         cd dist
-        sha256sum ./* > checksums.txt
+        sha256sum ./* | sed 's#  \./#  #' > checksums.txt
 
     - name: Create Release (draft during asset upload)
       uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2


### PR DESCRIPTION
## Summary
- strip leading ./ from release checksums.txt entries
- keep release asset hashes unchanged while making checksum names compatible with older wfctl updaters

## Verification
- printf '%s\n' 'abc123  ./wfctl-darwin-arm64' | sed 's#  \./#  #' | awk '{print }' | rg '^wfctl-darwin-arm64$'
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- actionlint .github/workflows/release.yml
- git diff --check

This lets a new patch release salvage the v0.74.x -> latest wfctl update path; v0.75.1 itself is immutable, so its checksums.txt cannot be patched in place.