### PR TITLE
fix(wfctl): improve secrets setup discovery

### DIFF
--- a/cmd/wfctl/internal/prompt/input.go
+++ b/cmd/wfctl/internal/prompt/input.go
@@ -14,12 +14,23 @@ import (
 //
 // Returns ("", ErrNotInteractive) when stdin is not a terminal.
 func Input(label string, masked bool) (string, error) {
+	return InputWithSuggestions(label, masked, nil)
+}
+
+// InputWithSuggestions prompts the user for a single-line text value and shows
+// completion suggestions when suggestions is non-empty. Tab accepts the current
+// suggestion using the underlying bubbles textinput behavior.
+func InputWithSuggestions(label string, masked bool, suggestions []string) (string, error) {
 	if !isTTY() {
 		return "", ErrNotInteractive
 	}
 	ti := textinput.New()
 	ti.Placeholder = label
 	ti.Focus()
+	if len(suggestions) > 0 {
+		ti.ShowSuggestions = true
+		ti.SetSuggestions(suggestions)
+	}
 	if masked {
 		ti.EchoMode = textinput.EchoPassword
 		ti.EchoCharacter = '*'

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
@@ -45,11 +47,14 @@ func runSecretsSetup(args []string) error {
 	allFlag := fs.Bool("all", false, "Set all declared secrets (the default when --only is absent; explicit form)")
 	skipExisting := fs.Bool("skip-existing", false, "Skip secrets that already have a value in the store")
 	storeName := fs.String("store", "", "Named store to use (overrides config defaultStore)")
-	// Legacy flags (kept for backwards compatibility with --plugin path).
-	fs.String("scope", "repo", "GitHub scope: repo | env | org (legacy --plugin path)")
-	fs.String("org", "", "Organization slug (legacy --plugin path)")
-	fs.String("visibility", "all", "Org-scope visibility (legacy --plugin path)")
-	fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT (legacy --plugin path)")
+	// Manifest-backed GitHub setup flags. These also keep the legacy --plugin
+	// path compatible because runSecrets dispatches --plugin before this path.
+	scope := fs.String("scope", "repo", "GitHub scope: repo | env | org")
+	org := fs.String("org", "", "Organization slug (required with --scope=org)")
+	visibility := fs.String("visibility", "all", "Org-scope visibility: all | selected | private")
+	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT")
+	lockFile := fs.String("lock-file", ".wfctl-lock.yaml", "wfctl plugin lockfile used when wfctl.yaml is auto-discovered")
+	pluginDir := fs.String("plugin-dir", "", "Plugin install dir used when wfctl.yaml is auto-discovered")
 
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), `Usage: wfctl secrets setup [options]
@@ -99,6 +104,35 @@ Options:
 	}
 
 	ctx := context.Background()
+	explicitConfig := hasFlag(args, "config")
+	if !explicitConfig {
+		target, err := resolveDefaultSecretsSetupTarget(!useNonInteractive)
+		if err != nil {
+			return err
+		}
+		if target.kind == secretsSetupTargetManifest {
+			return runSecretsSetupManifestWithIO(&manifestSetupArgs{
+				manifestPath:   target.path,
+				lockfilePath:   *lockFile,
+				pluginDir:      *pluginDir,
+				configPatterns: defaultManifestSetupConfigPatterns(),
+				scope:          *scope,
+				envName:        *envName,
+				org:            *org,
+				visibility:     *visibility,
+				tokenEnv:       *tokenEnv,
+				fromEnv:        *fromEnv,
+				secretLiterals: []string(secretFlag),
+				only:           only,
+				skipExisting:   *skipExisting,
+			}, nil, os.Stdout)
+		}
+		if target.path != "" {
+			*configFile = target.path
+		}
+	} else if !fileExists(*configFile) {
+		return missingExplicitSecretsConfigError(*configFile)
+	}
 
 	if useNonInteractive {
 		return runSecretsSetupNonInteractiveCtx(ctx, &nonInteractiveSetupArgs{
@@ -133,6 +167,174 @@ Options:
 		}, os.Stdout)
 	}
 	return err
+}
+
+type secretsSetupTargetKind string
+
+const (
+	secretsSetupTargetConfig   secretsSetupTargetKind = "config"
+	secretsSetupTargetManifest secretsSetupTargetKind = "manifest"
+)
+
+type secretsSetupTarget struct {
+	kind secretsSetupTargetKind
+	path string
+}
+
+func hasFlag(args []string, name string) bool {
+	long := "--" + name
+	for _, arg := range args {
+		if arg == long || strings.HasPrefix(arg, long+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveDefaultSecretsSetupTarget(interactive bool) (secretsSetupTarget, error) {
+	if fileExists("app.yaml") {
+		return secretsSetupTarget{kind: secretsSetupTargetConfig, path: "app.yaml"}, nil
+	}
+	if fileExists("wfctl.yaml") {
+		return secretsSetupTarget{kind: secretsSetupTargetManifest, path: "wfctl.yaml"}, nil
+	}
+	configs := discoverSecretsSetupConfigCandidates()
+	if len(configs) == 1 {
+		return secretsSetupTarget{kind: secretsSetupTargetConfig, path: configs[0]}, nil
+	}
+	if len(configs) > 1 {
+		if interactive {
+			options := append([]string{}, configs...)
+			options = append(options, "Enter another path")
+			idx, err := prompt.Select("Pick a secrets config", options)
+			if err != nil {
+				return secretsSetupTarget{}, err
+			}
+			if idx < len(configs) {
+				return secretsSetupTarget{kind: secretsSetupTargetConfig, path: configs[idx]}, nil
+			}
+			path, err := prompt.InputWithSuggestions("Config path", false, discoverYAMLPathSuggestions("."))
+			if err != nil {
+				return secretsSetupTarget{}, err
+			}
+			path = strings.TrimSpace(path)
+			if path == "" {
+				return secretsSetupTarget{}, fmt.Errorf("config path is required")
+			}
+			if !fileExists(path) {
+				return secretsSetupTarget{}, missingExplicitSecretsConfigError(path)
+			}
+			return secretsSetupTarget{kind: secretsSetupTargetConfig, path: path}, nil
+		}
+		return secretsSetupTarget{}, ambiguousSecretsConfigError(configs)
+	}
+	if interactive {
+		path, err := prompt.InputWithSuggestions("Config path", false, discoverYAMLPathSuggestions("."))
+		if err != nil {
+			return secretsSetupTarget{}, err
+		}
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return secretsSetupTarget{}, missingSecretsSetupConfigError(nil)
+		}
+		if fileExists(path) {
+			if filepath.Base(path) == "wfctl.yaml" {
+				return secretsSetupTarget{kind: secretsSetupTargetManifest, path: path}, nil
+			}
+			return secretsSetupTarget{kind: secretsSetupTargetConfig, path: path}, nil
+		}
+		return secretsSetupTarget{}, missingExplicitSecretsConfigError(path)
+	}
+	return secretsSetupTarget{}, missingSecretsSetupConfigError(nil)
+}
+
+func discoverSecretsSetupConfigCandidates() []string {
+	return existingFiles([]string{
+		"app.yml",
+		"workflow.yaml",
+		"workflow.yml",
+		"infra.yaml",
+		"infra.yml",
+	})
+}
+
+func defaultManifestSetupConfigPatterns() string {
+	candidates := []string{
+		"app.yaml",
+		"app.yml",
+		"workflow.yaml",
+		"workflow.yml",
+		"infra.yaml",
+		"infra.yml",
+		"infra/*.wfctl.yaml",
+		"*.wfctl.yaml",
+	}
+	var patterns []string
+	for _, candidate := range candidates {
+		if strings.ContainsAny(candidate, "*?[") {
+			matches, err := filepath.Glob(candidate)
+			if err == nil && len(matches) > 0 {
+				patterns = append(patterns, candidate)
+			}
+			continue
+		}
+		if fileExists(candidate) {
+			patterns = append(patterns, candidate)
+		}
+	}
+	if len(patterns) == 0 {
+		return "app.yaml,infra/*.wfctl.yaml,*.wfctl.yaml"
+	}
+	return strings.Join(patterns, ",")
+}
+
+func existingFiles(paths []string) []string {
+	var out []string
+	for _, path := range paths {
+		if fileExists(path) {
+			out = append(out, path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func discoverYAMLPathSuggestions(root string) []string {
+	var suggestions []string
+	seen := map[string]bool{}
+	for _, pattern := range []string{"*.yaml", "*.yml", "*.wfctl.yaml", "infra/*.yaml", "infra/*.yml", "infra/*.wfctl.yaml"} {
+		matches, err := filepath.Glob(filepath.Join(root, pattern))
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			if rel, err := filepath.Rel(root, match); err == nil {
+				match = rel
+			}
+			if seen[match] {
+				continue
+			}
+			seen[match] = true
+			suggestions = append(suggestions, match)
+		}
+	}
+	sort.Strings(suggestions)
+	return suggestions
+}
+
+func missingExplicitSecretsConfigError(path string) error {
+	return fmt.Errorf("secrets setup config %q not found; pass --config <path> for app/workflow secrets or --manifest wfctl.yaml for plugin/infra secrets", path)
+}
+
+func ambiguousSecretsConfigError(configs []string) error {
+	return fmt.Errorf("multiple plausible secrets setup configs found: %s; rerun with --config <path> or --manifest wfctl.yaml", strings.Join(configs, ", "))
+}
+
+func missingSecretsSetupConfigError(configs []string) error {
+	if len(configs) > 0 {
+		return ambiguousSecretsConfigError(configs)
+	}
+	return fmt.Errorf("no secrets setup config found; looked for app.yaml, workflow.yaml, infra.yaml, and wfctl.yaml. Rerun with --config <path> for app/workflow secrets or --manifest wfctl.yaml for plugin/infra secrets")
 }
 
 // isAutoGenCandidate returns true if the secret name looks like a key, token, or signing secret.

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -49,10 +49,10 @@ func runSecretsSetup(args []string) error {
 	storeName := fs.String("store", "", "Named store to use (overrides config defaultStore)")
 	// Manifest-backed GitHub setup flags. These also keep the legacy --plugin
 	// path compatible because runSecrets dispatches --plugin before this path.
-	scope := fs.String("scope", "repo", "GitHub scope: repo | env | org")
-	org := fs.String("org", "", "Organization slug (required with --scope=org)")
-	visibility := fs.String("visibility", "all", "Org-scope visibility: all | selected | private")
-	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT")
+	scope := fs.String("scope", "repo", "GitHub scope for manifest-backed setup: repo | env | org")
+	org := fs.String("org", "", "Organization slug for manifest-backed --scope=org")
+	visibility := fs.String("visibility", "all", "Manifest-backed org-scope visibility: all | selected | private")
+	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT for manifest-backed setup")
 	lockFile := fs.String("lock-file", ".wfctl-lock.yaml", "wfctl plugin lockfile used when wfctl.yaml is auto-discovered")
 	pluginDir := fs.String("plugin-dir", "", "Plugin install dir used when wfctl.yaml is auto-discovered")
 
@@ -334,7 +334,7 @@ func missingSecretsSetupConfigError(configs []string) error {
 	if len(configs) > 0 {
 		return ambiguousSecretsConfigError(configs)
 	}
-	return fmt.Errorf("no secrets setup config found; looked for app.yaml, workflow.yaml, infra.yaml, and wfctl.yaml. Rerun with --config <path> for app/workflow secrets or --manifest wfctl.yaml for plugin/infra secrets")
+	return fmt.Errorf("no secrets setup config found; looked for app.yaml/app.yml, workflow.yaml/workflow.yml, infra.yaml/infra.yml, and wfctl.yaml. Rerun with --config <path> for app/workflow secrets or --manifest wfctl.yaml for plugin/infra secrets")
 }
 
 // isAutoGenCandidate returns true if the secret name looks like a key, token, or signing secret.

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -373,7 +373,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 	manifestPath := fs.String("manifest", "", "wfctl.yaml plugin manifest")
 	lockfilePath := fs.String("lock-file", ".wfctl-lock.yaml", "wfctl plugin lockfile")
 	pluginDir := fs.String("plugin-dir", "", "Plugin install dir (default: $WFCTL_PLUGIN_DIR or ./data/plugins)")
-	configPatterns := fs.String("config", "app.yaml", "Workflow config file or comma-separated glob list for env reference discovery")
+	configPatterns := fs.String("config", defaultManifestSetupConfigPatterns(), "Workflow config file or comma-separated glob list for env reference discovery")
 	scope := fs.String("scope", "repo", "GitHub scope: repo | env | org")
 	envName := fs.String("env", "", "Environment name (required with --scope=env)")
 	org := fs.String("org", "", "Organization slug (required with --scope=org)")

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -360,10 +360,32 @@ func readKVLines(r io.Reader) []string {
 }
 
 func firstConfigPattern(patterns string) string {
+	fallback := ""
 	for _, raw := range strings.Split(patterns, ",") {
 		if pattern := strings.TrimSpace(raw); pattern != "" {
-			return pattern
+			if fallback == "" {
+				fallback = pattern
+			}
+			if strings.ContainsAny(pattern, "*?[") {
+				matches, err := filepath.Glob(pattern)
+				if err != nil {
+					continue
+				}
+				sort.Strings(matches)
+				for _, match := range matches {
+					if fileExists(match) {
+						return match
+					}
+				}
+				continue
+			}
+			if fileExists(pattern) {
+				return pattern
+			}
 		}
+	}
+	if fallback != "" {
+		return fallback
 	}
 	return "app.yaml"
 }

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -91,3 +91,22 @@ func TestParseManifestSetupFlagsAcceptsSetupSelectors(t *testing.T) {
 		t.Fatalf("flags not preserved: %+v", args)
 	}
 }
+
+func TestParseManifestSetupFlagsDefaultsConfigPatterns(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatalf("mkdir infra: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "infra", "dns.wfctl.yaml"), []byte("resources: []\n"), 0o644); err != nil {
+		t.Fatalf("write infra config: %v", err)
+	}
+
+	args, err := parseManifestSetupFlags([]string{"--manifest", "wfctl.yaml"})
+	if err != nil {
+		t.Fatalf("parseManifestSetupFlags: %v", err)
+	}
+	if args.configPatterns != "infra/*.wfctl.yaml" {
+		t.Fatalf("configPatterns = %q, want infra/*.wfctl.yaml", args.configPatterns)
+	}
+}

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -110,3 +110,21 @@ func TestParseManifestSetupFlagsDefaultsConfigPatterns(t *testing.T) {
 		t.Fatalf("configPatterns = %q, want infra/*.wfctl.yaml", args.configPatterns)
 	}
 }
+
+func TestFirstConfigPatternResolvesGlobToExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatalf("mkdir infra: %v", err)
+	}
+	for _, name := range []string{"b.wfctl.yaml", "a.wfctl.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, "infra", name), []byte("resources: []\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	got := firstConfigPattern("missing.yaml,infra/*.wfctl.yaml")
+	if got != filepath.Join("infra", "a.wfctl.yaml") {
+		t.Fatalf("firstConfigPattern = %q, want infra/a.wfctl.yaml", got)
+	}
+}

--- a/cmd/wfctl/secrets_setup_noninteractive_test.go
+++ b/cmd/wfctl/secrets_setup_noninteractive_test.go
@@ -10,6 +10,22 @@ import (
 	"testing"
 )
 
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore cwd %s: %v", wd, err)
+		}
+	})
+}
+
 // writeSetupConfig writes a minimal app.yaml + a file-store directory for
 // non-interactive setup tests.  Returns (configPath, storeDir).
 func writeSetupConfig(t *testing.T, entries ...string) (string, string) {
@@ -46,6 +62,81 @@ secretStores:
 		t.Fatalf("write app.yaml: %v", err)
 	}
 	return cfgPath, storeDir
+}
+
+func TestSetupNoArgsMissingConfigExplainsDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+
+	err := runSecretsSetup(nil)
+	if err == nil {
+		t.Fatal("expected missing config error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"no secrets setup config found",
+		"--config <path>",
+		"--manifest wfctl.yaml",
+		"app.yaml",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "open app.yaml") {
+		t.Fatalf("error should not expose raw app.yaml open failure: %q", msg)
+	}
+}
+
+func TestSetupNoArgsDiscoversWorkflowYAML(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	storeDir := filepath.Join(dir, "store")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	cfg := `modules:
+  - name: http
+    type: http.server
+    config:
+      address: ":0"
+secrets:
+  defaultStore: localfs
+  entries:
+    - name: A
+secretStores:
+  localfs:
+    provider: file
+    config:
+      path: ` + storeDir + `
+`
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write workflow.yaml: %v", err)
+	}
+
+	err := runSecretsSetup([]string{"--secret", "A=av", "--store", "localfs"})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(storeDir, "A"))
+	if err != nil {
+		t.Fatalf("read secret: %v", err)
+	}
+	if string(data) != "av" {
+		t.Fatalf("stored secret = %q, want av", data)
+	}
+}
+
+func TestSetupNoArgsDiscoversWfctlManifest(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "wfctl.yaml"), []byte("version: 1\nplugins: []\n"), 0o644); err != nil {
+		t.Fatalf("write wfctl.yaml: %v", err)
+	}
+
+	if err := runSecretsSetup(nil); err != nil {
+		t.Fatalf("setup should use wfctl.yaml manifest defaults: %v", err)
+	}
 }
 
 // TestSetupAllOnlyConflict verifies --all and --only are mutually exclusive.


### PR DESCRIPTION
## Summary
- auto-discover the secrets setup target when `wfctl secrets setup` is run without `--config`
- prefer `wfctl.yaml` manifest setup when present, using default lockfile/plugin-dir/config-pattern discovery
- add prompt input suggestions for manual config path entry
- make explicit `--manifest wfctl.yaml` discover `infra/*.wfctl.yaml` config refs by default

Fixes #882.

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestSetupNoArgs(MissingConfigExplainsDiscovery|DiscoversWorkflowYAML|DiscoversWfctlManifest)|TestSetupAll|TestNonInteractive|TestParseManifestSetupFlags|TestDiscoverManifestSecrets' -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestParseManifestSetupFlagsDefaultsConfigPatterns|TestSetupNoArgs(MissingConfigExplainsDiscovery|DiscoversWorkflowYAML|DiscoversWfctlManifest)' -count=1`
- `GOWORK=off go test ./cmd/wfctl/internal/prompt -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `GOWORK=off go build -o /tmp/wfctl-issue882 ./cmd/wfctl`
- built-binary smoke tests for missing config, discovered workflow.yaml, and explicit manifest defaults
