### PR TITLE
fix(wfctl): validate infra secret pseudo-modules

### DIFF
--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -245,6 +245,29 @@ func TestRunValidateValid(t *testing.T) {
 	}
 }
 
+func TestRunValidateAllowsInfraSecretPseudoModules(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `
+modules:
+  - name: required-secrets
+    type: secrets.requires
+    config:
+      requires:
+        - key: EXTERNAL_API_TOKEN
+  - name: generated-secrets
+    type: secrets.generate
+    config:
+      generate:
+        - key: DATABASE_URL
+          type: infra_output
+          source: database.uri
+`
+	path := writeTestConfig(t, dir, "infra-secrets.yaml", cfg)
+	if err := runValidate([]string{"--allow-no-entry-points", path}); err != nil {
+		t.Fatalf("expected secrets pseudo-modules to validate, got: %v", err)
+	}
+}
+
 func TestRunValidateInvalid(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestConfig(t, dir, "invalid.yaml", invalidConfig)

--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -268,6 +268,42 @@ modules:
 	}
 }
 
+func TestRunValidateRejectsInfraSecretPseudoModulesByDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `
+modules:
+  - name: required-secrets
+    type: secrets.requires
+    config:
+      requires:
+        - key: EXTERNAL_API_TOKEN
+  - name: server
+    type: http.server
+    config:
+      address: ":8080"
+pipelines:
+  ping:
+    trigger:
+      type: http
+      config:
+        path: /ping
+        method: GET
+    steps:
+      - name: log
+        type: step.log
+        config:
+          message: pong
+`
+	path := writeTestConfig(t, dir, "app-with-infra-secret.yaml", cfg)
+	err := runValidate([]string{path})
+	if err == nil {
+		t.Fatal("expected default validation to reject infra-only secrets pseudo-modules")
+	}
+	if !strings.Contains(err.Error(), `unknown module type "secrets.requires"`) {
+		t.Fatalf("expected unknown secrets.requires module type error, got: %v", err)
+	}
+}
+
 func TestRunValidateInvalid(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestConfig(t, dir, "invalid.yaml", invalidConfig)

--- a/cmd/wfctl/validate.go
+++ b/cmd/wfctl/validate.go
@@ -181,13 +181,15 @@ func validateFile(cfgPath string, strict, skipUnknownTypes, allowNoEntryPoints, 
 		opts = append(opts, schema.WithAllowNoEntryPoints())
 	}
 
-	// Infra pseudo-modules are consumed by wfctl infra plan/align/bootstrap,
-	// not by the runtime engine, so keep them local to CLI validation rather
-	// than adding them to the engine's core module registry.
-	opts = append(opts,
-		schema.WithExtraModuleTypes("secrets.generate"),
-		schema.WithExtraModuleTypes("secrets.requires"),
-	)
+	if allowNoEntryPoints && !skipUnknownTypes {
+		// Infra pseudo-modules are consumed by wfctl infra plan/align/bootstrap,
+		// not by the runtime engine, so keep them scoped to infra-style CLI
+		// validation rather than adding them to the engine's core registry.
+		opts = append(opts,
+			schema.WithExtraModuleTypes("secrets.generate"),
+			schema.WithExtraModuleTypes("secrets.requires"),
+		)
+	}
 
 	// Pass legacy DO module types through schema validation so the actionable
 	// migration error fires below instead of a generic "unknown module type".

--- a/cmd/wfctl/validate.go
+++ b/cmd/wfctl/validate.go
@@ -181,6 +181,14 @@ func validateFile(cfgPath string, strict, skipUnknownTypes, allowNoEntryPoints, 
 		opts = append(opts, schema.WithAllowNoEntryPoints())
 	}
 
+	// Infra pseudo-modules are consumed by wfctl infra plan/align/bootstrap,
+	// not by the runtime engine, so keep them local to CLI validation rather
+	// than adding them to the engine's core module registry.
+	opts = append(opts,
+		schema.WithExtraModuleTypes("secrets.generate"),
+		schema.WithExtraModuleTypes("secrets.requires"),
+	)
+
 	// Pass legacy DO module types through schema validation so the actionable
 	// migration error fires below instead of a generic "unknown module type".
 	for t := range legacydo.ModuleTypes {


### PR DESCRIPTION
## Summary

`wfctl validate` now accepts the infra-only pseudo-module types `secrets.generate` and `secrets.requires` without requiring `--skip-unknown-types`.

These module types are already consumed by `wfctl infra plan/align/bootstrap`; the validator was the outlier and rejected valid infra configs before plugin/type validation could finish.

## Why

While validating GoCodeAlone/buymywishlist#276 against current `main`, BMW's original `infra.eventbus*` blocker was already resolved/superseded by the pgchannel migration, but strict validation of `infra.yaml` still failed on:

```console
error: modules[0].type: unknown module type "secrets.requires"
```

The fix keeps these types local to CLI validation rather than adding them to the runtime engine's core module registry.

## Verification

Red/green invariant:

```console
# With fix absent, new regression fails:
$ GOWORK=off go test ./cmd/wfctl -run TestRunValidateAllowsInfraSecretPseudoModules -count=1
--- FAIL: TestRunValidateAllowsInfraSecretPseudoModules
    main_test.go:267: expected secrets pseudo-modules to validate, got: 1 config(s) failed validation: - modules[1].type: unknown module type "secrets.generate"
FAIL

# With fix restored:
$ GOWORK=off go test ./cmd/wfctl -run TestRunValidateAllowsInfraSecretPseudoModules -count=1
ok  github.com/GoCodeAlone/workflow/cmd/wfctl
```

Additional local verification:

```console
$ GOWORK=off go test ./cmd/wfctl -run 'TestRunValidate(AllowsInfraSecretPseudoModules|Valid|Invalid|StrictByDefault|LooseAllowsEmptyModules)|TestValidateLocalManifest' -count=1
ok  github.com/GoCodeAlone/workflow/cmd/wfctl

$ GOWORK=off go test ./schema -count=1
ok  github.com/GoCodeAlone/workflow/schema

$ GOWORK=off go test ./cmd/wfctl -count=1
ok  github.com/GoCodeAlone/workflow/cmd/wfctl  161.324s
```

End-to-end BMW validation using a `wfctl` binary built from this branch and BMW's pinned plugins installed into `/tmp/bmw-wfctl-plugins-issue276`:

```console
$ /tmp/wfctl-issue276 validate --allow-no-entry-points --plugin-dir /tmp/bmw-wfctl-plugins-issue276 infra.yaml
PASS infra.yaml (11 modules, 0 workflows, 0 triggers)

$ /tmp/wfctl-issue276 validate --plugin-dir /tmp/bmw-wfctl-plugins-issue276 app.yaml
PASS app.yaml (27 modules, 1 workflows, 0 triggers)
# existing pipeline-reference warnings only
```
