### PR TITLE
fix: publish releases with gh cli

### DIFF
--- a/.github/workflows/ci-wfctl.yml.example
+++ b/.github/workflows/ci-wfctl.yml.example
@@ -22,7 +22,7 @@
 #   - GOPRIVATE / GONOSUMCHECK for private module access
 #   - SHA-tag + major.minor tag aliases (sha-<sha>, v0.3, etc.)
 #   - sha256sum checksums.txt for release assets
-#   - softprops/action-gh-release with prerelease detection
+#   - gh release create with prerelease detection
 #   - Homebrew tap dispatch (peter-evans/repository-dispatch → homebrew-tap)
 #   - IDE plugin dispatch (→ workflow-editor)
 #   - go mod tidy auto-commit + PR diff check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,14 +295,20 @@ jobs:
         sha256sum ./* | sed 's#  \./#  #' > checksums.txt
 
     - name: Create Release (draft during asset upload)
-      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-      with:
-        tag_name: ${{ env.TAG_NAME }}
-        files: |
-          dist/*
-        draft: true
-        prerelease: ${{ contains(env.TAG_NAME, '-') }}
-        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        prerelease_flag=()
+        if [[ "${TAG_NAME}" == *-* ]]; then
+          prerelease_flag+=(--prerelease)
+        fi
+        gh release create "${TAG_NAME}" dist/* \
+          --repo "${GITHUB_REPOSITORY}" \
+          --draft \
+          --verify-tag \
+          --generate-notes \
+          "${prerelease_flag[@]}"
 
     - name: Publish release (was draft during asset upload)
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
 
     - name: Create Release (draft during asset upload)
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
         prerelease_flag=()
@@ -312,7 +312,7 @@ jobs:
 
     - name: Publish release (was draft during asset upload)
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release edit ${{ env.TAG_NAME }} --draft=false --repo ${{ github.repository }}
 
   update-homebrew:

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -291,7 +291,7 @@ jobs:
           done
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           gh release create "${GITHUB_REF_NAME}" dist/* \

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -290,9 +290,14 @@ jobs:
             done
           done
       - name: Create release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --generate-notes
 `
 	return os.WriteFile(path, []byte(content), 0600)
 }

--- a/cmd/wfctl/generate_test.go
+++ b/cmd/wfctl/generate_test.go
@@ -239,8 +239,12 @@ func TestRunGenerateGithubActionsWithPlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read release.yml: %v", err)
 	}
-	if !strings.Contains(string(data), "softprops/action-gh-release") {
-		t.Error("release.yml should use softprops/action-gh-release")
+	content := string(data)
+	if strings.Contains(content, "softprops/action-gh-release") {
+		t.Error("release.yml should not use softprops/action-gh-release")
+	}
+	if !strings.Contains(content, "gh release create") {
+		t.Error("release.yml should publish releases with gh release create")
 	}
 }
 
@@ -454,8 +458,11 @@ func TestReleaseWorkflowContent(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "softprops/action-gh-release") {
-		t.Error("release.yml should use softprops/action-gh-release")
+	if strings.Contains(content, "softprops/action-gh-release") {
+		t.Error("release.yml should not use softprops/action-gh-release")
+	}
+	if !strings.Contains(content, "gh release create") {
+		t.Error("release.yml should publish releases with gh release create")
 	}
 	if !strings.Contains(content, "dist/*") {
 		t.Error("release.yml should upload dist/* files")

--- a/cmd/wfctl/generate_test.go
+++ b/cmd/wfctl/generate_test.go
@@ -246,6 +246,9 @@ func TestRunGenerateGithubActionsWithPlugin(t *testing.T) {
 	if !strings.Contains(content, "gh release create") {
 		t.Error("release.yml should publish releases with gh release create")
 	}
+	if !strings.Contains(content, "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}") {
+		t.Error("release.yml should authenticate gh with GH_TOKEN")
+	}
 }
 
 func TestRunGenerateGithubActionsCIOnly(t *testing.T) {
@@ -463,6 +466,9 @@ func TestReleaseWorkflowContent(t *testing.T) {
 	}
 	if !strings.Contains(content, "gh release create") {
 		t.Error("release.yml should publish releases with gh release create")
+	}
+	if !strings.Contains(content, "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}") {
+		t.Error("release.yml should authenticate gh with GH_TOKEN")
 	}
 	if !strings.Contains(content, "dist/*") {
 		t.Error("release.yml should upload dist/* files")

--- a/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
@@ -29,7 +29,7 @@ jobs:
         run: wfctl plugin validate-contract --for-publish --tag "${{ "{{" }} github.ref_name {{ "}}" }}" .
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
+          GH_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
         run: |
           set -euo pipefail
           gh release create "${GITHUB_REF_NAME}" dist/* \

--- a/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
@@ -28,6 +28,11 @@ jobs:
       - name: Validate packaged release contract
         run: wfctl plugin validate-contract --for-publish --tag "${{ "{{" }} github.ref_name {{ "}}" }}" .
       - name: Create release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
+        run: |
+          set -euo pipefail
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --generate-notes

--- a/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
@@ -34,6 +34,11 @@ jobs:
       - name: Validate packaged release contract
         run: wfctl plugin validate-contract --for-publish --tag "${{ "{{" }} github.ref_name {{ "}}" }}" .
       - name: Create release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
+        run: |
+          set -euo pipefail
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --generate-notes

--- a/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
@@ -35,7 +35,7 @@ jobs:
         run: wfctl plugin validate-contract --for-publish --tag "${{ "{{" }} github.ref_name {{ "}}" }}" .
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
+          GH_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
         run: |
           set -euo pipefail
           gh release create "${GITHUB_REF_NAME}" dist/* \

--- a/mcp/scaffold_tools_test.go
+++ b/mcp/scaffold_tools_test.go
@@ -252,6 +252,9 @@ func TestMCPGenerateReleaseWorkflowUsesGHCLI(t *testing.T) {
 	if !strings.Contains(text, "gh release create") {
 		t.Error("release workflow should publish releases with gh release create")
 	}
+	if !strings.Contains(text, "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}") {
+		t.Error("release workflow should authenticate gh with GH_TOKEN")
+	}
 }
 
 func TestHandleGenerateBootstrap_InvalidPlatform(t *testing.T) {

--- a/mcp/scaffold_tools_test.go
+++ b/mcp/scaffold_tools_test.go
@@ -244,6 +244,16 @@ ci:
 	}
 }
 
+func TestMCPGenerateReleaseWorkflowUsesGHCLI(t *testing.T) {
+	text := mcpGenerateReleaseWorkflow()
+	if strings.Contains(text, "softprops/action-gh-release") {
+		t.Error("release workflow should not use softprops/action-gh-release")
+	}
+	if !strings.Contains(text, "gh release create") {
+		t.Error("release workflow should publish releases with gh release create")
+	}
+}
+
 func TestHandleGenerateBootstrap_InvalidPlatform(t *testing.T) {
 	s := newTestServer()
 	req := mcp.CallToolRequest{}

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -1928,7 +1928,7 @@ jobs:
           done
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           gh release create "${GITHUB_REF_NAME}" dist/* \

--- a/mcp/wfctl_tools.go
+++ b/mcp/wfctl_tools.go
@@ -1927,8 +1927,13 @@ jobs:
             done
           done
       - name: Create release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --generate-notes
 `
 }


### PR DESCRIPTION
## Summary
- replace the live release publishing step with `gh release create` so the release job no longer depends on the Node 20-backed `softprops/action-gh-release` action
- update wfctl-generated release workflows, MCP scaffold output, and plugin templates to use the same GitHub CLI release path
- keep draft upload/publish behavior and release-note generation for the main workflow

Closes #878

## TDD / Regression Proof
With the implementation reverted and the new tests kept:
```console
$ GOWORK=off go test ./cmd/wfctl -run TestReleaseWorkflowContent -count=1
--- FAIL: TestReleaseWorkflowContent
    generate_test.go:462: release.yml should not use softprops/action-gh-release
    generate_test.go:465: release.yml should publish releases with gh release create
FAIL
```

With the implementation restored:
```console
$ GOWORK=off go test ./cmd/wfctl -run 'TestRunGenerateGithubActionsPluginRelease|TestReleaseWorkflowContent|TestInitTemplatesIncludeGithubWorkflows' -count=1\nok github.com/GoCodeAlone/workflow/cmd/wfctl\n\n$ GOWORK=off go test ./mcp -run TestMCPGenerateReleaseWorkflowUsesGHCLI -count=1\nok github.com/GoCodeAlone/workflow/mcp\n```\n\n## Verification\n```console\n$ GOWORK=off go test ./cmd/wfctl ./mcp -count=1\nok github.com/GoCodeAlone/workflow/cmd/wfctl 167.360s\nok github.com/GoCodeAlone/workflow/mcp 2.646s\n\n$ ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'\n# exit 0\n\n$ actionlint .github/workflows/release.yml\n# exit 0\n\n$ git diff --check\n# exit 0\n```