### PR TITLE
Route wfctl secrets setup by provider target

### DIFF
--- a/cmd/wfctl/download_progress.go
+++ b/cmd/wfctl/download_progress.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"github.com/mattn/go-isatty"
 )
 
 const downloadProgressInterval = 2 * time.Second
@@ -25,10 +27,15 @@ type downloadProgress struct {
 	total int64
 	read  int64
 	last  time.Time
+	tty   bool
 }
 
 func newDownloadProgress(w io.Writer, total int64) *downloadProgress {
-	p := &downloadProgress{w: w, total: total}
+	return newDownloadProgressWithTerminal(w, total, isatty.IsTerminal(os.Stderr.Fd()))
+}
+
+func newDownloadProgressWithTerminal(w io.Writer, total int64, tty bool) *downloadProgress {
+	p := &downloadProgress{w: w, total: total, tty: tty}
 	p.emit("Download progress")
 	return p
 }
@@ -45,6 +52,9 @@ func (p *downloadProgress) Write(data []byte) (int, error) {
 
 func (p *downloadProgress) finish() {
 	p.emit("Download complete")
+	if p.tty && p.w != nil {
+		fmt.Fprintln(p.w)
+	}
 }
 
 func (p *downloadProgress) emit(prefix string) {
@@ -52,12 +62,18 @@ func (p *downloadProgress) emit(prefix string) {
 		return
 	}
 	p.last = time.Now()
+	line := ""
 	if p.total > 0 {
 		percent := float64(p.read) / float64(p.total) * 100
-		fmt.Fprintf(p.w, "%s: %s/%s (%.0f%%)\n", prefix, formatDownloadBytes(p.read), formatDownloadBytes(p.total), percent)
-		return
+		line = fmt.Sprintf("%s: %s/%s (%.0f%%)", prefix, formatDownloadBytes(p.read), formatDownloadBytes(p.total), percent)
+	} else {
+		line = fmt.Sprintf("%s: %s", prefix, formatDownloadBytes(p.read))
 	}
-	fmt.Fprintf(p.w, "%s: %s\n", prefix, formatDownloadBytes(p.read))
+	if p.tty {
+		fmt.Fprintf(p.w, "\r%s", line)
+	} else {
+		fmt.Fprintln(p.w, line)
+	}
 }
 
 func formatDownloadBytes(n int64) string {

--- a/cmd/wfctl/download_progress_test.go
+++ b/cmd/wfctl/download_progress_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDownloadProgressTTYUsesLiveLine(t *testing.T) {
+	var out bytes.Buffer
+	p := newDownloadProgressWithTerminal(&out, 100, true)
+	if _, err := p.Write([]byte(strings.Repeat("x", 25))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	p.finish()
+
+	got := out.String()
+	if !strings.Contains(got, "\rDownload progress:") {
+		t.Fatalf("TTY progress output = %q, want carriage-return live progress", got)
+	}
+	if !strings.Contains(got, "\rDownload complete:") {
+		t.Fatalf("TTY progress output = %q, want live completion line", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("TTY progress output = %q, want final newline", got)
+	}
+}
+
+func TestDownloadProgressNonTTYUsesLogLines(t *testing.T) {
+	var out bytes.Buffer
+	p := newDownloadProgressWithTerminal(&out, 100, false)
+	if _, err := p.Write([]byte(strings.Repeat("x", 25))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	p.finish()
+
+	got := out.String()
+	if strings.Contains(got, "\r") {
+		t.Fatalf("non-TTY progress output = %q, want no carriage returns", got)
+	}
+	if !strings.Contains(got, "Download progress:") || !strings.Contains(got, "Download complete:") {
+		t.Fatalf("non-TTY progress output = %q, want progress and completion lines", got)
+	}
+}

--- a/cmd/wfctl/secrets_providers.go
+++ b/cmd/wfctl/secrets_providers.go
@@ -66,6 +66,10 @@ func (a secretsProviderAdapter) Delete(ctx context.Context, name string) error {
 	return a.p.Delete(ctx, name)
 }
 
+func (a secretsProviderAdapter) SecretTarget() secrets.ProviderTarget {
+	return secrets.DescribeTarget(a.p)
+}
+
 // Check returns the SecretState for the named secret.
 //
 // Resolution order, most-precise first:

--- a/cmd/wfctl/secrets_providers_test.go
+++ b/cmd/wfctl/secrets_providers_test.go
@@ -48,6 +48,15 @@ func (f *metadataSecretsProvider) StatAll(_ context.Context) ([]secrets.SecretMe
 	return f.metas, nil
 }
 
+type targetSecretsProvider struct {
+	*plainSecretsProvider
+	target secrets.ProviderTarget
+}
+
+func (f *targetSecretsProvider) SecretTarget() secrets.ProviderTarget {
+	return f.target
+}
+
 // ---------------------------------------------------------------------------
 // Adapter tests
 // ---------------------------------------------------------------------------
@@ -118,6 +127,24 @@ func TestSecretsProviderAdapter_List_MetadataProvider_UpdatedAt(t *testing.T) {
 	}
 	if statuses[0].LastRotated != ts {
 		t.Errorf("LastRotated = %v, want %v", statuses[0].LastRotated, ts)
+	}
+}
+
+func TestSecretsProviderAdapter_SecretTargetUsesProviderContract(t *testing.T) {
+	fp := &targetSecretsProvider{
+		plainSecretsProvider: &plainSecretsProvider{stored: map[string]string{}},
+		target: secrets.ProviderTarget{
+			Provider: "custom",
+			Scope:    "namespace",
+			Subject:  "example",
+			Label:    "custom namespace example",
+		},
+	}
+	adapter := secretsProviderAdapter{fp}
+
+	target := adapter.SecretTarget()
+	if target.Label != "custom namespace example" || target.Scope != "namespace" {
+		t.Fatalf("target = %+v", target)
 	}
 }
 

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -123,6 +123,7 @@ Options:
 				pluginDir:      *pluginDir,
 				configPatterns: defaultManifestSetupConfigPatterns(),
 				scope:          *scope,
+				scopeExplicit:  hasFlag(args, "scope"),
 				envName:        *envName,
 				org:            *org,
 				visibility:     *visibility,

--- a/cmd/wfctl/secrets_setup_interactive.go
+++ b/cmd/wfctl/secrets_setup_interactive.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
@@ -25,6 +26,7 @@ type setupDecl struct {
 	name        string
 	sensitive   bool
 	description string
+	store       string
 }
 
 // builtinProviderTypes are the provider names a user can pick when no named
@@ -51,34 +53,21 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 		return nil
 	}
 
-	decls := make([]setupDecl, 0, len(cfg.Secrets.Entries))
-	for _, e := range cfg.Secrets.Entries {
-		decls = append(decls, setupDecl{
-			name:        e.Name,
-			sensitive:   isSecretSensitive(e.Name),
-			description: e.Description,
-		})
-	}
-
-	// 1. Resolve the store (prompt when unresolved + interactive).
-	storeName, err := resolveSetupStoreInteractive(a.storeName, cfg)
-	if err != nil {
-		return err
-	}
-
-	// 2. Build the provider + print an access line.
-	provider, err := getProviderForStore(storeName, cfg)
-	if err != nil {
-		return fmt.Errorf("resolve store %q: %w", storeName, err)
-	}
-	printStoreAccessLine(ctx, out, storeName, provider)
+	decls := buildSetupDecls(cfg, a.envName, a.storeName)
 
 	// 3. Query per-entry status and let the user MultiSelect.
-	statuses := queryDeclStatuses(ctx, decls, provider)
+	for _, storeName := range setupDeclStores(decls) {
+		provider, err := getProviderForStore(storeName, cfg)
+		if err != nil {
+			return fmt.Errorf("resolve store %q: %w", storeName, err)
+		}
+		printStoreAccessLine(ctx, out, storeName, provider)
+	}
+	statuses := querySetupDeclStatuses(ctx, decls, cfg)
 	items := buildMultiSelectItems(decls, statuses)
 
 	selectedIdx, err := prompt.MultiSelect(
-		fmt.Sprintf("Select secrets to set in %q (space to toggle, enter to confirm)", storeName),
+		"Select secrets to set (space to toggle, enter to confirm)",
 		items,
 	)
 	if err != nil {
@@ -94,7 +83,7 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 
 	// 4. Confirm before writing.
 	ok, err := prompt.Confirm(
-		fmt.Sprintf("Set %d secret(s) to store %q?", len(selectedIdx), storeName),
+		fmt.Sprintf("Set %d secret(s) to their resolved store(s)?", len(selectedIdx)),
 		true,
 	)
 	if err != nil {
@@ -110,18 +99,15 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 
 	// 5. Build the engine selector (the user's MultiSelect choice) + valuer
 	//    (masked prompt.Input). Reuse the SAME engine + audit as non-interactive.
-	selectedSet := make(map[string]bool, len(selectedIdx))
+	selectedSet := make(map[int]bool, len(selectedIdx))
 	for _, i := range selectedIdx {
-		selectedSet[decls[i].name] = true
+		selectedSet[i] = true
 	}
-	selector := func(ds []setupDecl, _ []SecretStatus) ([]setupDecl, error) {
-		var keep []setupDecl
-		for _, d := range ds {
-			if selectedSet[d.name] {
-				keep = append(keep, d)
-			}
+	selectedDecls := make([]setupDecl, 0, len(selectedIdx))
+	for i, decl := range decls {
+		if selectedSet[i] {
+			selectedDecls = append(selectedDecls, decl)
 		}
-		return keep, nil
 	}
 
 	var promptErr error
@@ -144,13 +130,11 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 		return v, true, nil
 	}
 
-	auditFn := func(name, _ string) {
-		_ = writeSecretsAuditRecord(name, storeName) //nolint:errcheck // best-effort audit
+	auditFn := func(name, store string) {
+		_ = writeSecretsAuditRecord(name, store) //nolint:errcheck // best-effort audit
 	}
 
-	report, err := runSetupEngine(ctx, decls,
-		func(d setupDecl) string { return d.name },
-		provider, selector, valuer, auditFn, false)
+	report, err := runSetupDeclsByStore(ctx, cfg, selectedDecls, valuer, auditFn, false)
 	// If a prompt.Input hit a non-TTY mid-flow, surface ErrNotInteractive so the
 	// caller's fallback triggers. The engine runs with stopOnErr=false, so it
 	// returns (report, nil) even when the valuer reported ErrNotInteractive —
@@ -167,6 +151,41 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 		return fmt.Errorf("%d secret(s) failed to set", len(report.Failed))
 	}
 	return nil
+}
+
+func buildSetupDecls(cfg *config.WorkflowConfig, envName, storeOverride string) []setupDecl {
+	if cfg == nil || cfg.Secrets == nil {
+		return nil
+	}
+	decls := make([]setupDecl, 0, len(cfg.Secrets.Entries))
+	for _, e := range cfg.Secrets.Entries {
+		storeName := strings.TrimSpace(storeOverride)
+		if storeName == "" {
+			storeName = ResolveSecretStore(e.Name, envName, cfg)
+		}
+		decls = append(decls, setupDecl{
+			name:        e.Name,
+			sensitive:   isSecretSensitive(e.Name),
+			description: e.Description,
+			store:       storeName,
+		})
+	}
+	return decls
+}
+
+func setupDeclStores(decls []setupDecl) []string {
+	seen := map[string]bool{}
+	var stores []string
+	for _, decl := range decls {
+		store := strings.TrimSpace(decl.store)
+		if store == "" || seen[store] {
+			continue
+		}
+		seen[store] = true
+		stores = append(stores, store)
+	}
+	sort.Strings(stores)
+	return stores
 }
 
 // resolveSetupStoreInteractive resolves the store, prompting the user with
@@ -228,6 +247,40 @@ func queryDeclStatuses(ctx context.Context, decls []setupDecl, provider SecretsP
 	return statuses
 }
 
+func querySetupDeclStatuses(ctx context.Context, decls []setupDecl, cfg *config.WorkflowConfig) []SecretStatus {
+	statuses := make([]SecretStatus, 0, len(decls))
+	providers := map[string]SecretsProvider{}
+	for _, d := range decls {
+		provider, ok := providers[d.store]
+		if !ok {
+			var err error
+			provider, err = getProviderForStore(d.store, cfg)
+			if err != nil {
+				statuses = append(statuses, SecretStatus{
+					Name:  d.name,
+					Store: d.store,
+					State: SecretUnconfigured,
+					Error: err.Error(),
+				})
+				continue
+			}
+			providers[d.store] = provider
+		}
+		state, err := provider.Check(ctx, d.name)
+		status := SecretStatus{
+			Name:  d.name,
+			Store: d.store,
+			State: state,
+			IsSet: state == SecretSet,
+		}
+		if err != nil {
+			status.Error = err.Error()
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses
+}
+
 // buildMultiSelectItems builds the prompt.MultiSelect rows. Unset secrets are
 // preselected; set secrets show their last-updated age when known.
 func buildMultiSelectItems(decls []setupDecl, statuses []SecretStatus) []prompt.Item {
@@ -238,12 +291,60 @@ func buildMultiSelectItems(decls []setupDecl, statuses []SecretStatus) []prompt.
 	items := make([]prompt.Item, 0, len(decls))
 	for _, d := range decls {
 		st := statusByName[d.name]
+		label := formatStatusLabel(d.name, st)
+		if d.store != "" {
+			label += " [" + d.store + "]"
+		}
 		items = append(items, prompt.Item{
-			Label:       formatStatusLabel(d.name, st),
+			Label:       label,
 			Preselected: !st.IsSet, // preselect unset
 		})
 	}
 	return items
+}
+
+func runSetupDeclsByStore(ctx context.Context, cfg *config.WorkflowConfig, decls []setupDecl, valuer func(setupDecl) (string, bool, error), audit func(string, string), stopOnError bool) (setupReport, error) {
+	var report setupReport
+	providers := map[string]SecretsProvider{}
+	for _, decl := range decls {
+		provider, ok := providers[decl.store]
+		if !ok {
+			var err error
+			provider, err = getProviderForStore(decl.store, cfg)
+			if err != nil {
+				report.Failed = append(report.Failed, decl.name)
+				if stopOnError {
+					return report, err
+				}
+				continue
+			}
+			providers[decl.store] = provider
+		}
+		value, provided, err := valuer(decl)
+		if err != nil {
+			report.Failed = append(report.Failed, decl.name)
+			if stopOnError {
+				return report, err
+			}
+			continue
+		}
+		if !provided {
+			report.Skipped = append(report.Skipped, decl.name)
+			continue
+		}
+		if err := provider.Set(ctx, decl.name, value); err != nil {
+			report.Failed = append(report.Failed, decl.name)
+			if stopOnError {
+				return report, err
+			}
+			continue
+		}
+		report.Set = append(report.Set, decl.name)
+		if audit != nil {
+			audit(decl.name, decl.store)
+		}
+	}
+	return report, nil
 }
 
 // formatStatusLabel renders a MultiSelect row label for one secret.
@@ -251,6 +352,14 @@ func buildMultiSelectItems(decls []setupDecl, statuses []SecretStatus) []prompt.
 //	NAME   ✓ set · updated 3d ago
 //	NAME   ✗ unset
 func formatStatusLabel(name string, st SecretStatus) string {
+	switch st.State {
+	case SecretNoAccess:
+		return fmt.Sprintf("%-24s ! no access", name)
+	case SecretFetchError:
+		return fmt.Sprintf("%-24s ! check failed", name)
+	case SecretUnconfigured:
+		return fmt.Sprintf("%-24s ! unconfigured", name)
+	}
 	if st.IsSet {
 		age := formatRotatedAge(st.LastRotated)
 		if age != "" {

--- a/cmd/wfctl/secrets_setup_interactive.go
+++ b/cmd/wfctl/secrets_setup_interactive.go
@@ -188,32 +188,6 @@ func setupDeclStores(decls []setupDecl) []string {
 	return stores
 }
 
-// resolveSetupStoreInteractive resolves the store, prompting the user with
-// prompt.Select when the resolver returns unresolved ("" + nil error).
-func resolveSetupStoreInteractive(storeFlag string, cfg *config.WorkflowConfig) (string, error) {
-	defaultStore := ""
-	if cfg.Secrets != nil {
-		defaultStore = cfg.Secrets.DefaultStore
-		if defaultStore == "" {
-			defaultStore = cfg.Secrets.Provider
-		}
-	}
-	name, err := resolveSetupStoreName(storeFlag, defaultStore, cfg.SecretStores, true)
-	if err != nil {
-		return "", err
-	}
-	if name != "" {
-		return name, nil
-	}
-	// Unresolved + interactive → prompt over store keys + builtin provider types.
-	opts := storePickOptions(cfg.SecretStores)
-	idx, err := prompt.Select("Pick a secret store", opts)
-	if err != nil {
-		return "", err
-	}
-	return opts[idx], nil
-}
-
 // storePickOptions returns the ordered list of store names a user can pick:
 // configured secretStores keys (sorted) first, then builtin provider types
 // that aren't already a store name.

--- a/cmd/wfctl/secrets_setup_interactive_test.go
+++ b/cmd/wfctl/secrets_setup_interactive_test.go
@@ -71,6 +71,21 @@ func TestFormatStatusLabel(t *testing.T) {
 	if !strings.Contains(setWithTime, "✓ set · updated") || !strings.Contains(setWithTime, "3d ago") {
 		t.Errorf("set-with-time label = %q, want '✓ set · updated 3d ago'", setWithTime)
 	}
+
+	noAccess := formatStatusLabel("QUX", SecretStatus{Name: "QUX", State: SecretNoAccess})
+	if !strings.Contains(noAccess, "! no access") {
+		t.Errorf("no-access label = %q, want ! no access", noAccess)
+	}
+
+	fetchError := formatStatusLabel("QUUX", SecretStatus{Name: "QUUX", State: SecretFetchError})
+	if !strings.Contains(fetchError, "! check failed") {
+		t.Errorf("fetch-error label = %q, want ! check failed", fetchError)
+	}
+
+	unconfigured := formatStatusLabel("CORGE", SecretStatus{Name: "CORGE", State: SecretUnconfigured})
+	if !strings.Contains(unconfigured, "! unconfigured") {
+		t.Errorf("unconfigured label = %q, want ! unconfigured", unconfigured)
+	}
 }
 
 func TestFormatRotatedAge(t *testing.T) {
@@ -114,6 +129,55 @@ func TestBuildMultiSelectItems(t *testing.T) {
 	}
 	if !strings.Contains(items[1].Label, "✗ unset") {
 		t.Errorf("UNSET_ONE label = %q", items[1].Label)
+	}
+}
+
+func TestBuildSetupDeclsResolvesPerSecretStores(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		SecretStores: map[string]*config.SecretStoreConfig{
+			"github-repo": {Provider: "github", Config: map[string]any{"repo": "GoCodeAlone/example"}},
+			"aws-prod":    {Provider: "aws-secrets-manager", Config: map[string]any{"region": "us-east-1"}},
+		},
+		Secrets: &config.SecretsConfig{
+			DefaultStore: "github-repo",
+			Entries: []config.SecretEntry{
+				{Name: "GITHUB_TOKEN"},
+				{Name: "AWS_ACCESS_KEY_ID", Store: "aws-prod"},
+			},
+		},
+	}
+
+	decls := buildSetupDecls(cfg, "production", "")
+	if len(decls) != 2 {
+		t.Fatalf("decls len = %d, want 2", len(decls))
+	}
+	if decls[0].store != "github-repo" {
+		t.Fatalf("GITHUB_TOKEN store = %q, want github-repo", decls[0].store)
+	}
+	if decls[1].store != "aws-prod" {
+		t.Fatalf("AWS_ACCESS_KEY_ID store = %q, want aws-prod", decls[1].store)
+	}
+
+	decls = buildSetupDecls(cfg, "production", "github-repo")
+	if decls[1].store != "github-repo" {
+		t.Fatalf("--store override did not override per-secret store: %+v", decls[1])
+	}
+}
+
+func TestBuildMultiSelectItemsShowsResolvedStore(t *testing.T) {
+	decls := []setupDecl{
+		{name: "AWS_ACCESS_KEY_ID", store: "aws-prod"},
+	}
+	statuses := []SecretStatus{
+		{Name: "AWS_ACCESS_KEY_ID", Store: "aws-prod", IsSet: false, State: SecretNotSet},
+	}
+
+	items := buildMultiSelectItems(decls, statuses)
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(items))
+	}
+	if !strings.Contains(items[0].Label, "[aws-prod]") {
+		t.Fatalf("label = %q, want resolved store", items[0].Label)
 	}
 }
 

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/secrets"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,7 +22,22 @@ var manifestEnvRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
 type manifestDiscoveredSecret struct {
 	PluginRequiredSecret
-	Sources []string
+	Sources   []string
+	StoreHint string
+}
+
+type manifestSecretTarget struct {
+	Secret   manifestDiscoveredSecret
+	Store    string
+	Label    string
+	Provider SecretsProvider
+	Status   SecretStatus
+}
+
+type manifestSecretTargetProvider struct {
+	Store    string
+	Label    string
+	Provider SecretsProvider
 }
 
 type manifestSetupArgs struct {
@@ -30,6 +46,7 @@ type manifestSetupArgs struct {
 	pluginDir      string
 	configPatterns string
 	scope          string
+	scopeExplicit  bool
 	envName        string
 	org            string
 	visibility     string
@@ -52,12 +69,6 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 		return nil
 	}
 
-	ghProvider, scopeLabel, err := buildSecretWriter(strings.ToLower(strings.TrimSpace(a.scope)), a.envName, a.org, a.visibility, a.tokenEnv, firstConfigPattern(a.configPatterns))
-	if err != nil {
-		return err
-	}
-	provider := secretsProviderAdapter{p: ghProvider}
-
 	secretMap, err := buildSecretLiteralMap(a.secretLiterals)
 	if err != nil {
 		return err
@@ -71,6 +82,29 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 		}
 	}
 	interactive := in == nil && !a.nonInteractive && prompt.CanPrompt()
+
+	var promptErr error
+	valuer := func(secret manifestDiscoveredSecret) (string, bool, error) {
+		value, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
+			interactive: interactive,
+			fromEnv:     a.fromEnv,
+			secretMap:   secretMap,
+		})
+		if err != nil && errors.Is(err, prompt.ErrNotInteractive) {
+			promptErr = err
+		}
+		return value, provided, err
+	}
+
+	if interactive && !a.scopeExplicit {
+		return runSecretsSetupManifestTargets(context.Background(), a, discovered, valuer, out, &promptErr)
+	}
+
+	ghProvider, scopeLabel, err := buildSecretWriter(strings.ToLower(strings.TrimSpace(a.scope)), a.envName, a.org, a.visibility, a.tokenEnv, firstConfigPattern(a.configPatterns))
+	if err != nil {
+		return err
+	}
+	provider := secretsProviderAdapter{p: ghProvider}
 
 	onlySet := make(map[string]bool, len(a.only))
 	for _, name := range a.only {
@@ -100,18 +134,6 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 			includeExisting: true,
 			skipExisting:    a.skipExisting,
 		}), nil
-	}
-	var promptErr error
-	valuer := func(secret manifestDiscoveredSecret) (string, bool, error) {
-		value, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
-			interactive: interactive,
-			fromEnv:     a.fromEnv,
-			secretMap:   secretMap,
-		})
-		if err != nil && errors.Is(err, prompt.ErrNotInteractive) {
-			promptErr = err
-		}
-		return value, provided, err
 	}
 	auditFn := func(name, _ string) {
 		_ = writeSecretsAuditRecord(name, "github:"+strings.ToLower(strings.TrimSpace(a.scope))) //nolint:errcheck // best-effort audit
@@ -159,6 +181,335 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	return nil
 }
 
+func runSecretsSetupManifestTargets(ctx context.Context, a *manifestSetupArgs, discovered []manifestDiscoveredSecret, valuer func(manifestDiscoveredSecret) (string, bool, error), out io.Writer, promptErr *error) error {
+	providers, err := buildManifestSecretTargetProviders(a)
+	if err != nil {
+		return err
+	}
+	targets := queryManifestSecretTargets(ctx, discovered, providers)
+
+	onlySet := make(map[string]bool, len(a.only))
+	for _, name := range a.only {
+		onlySet[name] = true
+	}
+	selectable := selectManifestSecretTargetsForSetup(targets, manifestSecretSelectionOptions{
+		onlySet:         onlySet,
+		includeExisting: true,
+		skipExisting:    a.skipExisting,
+	})
+	if len(selectable) == 0 {
+		fmt.Fprintln(out, "No unset secrets found in the selected provider targets.")
+		return nil
+	}
+
+	fmt.Fprintf(out, "Setting up secrets from %s -> provider targets\n\n", a.manifestPath)
+	if a.skipExisting {
+		fmt.Fprintln(out, "Interactive mode: --skip-existing is set; existing secret targets are hidden.")
+	} else {
+		fmt.Fprintln(out, "Interactive mode: unset secret targets are selected by default; toggle set targets to update them.")
+	}
+	fmt.Fprintln(out, "Leave a value empty to skip every selected target for that secret.")
+	fmt.Fprintln(out, "Use --scope to force a single GitHub target, or configure secretStores for provider-specific targets.")
+	fmt.Fprintln(out)
+
+	items := buildManifestSecretTargetItems(selectable, a.all)
+	selectedIdx, err := prompt.MultiSelect(manifestMultiTargetSelectTitle(a.skipExisting), items)
+	if err != nil {
+		return err
+	}
+	selected := manifestSecretTargetsByIndexes(selectable, selectedIdx)
+	if len(selected) == 0 {
+		fmt.Fprintln(out, "No secret targets selected; nothing to do.")
+		return nil
+	}
+
+	report, err := runManifestSecretTargetSetup(ctx, selected, valuer, func(name, store string) {
+		_ = writeSecretsAuditRecord(name, store) //nolint:errcheck // best-effort audit
+	}, true)
+	if promptErr != nil && *promptErr != nil {
+		return *promptErr
+	}
+	if err != nil {
+		return err
+	}
+	for _, n := range report.Set {
+		fmt.Fprintf(out, "  %s: set\n", n)
+	}
+	for _, n := range report.Skipped {
+		fmt.Fprintf(out, "  %s: skipped (no value provided)\n", n)
+	}
+	fmt.Fprintln(out, "\nAll done.")
+	return nil
+}
+
+func buildManifestSecretTargetProviders(a *manifestSetupArgs) ([]manifestSecretTargetProvider, error) {
+	configPath := firstConfigPattern(a.configPatterns)
+	providers := make([]manifestSecretTargetProvider, 0, 4)
+	seen := map[string]bool{}
+	add := func(store, label string, provider SecretsProvider) {
+		if provider == nil || store == "" || seen[store] {
+			return
+		}
+		if targetLabel := secretProviderTargetLabel(provider); targetLabel != "" {
+			label = targetLabel
+		}
+		seen[store] = true
+		providers = append(providers, manifestSecretTargetProvider{
+			Store:    store,
+			Label:    label,
+			Provider: provider,
+		})
+	}
+
+	repo := ""
+	if p, label, err := buildSecretWriter("repo", a.envName, a.org, a.visibility, a.tokenEnv, configPath); err == nil {
+		add("github-repo", label, secretsProviderAdapter{p: p})
+		repo, _, _ = readGitHubRepoForSecretsSetup(configPath)
+	}
+	if a.envName != "" {
+		if p, label, err := buildSecretWriter("env", a.envName, a.org, a.visibility, a.tokenEnv, configPath); err == nil {
+			add("github-env:"+a.envName, label, secretsProviderAdapter{p: p})
+		}
+	}
+	org := strings.TrimSpace(a.org)
+	if org == "" {
+		if repo == "" {
+			repo, _, _ = readGitHubRepoForSecretsSetup(configPath)
+		}
+		org = githubOwnerFromRepo(repo)
+	}
+	if org != "" {
+		if p, label, err := buildSecretWriter("org", a.envName, org, a.visibility, a.tokenEnv, configPath); err == nil {
+			add("github-org:"+org, label, secretsProviderAdapter{p: p})
+		}
+	}
+
+	if cfg, err := config.LoadFromFile(configPath); err == nil && len(cfg.SecretStores) > 0 {
+		providers = providers[:0]
+		clear(seen)
+		for _, target := range buildConfiguredManifestSecretStoreTargets(cfg) {
+			add(target.Store, target.Label, target.Provider)
+		}
+	}
+
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("no secret provider targets could be configured from %s; configure GitHub repo/org settings or secretStores", configPath)
+	}
+	return providers, nil
+}
+
+func buildConfiguredManifestSecretStoreTargets(cfg *config.WorkflowConfig) []manifestSecretTargetProvider {
+	names := make([]string, 0, len(cfg.SecretStores))
+	for name := range cfg.SecretStores {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	providers := make([]manifestSecretTargetProvider, 0, len(names))
+	for _, name := range names {
+		store := cfg.SecretStores[name]
+		providers = append(providers, manifestSecretStoreTargets(name, store, cfg)...)
+	}
+	return providers
+}
+
+func manifestSecretStoreTargets(name string, store *config.SecretStoreConfig, cfg *config.WorkflowConfig) []manifestSecretTargetProvider {
+	if store == nil {
+		return nil
+	}
+	providerName := normalizedSecretStoreProvider(store.Provider)
+	if providerName == "github" {
+		return manifestGitHubSecretStoreTargets(name, store)
+	}
+	provider, err := getProviderForStore(name, cfg)
+	if err != nil {
+		return nil
+	}
+	label := secretProviderTargetLabel(provider)
+	if label == "" {
+		label = name
+	}
+	return []manifestSecretTargetProvider{{
+		Store:    name,
+		Label:    label + " (" + name + ")",
+		Provider: provider,
+	}}
+}
+
+func manifestGitHubSecretStoreTargets(name string, store *config.SecretStoreConfig) []manifestSecretTargetProvider {
+	cfg := store.Config
+	tokenEnv := stringConfigValue(cfg, "token_env")
+	if tokenEnv == "" {
+		tokenEnv = "GITHUB_TOKEN"
+	}
+	var targets []manifestSecretTargetProvider
+	if repo := stringConfigValue(cfg, "repo"); repo != "" {
+		if p, err := buildGitHubRepoSecretsTarget(repo, tokenEnv); err == nil {
+			provider := secretsProviderAdapter{p: p}
+			targets = append(targets, manifestSecretTargetProvider{
+				Store:    name + ":repo",
+				Label:    secretProviderTargetLabel(provider) + " (" + name + ")",
+				Provider: provider,
+			})
+		}
+		if env := stringConfigValue(cfg, "environment"); env != "" {
+			if p, err := buildGitHubEnvSecretsTarget(repo, env, tokenEnv); err == nil {
+				provider := secretsProviderAdapter{p: p}
+				targets = append(targets, manifestSecretTargetProvider{
+					Store:    name + ":env:" + env,
+					Label:    secretProviderTargetLabel(provider) + " (" + name + ")",
+					Provider: provider,
+				})
+			}
+		}
+	}
+	if org := stringConfigValue(cfg, "org"); org != "" {
+		visibility := stringConfigValue(cfg, "visibility")
+		if visibility == "" {
+			visibility = "all"
+		}
+		if p, err := buildGitHubOrgSecretsTarget(org, visibility, tokenEnv); err == nil {
+			provider := secretsProviderAdapter{p: p}
+			targets = append(targets, manifestSecretTargetProvider{
+				Store:    name + ":org:" + org,
+				Label:    fmt.Sprintf("%s (visibility=%s, %s)", secretProviderTargetLabel(provider), visibility, name),
+				Provider: provider,
+			})
+		}
+	}
+	return targets
+}
+
+func buildGitHubRepoSecretsTarget(repo, tokenEnv string) (secrets.Provider, error) {
+	return secrets.NewGitHubSecretsProvider(repo, tokenEnv)
+}
+
+func buildGitHubEnvSecretsTarget(repo, env, tokenEnv string) (secrets.Provider, error) {
+	provider, err := secrets.NewGitHubSecretsProvider(repo, tokenEnv)
+	if err != nil {
+		return nil, err
+	}
+	provider.SetEnvironment(env)
+	return provider, nil
+}
+
+func buildGitHubOrgSecretsTarget(org, visibility, tokenEnv string) (secrets.Provider, error) {
+	vis, err := parseGitHubOrgVisibility(visibility)
+	if err != nil {
+		return nil, err
+	}
+	return secrets.NewGitHubOrgSecretsProvider(org, tokenEnv, vis, nil)
+}
+
+func normalizedSecretStoreProvider(provider string) string {
+	switch strings.TrimSpace(provider) {
+	case "github-actions":
+		return "github"
+	case "aws-secrets-manager":
+		return "aws"
+	default:
+		return strings.TrimSpace(provider)
+	}
+}
+
+func githubOwnerFromRepo(repo string) string {
+	owner, _, ok := strings.Cut(strings.TrimSpace(repo), "/")
+	if !ok {
+		return ""
+	}
+	return owner
+}
+
+func secretProviderTargetLabel(provider SecretsProvider) string {
+	describer, ok := provider.(interface{ SecretTarget() secrets.ProviderTarget })
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(describer.SecretTarget().Label)
+}
+
+func queryManifestSecretTargets(ctx context.Context, secrets []manifestDiscoveredSecret, providers []manifestSecretTargetProvider) []manifestSecretTarget {
+	targets := make([]manifestSecretTarget, 0, len(secrets)*len(providers))
+	for _, secret := range secrets {
+		for _, provider := range providers {
+			if secret.StoreHint != "" && provider.Store != secret.StoreHint && !strings.HasPrefix(provider.Store, secret.StoreHint+":") {
+				continue
+			}
+			state, err := provider.Provider.Check(ctx, secret.Name)
+			status := SecretStatus{
+				Name:  secret.Name,
+				Store: provider.Store,
+				State: state,
+				IsSet: state == SecretSet,
+			}
+			if err != nil {
+				status.Error = err.Error()
+			}
+			targets = append(targets, manifestSecretTarget{
+				Secret:   secret,
+				Store:    provider.Store,
+				Label:    provider.Label,
+				Provider: provider.Provider,
+				Status:   status,
+			})
+		}
+	}
+	return targets
+}
+
+func runManifestSecretTargetSetup(ctx context.Context, targets []manifestSecretTarget, valuer func(manifestDiscoveredSecret) (string, bool, error), audit func(string, string), stopOnError bool) (setupReport, error) {
+	var report setupReport
+	type cachedValue struct {
+		value    string
+		provided bool
+		err      error
+	}
+	values := make(map[string]cachedValue)
+	for _, target := range targets {
+		name := target.Secret.Name
+		cached, ok := values[name]
+		if !ok {
+			value, provided, err := valuer(target.Secret)
+			cached = cachedValue{value: value, provided: provided, err: err}
+			values[name] = cached
+		}
+		displayName := manifestSecretTargetDisplayName(target)
+		if cached.err != nil {
+			report.Failed = append(report.Failed, displayName)
+			if stopOnError {
+				return report, cached.err
+			}
+			continue
+		}
+		if !cached.provided {
+			report.Skipped = append(report.Skipped, displayName)
+			continue
+		}
+		if err := target.Provider.Set(ctx, name, cached.value); err != nil {
+			report.Failed = append(report.Failed, displayName)
+			if stopOnError {
+				return report, err
+			}
+			continue
+		}
+		report.Set = append(report.Set, displayName)
+		if audit != nil {
+			audit(name, target.Store)
+		}
+	}
+	return report, nil
+}
+
+func manifestSecretTargetDisplayName(target manifestSecretTarget) string {
+	label := target.Label
+	if label == "" {
+		label = target.Store
+	}
+	if label == "" {
+		return target.Secret.Name
+	}
+	return target.Secret.Name + " [" + label + "]"
+}
+
 func discoverManifestSecrets(manifestPath, lockfilePath, pluginDir, configPatterns string) ([]manifestDiscoveredSecret, error) {
 	plugins, err := discoverManifestPlugins(manifestPath, lockfilePath)
 	if err != nil {
@@ -190,11 +541,12 @@ func discoverManifestSecrets(manifestPath, lockfilePath, pluginDir, configPatter
 		if err != nil {
 			return nil, err
 		}
+		storeHints := discoverConfigSecretStoreHints(configFile)
 		for _, ref := range refs {
-			addDiscoveredSecret(secretsByName, PluginRequiredSecret{
+			addDiscoveredSecretWithStoreHint(secretsByName, PluginRequiredSecret{
 				Name:      ref,
 				Sensitive: isSecretSensitive(ref),
-			}, "config:"+filepath.Base(configFile))
+			}, "config:"+filepath.Base(configFile), storeHints[ref])
 		}
 	}
 	return sortedManifestSecrets(secretsByName), nil
@@ -277,11 +629,67 @@ func buildManifestMultiSelectItems(secrets []manifestDiscoveredSecret, statuses 
 	return items
 }
 
+func buildManifestSecretTargetItems(targets []manifestSecretTarget, includeExisting bool) []prompt.Item {
+	items := make([]prompt.Item, 0, len(targets))
+	for _, target := range targets {
+		label := formatStatusLabel(target.Secret.Name, target.Status)
+		if target.Label != "" {
+			label += " [" + target.Label + "]"
+		} else if target.Store != "" {
+			label += " [" + target.Store + "]"
+		}
+		if len(target.Secret.Sources) > 0 {
+			label += " (" + strings.Join(target.Secret.Sources, ", ") + ")"
+		}
+		items = append(items, prompt.Item{
+			Label:       label,
+			Preselected: includeExisting || !target.Status.IsSet,
+		})
+	}
+	return items
+}
+
+func selectManifestSecretTargetsForSetup(targets []manifestSecretTarget, opts manifestSecretSelectionOptions) []manifestSecretTarget {
+	selected := make([]manifestSecretTarget, 0, len(targets))
+	for _, target := range targets {
+		if len(opts.onlySet) > 0 {
+			if !opts.onlySet[target.Secret.Name] {
+				continue
+			}
+		} else if !opts.includeExisting && target.Status.IsSet {
+			continue
+		}
+		if opts.skipExisting && target.Status.IsSet {
+			continue
+		}
+		selected = append(selected, target)
+	}
+	return selected
+}
+
+func manifestSecretTargetsByIndexes(targets []manifestSecretTarget, indexes []int) []manifestSecretTarget {
+	selected := make([]manifestSecretTarget, 0, len(indexes))
+	for _, i := range indexes {
+		if i < 0 || i >= len(targets) {
+			continue
+		}
+		selected = append(selected, targets[i])
+	}
+	return selected
+}
+
 func manifestMultiSelectTitle(scopeLabel string, skipExisting bool) string {
 	if skipExisting {
 		return fmt.Sprintf("Select unset secrets to set for %s (--skip-existing hides existing secrets)", scopeLabel)
 	}
 	return fmt.Sprintf("Select secrets to set for %s (unset selected by default; toggle set secrets to update)", scopeLabel)
+}
+
+func manifestMultiTargetSelectTitle(skipExisting bool) string {
+	if skipExisting {
+		return "Select unset secret provider targets (--skip-existing hides existing targets)"
+	}
+	return "Select secret provider targets (unset selected by default; toggle set targets to update)"
 }
 
 func secretStatusByName(statuses []SecretStatus) map[string]SecretStatus {
@@ -338,6 +746,10 @@ func discoverManifestPlugins(manifestPath, lockfilePath string) ([]string, error
 }
 
 func addDiscoveredSecret(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source string) {
+	addDiscoveredSecretWithStoreHint(secretsByName, required, source, "")
+}
+
+func addDiscoveredSecretWithStoreHint(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source, storeHint string) {
 	name := strings.TrimSpace(required.Name)
 	if name == "" {
 		return
@@ -350,6 +762,9 @@ func addDiscoveredSecret(secretsByName map[string]*manifestDiscoveredSecret, req
 	}
 	if required.Description != "" && secret.Description == "" {
 		secret.Description = required.Description
+	}
+	if storeHint != "" && secret.StoreHint == "" {
+		secret.StoreHint = storeHint
 	}
 	secret.Sensitive = secret.Sensitive || required.Sensitive || isSecretSensitive(name)
 	for _, existing := range secret.Sources {
@@ -423,6 +838,23 @@ func discoverConfigEnvRefs(path string) ([]string, error) {
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+func discoverConfigSecretStoreHints(path string) map[string]string {
+	cfg, err := config.LoadFromFile(path)
+	if err != nil || cfg == nil || cfg.Secrets == nil {
+		return nil
+	}
+	hints := make(map[string]string, len(cfg.Secrets.Entries))
+	for _, entry := range cfg.Secrets.Entries {
+		name := strings.TrimSpace(entry.Name)
+		store := strings.TrimSpace(entry.Store)
+		if name == "" || store == "" {
+			continue
+		}
+		hints[name] = store
+	}
+	return hints
 }
 
 func collectEnvRefs(node *yaml.Node, refs map[string]bool) {
@@ -537,6 +969,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 		pluginDir:      *pluginDir,
 		configPatterns: *configPatterns,
 		scope:          *scope,
+		scopeExplicit:  hasFlag(args, "scope"),
 		envName:        *envName,
 		org:            *org,
 		visibility:     *visibility,

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -339,7 +339,7 @@ func manifestGitHubSecretStoreTargets(name string, store *config.SecretStoreConf
 	cfg := store.Config
 	tokenEnv := stringConfigValue(cfg, "token_env")
 	if tokenEnv == "" {
-		tokenEnv = "GITHUB_TOKEN"
+		tokenEnv = "GITHUB_TOKEN" //nolint:gosec // G101: env var name, not a credential value
 	}
 	var targets []manifestSecretTargetProvider
 	if repo := stringConfigValue(cfg, "repo"); repo != "" {
@@ -464,7 +464,8 @@ func runManifestSecretTargetSetup(ctx context.Context, targets []manifestSecretT
 		err      error
 	}
 	values := make(map[string]cachedValue)
-	for _, target := range targets {
+	for i := range targets {
+		target := &targets[i]
 		name := target.Secret.Name
 		cached, ok := values[name]
 		if !ok {
@@ -472,7 +473,7 @@ func runManifestSecretTargetSetup(ctx context.Context, targets []manifestSecretT
 			cached = cachedValue{value: value, provided: provided, err: err}
 			values[name] = cached
 		}
-		displayName := manifestSecretTargetDisplayName(target)
+		displayName := manifestSecretTargetDisplayName(*target)
 		if cached.err != nil {
 			report.Failed = append(report.Failed, displayName)
 			if stopOnError {
@@ -631,7 +632,8 @@ func buildManifestMultiSelectItems(secrets []manifestDiscoveredSecret, statuses 
 
 func buildManifestSecretTargetItems(targets []manifestSecretTarget, includeExisting bool) []prompt.Item {
 	items := make([]prompt.Item, 0, len(targets))
-	for _, target := range targets {
+	for i := range targets {
+		target := &targets[i]
 		label := formatStatusLabel(target.Secret.Name, target.Status)
 		if target.Label != "" {
 			label += " [" + target.Label + "]"
@@ -651,7 +653,8 @@ func buildManifestSecretTargetItems(targets []manifestSecretTarget, includeExist
 
 func selectManifestSecretTargetsForSetup(targets []manifestSecretTarget, opts manifestSecretSelectionOptions) []manifestSecretTarget {
 	selected := make([]manifestSecretTarget, 0, len(targets))
-	for _, target := range targets {
+	for i := range targets {
+		target := &targets[i]
 		if len(opts.onlySet) > 0 {
 			if !opts.onlySet[target.Secret.Name] {
 				continue
@@ -662,7 +665,7 @@ func selectManifestSecretTargetsForSetup(targets []manifestSecretTarget, opts ma
 		if opts.skipExisting && target.Status.IsSet {
 			continue
 		}
-		selected = append(selected, target)
+		selected = append(selected, *target)
 	}
 	return selected
 }

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,6 +76,50 @@ plugins:
 	}
 }
 
+func TestDiscoverManifestSecretsPreservesConfiguredStoreHint(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "wfctl.yaml")
+	lockPath := filepath.Join(dir, ".wfctl-lock.yaml")
+	pluginDir := filepath.Join(dir, "plugins")
+	configPath := filepath.Join(dir, "app.yaml")
+
+	if err := os.WriteFile(manifestPath, []byte("version: 1\nplugins: []\n"), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("version: 1\nplugins: {}\n"), 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`secretStores:
+  aws-prod:
+    provider: aws-secrets-manager
+    config:
+      region: us-east-1
+secrets:
+  entries:
+    - name: AWS_ACCESS_KEY_ID
+      store: aws-prod
+providers:
+  aws:
+    access_key_id: ${AWS_ACCESS_KEY_ID}
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	secrets, err := discoverManifestSecrets(manifestPath, lockPath, pluginDir, configPath)
+	if err != nil {
+		t.Fatalf("discoverManifestSecrets: %v", err)
+	}
+	if len(secrets) != 1 {
+		t.Fatalf("secrets = %+v, want one AWS secret", secrets)
+	}
+	if secrets[0].StoreHint != "aws-prod" {
+		t.Fatalf("StoreHint = %q, want aws-prod", secrets[0].StoreHint)
+	}
+}
+
 func TestParseManifestSetupFlagsAcceptsSetupSelectors(t *testing.T) {
 	args, err := parseManifestSetupFlags([]string{
 		"--manifest", "wfctl.yaml",
@@ -107,6 +152,29 @@ func TestParseManifestSetupFlagsPreservesAll(t *testing.T) {
 	}
 	if !args.all {
 		t.Fatalf("--all was not preserved: %+v", args)
+	}
+}
+
+func TestParseManifestSetupFlagsTracksExplicitScope(t *testing.T) {
+	args, err := parseManifestSetupFlags([]string{
+		"--manifest", "wfctl.yaml",
+	})
+	if err != nil {
+		t.Fatalf("parseManifestSetupFlags: %v", err)
+	}
+	if args.scopeExplicit {
+		t.Fatalf("default scope should not be treated as explicit: %+v", args)
+	}
+
+	args, err = parseManifestSetupFlags([]string{
+		"--manifest", "wfctl.yaml",
+		"--scope", "org",
+	})
+	if err != nil {
+		t.Fatalf("parseManifestSetupFlags: %v", err)
+	}
+	if !args.scopeExplicit {
+		t.Fatalf("--scope flag was not tracked as explicit: %+v", args)
 	}
 }
 
@@ -178,6 +246,212 @@ func TestBuildManifestMultiSelectItemsShowsStatusSourcesAndDefaults(t *testing.T
 		if !strings.Contains(items[1].Label, want) {
 			t.Fatalf("unset label %q does not contain %q", items[1].Label, want)
 		}
+	}
+}
+
+func TestBuildManifestSecretTargetItemsShowProviderScopes(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"},
+				Sources:              []string{"config:digitalocean.wfctl.yaml"},
+			},
+			Store: "github-repo",
+			Label: "github repo GoCodeAlone/gocodealone-dns",
+			Status: SecretStatus{
+				Name:  "DIGITALOCEAN_TOKEN",
+				Store: "github-repo",
+				State: SecretNotSet,
+				IsSet: false,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"},
+				Sources:              []string{"config:digitalocean.wfctl.yaml"},
+			},
+			Store: "github-org",
+			Label: "github org GoCodeAlone",
+			Status: SecretStatus{
+				Name:  "DIGITALOCEAN_TOKEN",
+				Store: "github-org",
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "AWS_ACCESS_KEY_ID"},
+				Sources:              []string{"config:aws.wfctl.yaml"},
+			},
+			Store: "aws-prod",
+			Label: "aws secrets-manager aws-prod",
+			Status: SecretStatus{
+				Name:  "AWS_ACCESS_KEY_ID",
+				Store: "aws-prod",
+				State: SecretNotSet,
+				IsSet: false,
+			},
+		},
+	}
+
+	items := buildManifestSecretTargetItems(targets, false)
+	if len(items) != 3 {
+		t.Fatalf("items len = %d, want 3", len(items))
+	}
+	if !items[0].Preselected {
+		t.Fatalf("unset repo target should be preselected: %+v", items[0])
+	}
+	if items[1].Preselected {
+		t.Fatalf("set org target should not be preselected: %+v", items[1])
+	}
+	if !items[2].Preselected {
+		t.Fatalf("unset AWS target should be preselected: %+v", items[2])
+	}
+	for _, want := range []string{"DIGITALOCEAN_TOKEN", "github repo GoCodeAlone/gocodealone-dns", "✗ unset"} {
+		if !strings.Contains(items[0].Label, want) {
+			t.Fatalf("repo target label %q does not contain %q", items[0].Label, want)
+		}
+	}
+	for _, want := range []string{"DIGITALOCEAN_TOKEN", "github org GoCodeAlone", "✓ set"} {
+		if !strings.Contains(items[1].Label, want) {
+			t.Fatalf("org target label %q does not contain %q", items[1].Label, want)
+		}
+	}
+	for _, want := range []string{"AWS_ACCESS_KEY_ID", "aws secrets-manager aws-prod", "✗ unset"} {
+		if !strings.Contains(items[2].Label, want) {
+			t.Fatalf("AWS target label %q does not contain %q", items[2].Label, want)
+		}
+	}
+}
+
+func TestSelectManifestSecretTargetsSkipExistingPerTarget(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}}, Store: "repo", Status: SecretStatus{Name: "TOKEN", Store: "repo", IsSet: false}},
+		{Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}}, Store: "org", Status: SecretStatus{Name: "TOKEN", Store: "org", IsSet: true}},
+	}
+
+	selected := selectManifestSecretTargetsForSetup(targets, manifestSecretSelectionOptions{
+		includeExisting: true,
+		skipExisting:    true,
+	})
+	if len(selected) != 1 || selected[0].Store != "repo" {
+		t.Fatalf("selected targets = %+v, want only unset repo target", selected)
+	}
+
+	selected = selectManifestSecretTargetsForSetup(targets, manifestSecretSelectionOptions{
+		includeExisting: true,
+	})
+	if len(selected) != 2 {
+		t.Fatalf("selected targets len = %d, want both targets", len(selected))
+	}
+}
+
+func TestQueryManifestSecretTargetsUsesProviderStatusPerTarget(t *testing.T) {
+	secrets := []manifestDiscoveredSecret{
+		{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+	}
+	providers := []manifestSecretTargetProvider{
+		{
+			Store:    "github-repo",
+			Label:    "github repo GoCodeAlone/example",
+			Provider: newEngineTestProvider(nil),
+		},
+		{
+			Store:    "github-org",
+			Label:    "github org GoCodeAlone",
+			Provider: newEngineTestProvider(map[string]string{"TOKEN": "set"}),
+		},
+	}
+
+	targets := queryManifestSecretTargets(context.Background(), secrets, providers)
+	if len(targets) != 2 {
+		t.Fatalf("targets len = %d, want 2", len(targets))
+	}
+	if targets[0].Status.IsSet {
+		t.Fatalf("repo target status = %+v, want unset", targets[0].Status)
+	}
+	if !targets[1].Status.IsSet {
+		t.Fatalf("org target status = %+v, want set", targets[1].Status)
+	}
+}
+
+func TestQueryManifestSecretTargetsHonorsSecretStoreHint(t *testing.T) {
+	secrets := []manifestDiscoveredSecret{
+		{
+			PluginRequiredSecret: PluginRequiredSecret{Name: "AWS_ACCESS_KEY_ID"},
+			StoreHint:            "aws-prod",
+		},
+	}
+	providers := []manifestSecretTargetProvider{
+		{
+			Store:    "github-repo",
+			Label:    "github repo GoCodeAlone/example",
+			Provider: newEngineTestProvider(nil),
+		},
+		{
+			Store:    "aws-prod",
+			Label:    "aws-secrets-manager aws-prod",
+			Provider: newEngineTestProvider(nil),
+		},
+	}
+
+	targets := queryManifestSecretTargets(context.Background(), secrets, providers)
+	if len(targets) != 1 {
+		t.Fatalf("targets = %+v, want only configured AWS target", targets)
+	}
+	if targets[0].Store != "aws-prod" {
+		t.Fatalf("target store = %q, want aws-prod", targets[0].Store)
+	}
+	if strings.Contains(targets[0].Label, "repo") || strings.Contains(targets[0].Label, "org") {
+		t.Fatalf("AWS target leaked GitHub label semantics: %q", targets[0].Label)
+	}
+}
+
+func TestRunManifestSecretTargetSetupWritesEachSelectedProvider(t *testing.T) {
+	repoProvider := newEngineTestProvider(nil)
+	orgProvider := newEngineTestProvider(nil)
+	targets := []manifestSecretTarget{
+		{
+			Secret:   manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:    "github-repo",
+			Label:    "github repo GoCodeAlone/example",
+			Provider: repoProvider,
+		},
+		{
+			Secret:   manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:    "github-org",
+			Label:    "github org GoCodeAlone",
+			Provider: orgProvider,
+		},
+	}
+	valueCalls := 0
+	var audited []string
+
+	report, err := runManifestSecretTargetSetup(context.Background(), targets,
+		func(secret manifestDiscoveredSecret) (string, bool, error) {
+			valueCalls++
+			return "value", true, nil
+		},
+		func(name, store string) {
+			audited = append(audited, name+"@"+store)
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("runManifestSecretTargetSetup: %v", err)
+	}
+	if valueCalls != 1 {
+		t.Fatalf("valuer calls = %d, want one prompt reused for both targets", valueCalls)
+	}
+	if repoProvider.data["TOKEN"] != "value" || orgProvider.data["TOKEN"] != "value" {
+		t.Fatalf("providers not both set: repo=%q org=%q", repoProvider.data["TOKEN"], orgProvider.data["TOKEN"])
+	}
+	if !reflect.DeepEqual(report.Set, []string{"TOKEN [github repo GoCodeAlone/example]", "TOKEN [github org GoCodeAlone]"}) {
+		t.Fatalf("report.Set = %v", report.Set)
+	}
+	if !reflect.DeepEqual(audited, []string{"TOKEN@github-repo", "TOKEN@github-org"}) {
+		t.Fatalf("audited = %v", audited)
 	}
 }
 

--- a/cmd/wfctl/secrets_setup_noninteractive.go
+++ b/cmd/wfctl/secrets_setup_noninteractive.go
@@ -35,10 +35,11 @@ func runSecretsSetupNonInteractive(a *nonInteractiveSetupArgs, out io.Writer) er
 // runSecretsSetupNonInteractiveCtx executes the non-interactive setup path.
 // It:
 //  1. Loads the workflow config.
-//  2. Resolves the named store (--store > config.defaultStore > "env").
+//  2. Resolves each secret's store (--store > entry.store > env override >
+//     defaultStore > legacy provider > env).
 //  3. Builds a selector from --only / --skip-existing / --all.
 //  4. Builds a valuer from --from-env > stdin-KV > --secret.
-//  5. Runs the engine and prints a summary.
+//  5. Writes each selected secret through its resolved provider and prints a summary.
 func runSecretsSetupNonInteractiveCtx(ctx context.Context, a *nonInteractiveSetupArgs, out io.Writer) error {
 	cfg, err := config.LoadFromFile(a.configFile)
 	if err != nil {
@@ -48,24 +49,6 @@ func runSecretsSetupNonInteractiveCtx(ctx context.Context, a *nonInteractiveSetu
 	if cfg.Secrets == nil || len(cfg.Secrets.Entries) == 0 {
 		fmt.Fprintln(out, "No secrets declared in config.")
 		return nil
-	}
-
-	// Resolve which store to use via the 5-priority resolver.
-	defaultStore := ""
-	if cfg.Secrets != nil {
-		defaultStore = cfg.Secrets.DefaultStore
-		if defaultStore == "" {
-			defaultStore = cfg.Secrets.Provider
-		}
-	}
-	storeName, err := resolveSetupStoreName(a.storeName, defaultStore, cfg.SecretStores, false)
-	if err != nil {
-		return err
-	}
-
-	provider, err := getProviderForStore(storeName, cfg)
-	if err != nil {
-		return fmt.Errorf("resolve store %q: %w", storeName, err)
 	}
 
 	// Build value lookup maps (priority: from-env > stdin-KV > --secret).
@@ -86,15 +69,8 @@ func runSecretsSetupNonInteractiveCtx(ctx context.Context, a *nonInteractiveSetu
 		secretMap[k] = v
 	}
 
-	// Build the declared list from config entries.
-	type decl struct {
-		name      string
-		sensitive bool
-	}
-	var decls []decl
-	for _, e := range cfg.Secrets.Entries {
-		decls = append(decls, decl{name: e.Name, sensitive: isSecretSensitive(e.Name)})
-	}
+	decls := buildSetupDecls(cfg, "", a.storeName)
+	statuses := querySetupDeclStatuses(ctx, decls, cfg)
 
 	// Selector: --only restricts; --skip-existing filters already-set.
 	onlySet := make(map[string]bool, len(a.only))
@@ -102,14 +78,14 @@ func runSecretsSetupNonInteractiveCtx(ctx context.Context, a *nonInteractiveSetu
 		onlySet[n] = true
 	}
 
-	selector := func(ds []decl, statuses []SecretStatus) ([]decl, error) {
+	selector := func(ds []setupDecl, statuses []SecretStatus) ([]setupDecl, error) {
 		setMap := make(map[string]bool, len(statuses))
 		for _, s := range statuses {
 			if s.IsSet {
 				setMap[s.Name] = true
 			}
 		}
-		var out []decl
+		var out []setupDecl
 		for _, d := range ds {
 			if len(onlySet) > 0 && !onlySet[d.name] {
 				continue
@@ -131,7 +107,7 @@ func runSecretsSetupNonInteractiveCtx(ctx context.Context, a *nonInteractiveSetu
 	// When --from-env is set, a missing env var is a skip (provided=false)
 	// rather than an error — the caller only wants to set what's available.
 	// When no value source at all is configured, this is a hard error.
-	valuer := func(d decl) (string, bool, error) {
+	valuer := func(d setupDecl) (string, bool, error) {
 		if a.fromEnv {
 			v := os.Getenv(d.name)
 			if v != "" {
@@ -159,13 +135,15 @@ func runSecretsSetupNonInteractiveCtx(ctx context.Context, a *nonInteractiveSetu
 	}
 
 	// Audit: append a JSONL record for each successful Set (never the value).
-	auditFn := func(name, _ string) {
-		_ = writeSecretsAuditRecord(name, storeName) //nolint:errcheck // best-effort audit
+	auditFn := func(name, store string) {
+		_ = writeSecretsAuditRecord(name, store) //nolint:errcheck // best-effort audit
 	}
 
-	report, err := runSetupEngine(ctx, decls,
-		func(d decl) string { return d.name },
-		provider, selector, valuer, auditFn, false)
+	selectedDecls, err := selector(decls, statuses)
+	if err != nil {
+		return err
+	}
+	report, err := runSetupDeclsByStore(ctx, cfg, selectedDecls, valuer, auditFn, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/secrets_setup_noninteractive_test.go
+++ b/cmd/wfctl/secrets_setup_noninteractive_test.go
@@ -212,6 +212,65 @@ func TestNonInteractive_FromEnv(t *testing.T) {
 	}
 }
 
+func TestNonInteractive_PerSecretStoresRouteToDifferentProviders(t *testing.T) {
+	tmp := t.TempDir()
+	primaryDir := filepath.Join(tmp, "primary")
+	secondaryDir := filepath.Join(tmp, "secondary")
+	if err := os.MkdirAll(primaryDir, 0o755); err != nil {
+		t.Fatalf("mkdir primary: %v", err)
+	}
+	if err := os.MkdirAll(secondaryDir, 0o755); err != nil {
+		t.Fatalf("mkdir secondary: %v", err)
+	}
+	cfgPath := filepath.Join(tmp, "app.yaml")
+	cfg := `secrets:
+  entries:
+    - name: A
+      store: primary
+    - name: B
+      store: secondary
+secretStores:
+  primary:
+    provider: file
+    config:
+      path: ` + primaryDir + `
+  secondary:
+    provider: file
+    config:
+      path: ` + secondaryDir + `
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write app.yaml: %v", err)
+	}
+
+	var out bytes.Buffer
+	err := runSecretsSetupNonInteractive(&nonInteractiveSetupArgs{
+		configFile:     cfgPath,
+		secretLiterals: []string{"A=av", "B=bv"},
+	}, &out)
+	if err != nil {
+		t.Fatalf("runSecretsSetupNonInteractive: %v", err)
+	}
+
+	a, err := os.ReadFile(filepath.Join(primaryDir, "A"))
+	if err != nil {
+		t.Fatalf("read primary A: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(secondaryDir, "B"))
+	if err != nil {
+		t.Fatalf("read secondary B: %v", err)
+	}
+	if string(a) != "av" || string(b) != "bv" {
+		t.Fatalf("stored values A=%q B=%q", a, b)
+	}
+	if _, err := os.Stat(filepath.Join(primaryDir, "B")); !os.IsNotExist(err) {
+		t.Fatalf("B should not be written to primary store: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(secondaryDir, "A")); !os.IsNotExist(err) {
+		t.Fatalf("A should not be written to secondary store: %v", err)
+	}
+}
+
 // TestNonInteractive_SkipExisting verifies --skip-existing skips secrets
 // that are already set in the store.
 func TestNonInteractive_SkipExisting(t *testing.T) {

--- a/secrets/aws_provider.go
+++ b/secrets/aws_provider.go
@@ -73,6 +73,16 @@ func NewAWSSecretsManagerProviderWithClient(cfg AWSConfig, client HTTPClient) *A
 
 func (p *AWSSecretsManagerProvider) Name() string { return "aws-sm" }
 
+// SecretTarget describes the AWS Secrets Manager region namespace.
+func (p *AWSSecretsManagerProvider) SecretTarget() ProviderTarget {
+	return ProviderTarget{
+		Provider: "aws-secrets-manager",
+		Scope:    "region",
+		Subject:  p.config.Region,
+		Label:    "aws secrets-manager " + p.config.Region,
+	}
+}
+
 func (p *AWSSecretsManagerProvider) Get(ctx context.Context, key string) (string, error) {
 	if key == "" {
 		return "", ErrInvalidKey

--- a/secrets/github_provider.go
+++ b/secrets/github_provider.go
@@ -128,6 +128,36 @@ func (p *GitHubSecretsProvider) Scope() GitHubSecretScope { return p.scope }
 
 func (p *GitHubSecretsProvider) Name() string { return "github" }
 
+// SecretTarget describes the GitHub Actions secret namespace represented by
+// this provider: repository, environment, or organization.
+func (p *GitHubSecretsProvider) SecretTarget() ProviderTarget {
+	switch p.scope {
+	case GitHubScopeOrg:
+		return ProviderTarget{
+			Provider: "github",
+			Scope:    string(GitHubScopeOrg),
+			Subject:  p.org,
+			Label:    "github org " + p.org,
+		}
+	case GitHubScopeEnv:
+		subject := fmt.Sprintf("%s on %s/%s", p.env, p.owner, p.repo)
+		return ProviderTarget{
+			Provider: "github",
+			Scope:    string(GitHubScopeEnv),
+			Subject:  subject,
+			Label:    "github env " + subject,
+		}
+	default:
+		subject := p.owner + "/" + p.repo
+		return ProviderTarget{
+			Provider: "github",
+			Scope:    string(GitHubScopeRepo),
+			Subject:  subject,
+			Label:    "github repo " + subject,
+		}
+	}
+}
+
 // SetEnvironment scopes subsequent operations to a GitHub Actions environment.
 // Empty scope means repository-level secrets. Calling SetEnvironment with a
 // non-empty value flips scope to env.

--- a/secrets/keychain_provider.go
+++ b/secrets/keychain_provider.go
@@ -47,6 +47,16 @@ func NewKeychainProvider(service string) (*KeychainProvider, error) {
 // Name returns the provider identifier "keychain".
 func (p *KeychainProvider) Name() string { return "keychain" }
 
+// SecretTarget describes the OS keychain service namespace.
+func (p *KeychainProvider) SecretTarget() ProviderTarget {
+	return ProviderTarget{
+		Provider: "keychain",
+		Scope:    "service",
+		Subject:  p.service,
+		Label:    "keychain service " + p.service,
+	}
+}
+
 // Get retrieves the secret stored under the given key from the OS keychain.
 func (p *KeychainProvider) Get(ctx context.Context, key string) (string, error) {
 	if err := ctx.Err(); err != nil {

--- a/secrets/provider_target_test.go
+++ b/secrets/provider_target_test.go
@@ -1,0 +1,94 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitHubProviderSecretTargetDescribesScope(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "x")
+
+	repoProvider, err := NewGitHubSecretsProvider("owner/repo", "GITHUB_TOKEN")
+	if err != nil {
+		t.Fatalf("NewGitHubSecretsProvider: %v", err)
+	}
+	repoTarget := repoProvider.SecretTarget()
+	if repoTarget.Provider != "github" || repoTarget.Scope != "repo" || repoTarget.Subject != "owner/repo" {
+		t.Fatalf("repo target = %+v", repoTarget)
+	}
+	if !strings.Contains(repoTarget.Label, "github repo owner/repo") {
+		t.Fatalf("repo label = %q", repoTarget.Label)
+	}
+
+	repoProvider.SetEnvironment("staging")
+	envTarget := repoProvider.SecretTarget()
+	if envTarget.Scope != "env" || envTarget.Subject != "staging on owner/repo" {
+		t.Fatalf("env target = %+v", envTarget)
+	}
+	if !strings.Contains(envTarget.Label, "github env staging on owner/repo") {
+		t.Fatalf("env label = %q", envTarget.Label)
+	}
+
+	orgProvider, err := NewGitHubOrgSecretsProvider("my-org", "GITHUB_TOKEN", OrgVisibilityPrivate, nil)
+	if err != nil {
+		t.Fatalf("NewGitHubOrgSecretsProvider: %v", err)
+	}
+	orgTarget := orgProvider.SecretTarget()
+	if orgTarget.Scope != "org" || orgTarget.Subject != "my-org" {
+		t.Fatalf("org target = %+v", orgTarget)
+	}
+	if !strings.Contains(orgTarget.Label, "github org my-org") {
+		t.Fatalf("org label = %q", orgTarget.Label)
+	}
+}
+
+func TestProviderSecretTargetDescribesNonGitHubProviders(t *testing.T) {
+	cases := []struct {
+		name        string
+		provider    Provider
+		wantScope   string
+		wantSubject string
+		wantLabel   string
+	}{
+		{
+			name:        "env",
+			provider:    NewEnvProvider("APP_"),
+			wantScope:   "process",
+			wantSubject: "APP_",
+			wantLabel:   "env prefix APP_",
+		},
+		{
+			name:        "file",
+			provider:    NewFileProvider("/tmp/workflow-secrets"),
+			wantScope:   "directory",
+			wantSubject: "/tmp/workflow-secrets",
+			wantLabel:   "file /tmp/workflow-secrets",
+		},
+		{
+			name:        "aws",
+			provider:    NewAWSSecretsManagerProviderWithClient(AWSConfig{Region: "us-west-2"}, nil),
+			wantScope:   "region",
+			wantSubject: "us-west-2",
+			wantLabel:   "aws secrets-manager us-west-2",
+		},
+		{
+			name:        "vault",
+			provider:    NewVaultProviderFromClient(nil, VaultConfig{Address: "https://vault.example", MountPath: "kv"}),
+			wantScope:   "mount",
+			wantSubject: "https://vault.example/kv",
+			wantLabel:   "vault https://vault.example/kv",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := DescribeTarget(tc.provider)
+			if target.Scope != tc.wantScope || target.Subject != tc.wantSubject {
+				t.Fatalf("target = %+v, want scope=%q subject=%q", target, tc.wantScope, tc.wantSubject)
+			}
+			if target.Label != tc.wantLabel {
+				t.Fatalf("label = %q, want %q", target.Label, tc.wantLabel)
+			}
+		})
+	}
+}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -35,6 +35,42 @@ type Provider interface {
 	List(ctx context.Context) ([]string, error)
 }
 
+// ProviderTarget describes the concrete provider namespace a Provider instance
+// reads or writes. It is intentionally value-only and must not include secret
+// values or credential material.
+type ProviderTarget struct {
+	Provider string
+	Scope    string
+	Subject  string
+	Label    string
+}
+
+// TargetDescriber is optional: providers implement it when they can describe
+// their concrete namespace, such as GitHub repo/env/org or AWS region.
+type TargetDescriber interface {
+	SecretTarget() ProviderTarget
+}
+
+// DescribeTarget returns a safe provider-owned target description. Providers
+// that do not implement TargetDescriber fall back to their Name.
+func DescribeTarget(provider Provider) ProviderTarget {
+	if provider == nil {
+		return ProviderTarget{}
+	}
+	if describer, ok := provider.(TargetDescriber); ok {
+		target := describer.SecretTarget()
+		if target.Provider == "" {
+			target.Provider = provider.Name()
+		}
+		if target.Label == "" {
+			target.Label = strings.TrimSpace(target.Provider + " " + target.Subject)
+		}
+		return target
+	}
+	name := provider.Name()
+	return ProviderTarget{Provider: name, Scope: "default", Label: name}
+}
+
 // SecretMeta is presence + freshness for one key. Never carries a value.
 type SecretMeta struct {
 	Name      string
@@ -79,6 +115,21 @@ func NewEnvProvider(prefix string) *EnvProvider {
 }
 
 func (p *EnvProvider) Name() string { return "env" }
+
+// SecretTarget describes the current process environment namespace.
+func (p *EnvProvider) SecretTarget() ProviderTarget {
+	label := "env"
+	subject := p.prefix
+	if subject != "" {
+		label = "env prefix " + subject
+	}
+	return ProviderTarget{
+		Provider: "env",
+		Scope:    "process",
+		Subject:  subject,
+		Label:    label,
+	}
+}
 
 func (p *EnvProvider) Get(_ context.Context, key string) (string, error) {
 	if key == "" {
@@ -177,6 +228,16 @@ func NewFileProvider(dir string) *FileProvider {
 }
 
 func (p *FileProvider) Name() string { return "file" }
+
+// SecretTarget describes the directory-backed file secret namespace.
+func (p *FileProvider) SecretTarget() ProviderTarget {
+	return ProviderTarget{
+		Provider: "file",
+		Scope:    "directory",
+		Subject:  p.dir,
+		Label:    "file " + p.dir,
+	}
+}
 
 func (p *FileProvider) Get(_ context.Context, key string) (string, error) {
 	if key == "" {

--- a/secrets/vault_provider.go
+++ b/secrets/vault_provider.go
@@ -74,6 +74,23 @@ func NewVaultProviderFromClient(client *vault.Client, cfg VaultConfig) *VaultPro
 
 func (p *VaultProvider) Name() string { return "vault" }
 
+// SecretTarget describes the Vault KV namespace used by this provider.
+func (p *VaultProvider) SecretTarget() ProviderTarget {
+	subject := strings.TrimRight(p.config.Address, "/")
+	if p.config.MountPath != "" {
+		subject += "/" + strings.Trim(p.config.MountPath, "/")
+	}
+	if p.config.Namespace != "" {
+		subject += " namespace " + p.config.Namespace
+	}
+	return ProviderTarget{
+		Provider: "vault",
+		Scope:    "mount",
+		Subject:  subject,
+		Label:    "vault " + subject,
+	}
+}
+
 // Get retrieves a secret value from Vault KV v2.
 // The key can be in the format "path" or "path#field".
 // If #field is specified, returns that specific field from the secret data.


### PR DESCRIPTION
## Summary
- add provider-owned secret target descriptors for GitHub, AWS Secrets Manager, Vault, env, file, and keychain providers
- route `wfctl secrets setup` through resolved per-secret provider targets for interactive, non-interactive, and manifest-backed setup
- show provider target/status rows distinctly, including no-access/check-failed/unconfigured states
- add TTY-aware live download progress while preserving log lines for non-TTY output

## Verification
- `GOWORK=off go test ./secrets ./cmd/wfctl`
- `GOWORK=off go test ./...`