### PR TITLE
fix: preserve secrets provider config

### DIFF
--- a/cmd/wfctl/secrets_delete.go
+++ b/cmd/wfctl/secrets_delete.go
@@ -47,7 +47,7 @@ func runSecretsDelete(args []string) error {
 	if err != nil {
 		return err
 	}
-	provider, err := newSecretsProvider(cfg.Provider)
+	provider, err := newSecretsProviderFromConfig(cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/secrets_detect.go
+++ b/cmd/wfctl/secrets_detect.go
@@ -102,7 +102,7 @@ func detectSecrets(cfg *config.WorkflowConfig) []detectedSecret {
 
 	// Also check secrets: entries against the provider.
 	if cfg.Secrets != nil {
-		provider, err := newSecretsProvider(cfg.Secrets.Provider)
+		provider, err := newSecretsProviderFromConfig(cfg.Secrets)
 		if err == nil {
 			ctx := context.Background()
 			for _, entry := range cfg.Secrets.Entries {
@@ -279,7 +279,7 @@ Options:
 	if err != nil {
 		return err
 	}
-	provider, err := newSecretsProvider(cfg.Provider)
+	provider, err := newSecretsProviderFromConfig(cfg)
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func runSecretsList(args []string) error {
 	if secretsCfg == nil {
 		secretsCfg = &config.SecretsConfig{Provider: "env"}
 	}
-	provider, err := newSecretsProvider(secretsCfg.Provider)
+	provider, err := newSecretsProviderFromConfig(secretsCfg)
 	if err != nil {
 		return err
 	}
@@ -558,7 +558,7 @@ func runSecretsValidate(args []string) error {
 		return err
 	}
 
-	provider, err := newSecretsProvider(cfg.Provider)
+	provider, err := newSecretsProviderFromConfig(cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/secrets_get.go
+++ b/cmd/wfctl/secrets_get.go
@@ -53,7 +53,7 @@ func runSecretsGetWithWriter(args []string, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	provider, err := newSecretsProvider(cfg.Provider)
+	provider, err := newSecretsProviderFromConfig(cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/secrets_imports_test.go
+++ b/cmd/wfctl/secrets_imports_test.go
@@ -247,6 +247,26 @@ func TestSecretsValidate_HonorsImports(t *testing.T) {
 	}
 }
 
+func TestSecretsValidate_PreservesGitHubProviderConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GH_MANAGEMENT_TOKEN", "test-token")
+
+	cfg := `secrets:
+  provider: github
+  config:
+    repo: GoCodeAlone/buymywishlist
+    token_env: GH_MANAGEMENT_TOKEN
+`
+	path := filepath.Join(dir, "infra.yaml")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runSecretsValidate([]string{"--config", path}); err != nil {
+		t.Fatalf("runSecretsValidate should preserve github repo/token_env config: %v", err)
+	}
+}
+
 // TestSecretsValidate_ImportedEntryUnset verifies that runSecretsValidate
 // reports missing imported entries as errors.
 func TestSecretsValidate_ImportedEntryUnset(t *testing.T) {

--- a/cmd/wfctl/secrets_providers.go
+++ b/cmd/wfctl/secrets_providers.go
@@ -182,14 +182,29 @@ func (a secretsProviderAdapter) checkAccess(ctx context.Context) error {
 }
 
 // newSecretsProvider constructs the provider matching the given name.
-// It now supports all 5 backends (env, github, vault, aws, keychain) by
-// delegating to resolveSecretsProvider, then wrapping the result in the adapter.
+// It is intended for ad-hoc provider selection where no provider-specific
+// config was loaded from a workflow config file.
 func newSecretsProvider(providerName string) (SecretsProvider, error) {
 	name := providerName
 	if name == "" {
 		name = "env"
 	}
-	p, err := resolveSecretsProvider(&SecretsConfig{Provider: name})
+	return newSecretsProviderFromConfig(&SecretsConfig{Provider: name})
+}
+
+// newSecretsProviderFromConfig constructs the provider from a full SecretsConfig.
+// It preserves provider-specific config such as GitHub repo/token_env, Vault
+// address/token, and env prefixes loaded from app.yaml/infra.yaml.
+func newSecretsProviderFromConfig(cfg *SecretsConfig) (SecretsProvider, error) {
+	if cfg == nil {
+		cfg = &SecretsConfig{Provider: "env"}
+	}
+	if cfg.Provider == "" {
+		copied := *cfg
+		copied.Provider = "env"
+		cfg = &copied
+	}
+	p, err := resolveSecretsProvider(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wfctl/secrets_providers_test.go
+++ b/cmd/wfctl/secrets_providers_test.go
@@ -137,6 +137,24 @@ func TestNewSecretsProvider_NotUnknownProviderError(t *testing.T) {
 	}
 }
 
+func TestNewSecretsProviderFromConfig_PreservesGitHubConfig(t *testing.T) {
+	t.Setenv("GH_MANAGEMENT_TOKEN", "test-token")
+
+	p, err := newSecretsProviderFromConfig(&SecretsConfig{
+		Provider: "github",
+		Config: map[string]any{
+			"repo":      "GoCodeAlone/buymywishlist",
+			"token_env": "GH_MANAGEMENT_TOKEN",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSecretsProviderFromConfig: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
 func TestNewSecretsProvider_Env_Success(t *testing.T) {
 	p, err := newSecretsProvider("env")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add a config-preserving secrets provider construction path for YAML-loaded `secrets:` blocks
- route `secrets list`, `validate`, `get`, `delete`, `set`, and detection paths through the full `SecretsConfig` instead of only the provider name
- add regressions for GitHub `repo`/`token_env` preservation from `infra.yaml`

Closes #880

## TDD / Regression Proof
With the old config-dropping behavior restored inside the helper:
```console
$ GOWORK=off go test ./cmd/wfctl -run TestSecretsValidate_PreservesGitHubProviderConfig -count=1
--- FAIL: TestSecretsValidate_PreservesGitHubProviderConfig
    secrets_imports_test.go:266: runSecretsValidate should preserve github repo/token_env config: secrets: github repo must be 'owner/repo', got ""\nFAIL\n```\n\nWith the fix restored:\n```console\n$ GOWORK=off go test ./cmd/wfctl -run 'TestNewSecretsProviderFromConfig_PreservesGitHubConfig|TestSecretsValidate_PreservesGitHubProviderConfig' -count=1\nok github.com/GoCodeAlone/workflow/cmd/wfctl\n```\n\n## Verification\n```console\n$ GOWORK=off go test ./cmd/wfctl -run 'Test.*Secrets|TestNewSecretsProvider|TestLoadSecretsConfig|TestParseSecretsConfig' -count=1\nok github.com/GoCodeAlone/workflow/cmd/wfctl 18.242s\n\n$ GOWORK=off go test ./cmd/wfctl -count=1\nok github.com/GoCodeAlone/workflow/cmd/wfctl 167.041s\n\n$ git diff --check\n# exit 0\n```