### PR TITLE
ci: parallelize release artifact builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ jobs:
   build-ui:
     name: Build Admin UI
     runs-on: ubuntu-latest
-    needs: test
 
     steps:
     - name: Check out code
@@ -163,7 +162,6 @@ jobs:
   build-binaries:
     name: Build ${{ matrix.name }} binaries
     runs-on: ubuntu-latest
-    needs: test
     strategy:
       fail-fast: false
       matrix:
@@ -241,7 +239,11 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-ui]
+    # Build temporary release artifacts in parallel with the pre-release test
+    # job, but do not publish the GitHub release until tests and artifacts have
+    # completed. The Docker job still waits for tests because it pushes to GHCR
+    # directly rather than uploading a temporary artifact.
+    needs: [test, build-binaries, build-ui]
 
     steps:
     - name: Check out code


### PR DESCRIPTION
## Summary
- Start release binary and admin UI artifact builds immediately instead of waiting for pre-release tests
- Keep the public GitHub release gated on pre-release tests plus uploaded artifacts
- Leave the Docker/GHCR push behind pre-release tests because it publishes directly

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/release.yml`
- `git diff --check`