### PR TITLE
fix: explain wfctl secrets repo inference

### DIFF
--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -71,6 +71,39 @@ func isHelpRequested(err error) bool {
 	return strings.Contains(err.Error(), "flag: help requested")
 }
 
+type contextualCLIError struct {
+	err error
+}
+
+func (e contextualCLIError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e contextualCLIError) Unwrap() error {
+	return e.err
+}
+
+// commandErrorForDisplay strips workflow execution wrappers while preserving
+// errors that intentionally carry concise CLI context.
+func commandErrorForDisplay(err error) error {
+	if err == nil {
+		return nil
+	}
+	for {
+		if _, ok := err.(contextualCLIError); ok {
+			return err
+		}
+		next := errors.Unwrap(err)
+		if next == nil {
+			return err
+		}
+		err = next
+	}
+}
+
 // commands maps each CLI command name to its Go implementation. The command
 // metadata (name, description) is declared in wfctl.yaml; this map provides
 // the runtime functions that are registered in the CLICommandRegistry service
@@ -248,12 +281,7 @@ func main() {
 		// The handler already printed routing errors (unknown/missing command).
 		// Only emit the "error:" prefix for actual command execution failures.
 		if _, isKnown := commands[cmd]; isKnown {
-			// Unwrap to the root cause so users see a concise, actionable message
-			// rather than the full pipeline execution chain.
-			rootErr := dispatchErr
-			for errors.Unwrap(rootErr) != nil {
-				rootErr = errors.Unwrap(rootErr)
-			}
+			rootErr := commandErrorForDisplay(dispatchErr)
 			fmt.Fprintf(os.Stderr, "error: %v\n", rootErr) //nolint:gosec // G705
 		}
 		os.Exit(1)

--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -52,6 +52,33 @@ func TestHelpFlagDoesNotLeakEngineError(t *testing.T) {
 	}
 }
 
+func TestCommandErrorForDisplayStopsAtContextualCLIError(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	contextErr := contextualCLIError{err: fmt.Errorf("configure GitHub repo secrets for owner/repo (inferred from git remote.origin.url): %w", sentinel)}
+	err := fmt.Errorf("pipeline step failed: %w", contextErr)
+
+	got := commandErrorForDisplay(err)
+	if got == nil {
+		t.Fatal("expected display error")
+	}
+	if got.Error() != contextErr.Error() {
+		t.Fatalf("display error = %q, want %q", got.Error(), contextErr.Error())
+	}
+	if !errors.Is(got, sentinel) {
+		t.Fatal("display error must preserve underlying error unwrapping")
+	}
+}
+
+func TestCommandErrorForDisplayFallsBackToRootCause(t *testing.T) {
+	root := errors.New("root cause")
+	err := fmt.Errorf("pipeline step failed: %w", fmt.Errorf("invoke failed: %w", root))
+
+	got := commandErrorForDisplay(err)
+	if got != root {
+		t.Fatalf("display error = %v, want root cause", got)
+	}
+}
+
 func TestBuildVersionStripsDirtyMarker(t *testing.T) {
 	// cleanBuildVersion must strip +dirty from both release tags and pseudo-versions.
 	for _, tc := range []struct {

--- a/cmd/wfctl/secrets_detect.go
+++ b/cmd/wfctl/secrets_detect.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
-	"regexp"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -290,21 +293,210 @@ Options:
 	return nil
 }
 
-// readGitHubRepoFromAppYAML loads app.yaml and returns the configured
-// github repo from secrets.config.repo (or secrets.secretStores.<name>.config.repo).
+// readGitHubRepoFromAppYAML returns the target GitHub repository for repo/env
+// secrets. It first honors explicit YAML configuration
+// (secrets.config.repo or GitHub secretStores.<name>.config.repo), then falls
+// back to the current git remote so repo-local wfctl.yaml setup works for
+// infra-only configs that only contain ${ENV_VAR} references.
 func readGitHubRepoFromAppYAML(path string) (string, error) {
-	data, err := os.ReadFile(path)
+	repo, _, err := readGitHubRepoForSecretsSetup(path)
+	return repo, err
+}
+
+func readGitHubRepoForSecretsSetup(path string) (string, string, error) {
+	if repo, source, err := readGitHubRepoFromWorkflowConfig(path); err != nil {
+		return "", "", err
+	} else if repo != "" {
+		return repo, "configured by " + source, nil
+	}
+
+	dir := "."
+	if strings.TrimSpace(path) != "" {
+		dir = filepath.Dir(path)
+	}
+	repo, err := readGitHubRepoFromGitRemote(dir)
 	if err != nil {
-		return "", fmt.Errorf("read %s: %w", path, err)
+		return "", "", fmt.Errorf("could not determine GitHub repo for secrets setup from %s (checked secrets.config.repo, GitHub secretStores.<name>.config.repo, and git remote.origin.url): %w", path, err)
 	}
-	// Lightweight regexp scan — avoids full YAML round-trip and tolerates
-	// either `secrets.config.repo` or `secretStores.<name>.config.repo`.
-	re := regexp.MustCompile(`(?m)^\s*repo:\s*([^\s#]+)`)
-	m := re.FindStringSubmatch(string(data))
-	if len(m) < 2 {
-		return "", fmt.Errorf("could not find `repo:` in %s (expected secrets.config.repo or secretStores.<name>.config.repo)", path)
+	return repo, "inferred from git remote.origin.url", nil
+}
+
+func readGitHubRepoFromWorkflowConfig(path string) (string, string, error) {
+	cfg, err := config.LoadFromFile(path)
+	if err != nil {
+		return "", "", fmt.Errorf("load config %s: %w", path, err)
 	}
-	return strings.Trim(m[1], `"'`), nil
+	if cfg.Secrets != nil {
+		if repo := stringConfigValue(cfg.Secrets.Config, "repo"); repo != "" {
+			return repo, "secrets.config.repo", nil
+		}
+		if cfg.Secrets.DefaultStore != "" {
+			if repo := githubRepoFromSecretStore(cfg.SecretStores[cfg.Secrets.DefaultStore]); repo != "" {
+				return repo, fmt.Sprintf("secretStores.%s.config.repo", cfg.Secrets.DefaultStore), nil
+			}
+		}
+	}
+	if len(cfg.SecretStores) > 0 {
+		names := make([]string, 0, len(cfg.SecretStores))
+		for name := range cfg.SecretStores {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if repo := githubRepoFromSecretStore(cfg.SecretStores[name]); repo != "" {
+				return repo, fmt.Sprintf("secretStores.%s.config.repo", name), nil
+			}
+		}
+	}
+	return "", "", nil
+}
+
+func githubRepoFromSecretStore(store *config.SecretStoreConfig) string {
+	if store == nil || store.Provider != "github" {
+		return ""
+	}
+	return stringConfigValue(store.Config, "repo")
+}
+
+func stringConfigValue(cfg map[string]any, key string) string {
+	if cfg == nil {
+		return ""
+	}
+	value, _ := cfg[key].(string)
+	return strings.TrimSpace(strings.Trim(value, `"'`))
+}
+
+func readGitHubRepoFromGitRemote(dir string) (string, error) {
+	remote, err := gitRemoteOriginURLFromConfig(dir)
+	if err != nil {
+		return "", err
+	}
+	if repo, ok := githubRepoFromRemoteURL(remote); ok {
+		return repo, nil
+	}
+	return "", fmt.Errorf("remote.origin.url is not a GitHub repo URL: %s", remote)
+}
+
+func gitRemoteOriginURLFromConfig(start string) (string, error) {
+	if strings.TrimSpace(start) == "" {
+		start = "."
+	}
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolve git search path: %w", err)
+	}
+	if info, statErr := os.Stat(dir); statErr == nil && !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+	for {
+		gitPath := filepath.Join(dir, ".git")
+		if info, statErr := os.Stat(gitPath); statErr == nil {
+			configs, configErr := gitConfigCandidates(gitPath, info)
+			if configErr != nil {
+				return "", configErr
+			}
+			for _, configPath := range configs {
+				remote, remoteErr := remoteOriginURLFromGitConfig(configPath)
+				if remoteErr == nil && remote != "" {
+					return remote, nil
+				}
+			}
+			return "", fmt.Errorf("git remote.origin.url is empty")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("no .git directory found")
+}
+
+func gitConfigCandidates(gitPath string, info os.FileInfo) ([]string, error) {
+	if info.IsDir() {
+		return []string{filepath.Join(gitPath, "config")}, nil
+	}
+	data, err := os.ReadFile(gitPath) //nolint:gosec // repository-local .git file
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", gitPath, err)
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return nil, fmt.Errorf("unsupported .git file format in %s", gitPath)
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(filepath.Dir(gitPath), gitDir)
+	}
+	candidates := []string{filepath.Join(gitDir, "config")}
+	if commonDirData, err := os.ReadFile(filepath.Join(gitDir, "commondir")); err == nil {
+		commonDir := strings.TrimSpace(string(commonDirData))
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitDir, commonDir)
+		}
+		candidates = append(candidates, filepath.Join(commonDir, "config"))
+	}
+	return candidates, nil
+}
+
+func remoteOriginURLFromGitConfig(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // repository-local git config
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	inOrigin := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inOrigin = line == `[remote "origin"]`
+			continue
+		}
+		if !inOrigin || !strings.HasPrefix(line, "url") {
+			continue
+		}
+		_, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		return strings.TrimSpace(value), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan %s: %w", path, err)
+	}
+	return "", nil
+}
+
+func githubRepoFromRemoteURL(remote string) (string, bool) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "", false
+	}
+	if strings.HasPrefix(remote, "git@github.com:") {
+		return cleanGitHubRepoPath(strings.TrimPrefix(remote, "git@github.com:"))
+	}
+	if strings.HasPrefix(remote, "github.com/") {
+		return cleanGitHubRepoPath(strings.TrimPrefix(remote, "github.com/"))
+	}
+	if u, err := url.Parse(remote); err == nil && strings.EqualFold(u.Hostname(), "github.com") {
+		return cleanGitHubRepoPath(u.Path)
+	}
+	return "", false
+}
+
+func cleanGitHubRepoPath(path string) (string, bool) {
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", false
+	}
+	return parts[0] + "/" + parts[1], true
 }
 
 // parseGitHubOrgVisibility canonicalises the --visibility flag.

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -126,5 +128,111 @@ func TestFirstConfigPatternResolvesGlobToExistingFile(t *testing.T) {
 	got := firstConfigPattern("missing.yaml,infra/*.wfctl.yaml")
 	if got != filepath.Join("infra", "a.wfctl.yaml") {
 		t.Fatalf("firstConfigPattern = %q, want infra/a.wfctl.yaml", got)
+	}
+}
+
+func TestBuildSecretWriterRepoScopeFallsBackToGitRemote(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	runGitForTest(t, dir, "init")
+	runGitForTest(t, dir, "remote", "add", "origin", "git@github.com:GoCodeAlone/gocodealone-dns.git")
+	t.Setenv("GITHUB_TOKEN", "stub")
+
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatalf("mkdir infra: %v", err)
+	}
+	configPath := filepath.Join(dir, "infra", "digitalocean.wfctl.yaml")
+	if err := os.WriteFile(configPath, []byte(`modules:
+  - name: do
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, label, err := buildSecretWriter("repo", "", "", "all", "GITHUB_TOKEN", configPath)
+	if err != nil {
+		t.Fatalf("buildSecretWriter: %v", err)
+	}
+	if !strings.Contains(label, "GoCodeAlone/gocodealone-dns") {
+		t.Fatalf("label = %q, want git remote repo", label)
+	}
+	if !strings.Contains(label, "inferred from git remote.origin.url") {
+		t.Fatalf("label = %q, want inference source", label)
+	}
+}
+
+func TestBuildSecretWriterRepoScopeErrorIncludesInferredRepo(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	runGitForTest(t, dir, "init")
+	runGitForTest(t, dir, "remote", "add", "origin", "https://github.com/GoCodeAlone/gocodealone-dns.git")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatalf("mkdir infra: %v", err)
+	}
+	configPath := filepath.Join(dir, "infra", "digitalocean.wfctl.yaml")
+	if err := os.WriteFile(configPath, []byte(`modules:
+  - name: do
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := buildSecretWriter("repo", "", "", "all", "GITHUB_TOKEN", configPath)
+	if err == nil {
+		t.Fatal("expected missing token error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"GoCodeAlone/gocodealone-dns",
+		"inferred from git remote.origin.url",
+		`env var "GITHUB_TOKEN"`,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestReadGitHubRepoFromConfigUsesSecretStores(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(configPath, []byte(`modules: []
+secrets:
+  defaultStore: github
+  entries:
+    - name: TOKEN
+secretStores:
+  github:
+    provider: github
+    config:
+      repo: GoCodeAlone/workflow
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got, err := readGitHubRepoFromAppYAML(configPath)
+	if err != nil {
+		t.Fatalf("readGitHubRepoFromAppYAML: %v", err)
+	}
+	if got != "GoCodeAlone/workflow" {
+		t.Fatalf("repo = %q, want GoCodeAlone/workflow", got)
+	}
+}
+
+func runGitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }

--- a/cmd/wfctl/secrets_setup_plugin.go
+++ b/cmd/wfctl/secrets_setup_plugin.go
@@ -311,7 +311,7 @@ func buildSecretWriter(scope, envName, org, visibility, tokenEnv, configFile str
 		}
 		p, err := secrets.NewGitHubSecretsProvider(repo, tokenEnv)
 		if err != nil {
-			return nil, "", fmt.Errorf("configure GitHub env secrets for %s (%s): %v", repo, source, err)
+			return nil, "", contextualCLIError{err: fmt.Errorf("configure GitHub env secrets for %s (%s): %w", repo, source, err)}
 		}
 		p.SetEnvironment(envName)
 		return p, fmt.Sprintf("github env %q on %s (%s)", envName, repo, source), nil
@@ -323,7 +323,7 @@ func buildSecretWriter(scope, envName, org, visibility, tokenEnv, configFile str
 		}
 		p, err := secrets.NewGitHubSecretsProvider(repo, tokenEnv)
 		if err != nil {
-			return nil, "", fmt.Errorf("configure GitHub repo secrets for %s (%s): %v", repo, source, err)
+			return nil, "", contextualCLIError{err: fmt.Errorf("configure GitHub repo secrets for %s (%s): %w", repo, source, err)}
 		}
 		return p, fmt.Sprintf("github repo %s (%s)", repo, source), nil
 

--- a/cmd/wfctl/secrets_setup_plugin.go
+++ b/cmd/wfctl/secrets_setup_plugin.go
@@ -305,27 +305,27 @@ func buildSecretWriter(scope, envName, org, visibility, tokenEnv, configFile str
 		if envName == "" {
 			return nil, "", errors.New("--scope=env requires --env <environment-name>")
 		}
-		repo, err := readGitHubRepoFromAppYAML(configFile)
+		repo, source, err := readGitHubRepoForSecretsSetup(configFile)
 		if err != nil {
 			return nil, "", err
 		}
 		p, err := secrets.NewGitHubSecretsProvider(repo, tokenEnv)
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf("configure GitHub env secrets for %s (%s): %v", repo, source, err)
 		}
 		p.SetEnvironment(envName)
-		return p, fmt.Sprintf("github env %q on %s", envName, repo), nil
+		return p, fmt.Sprintf("github env %q on %s (%s)", envName, repo, source), nil
 
 	case "", "repo":
-		repo, err := readGitHubRepoFromAppYAML(configFile)
+		repo, source, err := readGitHubRepoForSecretsSetup(configFile)
 		if err != nil {
 			return nil, "", err
 		}
 		p, err := secrets.NewGitHubSecretsProvider(repo, tokenEnv)
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf("configure GitHub repo secrets for %s (%s): %v", repo, source, err)
 		}
-		return p, fmt.Sprintf("github repo %s", repo), nil
+		return p, fmt.Sprintf("github repo %s (%s)", repo, source), nil
 
 	default:
 		return nil, "", fmt.Errorf("unknown --scope %q (want repo|env|org)", scope)

--- a/cmd/wfctl/update.go
+++ b/cmd/wfctl/update.go
@@ -121,6 +121,8 @@ Options:
 
 	latest := strings.TrimPrefix(rel.TagName, "v")
 	current := strings.TrimPrefix(version, "v")
+	fmt.Fprintf(os.Stderr, "Current version: %s\n", version)
+	fmt.Fprintf(os.Stderr, "Latest version: %s\n", rel.TagName)
 
 	if *checkOnly {
 		if current == "dev" || !isNewerVersion(latest, current) {
@@ -137,6 +139,7 @@ Options:
 		fmt.Printf("wfctl %s is already the latest version.\n", version)
 		return nil
 	}
+	fmt.Fprintf(os.Stderr, "Updating wfctl %s -> %s\n", version, rel.TagName)
 
 	asset, err := findReleaseAsset(rel.Assets)
 	if err != nil {

--- a/cmd/wfctl/update_test.go
+++ b/cmd/wfctl/update_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -85,6 +86,41 @@ func TestRunUpdate_CheckOnly(t *testing.T) {
 	}
 }
 
+func TestRunUpdatePrintsVersionContext(t *testing.T) {
+	origVersion := version
+	version = "v1.2.3"
+	defer func() { version = origVersion }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		rel := githubRelease{
+			TagName: "v9.9.9",
+			HTMLURL: "https://github.com/GoCodeAlone/workflow/releases/tag/v9.9.9",
+			Assets:  []githubAsset{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rel)
+	}))
+	defer srv.Close()
+
+	githubReleasesURLOverride = srv.URL
+	defer func() { githubReleasesURLOverride = "" }()
+
+	output, err := captureStdoutStderr(func() error {
+		return runUpdate([]string{"--check"})
+	})
+	if err != nil {
+		t.Fatalf("runUpdate --check: %v\n%s", err, output)
+	}
+	for _, want := range []string{
+		"Current version: v1.2.3",
+		"Latest version: v9.9.9",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestRunUpdate_AlreadyLatest(t *testing.T) {
 	origVersion := version
 	version = "1.2.3"
@@ -107,6 +143,33 @@ func TestRunUpdate_AlreadyLatest(t *testing.T) {
 	if err := runUpdate([]string{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func captureStdoutStderr(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+	os.Stderr = w
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	callErr := fn()
+	closeErr := w.Close()
+	data, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if readErr != nil {
+		return "", readErr
+	}
+	if closeErr != nil {
+		return string(data), closeErr
+	}
+	return string(data), callErr
 }
 
 func TestRunUpdate_GitHubAPIError(t *testing.T) {

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2526,7 +2526,7 @@ wfctl secrets sync --from staging --to production
 
 #### `secrets setup`
 
-Set secrets declared in the config for a given environment. Automatically selects interactive or non-interactive mode based on whether stdin is a TTY. With `--manifest`, discovers secrets from `wfctl.yaml`, `.wfctl-lock.yaml`, installed plugin `required_secrets[]`, and `${ENV_VAR}` references in workflow configs.
+Set secrets declared in the config for a given environment. Automatically selects interactive or non-interactive mode based on whether stdin is a TTY. With `--manifest`, discovers secrets from `wfctl.yaml`, `.wfctl-lock.yaml`, installed plugin `required_secrets[]`, and `${ENV_VAR}` references in workflow configs. Repo/env-scoped GitHub setup uses `secrets.config.repo` or `secretStores.<name>.config.repo` when configured; otherwise it infers the repo from `git remote.origin.url` and prints that assumption in the setup target or error.
 
 **Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names.
 
@@ -2757,7 +2757,7 @@ steps:
 
 ### `update`
 
-Download and install the latest version of wfctl, replacing the current binary. Automatically checks for updates in the background after most commands (suppress with `WFCTL_NO_UPDATE_CHECK=1`).
+Download and install the latest version of wfctl, replacing the current binary. Automatically checks for updates in the background after most commands (suppress with `WFCTL_NO_UPDATE_CHECK=1`). The foreground update command prints the current and latest versions before reporting whether it will install an update.
 
 ```
 wfctl update [options]


### PR DESCRIPTION
## Summary
- Resolve repo/env GitHub secrets setup targets from structured config first, then infer from `git remote.origin.url` for infra-only manifest setup flows.
- Include the repo inference source in setup labels and provider-construction errors so users can see assumptions like `inferred from git remote.origin.url`.
- Print `wfctl update` current/latest version context before check/install results.
- Document the repo inference behavior and update version output.

## TDD proof
With fix absent:
```text
$ GOWORK=off go test ./cmd/wfctl -run 'TestBuildSecretWriterRepoScopeFallsBackToGitRemote|TestReadGitHubRepoFromConfigUsesSecretStores' -count=1
FAIL — buildSecretWriter: could not find `repo:` in .../infra/digitalocean.wfctl.yaml (expected secrets.config.repo or secretStores.<name>.config.repo)

$ GOWORK=off go test ./cmd/wfctl -run TestRunUpdatePrintsVersionContext -count=1
FAIL — output missing "Current version: v1.2.3"

$ GOWORK=off go test ./cmd/wfctl -run 'TestBuildSecretWriterRepoScopeFallsBackToGitRemote|TestBuildSecretWriterRepoScopeErrorIncludesInferredRepo' -count=1
FAIL — label did not include "inferred from git remote.origin.url" and token error did not include the inferred repo
```

With fix restored:
```text
$ GOWORK=off go test ./cmd/wfctl -run 'TestBuildSecretWriterRepoScopeFallsBackToGitRemote|TestBuildSecretWriterRepoScopeErrorIncludesInferredRepo|TestReadGitHubRepoFromConfigUsesSecretStores|TestRunUpdatePrintsVersionContext' -count=1
ok github.com/GoCodeAlone/workflow/cmd/wfctl 1.209s

$ GOWORK=off go test ./cmd/wfctl -count=1
ok github.com/GoCodeAlone/workflow/cmd/wfctl 148.017s
```

## Runtime smoke
```text
$ env -u GITHUB_TOKEN WFCTL_NO_UPDATE_CHECK=1 CI=true /tmp/wfctl-secrets-setup-fix secrets setup  # cwd: ../gocodealone-dns
error: configure GitHub repo secrets for GoCodeAlone/gocodealone-dns (inferred from git remote.origin.url): secrets: env var "GITHUB_TOKEN" is empty or unset

$ WFCTL_NO_UPDATE_CHECK=1 CI=true /tmp/wfctl-update-output-fix update --check
Checking for updates...
Current version: v0.74.3-0.20260605062651-c366287289bd
Latest version: v0.75.4
Update available: v0.74.3-0.20260605062651-c366287289bd → v0.75.4
Run 'wfctl update' to install the latest version.
Release notes: https://github.com/GoCodeAlone/workflow/releases/tag/v0.75.4
```

## Verification
- `git diff --check`
- `GOWORK=off go test ./cmd/wfctl -count=1`
