### PR TITLE
fix: show manifest secret status in setup

### DIFF
--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -131,6 +131,7 @@ Options:
 				nonInteractive: manifestNonInteractive,
 				secretLiterals: []string(secretFlag),
 				only:           only,
+				all:            *allFlag,
 				skipExisting:   *skipExisting,
 			}, nil, os.Stdout)
 		}

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -43,8 +43,8 @@ func runSecretsSetup(args []string) error {
 	fromEnv := fs.Bool("from-env", false, "Read each secret value from $NAME (recommended for CI; avoids process-table leaks)")
 	var secretFlag multiStringFlag
 	fs.Var(&secretFlag, "secret", "NAME=VALUE literal (WARNING: leaks to process table; use --from-env in CI). Repeatable.")
-	onlyFlag := fs.String("only", "", "Comma-separated list of secret names to set (default: all)")
-	allFlag := fs.Bool("all", false, "Set all declared secrets (the default when --only is absent; explicit form)")
+	onlyFlag := fs.String("only", "", "Comma-separated list of secret names to set")
+	allFlag := fs.Bool("all", false, "Set all declared secrets; preselect all in manifest interactive mode")
 	skipExisting := fs.Bool("skip-existing", false, "Skip secrets that already have a value in the store")
 	storeName := fs.String("store", "", "Named store to use (overrides config defaultStore)")
 	// Manifest-backed GitHub setup flags. These also keep the legacy --plugin
@@ -64,12 +64,14 @@ Set secrets declared in the config for a given environment.
 Interactive (default when stdin is a TTY):
   Lists each declared secret with its status, lets you select which to set,
   prompts to pick a store when none is configured, and masks sensitive input.
+  Manifest-backed setup selects unset secrets by default; toggle set secrets
+  to update them, or pass --all to preselect every discovered secret.
 
 Non-interactive (--non-interactive, --auto-gen-keys, or when stdin is not a TTY):
   --from-env        Read each value from $NAME. Recommended for CI.
   --secret NAME=VAL Set a specific secret inline (WARNING: leaks to process table).
   Pipe KEY=VALUE    Read KEY=VALUE lines from stdin.
-  --all             Set all declared secrets (default when --only is absent).
+  --all             Set all declared secrets; preselect all in manifest interactive mode.
   --only A,B        Restrict which secrets to set (mutually exclusive with --all).
   --skip-existing   Skip secrets already set in the store.
   --auto-gen-keys   Generate random values for _KEY/_SECRET/_TOKEN/_SIGNING names.

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -38,6 +38,7 @@ type manifestSetupArgs struct {
 	nonInteractive bool
 	secretLiterals []string
 	only           []string
+	all            bool
 	skipExisting   bool
 }
 
@@ -76,23 +77,32 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 		onlySet[name] = true
 	}
 	selector := func(ds []manifestDiscoveredSecret, statuses []SecretStatus) ([]manifestDiscoveredSecret, error) {
-		setMap := make(map[string]bool, len(statuses))
-		for _, status := range statuses {
-			if status.IsSet {
-				setMap[status.Name] = true
+		if interactive && len(onlySet) == 0 {
+			selectable := ds
+			if a.skipExisting {
+				selectable = selectManifestSecretsForSetup(ds, statuses, manifestSecretSelectionOptions{
+					includeExisting: true,
+					skipExisting:    true,
+				})
 			}
+			if len(selectable) == 0 {
+				return nil, nil
+			}
+			items := buildManifestMultiSelectItems(selectable, statuses, a.all)
+			selectedIdx, err := prompt.MultiSelect(
+				fmt.Sprintf("Select secrets to set for %s (unset selected by default; toggle set secrets to update)", scopeLabel),
+				items,
+			)
+			if err != nil {
+				return nil, err
+			}
+			return manifestSecretsByIndexes(selectable, selectedIdx), nil
 		}
-		var selected []manifestDiscoveredSecret
-		for _, secret := range ds {
-			if len(onlySet) > 0 && !onlySet[secret.Name] {
-				continue
-			}
-			if a.skipExisting && setMap[secret.Name] {
-				continue
-			}
-			selected = append(selected, secret)
-		}
-		return selected, nil
+		return selectManifestSecretsForSetup(ds, statuses, manifestSecretSelectionOptions{
+			onlySet:         onlySet,
+			includeExisting: true,
+			skipExisting:    a.skipExisting,
+		}), nil
 	}
 	var promptErr error
 	valuer := func(secret manifestDiscoveredSecret) (string, bool, error) {
@@ -113,7 +123,8 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	fmt.Fprintf(out, "Setting up secrets from %s -> %s\n\n", a.manifestPath, scopeLabel)
 	switch {
 	case interactive:
-		fmt.Fprintln(out, "Interactive mode: prompting for secret values. Leave a value empty to skip it.")
+		fmt.Fprintln(out, "Interactive mode: unset secrets are selected by default; toggle existing secrets to update them.")
+		fmt.Fprintln(out, "Leave a value empty to skip it.")
 		fmt.Fprintln(out, "Use --from-env, --secret NAME=VALUE, or --non-interactive for scripted setup.")
 	case a.fromEnv:
 		fmt.Fprintln(out, "Non-interactive mode: reading values from matching environment variables; unset values will be skipped.")
@@ -121,10 +132,12 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 		fmt.Fprintln(out, "Non-interactive mode: using --secret NAME=VALUE or piped KEY=VALUE values; missing values will fail.")
 	}
 	fmt.Fprintln(out)
-	for _, secret := range discovered {
-		fmt.Fprintf(out, "  %s (%s)\n", secret.Name, strings.Join(secret.Sources, ", "))
+	if !interactive {
+		for _, secret := range discovered {
+			fmt.Fprintf(out, "  %s (%s)\n", secret.Name, strings.Join(secret.Sources, ", "))
+		}
+		fmt.Fprintln(out)
 	}
-	fmt.Fprintln(out)
 
 	report, err := runSetupEngine(context.Background(), discovered,
 		func(secret manifestDiscoveredSecret) string { return secret.Name },
@@ -219,6 +232,67 @@ func manifestSecretValue(secret manifestDiscoveredSecret, opts manifestSecretVal
 		return "", false, nil
 	}
 	return "", false, fmt.Errorf("no value for secret %q: set $%s and pass --from-env, use --secret %s=VALUE, or run interactively from a terminal", secret.Name, secret.Name, secret.Name)
+}
+
+type manifestSecretSelectionOptions struct {
+	onlySet         map[string]bool
+	includeExisting bool
+	skipExisting    bool
+}
+
+func selectManifestSecretsForSetup(secrets []manifestDiscoveredSecret, statuses []SecretStatus, opts manifestSecretSelectionOptions) []manifestDiscoveredSecret {
+	statusByName := secretStatusByName(statuses)
+	selected := make([]manifestDiscoveredSecret, 0, len(secrets))
+	for _, secret := range secrets {
+		if len(opts.onlySet) > 0 {
+			if !opts.onlySet[secret.Name] {
+				continue
+			}
+		} else if !opts.includeExisting && statusByName[secret.Name].IsSet {
+			continue
+		}
+		if opts.skipExisting && statusByName[secret.Name].IsSet {
+			continue
+		}
+		selected = append(selected, secret)
+	}
+	return selected
+}
+
+func buildManifestMultiSelectItems(secrets []manifestDiscoveredSecret, statuses []SecretStatus, includeExisting bool) []prompt.Item {
+	statusByName := secretStatusByName(statuses)
+	items := make([]prompt.Item, 0, len(secrets))
+	for _, secret := range secrets {
+		st := statusByName[secret.Name]
+		label := formatStatusLabel(secret.Name, st)
+		if len(secret.Sources) > 0 {
+			label += " (" + strings.Join(secret.Sources, ", ") + ")"
+		}
+		items = append(items, prompt.Item{
+			Label:       label,
+			Preselected: includeExisting || !st.IsSet,
+		})
+	}
+	return items
+}
+
+func secretStatusByName(statuses []SecretStatus) map[string]SecretStatus {
+	statusByName := make(map[string]SecretStatus, len(statuses))
+	for _, status := range statuses {
+		statusByName[status.Name] = status
+	}
+	return statusByName
+}
+
+func manifestSecretsByIndexes(secrets []manifestDiscoveredSecret, indexes []int) []manifestDiscoveredSecret {
+	selected := make([]manifestDiscoveredSecret, 0, len(indexes))
+	for _, i := range indexes {
+		if i < 0 || i >= len(secrets) {
+			continue
+		}
+		selected = append(selected, secrets[i])
+	}
+	return selected
 }
 
 func discoverManifestPlugins(manifestPath, lockfilePath string) ([]string, error) {
@@ -463,6 +537,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 		nonInteractive: *nonInteractive,
 		secretLiterals: []string(secretFlag),
 		only:           only,
+		all:            *allFlag,
 		skipExisting:   *skipExisting,
 	}, nil
 }

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -89,10 +89,7 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 				return nil, nil
 			}
 			items := buildManifestMultiSelectItems(selectable, statuses, a.all)
-			selectedIdx, err := prompt.MultiSelect(
-				fmt.Sprintf("Select secrets to set for %s (unset selected by default; toggle set secrets to update)", scopeLabel),
-				items,
-			)
+			selectedIdx, err := prompt.MultiSelect(manifestMultiSelectTitle(scopeLabel, a.skipExisting), items)
 			if err != nil {
 				return nil, err
 			}
@@ -122,6 +119,10 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 
 	fmt.Fprintf(out, "Setting up secrets from %s -> %s\n\n", a.manifestPath, scopeLabel)
 	switch {
+	case interactive && a.skipExisting:
+		fmt.Fprintln(out, "Interactive mode: --skip-existing is set; existing secrets are hidden and unset secrets are selected by default.")
+		fmt.Fprintln(out, "Leave a value empty to skip it.")
+		fmt.Fprintln(out, "Use --from-env, --secret NAME=VALUE, or --non-interactive for scripted setup.")
 	case interactive:
 		fmt.Fprintln(out, "Interactive mode: unset secrets are selected by default; toggle existing secrets to update them.")
 		fmt.Fprintln(out, "Leave a value empty to skip it.")
@@ -274,6 +275,13 @@ func buildManifestMultiSelectItems(secrets []manifestDiscoveredSecret, statuses 
 		})
 	}
 	return items
+}
+
+func manifestMultiSelectTitle(scopeLabel string, skipExisting bool) string {
+	if skipExisting {
+		return fmt.Sprintf("Select unset secrets to set for %s (--skip-existing hides existing secrets)", scopeLabel)
+	}
+	return fmt.Sprintf("Select secrets to set for %s (unset selected by default; toggle set secrets to update)", scopeLabel)
 }
 
 func secretStatusByName(statuses []SecretStatus) map[string]SecretStatus {

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -181,6 +181,22 @@ func TestBuildManifestMultiSelectItemsShowsStatusSourcesAndDefaults(t *testing.T
 	}
 }
 
+func TestManifestMultiSelectTitleRespectsSkipExisting(t *testing.T) {
+	normal := manifestMultiSelectTitle("github repo GoCodeAlone/example", false)
+	if !strings.Contains(normal, "toggle set secrets to update") {
+		t.Fatalf("normal title = %q, want update hint", normal)
+	}
+	skipExisting := manifestMultiSelectTitle("github repo GoCodeAlone/example", true)
+	if strings.Contains(skipExisting, "toggle set secrets") {
+		t.Fatalf("skip-existing title = %q, must not offer toggling hidden set secrets", skipExisting)
+	}
+	for _, want := range []string{"--skip-existing", "hides existing secrets"} {
+		if !strings.Contains(skipExisting, want) {
+			t.Fatalf("skip-existing title = %q, want %q", skipExisting, want)
+		}
+	}
+}
+
 func TestSelectManifestSecretsForSetupDefaultsToUnsetButCanUpdateAll(t *testing.T) {
 	secrets := []manifestDiscoveredSecret{
 		{PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"}},

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -97,6 +97,19 @@ func TestParseManifestSetupFlagsAcceptsSetupSelectors(t *testing.T) {
 	}
 }
 
+func TestParseManifestSetupFlagsPreservesAll(t *testing.T) {
+	args, err := parseManifestSetupFlags([]string{
+		"--manifest", "wfctl.yaml",
+		"--all",
+	})
+	if err != nil {
+		t.Fatalf("parseManifestSetupFlags: %v", err)
+	}
+	if !args.all {
+		t.Fatalf("--all was not preserved: %+v", args)
+	}
+}
+
 func TestManifestSecretValueNonInteractiveRequiresValueSource(t *testing.T) {
 	secret := manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"}}
 	got, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
@@ -128,6 +141,88 @@ func TestManifestSecretValueFromEnvMissingSkips(t *testing.T) {
 	if provided || got != "" {
 		t.Fatalf("got value=%q provided=%v, want skipped empty value", got, provided)
 	}
+}
+
+func TestBuildManifestMultiSelectItemsShowsStatusSourcesAndDefaults(t *testing.T) {
+	secrets := []manifestDiscoveredSecret{
+		{
+			PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"},
+			Sources:              []string{"config:digitalocean.wfctl.yaml", "plugin:workflow-plugin-digitalocean"},
+		},
+		{
+			PluginRequiredSecret: PluginRequiredSecret{Name: "HOVER_PASSWORD"},
+			Sources:              []string{"config:hover.wfctl.yaml", "plugin:workflow-plugin-hover"},
+		},
+	}
+	statuses := []SecretStatus{
+		{Name: "DIGITALOCEAN_TOKEN", State: SecretSet, IsSet: true},
+		{Name: "HOVER_PASSWORD", State: SecretNotSet, IsSet: false},
+	}
+
+	items := buildManifestMultiSelectItems(secrets, statuses, false)
+	if len(items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(items))
+	}
+	if items[0].Preselected {
+		t.Fatalf("set secret was preselected: %+v", items[0])
+	}
+	if !items[1].Preselected {
+		t.Fatalf("unset secret was not preselected: %+v", items[1])
+	}
+	for _, want := range []string{"DIGITALOCEAN_TOKEN", "✓ set", "config:digitalocean.wfctl.yaml", "plugin:workflow-plugin-digitalocean"} {
+		if !strings.Contains(items[0].Label, want) {
+			t.Fatalf("set label %q does not contain %q", items[0].Label, want)
+		}
+	}
+	for _, want := range []string{"HOVER_PASSWORD", "✗ unset", "config:hover.wfctl.yaml", "plugin:workflow-plugin-hover"} {
+		if !strings.Contains(items[1].Label, want) {
+			t.Fatalf("unset label %q does not contain %q", items[1].Label, want)
+		}
+	}
+}
+
+func TestSelectManifestSecretsForSetupDefaultsToUnsetButCanUpdateAll(t *testing.T) {
+	secrets := []manifestDiscoveredSecret{
+		{PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"}},
+		{PluginRequiredSecret: PluginRequiredSecret{Name: "HOVER_PASSWORD"}},
+	}
+	statuses := []SecretStatus{
+		{Name: "DIGITALOCEAN_TOKEN", State: SecretSet, IsSet: true},
+		{Name: "HOVER_PASSWORD", State: SecretNotSet, IsSet: false},
+	}
+
+	selected := selectManifestSecretsForSetup(secrets, statuses, manifestSecretSelectionOptions{})
+	if got := manifestSecretNames(selected); !reflect.DeepEqual(got, []string{"HOVER_PASSWORD"}) {
+		t.Fatalf("default selected = %v, want only unset secret", got)
+	}
+
+	selected = selectManifestSecretsForSetup(secrets, statuses, manifestSecretSelectionOptions{includeExisting: true})
+	if got := manifestSecretNames(selected); !reflect.DeepEqual(got, []string{"DIGITALOCEAN_TOKEN", "HOVER_PASSWORD"}) {
+		t.Fatalf("includeExisting selected = %v, want all secrets", got)
+	}
+
+	selected = selectManifestSecretsForSetup(secrets, statuses, manifestSecretSelectionOptions{
+		includeExisting: true,
+		skipExisting:    true,
+	})
+	if got := manifestSecretNames(selected); !reflect.DeepEqual(got, []string{"HOVER_PASSWORD"}) {
+		t.Fatalf("skipExisting selected = %v, want only unset secret", got)
+	}
+
+	selected = selectManifestSecretsForSetup(secrets, statuses, manifestSecretSelectionOptions{
+		onlySet: map[string]bool{"DIGITALOCEAN_TOKEN": true},
+	})
+	if got := manifestSecretNames(selected); !reflect.DeepEqual(got, []string{"DIGITALOCEAN_TOKEN"}) {
+		t.Fatalf("explicit only selected = %v, want selected set secret", got)
+	}
+}
+
+func manifestSecretNames(secrets []manifestDiscoveredSecret) []string {
+	names := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		names = append(names, secret.Name)
+	}
+	return names
 }
 
 func TestParseManifestSetupFlagsDefaultsConfigPatterns(t *testing.T) {

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2528,7 +2528,7 @@ wfctl secrets sync --from staging --to production
 
 Set secrets declared in the config for a given environment. Automatically selects interactive or non-interactive mode based on whether stdin is a TTY. With `--manifest`, discovers secrets from `wfctl.yaml`, `.wfctl-lock.yaml`, installed plugin `required_secrets[]`, and `${ENV_VAR}` references in workflow configs. Repo/env-scoped GitHub setup uses `secrets.config.repo` or `secretStores.<name>.config.repo` when configured; otherwise it infers the repo from `git remote.origin.url` and prints that assumption in the setup target or error.
 
-**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names. Manifest-backed setup prints the selected GitHub target and whether the repo was configured explicitly or inferred before prompting for values.
+**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names. Manifest-backed setup prints the selected GitHub target and whether the repo was configured explicitly or inferred, shows discovered provider/config secrets with set/unset status and their sources, and selects only unset secrets by default. Toggle existing secrets to update them, or pass `--all` to preselect every discovered secret.
 
 **Non-interactive mode** (auto when stdin is not a TTY, or forced with `--non-interactive` / `--auto-gen-keys`): reads values from the sources below in priority order:
 - `--from-env` — reads `$NAME` for each secret. Recommended for CI; avoids process-table leaks. Secrets whose env var is unset are skipped.
@@ -2557,7 +2557,7 @@ wfctl secrets setup [options]
 | `--non-interactive` | `false` | Force non-interactive mode (also auto when stdin is not a TTY) |
 | `--from-env` | `false` | Read each secret value from `$NAME`. Recommended for CI. |
 | `--secret` | _(none)_ | `NAME=VALUE` literal. **Warning: leaks to process table.** Repeatable. |
-| `--all` | `false` | Set all declared secrets (explicit form of the default when `--only` is absent) |
+| `--all` | `false` | Set all declared secrets; in manifest-backed interactive setup, preselect existing secrets too |
 | `--only` | _(all)_ | Comma-separated list of secret names to set; mutually exclusive with `--all` |
 | `--skip-existing` | `false` | Skip secrets that already have a value in the store |
 | `--auto-gen-keys` | `false` | Auto-generate random values for config-backed secrets ending in `_KEY`, `_SECRET`, `_TOKEN`, or `_SIGNING`; implies non-interactive; not supported for manifest-backed `wfctl.yaml` setup |


### PR DESCRIPTION
## Summary
- show manifest-backed `wfctl secrets setup` rows with set/unset status and source metadata in the multiselect
- select only unset manifest secrets by default in interactive mode, while `--all` preselects existing secrets too
- preserve explicit `--only`, `--skip-existing`, and non-interactive selection behavior
- update CLI help and `docs/WFCTL.md`

## Verification
- RED: `GOWORK=off go test ./cmd/wfctl -run 'TestBuildManifestMultiSelectItemsShowsStatusSourcesAndDefaults|TestSelectManifestSecretsForSetupDefaultsToUnsetButCanUpdateAll' -count=1` failed with undefined manifest selection helpers before implementation.
- Regression proof with fix removed: `GOWORK=off go test ./cmd/wfctl -run 'TestSelectManifestSecretsForSetupDefaultsToUnsetButCanUpdateAll' -count=1` failed with `default selected = [DIGITALOCEAN_TOKEN HOVER_PASSWORD], want only unset secret`.
- GREEN focused: `GOWORK=off go test ./cmd/wfctl -run 'TestBuildManifestMultiSelectItemsShowsStatusSourcesAndDefaults|TestSelectManifestSecretsForSetupDefaultsToUnsetButCanUpdateAll|TestParseManifestSetupFlags' -count=1`
- Full package: `GOWORK=off go test ./cmd/wfctl ./cmd/wfctl/internal/prompt -count=1`
- Build/help smoke: `GOWORK=off go build -o /tmp/wfctl-secrets-existing-status ./cmd/wfctl && WFCTL_NO_UPDATE_CHECK=1 /tmp/wfctl-secrets-existing-status secrets setup --help`
- Hygiene: `git diff --check`
