### PR TITLE
fix: clean up wfctl plugin help and compatibility version handling

### DIFF
--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -16,45 +16,46 @@ func runPlugin(args []string) error {
 		printPluginUsage()
 		return nil
 	}
+	subArgs := args[1:]
 	switch args[0] {
 	case "init":
-		return runPluginInit(args[1:])
+		return runPluginInit(subArgs)
 	case "docs":
-		return runPluginDocs(args[1:])
+		return runPluginDocs(subArgs)
 	case "test":
-		return runPluginTest(args[1:])
+		return runPluginTest(subArgs)
 	case "search":
-		return runPluginSearch(args[1:])
+		return runPluginSearch(subArgs)
 	case "add":
-		return runPluginAdd(args[1:])
+		return runPluginAdd(subArgs)
 	case "lock":
-		return runPluginLock(args[1:])
+		return runPluginLock(subArgs)
 	case "install":
-		return runPluginInstall(args[1:])
+		return runPluginInstall(subArgs)
 	case "list":
-		return runPluginList(args[1:])
+		return runPluginList(subArgs)
 	case "update":
-		return runPluginUpdate(args[1:])
+		return runPluginUpdate(subArgs)
 	case "remove":
-		return runPluginRemove(args[1:])
+		return runPluginRemove(subArgs)
 	case "validate":
-		return runPluginValidate(args[1:])
+		return runPluginValidate(subArgs)
 	case "audit":
-		return runPluginAudit(args[1:])
+		return runPluginAudit(subArgs)
 	case "validate-contract":
-		return runPluginValidateContract(args[1:])
+		return runPluginValidateContract(subArgs)
 	case "verify-capabilities":
-		return runPluginVerifyCapabilities(args[1:])
+		return runPluginVerifyCapabilities(subArgs)
 	case "registry-sync":
-		return runPluginRegistrySync(args[1:])
+		return runPluginRegistrySync(subArgs)
 	case "conformance":
-		return runPluginConformance(args[1:])
+		return runPluginConformance(subArgs)
 	case "info":
-		return runPluginInfo(args[1:])
+		return runPluginInfo(subArgs)
 	case "deps":
-		return runPluginDeps(args[1:])
+		return runPluginDeps(subArgs)
 	case "marketplace-verify":
-		return runPluginMarketplaceVerify(args[1:])
+		return runPluginMarketplaceVerify(subArgs)
 	default:
 		return pluginUsage()
 	}

--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -12,6 +12,10 @@ func runPlugin(args []string) error {
 	if len(args) < 1 {
 		return pluginUsage()
 	}
+	if args[0] == "-h" || args[0] == "--help" {
+		printPluginUsage()
+		return nil
+	}
 	switch args[0] {
 	case "init":
 		return runPluginInit(args[1:])
@@ -57,6 +61,11 @@ func runPlugin(args []string) error {
 }
 
 func pluginUsage() error {
+	printPluginUsage()
+	return fmt.Errorf("plugin subcommand is required")
+}
+
+func printPluginUsage() {
 	fmt.Fprintf(flag.CommandLine.Output(), `Usage: wfctl plugin <subcommand> [options]
 
 Subcommands:
@@ -82,7 +91,6 @@ Subcommands:
 
 Use -plugin-dir to specify a custom plugin directory (replaces deprecated -data-dir).
 `)
-	return fmt.Errorf("plugin subcommand is required")
 }
 
 func runPluginInit(args []string) error {

--- a/cmd/wfctl/plugin_compat_model_test.go
+++ b/cmd/wfctl/plugin_compat_model_test.go
@@ -67,6 +67,23 @@ func TestPluginCompatResolverEngineVersionStaysReleaseComparable(t *testing.T) {
 	}
 }
 
+func TestPluginCompatResolverUsesLinkedWfctlVersion(t *testing.T) {
+	origVersion := version
+	version = "v0.75.3"
+	t.Cleanup(func() {
+		version = origVersion
+	})
+	t.Setenv("WFCTL_ENGINE_VERSION", "")
+
+	got, comparable := resolvePluginCompatEngineVersion("")
+	if !comparable {
+		t.Fatalf("linked wfctl version comparable = false, got %q", got)
+	}
+	if got != "v0.75.3" {
+		t.Fatalf("linked wfctl version = %q, want v0.75.3", got)
+	}
+}
+
 func TestPluginCompatDigestOmitsEvidenceDigest(t *testing.T) {
 	ev := PluginCompatibilityEvidence{
 		Plugin:               "workflow-plugin-test",

--- a/cmd/wfctl/plugin_compat_resolver.go
+++ b/cmd/wfctl/plugin_compat_resolver.go
@@ -178,7 +178,7 @@ func resolvePluginCompatEngineVersion(raw string) (string, bool) {
 		raw = strings.TrimSpace(os.Getenv("WFCTL_ENGINE_VERSION"))
 	}
 	if raw == "" {
-		raw = buildVersion()
+		raw = version
 	}
 	engine, err := CanonicalEngineVersion(raw)
 	if err != nil {

--- a/cmd/wfctl/plugin_compat_resolver_test.go
+++ b/cmd/wfctl/plugin_compat_resolver_test.go
@@ -185,6 +185,33 @@ func TestPluginCompatResolverPseudoLocalVersionIsAdvisory(t *testing.T) {
 	}
 }
 
+func TestPluginCompatResolverLinkedVersionDoesNotWarnNotComparable(t *testing.T) {
+	origVersion := version
+	version = "v0.75.3"
+	t.Cleanup(func() {
+		version = origVersion
+	})
+	t.Setenv("WFCTL_ENGINE_VERSION", "")
+
+	idx := resolverIndex(resolverRecord("v0.2.0", passEvidence("v0.2.0", "v0.75.3")))
+	idx.EvidencePolicy.RequiredFromEngine = "v0.70.0"
+	decision, err := ResolvePluginCompatibility(idx, nil, PluginCompatResolverOptions{
+		CompatMode: PluginCompatModeEnforce,
+		Trust:      CompatibilityTrustFirstParty,
+		OS:         "darwin",
+		Arch:       "arm64",
+	})
+	if err != nil {
+		t.Fatalf("ResolvePluginCompatibility: %v", err)
+	}
+	if decision.Warning != "" {
+		t.Fatalf("decision warning = %q, want no warning", decision.Warning)
+	}
+	if decision.Evidence == nil || decision.Evidence.EngineVersion != "v0.75.3" {
+		t.Fatalf("decision evidence = %#v, want v0.75.3 evidence", decision.Evidence)
+	}
+}
+
 func TestPluginCompatResolverLegacyHostLoadEvidenceNeverSatisfiesIaC(t *testing.T) {
 	// An index containing only legacy-host-load evidence must behave as if no
 	// compatible evidence exists. The resolver already filters by typed-iac mode

--- a/cmd/wfctl/plugin_test_cmd_test.go
+++ b/cmd/wfctl/plugin_test_cmd_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,5 +140,28 @@ func TestPluginUsageIncludesTest(t *testing.T) {
 	err2 := runPlugin([]string{"unknown-subcommand"})
 	if err2 == nil {
 		t.Fatal("expected error for unknown subcommand")
+	}
+}
+
+func TestRunPluginHelpFlagsPrintUsageWithoutError(t *testing.T) {
+	for _, args := range [][]string{{"-h"}, {"--help"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var out bytes.Buffer
+			oldOutput := flag.CommandLine.Output()
+			flag.CommandLine.SetOutput(&out)
+			t.Cleanup(func() {
+				flag.CommandLine.SetOutput(oldOutput)
+			})
+
+			if err := runPlugin(args); err != nil {
+				t.Fatalf("runPlugin(%v) error = %v, want nil", args, err)
+			}
+			if !strings.Contains(out.String(), "Usage: wfctl plugin <subcommand>") {
+				t.Fatalf("help output missing plugin usage:\n%s", out.String())
+			}
+			if !strings.Contains(out.String(), "Subcommands:") {
+				t.Fatalf("help output missing subcommand list:\n%s", out.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Treat `wfctl plugin -h` and `wfctl plugin --help` as explicit help requests
- Keep missing/unknown plugin subcommands on the existing error path
- Use the linked/runtime wfctl version for plugin compatibility resolution so release binaries do not warn that the local engine version is not comparable
- Add regression coverage for plugin help flags and compatibility decisions using a release-linked wfctl version

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestRunPluginHelpFlagsPrintUsageWithoutError|TestRunPluginMissingSubcommand|TestPluginUsageIncludesTest' -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestPluginCompatResolverUsesLinkedWfctlVersion|TestPluginCompatResolverLinkedVersionDoesNotWarnNotComparable|TestPluginCompatResolverEngineVersionStaysReleaseComparable|TestPluginCompatResolverPseudoLocalVersionIsAdvisory|TestRunPluginHelpFlagsPrintUsageWithoutError|TestRunPluginMissingSubcommand|TestPluginUsageIncludesTest' -count=1`
- `GOWORK=off go build -o /tmp/wfctl-plugin-help ./cmd/wfctl`
- `WFCTL_NO_UPDATE_CHECK=1 /tmp/wfctl-plugin-help plugin -h` exits 0
- `WFCTL_NO_UPDATE_CHECK=1 /tmp/wfctl-plugin-help plugin` exits 1 with `plugin subcommand is required`
- `GOWORK=off go test ./cmd/wfctl ./cmd/wfctl/internal/prompt -count=1`
- `git diff --check`