### PR TITLE
fix: show wfctl secrets setup prompts

### DIFF
--- a/cmd/wfctl/internal/prompt/confirm.go
+++ b/cmd/wfctl/internal/prompt/confirm.go
@@ -15,12 +15,13 @@ func Confirm(question string, def bool) (bool, error) {
 	if !isTTY() {
 		return false, ErrNotInteractive
 	}
+	out, _ := outputWriter()
 	hint := "y/N"
 	if def {
 		hint = "Y/n"
 	}
 	m := &confirmModel{question: question, hint: hint, def: def}
-	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
+	p := tea.NewProgram(m, tea.WithOutput(out))
 	result, err := p.Run()
 	if err != nil {
 		return false, fmt.Errorf("prompt confirm: %w", err)

--- a/cmd/wfctl/internal/prompt/confirm.go
+++ b/cmd/wfctl/internal/prompt/confirm.go
@@ -2,7 +2,6 @@ package prompt
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -21,14 +20,14 @@ func Confirm(question string, def bool) (bool, error) {
 		hint = "Y/n"
 	}
 	m := &confirmModel{question: question, hint: hint, def: def}
-	p := tea.NewProgram(m, tea.WithOutput(io.Discard))
+	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
 	result, err := p.Run()
 	if err != nil {
 		return false, fmt.Errorf("prompt confirm: %w", err)
 	}
 	fm := result.(*confirmModel)
 	if fm.quit {
-		return false, ErrNotInteractive
+		return false, ErrInterrupted
 	}
 	return fm.answer, nil
 }

--- a/cmd/wfctl/internal/prompt/input.go
+++ b/cmd/wfctl/internal/prompt/input.go
@@ -2,7 +2,6 @@ package prompt
 
 import (
 	"fmt"
-	"io"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -37,14 +36,14 @@ func InputWithSuggestions(label string, masked bool, suggestions []string) (stri
 	}
 
 	m := &inputModel{label: label, ti: ti}
-	p := tea.NewProgram(m, tea.WithOutput(io.Discard))
+	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
 	result, err := p.Run()
 	if err != nil {
 		return "", fmt.Errorf("prompt input: %w", err)
 	}
 	fm := result.(*inputModel)
 	if fm.quit {
-		return "", ErrNotInteractive
+		return "", ErrInterrupted
 	}
 	return fm.ti.Value(), nil
 }

--- a/cmd/wfctl/internal/prompt/input.go
+++ b/cmd/wfctl/internal/prompt/input.go
@@ -23,6 +23,7 @@ func InputWithSuggestions(label string, masked bool, suggestions []string) (stri
 	if !isTTY() {
 		return "", ErrNotInteractive
 	}
+	out, _ := outputWriter()
 	ti := textinput.New()
 	ti.Placeholder = label
 	ti.Focus()
@@ -36,7 +37,7 @@ func InputWithSuggestions(label string, masked bool, suggestions []string) (stri
 	}
 
 	m := &inputModel{label: label, ti: ti}
-	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
+	p := tea.NewProgram(m, tea.WithOutput(out))
 	result, err := p.Run()
 	if err != nil {
 		return "", fmt.Errorf("prompt input: %w", err)

--- a/cmd/wfctl/internal/prompt/interrupt_test.go
+++ b/cmd/wfctl/internal/prompt/interrupt_test.go
@@ -1,0 +1,35 @@
+package prompt
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestPromptModelsMarkCtrlCAsInterrupted(t *testing.T) {
+	msg := tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl})
+
+	input := &inputModel{}
+	input.Update(msg)
+	if !input.quit {
+		t.Fatal("inputModel did not mark ctrl+c as quit")
+	}
+
+	confirm := &confirmModel{}
+	confirm.Update(msg)
+	if !confirm.quit {
+		t.Fatal("confirmModel did not mark ctrl+c as quit")
+	}
+
+	selectModel := &selectModel{}
+	selectModel.Update(msg)
+	if !selectModel.quit {
+		t.Fatal("selectModel did not mark ctrl+c as quit")
+	}
+
+	multiSelect := &multiSelectModel{}
+	multiSelect.Update(msg)
+	if !multiSelect.quit {
+		t.Fatal("multiSelectModel did not mark ctrl+c as quit")
+	}
+}

--- a/cmd/wfctl/internal/prompt/multiselect.go
+++ b/cmd/wfctl/internal/prompt/multiselect.go
@@ -16,6 +16,7 @@ func MultiSelect(title string, items []Item) ([]int, error) {
 	if !isTTY() {
 		return nil, ErrNotInteractive
 	}
+	out, _ := outputWriter()
 	selected := make(map[int]bool, len(items))
 	for i, it := range items {
 		if it.Preselected {
@@ -23,7 +24,7 @@ func MultiSelect(title string, items []Item) ([]int, error) {
 		}
 	}
 	m := &multiSelectModel{title: title, items: items, selected: selected}
-	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
+	p := tea.NewProgram(m, tea.WithOutput(out))
 	result, err := p.Run()
 	if err != nil {
 		return nil, fmt.Errorf("prompt multiselect: %w", err)

--- a/cmd/wfctl/internal/prompt/multiselect.go
+++ b/cmd/wfctl/internal/prompt/multiselect.go
@@ -2,7 +2,6 @@ package prompt
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -24,14 +23,14 @@ func MultiSelect(title string, items []Item) ([]int, error) {
 		}
 	}
 	m := &multiSelectModel{title: title, items: items, selected: selected}
-	p := tea.NewProgram(m, tea.WithOutput(io.Discard))
+	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
 	result, err := p.Run()
 	if err != nil {
 		return nil, fmt.Errorf("prompt multiselect: %w", err)
 	}
 	fm := result.(*multiSelectModel)
 	if fm.quit {
-		return nil, ErrNotInteractive
+		return nil, ErrInterrupted
 	}
 	var indices []int
 	for i := range items {

--- a/cmd/wfctl/internal/prompt/output_test.go
+++ b/cmd/wfctl/internal/prompt/output_test.go
@@ -1,0 +1,39 @@
+package prompt
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestChooseOutputWriterPrefersStderrTTY(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	got, ok := chooseOutputWriter(true, true, stderr, stdout)
+	if !ok {
+		t.Fatal("expected output writer")
+	}
+	if got != stderr {
+		t.Fatalf("writer = %p, want stderr %p", got, stderr)
+	}
+}
+
+func TestChooseOutputWriterFallsBackToStdoutTTY(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	got, ok := chooseOutputWriter(false, true, stderr, stdout)
+	if !ok {
+		t.Fatal("expected output writer")
+	}
+	if got != stdout {
+		t.Fatalf("writer = %p, want stdout %p", got, stdout)
+	}
+}
+
+func TestChooseOutputWriterRejectsNonTTYOutput(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	got, ok := chooseOutputWriter(false, false, stderr, stdout)
+	if ok {
+		t.Fatalf("expected no output writer, got %p", got)
+	}
+}

--- a/cmd/wfctl/internal/prompt/prompt.go
+++ b/cmd/wfctl/internal/prompt/prompt.go
@@ -2,10 +2,11 @@
 // charm.land/bubbletea/v2 and charm.land/bubbles/v2.
 //
 // Every public constructor checks whether stdin is an interactive terminal
-// before starting a bubbletea program. If stdin is not a terminal the
-// constructor returns (zero, ErrNotInteractive) immediately so callers in
-// CI / pipe mode can detect the condition and fall back to non-interactive
-// paths without any risk of hanging.
+// and whether stderr or stdout can render terminal output before starting a
+// bubbletea program. If either side is unavailable, the constructor returns
+// (zero, ErrNotInteractive) immediately so callers in CI / pipe mode can
+// detect the condition and fall back to non-interactive paths without any
+// risk of hanging.
 package prompt
 
 import (

--- a/cmd/wfctl/internal/prompt/prompt.go
+++ b/cmd/wfctl/internal/prompt/prompt.go
@@ -10,6 +10,7 @@ package prompt
 
 import (
 	"errors"
+	"io"
 	"os"
 
 	"github.com/mattn/go-isatty"
@@ -17,6 +18,9 @@ import (
 
 // ErrNotInteractive is returned by all constructors when stdin is not a terminal.
 var ErrNotInteractive = errors.New("prompt: stdin is not a terminal")
+
+// ErrInterrupted is returned when the user aborts an interactive prompt.
+var ErrInterrupted = errors.New("prompt: interrupted")
 
 // Item is a selectable entry for MultiSelect.
 type Item struct {
@@ -27,4 +31,8 @@ type Item struct {
 // isTTY reports whether os.Stdin is an interactive terminal.
 func isTTY() bool {
 	return isatty.IsTerminal(os.Stdin.Fd())
+}
+
+func outputWriter() io.Writer {
+	return os.Stderr
 }

--- a/cmd/wfctl/internal/prompt/prompt.go
+++ b/cmd/wfctl/internal/prompt/prompt.go
@@ -30,9 +30,34 @@ type Item struct {
 
 // isTTY reports whether os.Stdin is an interactive terminal.
 func isTTY() bool {
-	return isatty.IsTerminal(os.Stdin.Fd())
+	return CanPrompt()
 }
 
-func outputWriter() io.Writer {
-	return os.Stderr
+// CanPrompt reports whether prompts can safely read input and render output.
+func CanPrompt() bool {
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
+		return false
+	}
+	_, ok := outputWriter()
+	return ok
+}
+
+func outputWriter() (io.Writer, bool) {
+	return chooseOutputWriter(
+		isatty.IsTerminal(os.Stderr.Fd()),
+		isatty.IsTerminal(os.Stdout.Fd()),
+		os.Stderr,
+		os.Stdout,
+	)
+}
+
+func chooseOutputWriter(stderrTTY, stdoutTTY bool, stderr, stdout io.Writer) (io.Writer, bool) {
+	switch {
+	case stderrTTY:
+		return stderr, true
+	case stdoutTTY:
+		return stdout, true
+	default:
+		return nil, false
+	}
 }

--- a/cmd/wfctl/internal/prompt/select.go
+++ b/cmd/wfctl/internal/prompt/select.go
@@ -2,7 +2,6 @@ package prompt
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -18,14 +17,14 @@ func Select(title string, opts []string) (int, error) {
 		return 0, ErrNotInteractive
 	}
 	m := &selectModel{title: title, opts: opts}
-	p := tea.NewProgram(m, tea.WithOutput(io.Discard))
+	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
 	result, err := p.Run()
 	if err != nil {
 		return 0, fmt.Errorf("prompt select: %w", err)
 	}
 	fm := result.(*selectModel)
 	if fm.quit {
-		return 0, ErrNotInteractive
+		return 0, ErrInterrupted
 	}
 	return fm.cursor, nil
 }

--- a/cmd/wfctl/internal/prompt/select.go
+++ b/cmd/wfctl/internal/prompt/select.go
@@ -16,8 +16,9 @@ func Select(title string, opts []string) (int, error) {
 	if !isTTY() {
 		return 0, ErrNotInteractive
 	}
+	out, _ := outputWriter()
 	m := &selectModel{title: title, opts: opts}
-	p := tea.NewProgram(m, tea.WithOutput(outputWriter()))
+	p := tea.NewProgram(m, tea.WithOutput(out))
 	result, err := p.Run()
 	if err != nil {
 		return 0, fmt.Errorf("prompt select: %w", err)

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -111,6 +111,10 @@ Options:
 			return err
 		}
 		if target.kind == secretsSetupTargetManifest {
+			if *autoGenKeys {
+				return fmt.Errorf("--auto-gen-keys is not supported with wfctl.yaml manifest-backed secrets setup; use --from-env, --secret NAME=VALUE, or run interactively from a terminal")
+			}
+			manifestNonInteractive := *nonInteractive || !isatty.IsTerminal(os.Stdin.Fd())
 			return runSecretsSetupManifestWithIO(&manifestSetupArgs{
 				manifestPath:   target.path,
 				lockfilePath:   *lockFile,
@@ -122,7 +126,7 @@ Options:
 				visibility:     *visibility,
 				tokenEnv:       *tokenEnv,
 				fromEnv:        *fromEnv,
-				nonInteractive: useNonInteractive,
+				nonInteractive: manifestNonInteractive,
 				secretLiterals: []string(secretFlag),
 				only:           only,
 				skipExisting:   *skipExisting,

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -122,6 +122,7 @@ Options:
 				visibility:     *visibility,
 				tokenEnv:       *tokenEnv,
 				fromEnv:        *fromEnv,
+				nonInteractive: useNonInteractive,
 				secretLiterals: []string(secretFlag),
 				only:           only,
 				skipExisting:   *skipExisting,

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -36,6 +36,7 @@ type manifestSetupArgs struct {
 	visibility     string
 	tokenEnv       string
 	fromEnv        bool
+	nonInteractive bool
 	secretLiterals []string
 	only           []string
 	skipExisting   bool
@@ -69,7 +70,7 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 			}
 		}
 	}
-	interactive := in == nil && isatty.IsTerminal(os.Stdin.Fd())
+	interactive := in == nil && !a.nonInteractive && isatty.IsTerminal(os.Stdin.Fd())
 
 	onlySet := make(map[string]bool, len(a.only))
 	for _, name := range a.only {
@@ -96,38 +97,30 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	}
 	var promptErr error
 	valuer := func(secret manifestDiscoveredSecret) (string, bool, error) {
-		if a.fromEnv {
-			if v := os.Getenv(secret.Name); v != "" {
-				return v, true, nil
-			}
+		value, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
+			interactive: interactive,
+			fromEnv:     a.fromEnv,
+			secretMap:   secretMap,
+		})
+		if err != nil && errors.Is(err, prompt.ErrNotInteractive) {
+			promptErr = err
 		}
-		if v, ok := secretMap[secret.Name]; ok {
-			return v, true, nil
-		}
-		if interactive {
-			label := secret.Name
-			if secret.Description != "" {
-				label += " - " + secret.Description
-			}
-			value, err := prompt.Input(label, secret.Sensitive)
-			if err != nil {
-				if errors.Is(err, prompt.ErrNotInteractive) {
-					promptErr = err
-				}
-				return "", false, err
-			}
-			if value == "" {
-				return "", false, nil
-			}
-			return value, true, nil
-		}
-		return "", false, nil
+		return value, provided, err
 	}
 	auditFn := func(name, _ string) {
 		_ = writeSecretsAuditRecord(name, "github:"+strings.ToLower(strings.TrimSpace(a.scope))) //nolint:errcheck // best-effort audit
 	}
 
 	fmt.Fprintf(out, "Setting up secrets from %s -> %s\n\n", a.manifestPath, scopeLabel)
+	if interactive {
+		fmt.Fprintln(out, "Interactive mode: prompting for secret values. Leave a value empty to skip it.")
+		fmt.Fprintln(out, "Use --from-env, --secret NAME=VALUE, or --non-interactive for scripted setup.")
+	} else if a.fromEnv {
+		fmt.Fprintln(out, "Non-interactive mode: reading values from matching environment variables; unset values will be skipped.")
+	} else {
+		fmt.Fprintln(out, "Non-interactive mode: using --secret NAME=VALUE or piped KEY=VALUE values; missing values will fail.")
+	}
+	fmt.Fprintln(out)
 	for _, secret := range discovered {
 		fmt.Fprintf(out, "  %s (%s)\n", secret.Name, strings.Join(secret.Sources, ", "))
 	}
@@ -191,6 +184,41 @@ func discoverManifestSecrets(manifestPath, lockfilePath, pluginDir, configPatter
 		}
 	}
 	return sortedManifestSecrets(secretsByName), nil
+}
+
+type manifestSecretValueOptions struct {
+	interactive bool
+	fromEnv     bool
+	secretMap   map[string]string
+}
+
+func manifestSecretValue(secret manifestDiscoveredSecret, opts manifestSecretValueOptions) (string, bool, error) {
+	if opts.fromEnv {
+		if v := os.Getenv(secret.Name); v != "" {
+			return v, true, nil
+		}
+	}
+	if v, ok := opts.secretMap[secret.Name]; ok {
+		return v, true, nil
+	}
+	if opts.interactive {
+		label := secret.Name
+		if secret.Description != "" {
+			label += " - " + secret.Description
+		}
+		value, err := prompt.Input(label, secret.Sensitive)
+		if err != nil {
+			return "", false, err
+		}
+		if value == "" {
+			return "", false, nil
+		}
+		return value, true, nil
+	}
+	if opts.fromEnv {
+		return "", false, nil
+	}
+	return "", false, fmt.Errorf("no value for secret %q: set $%s and pass --from-env, use --secret %s=VALUE, or run interactively from a terminal", secret.Name, secret.Name, secret.Name)
 }
 
 func discoverManifestPlugins(manifestPath, lockfilePath string) ([]string, error) {
@@ -411,7 +439,6 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
-	_ = nonInteractive
 	if strings.TrimSpace(*manifestPath) == "" {
 		return nil, errors.New("--manifest <wfctl.yaml> is required")
 	}
@@ -433,6 +460,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 		visibility:     *visibility,
 		tokenEnv:       *tokenEnv,
 		fromEnv:        *fromEnv,
+		nonInteractive: *nonInteractive,
 		secretLiterals: []string(secretFlag),
 		only:           only,
 		skipExisting:   *skipExisting,

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -111,12 +111,13 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	}
 
 	fmt.Fprintf(out, "Setting up secrets from %s -> %s\n\n", a.manifestPath, scopeLabel)
-	if interactive {
+	switch {
+	case interactive:
 		fmt.Fprintln(out, "Interactive mode: prompting for secret values. Leave a value empty to skip it.")
 		fmt.Fprintln(out, "Use --from-env, --secret NAME=VALUE, or --non-interactive for scripted setup.")
-	} else if a.fromEnv {
+	case a.fromEnv:
 		fmt.Fprintln(out, "Non-interactive mode: reading values from matching environment variables; unset values will be skipped.")
-	} else {
+	default:
 		fmt.Fprintln(out, "Non-interactive mode: using --secret NAME=VALUE or piped KEY=VALUE values; missing values will fail.")
 	}
 	fmt.Fprintln(out)

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/config"
-	"github.com/mattn/go-isatty"
 	"gopkg.in/yaml.v3"
 )
 
@@ -70,7 +69,7 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 			}
 		}
 	}
-	interactive := in == nil && !a.nonInteractive && isatty.IsTerminal(os.Stdin.Fd())
+	interactive := in == nil && !a.nonInteractive && prompt.CanPrompt()
 
 	onlySet := make(map[string]bool, len(a.only))
 	for _, name := range a.only {

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -430,7 +430,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 	visibility := fs.String("visibility", "all", "Org-scope visibility: all | selected | private")
 	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT")
 	fromEnv := fs.Bool("from-env", false, "Read each secret value from $NAME")
-	nonInteractive := fs.Bool("non-interactive", false, "Accepted for parity with config setup; manifest setup auto-detects input mode")
+	nonInteractive := fs.Bool("non-interactive", false, "Force non-interactive mode for manifest setup")
 	onlyFlag := fs.String("only", "", "Comma-separated list of secret names to set")
 	allFlag := fs.Bool("all", false, "Set all discovered secrets")
 	skipExisting := fs.Bool("skip-existing", false, "Skip secrets that already have a value in the target scope")

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -92,6 +92,42 @@ func TestParseManifestSetupFlagsAcceptsSetupSelectors(t *testing.T) {
 	if !args.skipExisting || !args.fromEnv {
 		t.Fatalf("flags not preserved: %+v", args)
 	}
+	if !args.nonInteractive {
+		t.Fatalf("--non-interactive was not preserved: %+v", args)
+	}
+}
+
+func TestManifestSecretValueNonInteractiveRequiresValueSource(t *testing.T) {
+	secret := manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"}}
+	got, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
+		interactive: false,
+		fromEnv:     false,
+		secretMap:   map[string]string{},
+	})
+	if err == nil {
+		t.Fatalf("expected missing value error, got value=%q provided=%v", got, provided)
+	}
+	msg := err.Error()
+	for _, want := range []string{"DIGITALOCEAN_TOKEN", "--from-env", "--secret DIGITALOCEAN_TOKEN=VALUE"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestManifestSecretValueFromEnvMissingSkips(t *testing.T) {
+	secret := manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"}}
+	got, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
+		interactive: false,
+		fromEnv:     true,
+		secretMap:   map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("manifestSecretValue: %v", err)
+	}
+	if provided || got != "" {
+		t.Fatalf("got value=%q provided=%v, want skipped empty value", got, provided)
+	}
 }
 
 func TestParseManifestSetupFlagsDefaultsConfigPatterns(t *testing.T) {

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -149,6 +149,25 @@ func TestParseManifestSetupFlagsDefaultsConfigPatterns(t *testing.T) {
 	}
 }
 
+func TestRunSecretsSetupRejectsAutoGenKeysForManifestTarget(t *testing.T) {
+	dir := t.TempDir()
+	chdirForTest(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "wfctl.yaml"), []byte("version: 1\nplugins: []\n"), 0o644); err != nil {
+		t.Fatalf("write wfctl.yaml: %v", err)
+	}
+
+	err := runSecretsSetup([]string{"--auto-gen-keys"})
+	if err == nil {
+		t.Fatal("expected --auto-gen-keys manifest error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"--auto-gen-keys", "wfctl.yaml", "--from-env"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
 func TestFirstConfigPatternResolvesGlobToExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	chdirForTest(t, dir)

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2528,13 +2528,15 @@ wfctl secrets sync --from staging --to production
 
 Set secrets declared in the config for a given environment. Automatically selects interactive or non-interactive mode based on whether stdin is a TTY. With `--manifest`, discovers secrets from `wfctl.yaml`, `.wfctl-lock.yaml`, installed plugin `required_secrets[]`, and `${ENV_VAR}` references in workflow configs. Repo/env-scoped GitHub setup uses `secrets.config.repo` or `secretStores.<name>.config.repo` when configured; otherwise it infers the repo from `git remote.origin.url` and prints that assumption in the setup target or error.
 
-**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names.
+**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names. Manifest-backed setup prints the selected GitHub target and whether the repo was configured explicitly or inferred before prompting for values.
 
 **Non-interactive mode** (auto when stdin is not a TTY, or forced with `--non-interactive` / `--auto-gen-keys`): reads values from the sources below in priority order:
 - `--from-env` — reads `$NAME` for each secret. Recommended for CI; avoids process-table leaks. Secrets whose env var is unset are skipped.
 - Piped `KEY=VALUE` lines on stdin.
 - `--secret NAME=VALUE` — inline literal. **Warning: leaks to process table. Avoid in CI.**
 - `--auto-gen-keys` — generates random values for names ending in `_KEY`, `_SECRET`, `_TOKEN`, or `_SIGNING`.
+
+Manifest-backed setup treats missing values as an error in non-interactive mode unless `--from-env` is set. With `--from-env`, unset environment variables are skipped so CI can set only the values it has.
 
 Every successful `Set` call is appended to an audit log at `${XDG_STATE_HOME:-$HOME/.local/state}/wfctl/plugins/wfctl/secrets-audit.jsonl` (secret names only — values are never written).
 

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2538,6 +2538,8 @@ Set secrets declared in the config for a given environment. Automatically select
 
 Manifest-backed setup treats missing values as an error in non-interactive mode unless `--from-env` is set. With `--from-env`, unset environment variables are skipped so CI can set only the values it has.
 
+Manifest-backed setup discovers provider and config secrets from `wfctl.yaml` and does not support `--auto-gen-keys`; provide values with `--from-env`, `--secret NAME=VALUE`, piped `KEY=VALUE` input, or an interactive terminal prompt.
+
 Every successful `Set` call is appended to an audit log at `${XDG_STATE_HOME:-$HOME/.local/state}/wfctl/plugins/wfctl/secrets-audit.jsonl` (secret names only — values are never written).
 
 ```
@@ -2558,7 +2560,7 @@ wfctl secrets setup [options]
 | `--all` | `false` | Set all declared secrets (explicit form of the default when `--only` is absent) |
 | `--only` | _(all)_ | Comma-separated list of secret names to set; mutually exclusive with `--all` |
 | `--skip-existing` | `false` | Skip secrets that already have a value in the store |
-| `--auto-gen-keys` | `false` | Auto-generate random values for secrets ending in `_KEY`, `_SECRET`, `_TOKEN`, or `_SIGNING`; implies non-interactive |
+| `--auto-gen-keys` | `false` | Auto-generate random values for config-backed secrets ending in `_KEY`, `_SECRET`, `_TOKEN`, or `_SIGNING`; implies non-interactive; not supported for manifest-backed `wfctl.yaml` setup |
 | `--scope` | `repo` | GitHub scope for plugin or manifest setup: `repo` \| `env` \| `org` |
 | `--org` | _(none)_ | Organization slug for `--scope org` |
 | `--visibility` | `all` | Org-scope visibility: `all` \| `selected` \| `private` |


### PR DESCRIPTION
## Summary
- render wfctl interactive prompt widgets to stderr instead of discarding prompt UI
- preserve manifest `--non-interactive` and make manifest setup explain interactive/non-interactive assumptions
- fail fast with an actionable missing-value error for manifest non-interactive setup unless `--from-env` is explicitly used
- report Ctrl+C as `prompt: interrupted` instead of `prompt: stdin is not a terminal`

## Verification
- `GOWORK=off go test ./cmd/wfctl ./cmd/wfctl/internal/prompt -count=1`
- `GOWORK=off go build -o /tmp/wfctl-secrets-prompt-fix ./cmd/wfctl`
- `git diff --check`
- DNS non-TTY smoke: `env GITHUB_TOKEN="$(gh auth token)" WFCTL_NO_UPDATE_CHECK=1 CI=true /tmp/wfctl-secrets-prompt-fix secrets setup` exits quickly with `no value for secret "DIGITALOCEAN_TOKEN"...`
- DNS TTY smoke shows the `DIGITALOCEAN_TOKEN` prompt and Ctrl+C returns `prompt: interrupted`