### PR TITLE
feat(wfctl): add secrets scope matrix prompt

### DIFF
--- a/cmd/wfctl/internal/prompt/prompt_test.go
+++ b/cmd/wfctl/internal/prompt/prompt_test.go
@@ -66,6 +66,23 @@ func TestMultiSelectZeroValue(t *testing.T) {
 	}
 }
 
+func TestTableMultiSelect_NonTTY(t *testing.T) {
+	_, err := prompt.TableMultiSelect("Pick", []prompt.TableColumn{{Title: "Name", Width: 12}}, []prompt.TableItem{{Cells: []string{"TOKEN"}}})
+	if err != prompt.ErrNotInteractive {
+		t.Fatalf("TableMultiSelect: got %v, want ErrNotInteractive", err)
+	}
+}
+
+func TestTableMultiSelectZeroValue(t *testing.T) {
+	indices, err := prompt.TableMultiSelect("Pick", []prompt.TableColumn{{Title: "Name", Width: 12}}, []prompt.TableItem{{Cells: []string{"TOKEN"}}})
+	if err != prompt.ErrNotInteractive {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(indices) != 0 {
+		t.Errorf("indices = %v, want []", indices)
+	}
+}
+
 func TestInputZeroValue(t *testing.T) {
 	s, err := prompt.Input("label", false)
 	if err != prompt.ErrNotInteractive {

--- a/cmd/wfctl/internal/prompt/table_multiselect.go
+++ b/cmd/wfctl/internal/prompt/table_multiselect.go
@@ -1,0 +1,140 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+)
+
+// TableColumn describes a column in a table-based prompt.
+type TableColumn struct {
+	Title string
+	Width int
+}
+
+// TableItem is a selectable table row. Cells must match the number of caller
+// supplied columns; the prompt adds its own selection marker column.
+type TableItem struct {
+	Cells       []string
+	Preselected bool
+}
+
+// TableMultiSelect presents a table-shaped interactive multi-choice list.
+// Returns selected row indices.
+//
+// Returns (nil, ErrNotInteractive) when stdin is not a terminal.
+func TableMultiSelect(title string, columns []TableColumn, items []TableItem) ([]int, error) {
+	if !isTTY() {
+		return nil, ErrNotInteractive
+	}
+	out, _ := outputWriter()
+	m := newTableMultiSelectModel(title, columns, items)
+	p := tea.NewProgram(m, tea.WithOutput(out))
+	result, err := p.Run()
+	if err != nil {
+		return nil, fmt.Errorf("prompt table multiselect: %w", err)
+	}
+	fm := result.(*tableMultiSelectModel)
+	if fm.quit {
+		return nil, ErrInterrupted
+	}
+	var indices []int
+	for i := range items {
+		if fm.selected[i] {
+			indices = append(indices, i)
+		}
+	}
+	return indices, nil
+}
+
+type tableMultiSelectModel struct {
+	title    string
+	columns  []TableColumn
+	items    []TableItem
+	selected map[int]bool
+	table    table.Model
+	quit     bool
+}
+
+func newTableMultiSelectModel(title string, columns []TableColumn, items []TableItem) *tableMultiSelectModel {
+	selected := make(map[int]bool, len(items))
+	for i, item := range items {
+		if item.Preselected {
+			selected[i] = true
+		}
+	}
+	m := &tableMultiSelectModel{
+		title:    title,
+		columns:  columns,
+		items:    items,
+		selected: selected,
+	}
+	m.table = table.New(
+		table.WithColumns(m.tableColumns()),
+		table.WithRows(m.tableRows()),
+		table.WithFocused(true),
+		table.WithHeight(min(max(len(items)+2, 5), 18)), //nolint:mnd
+	)
+	return m
+}
+
+func (m *tableMultiSelectModel) Init() tea.Cmd { return nil }
+
+func (m *tableMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if msg, ok := msg.(tea.KeyPressMsg); ok {
+		switch msg.String() {
+		case "ctrl+c", "q":
+			m.quit = true
+			return m, tea.Quit
+		case " ":
+			cursor := m.table.Cursor()
+			if m.selected[cursor] {
+				delete(m.selected, cursor)
+			} else {
+				m.selected[cursor] = true
+			}
+			m.table.SetRows(m.tableRows())
+			return m, nil
+		case "enter":
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m *tableMultiSelectModel) View() tea.View {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(m.title))
+	b.WriteString("\n")
+	b.WriteString(m.table.View())
+	b.WriteString("\n\n(space to toggle, enter to confirm)\n")
+	return tea.NewView(b.String())
+}
+
+func (m *tableMultiSelectModel) tableColumns() []table.Column {
+	cols := make([]table.Column, 0, len(m.columns)+1)
+	cols = append(cols, table.Column{Title: "Set", Width: 3})
+	for _, col := range m.columns {
+		cols = append(cols, table.Column{Title: col.Title, Width: col.Width})
+	}
+	return cols
+}
+
+func (m *tableMultiSelectModel) tableRows() []table.Row {
+	rows := make([]table.Row, 0, len(m.items))
+	for i, item := range m.items {
+		mark := " "
+		if m.selected[i] {
+			mark = "x"
+		}
+		cells := make([]string, 0, len(item.Cells)+1)
+		cells = append(cells, mark)
+		cells = append(cells, item.Cells...)
+		rows = append(rows, table.Row(cells))
+	}
+	return rows
+}

--- a/cmd/wfctl/secrets_setup.go
+++ b/cmd/wfctl/secrets_setup.go
@@ -46,6 +46,7 @@ func runSecretsSetup(args []string) error {
 	onlyFlag := fs.String("only", "", "Comma-separated list of secret names to set")
 	allFlag := fs.Bool("all", false, "Set all declared secrets; preselect all in manifest interactive mode")
 	skipExisting := fs.Bool("skip-existing", false, "Skip secrets that already have a value in the store")
+	verbose := fs.Bool("verbose", false, "Show source and target details in manifest-backed interactive setup")
 	storeName := fs.String("store", "", "Named store to use (overrides config defaultStore)")
 	// Manifest-backed GitHub setup flags. These also keep the legacy --plugin
 	// path compatible because runSecrets dispatches --plugin before this path.
@@ -64,8 +65,9 @@ Set secrets declared in the config for a given environment.
 Interactive (default when stdin is a TTY):
   Lists each declared secret with its status, lets you select which to set,
   prompts to pick a store when none is configured, and masks sensitive input.
-  Manifest-backed setup selects unset secrets by default; toggle set secrets
-  to update them, or pass --all to preselect every discovered secret.
+  Manifest-backed setup shows a compact secret x target matrix first, then
+  lets you choose scope/store targets per selected secret. Use --verbose for
+  source files, plugin names, and full provider target labels.
 
 Non-interactive (--non-interactive, --auto-gen-keys, or when stdin is not a TTY):
   --from-env        Read each value from $NAME. Recommended for CI.
@@ -134,6 +136,7 @@ Options:
 				only:           only,
 				all:            *allFlag,
 				skipExisting:   *skipExisting,
+				verbose:        *verbose,
 			}, nil, os.Stdout)
 		}
 		if target.path != "" {

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -632,7 +632,11 @@ func runManifestSecretTargetSetupWithValues(ctx context.Context, targets []manif
 }
 
 func manifestSecretTargetKey(target manifestSecretTarget) string {
-	return target.Secret.Name + "\x00" + target.Store
+	return strings.Join([]string{
+		target.Secret.Name,
+		strings.TrimSpace(target.Store),
+		strings.TrimSpace(target.Label),
+	}, "\x00")
 }
 
 func manifestSecretTargetDisplayName(target manifestSecretTarget) string {
@@ -801,9 +805,10 @@ func buildManifestSecretTargetItems(targets []manifestSecretTarget, includeExist
 func buildManifestTargetItems(targets []manifestSecretTarget, includeExisting bool, verbose bool) []prompt.Item {
 	items := make([]prompt.Item, 0, len(targets))
 	counts := manifestSecretTargetScopeCounts(targets)
+	labels := manifestSecretTargetMatrixLabels(targets, counts)
 	for i := range targets {
 		target := &targets[i]
-		label := fmt.Sprintf("%-12s %s", manifestSecretTargetMatrixLabel(*target, counts), shortSecretStateLabel(target.Status))
+		label := fmt.Sprintf("%-12s %s", manifestSecretTargetMatrixLabelFor(*target, labels, counts), shortSecretStateLabel(target.Status))
 		if verbose {
 			if target.Label != "" {
 				label += "  " + target.Label
@@ -844,7 +849,8 @@ func selectManifestSecretTargetsForSetup(targets []manifestSecretTarget, opts ma
 func buildManifestSecretMatrixRows(targets []manifestSecretTarget, includeExisting bool, verbose bool) ([]prompt.TableColumn, []prompt.TableItem, []manifestSecretTargetGroup) {
 	groups := groupManifestSecretTargets(targets)
 	counts := manifestSecretTargetScopeCounts(targets)
-	scopes := manifestSecretMatrixScopes(targets, counts)
+	labels := manifestSecretTargetMatrixLabels(targets, counts)
+	scopes := manifestSecretMatrixScopes(targets, labels, counts)
 	nameWidth := manifestSecretNameColumnWidth(groups)
 	cols := []prompt.TableColumn{{Title: "Secret", Width: nameWidth}}
 	if verbose {
@@ -864,7 +870,7 @@ func buildManifestSecretMatrixRows(targets []manifestSecretTarget, includeExisti
 		anyUnset := false
 		for i := range group.Targets {
 			target := group.Targets[i]
-			statusByScope[manifestSecretTargetMatrixLabel(target, counts)] = target.Status
+			statusByScope[manifestSecretTargetMatrixLabelFor(target, labels, counts)] = target.Status
 			if !target.Status.IsSet {
 				anyUnset = true
 			}
@@ -902,12 +908,12 @@ func groupManifestSecretTargets(targets []manifestSecretTarget) []manifestSecret
 	return groups
 }
 
-func manifestSecretMatrixScopes(targets []manifestSecretTarget, counts map[string]int) []string {
+func manifestSecretMatrixScopes(targets []manifestSecretTarget, labels map[string]string, counts map[string]int) []string {
 	seen := map[string]bool{}
 	scopes := make([]string, 0)
 	for i := range targets {
 		target := targets[i]
-		scope := manifestSecretTargetMatrixLabel(target, counts)
+		scope := manifestSecretTargetMatrixLabelFor(target, labels, counts)
 		if scope == "" || seen[scope] {
 			continue
 		}
@@ -987,11 +993,7 @@ func manifestSecretTargetScopeCounts(targets []manifestSecretTarget) map[string]
 	seenTargets := map[string]bool{}
 	for i := range targets {
 		target := targets[i]
-		key := strings.Join([]string{
-			manifestSecretTargetScopeLabel(target),
-			strings.TrimSpace(target.Store),
-			strings.TrimSpace(target.Label),
-		}, "\x00")
+		key := manifestSecretProviderTargetKey(target)
 		if seenTargets[key] {
 			continue
 		}
@@ -999,6 +1001,41 @@ func manifestSecretTargetScopeCounts(targets []manifestSecretTarget) map[string]
 		counts[manifestSecretTargetScopeLabel(target)]++
 	}
 	return counts
+}
+
+func manifestSecretTargetMatrixLabels(targets []manifestSecretTarget, counts map[string]int) map[string]string {
+	labels := make(map[string]string, len(targets))
+	used := map[string]bool{}
+	for i := range targets {
+		target := targets[i]
+		key := manifestSecretProviderTargetKey(target)
+		if _, ok := labels[key]; ok {
+			continue
+		}
+		base := manifestSecretTargetMatrixLabel(target, counts)
+		label := base
+		for suffix := 2; used[label]; suffix++ {
+			label = fmt.Sprintf("%s#%d", base, suffix)
+		}
+		used[label] = true
+		labels[key] = label
+	}
+	return labels
+}
+
+func manifestSecretProviderTargetKey(target manifestSecretTarget) string {
+	return strings.Join([]string{
+		manifestSecretTargetScopeLabel(target),
+		strings.TrimSpace(target.Store),
+		strings.TrimSpace(target.Label),
+	}, "\x00")
+}
+
+func manifestSecretTargetMatrixLabelFor(target manifestSecretTarget, labels map[string]string, counts map[string]int) string {
+	if label, ok := labels[manifestSecretProviderTargetKey(target)]; ok {
+		return label
+	}
+	return manifestSecretTargetMatrixLabel(target, counts)
 }
 
 func manifestSecretTargetMatrixLabel(target manifestSecretTarget, counts map[string]int) string {

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -57,6 +57,7 @@ type manifestSetupArgs struct {
 	only           []string
 	all            bool
 	skipExisting   bool
+	verbose        bool
 }
 
 func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Writer) error {
@@ -83,6 +84,12 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	}
 	interactive := in == nil && !a.nonInteractive && prompt.CanPrompt()
 
+	preprovidedValuer := func(secret manifestDiscoveredSecret) (string, bool, error) {
+		return manifestPreprovidedSecretValue(secret, manifestSecretValueOptions{
+			fromEnv:   a.fromEnv,
+			secretMap: secretMap,
+		})
+	}
 	var promptErr error
 	valuer := func(secret manifestDiscoveredSecret) (string, bool, error) {
 		value, provided, err := manifestSecretValue(secret, manifestSecretValueOptions{
@@ -97,7 +104,7 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	}
 
 	if interactive && !a.scopeExplicit {
-		return runSecretsSetupManifestTargets(context.Background(), a, discovered, valuer, out, &promptErr)
+		return runSecretsSetupManifestTargets(context.Background(), a, discovered, preprovidedValuer, out, &promptErr)
 	}
 
 	ghProvider, scopeLabel, err := buildSecretWriter(strings.ToLower(strings.TrimSpace(a.scope)), a.envName, a.org, a.visibility, a.tokenEnv, firstConfigPattern(a.configPatterns))
@@ -181,7 +188,7 @@ func runSecretsSetupManifestWithIO(a *manifestSetupArgs, in io.Reader, out io.Wr
 	return nil
 }
 
-func runSecretsSetupManifestTargets(ctx context.Context, a *manifestSetupArgs, discovered []manifestDiscoveredSecret, valuer func(manifestDiscoveredSecret) (string, bool, error), out io.Writer, promptErr *error) error {
+func runSecretsSetupManifestTargets(ctx context.Context, a *manifestSetupArgs, discovered []manifestDiscoveredSecret, preprovidedValuer func(manifestDiscoveredSecret) (string, bool, error), out io.Writer, promptErr *error) error {
 	providers, err := buildManifestSecretTargetProviders(a)
 	if err != nil {
 		return err
@@ -208,22 +215,33 @@ func runSecretsSetupManifestTargets(ctx context.Context, a *manifestSetupArgs, d
 	} else {
 		fmt.Fprintln(out, "Interactive mode: unset secret targets are selected by default; toggle set targets to update them.")
 	}
-	fmt.Fprintln(out, "Leave a value empty to skip every selected target for that secret.")
+	fmt.Fprintln(out, "Select secrets first, then choose which scope/store targets to set for each secret.")
+	fmt.Fprintln(out, "For multiple targets, enter a value once and reuse it or provide target-specific values.")
 	fmt.Fprintln(out, "Use --scope to force a single GitHub target, or configure secretStores for provider-specific targets.")
 	fmt.Fprintln(out)
 
-	items := buildManifestSecretTargetItems(selectable, a.all)
-	selectedIdx, err := prompt.MultiSelect(manifestMultiTargetSelectTitle(a.skipExisting), items)
+	cols, rows, groups := buildManifestSecretMatrixRows(selectable, a.all, a.verbose)
+	secretIdx, err := prompt.TableMultiSelect(manifestSecretMatrixSelectTitle(a.skipExisting, a.verbose), cols, rows)
 	if err != nil {
 		return err
 	}
-	selected := manifestSecretTargetsByIndexes(selectable, selectedIdx)
+	selected, err := selectManifestTargetsBySecretGroups(groups, secretIdx, a.skipExisting, a.verbose)
+	if err != nil {
+		return err
+	}
 	if len(selected) == 0 {
 		fmt.Fprintln(out, "No secret targets selected; nothing to do.")
 		return nil
 	}
 
-	report, err := runManifestSecretTargetSetup(ctx, selected, valuer, func(name, store string) {
+	values, err := collectManifestSecretTargetValues(selected, preprovidedValuer, manifestTargetValuePrompt{
+		input:   prompt.Input,
+		confirm: prompt.Confirm,
+	})
+	if err != nil {
+		return err
+	}
+	report, err := runManifestSecretTargetSetupWithValues(ctx, selected, values, func(name, store string) {
 		_ = writeSecretsAuditRecord(name, store) //nolint:errcheck // best-effort audit
 	}, true)
 	if promptErr != nil && *promptErr != nil {
@@ -240,6 +258,11 @@ func runSecretsSetupManifestTargets(ctx context.Context, a *manifestSetupArgs, d
 	}
 	fmt.Fprintln(out, "\nAll done.")
 	return nil
+}
+
+type manifestSecretTargetGroup struct {
+	Secret  manifestDiscoveredSecret
+	Targets []manifestSecretTarget
 }
 
 func buildManifestSecretTargetProviders(a *manifestSetupArgs) ([]manifestSecretTargetProvider, error) {
@@ -500,6 +523,118 @@ func runManifestSecretTargetSetup(ctx context.Context, targets []manifestSecretT
 	return report, nil
 }
 
+type manifestProvidedSecretValue struct {
+	Value    string
+	Provided bool
+	Err      error
+}
+
+type manifestTargetValuePrompt struct {
+	input   func(label string, masked bool) (string, error)
+	confirm func(question string, def bool) (bool, error)
+}
+
+func collectManifestSecretTargetValues(targets []manifestSecretTarget, fallback func(manifestDiscoveredSecret) (string, bool, error), prompts manifestTargetValuePrompt) (map[string]manifestProvidedSecretValue, error) {
+	if prompts.input == nil {
+		prompts.input = prompt.Input
+	}
+	if prompts.confirm == nil {
+		prompts.confirm = prompt.Confirm
+	}
+	values := make(map[string]manifestProvidedSecretValue, len(targets))
+	groups := groupManifestSecretTargets(targets)
+	for _, group := range groups {
+		if fallback != nil {
+			value, provided, err := fallback(group.Secret)
+			if err != nil {
+				return nil, err
+			}
+			if provided {
+				for i := range group.Targets {
+					values[manifestSecretTargetKey(group.Targets[i])] = manifestProvidedSecretValue{Value: value, Provided: true}
+				}
+				continue
+			}
+		}
+		var first manifestProvidedSecretValue
+		firstSet := false
+		for i := range group.Targets {
+			target := group.Targets[i]
+			key := manifestSecretTargetKey(target)
+			if i == 0 {
+				value, err := promptManifestTargetValue(target, prompts)
+				if err != nil {
+					return nil, err
+				}
+				first = manifestProvidedSecretValue{Value: value, Provided: value != "", Err: nil}
+				firstSet = true
+				values[key] = first
+				continue
+			}
+			if firstSet && first.Provided && first.Err == nil {
+				useSame, err := prompts.confirm(fmt.Sprintf("Use same value for %s at %s?", group.Secret.Name, manifestSecretTargetScopeLabel(target)), true)
+				if err != nil {
+					return nil, err
+				}
+				if useSame {
+					values[key] = first
+					continue
+				}
+			}
+			value, err := promptManifestTargetValue(target, prompts)
+			if err != nil {
+				return nil, err
+			}
+			values[key] = manifestProvidedSecretValue{Value: value, Provided: value != "", Err: nil}
+		}
+	}
+	return values, nil
+}
+
+func promptManifestTargetValue(target manifestSecretTarget, prompts manifestTargetValuePrompt) (string, error) {
+	label := target.Secret.Name + " for " + manifestSecretTargetScopeLabel(target)
+	if target.Label != "" {
+		label += " (" + target.Label + ")"
+	}
+	return prompts.input(label, target.Secret.Sensitive)
+}
+
+func runManifestSecretTargetSetupWithValues(ctx context.Context, targets []manifestSecretTarget, values map[string]manifestProvidedSecretValue, audit func(string, string), stopOnError bool) (setupReport, error) {
+	var report setupReport
+	for i := range targets {
+		target := &targets[i]
+		displayName := manifestSecretTargetDisplayName(*target)
+		value := values[manifestSecretTargetKey(*target)]
+		if value.Err != nil {
+			report.Failed = append(report.Failed, displayName)
+			if stopOnError {
+				return report, value.Err
+			}
+			continue
+		}
+		if !value.Provided {
+			report.Skipped = append(report.Skipped, displayName)
+			continue
+		}
+		if err := target.Provider.Set(ctx, target.Secret.Name, value.Value); err != nil {
+			report.Failed = append(report.Failed, displayName)
+			if stopOnError {
+				return report, err
+			}
+			continue
+		}
+		report.Set = append(report.Set, displayName)
+		if audit != nil {
+			audit(target.Secret.Name, target.Store)
+		}
+	}
+	return report, nil
+}
+
+func manifestSecretTargetKey(target manifestSecretTarget) string {
+	return target.Secret.Name + "\x00" + target.Store
+}
+
 func manifestSecretTargetDisplayName(target manifestSecretTarget) string {
 	label := target.Label
 	if label == "" {
@@ -588,6 +723,18 @@ func manifestSecretValue(secret manifestDiscoveredSecret, opts manifestSecretVal
 	return "", false, fmt.Errorf("no value for secret %q: set $%s and pass --from-env, use --secret %s=VALUE, or run interactively from a terminal", secret.Name, secret.Name, secret.Name)
 }
 
+func manifestPreprovidedSecretValue(secret manifestDiscoveredSecret, opts manifestSecretValueOptions) (string, bool, error) {
+	if opts.fromEnv {
+		if v := os.Getenv(secret.Name); v != "" {
+			return v, true, nil
+		}
+	}
+	if v, ok := opts.secretMap[secret.Name]; ok {
+		return v, true, nil
+	}
+	return "", false, nil
+}
+
 type manifestSecretSelectionOptions struct {
 	onlySet         map[string]bool
 	includeExisting bool
@@ -651,6 +798,30 @@ func buildManifestSecretTargetItems(targets []manifestSecretTarget, includeExist
 	return items
 }
 
+func buildManifestTargetItems(targets []manifestSecretTarget, includeExisting bool, verbose bool) []prompt.Item {
+	items := make([]prompt.Item, 0, len(targets))
+	counts := manifestSecretTargetScopeCounts(targets)
+	for i := range targets {
+		target := &targets[i]
+		label := fmt.Sprintf("%-12s %s", manifestSecretTargetMatrixLabel(*target, counts), shortSecretStateLabel(target.Status))
+		if verbose {
+			if target.Label != "" {
+				label += "  " + target.Label
+			} else if target.Store != "" {
+				label += "  " + target.Store
+			}
+			if len(target.Secret.Sources) > 0 {
+				label += " (" + strings.Join(target.Secret.Sources, ", ") + ")"
+			}
+		}
+		items = append(items, prompt.Item{
+			Label:       label,
+			Preselected: includeExisting || !target.Status.IsSet,
+		})
+	}
+	return items
+}
+
 func selectManifestSecretTargetsForSetup(targets []manifestSecretTarget, opts manifestSecretSelectionOptions) []manifestSecretTarget {
 	selected := make([]manifestSecretTarget, 0, len(targets))
 	for i := range targets {
@@ -668,6 +839,240 @@ func selectManifestSecretTargetsForSetup(targets []manifestSecretTarget, opts ma
 		selected = append(selected, *target)
 	}
 	return selected
+}
+
+func buildManifestSecretMatrixRows(targets []manifestSecretTarget, includeExisting bool, verbose bool) ([]prompt.TableColumn, []prompt.TableItem, []manifestSecretTargetGroup) {
+	groups := groupManifestSecretTargets(targets)
+	counts := manifestSecretTargetScopeCounts(targets)
+	scopes := manifestSecretMatrixScopes(targets, counts)
+	nameWidth := manifestSecretNameColumnWidth(groups)
+	cols := []prompt.TableColumn{{Title: "Secret", Width: nameWidth}}
+	if verbose {
+		cols = append(cols, prompt.TableColumn{Title: "Sources", Width: 38}) //nolint:mnd
+	}
+	for _, scope := range scopes {
+		cols = append(cols, prompt.TableColumn{Title: scope, Width: max(5, min(len(scope)+1, 14))}) //nolint:mnd
+	}
+
+	rows := make([]prompt.TableItem, 0, len(groups))
+	for _, group := range groups {
+		cells := []string{group.Secret.Name}
+		if verbose {
+			cells = append(cells, strings.Join(group.Secret.Sources, ", "))
+		}
+		statusByScope := map[string]SecretStatus{}
+		anyUnset := false
+		for i := range group.Targets {
+			target := group.Targets[i]
+			statusByScope[manifestSecretTargetMatrixLabel(target, counts)] = target.Status
+			if !target.Status.IsSet {
+				anyUnset = true
+			}
+		}
+		for _, scope := range scopes {
+			status, ok := statusByScope[scope]
+			if !ok {
+				cells = append(cells, "-")
+				continue
+			}
+			cells = append(cells, secretStatusMatrixMark(status))
+		}
+		rows = append(rows, prompt.TableItem{
+			Cells:       cells,
+			Preselected: includeExisting || anyUnset,
+		})
+	}
+	return cols, rows, groups
+}
+
+func groupManifestSecretTargets(targets []manifestSecretTarget) []manifestSecretTargetGroup {
+	byName := map[string]int{}
+	groups := make([]manifestSecretTargetGroup, 0)
+	for i := range targets {
+		target := targets[i]
+		name := target.Secret.Name
+		idx, ok := byName[name]
+		if !ok {
+			idx = len(groups)
+			byName[name] = idx
+			groups = append(groups, manifestSecretTargetGroup{Secret: target.Secret})
+		}
+		groups[idx].Targets = append(groups[idx].Targets, target)
+	}
+	return groups
+}
+
+func manifestSecretMatrixScopes(targets []manifestSecretTarget, counts map[string]int) []string {
+	seen := map[string]bool{}
+	scopes := make([]string, 0)
+	for i := range targets {
+		target := targets[i]
+		scope := manifestSecretTargetMatrixLabel(target, counts)
+		if scope == "" || seen[scope] {
+			continue
+		}
+		seen[scope] = true
+		scopes = append(scopes, scope)
+	}
+	return scopes
+}
+
+func manifestSecretNameColumnWidth(groups []manifestSecretTargetGroup) int {
+	width := len("Secret")
+	for _, group := range groups {
+		width = max(width, len(group.Secret.Name))
+	}
+	return min(max(width+1, 18), 36) //nolint:mnd
+}
+
+func selectManifestTargetsBySecretGroups(groups []manifestSecretTargetGroup, indexes []int, skipExisting bool, verbose bool) ([]manifestSecretTarget, error) {
+	selected := make([]manifestSecretTarget, 0)
+	for _, i := range indexes {
+		if i < 0 || i >= len(groups) {
+			continue
+		}
+		group := groups[i]
+		targets := group.Targets
+		if skipExisting {
+			targets = selectManifestSecretTargetsForSetup(targets, manifestSecretSelectionOptions{
+				includeExisting: true,
+				skipExisting:    true,
+			})
+		}
+		if len(targets) == 0 {
+			continue
+		}
+		items := buildManifestTargetItems(targets, false, verbose)
+		selectedIdx, err := prompt.MultiSelect("Select scope/store targets for "+group.Secret.Name, items)
+		if err != nil {
+			return nil, err
+		}
+		selected = append(selected, manifestSecretTargetsByIndexes(targets, selectedIdx)...)
+	}
+	return selected, nil
+}
+
+func manifestSecretTargetScopeLabel(target manifestSecretTarget) string {
+	store := strings.ToLower(strings.TrimSpace(target.Store))
+	label := strings.ToLower(strings.TrimSpace(target.Label))
+	switch {
+	case strings.HasPrefix(store, "github-repo") || strings.HasPrefix(label, "github repo "):
+		return "github:repo"
+	case strings.HasPrefix(store, "github-env") || strings.HasPrefix(label, "github env "):
+		return "github:env"
+	case strings.HasPrefix(store, "github-org") || strings.HasPrefix(label, "github org "):
+		return "github:org"
+	case strings.HasPrefix(label, "aws ") || strings.Contains(label, "aws secrets-manager"):
+		return "aws"
+	case strings.HasPrefix(label, "vault "):
+		return "vault"
+	case strings.HasPrefix(label, "file "):
+		return "file"
+	case strings.HasPrefix(label, "env"):
+		return "env"
+	case strings.HasPrefix(label, "keychain "):
+		return "keychain"
+	}
+	if base, _, ok := strings.Cut(store, ":"); ok {
+		return base
+	}
+	if store != "" {
+		return store
+	}
+	return "target"
+}
+
+func manifestSecretTargetScopeCounts(targets []manifestSecretTarget) map[string]int {
+	counts := map[string]int{}
+	seenTargets := map[string]bool{}
+	for i := range targets {
+		target := targets[i]
+		key := strings.Join([]string{
+			manifestSecretTargetScopeLabel(target),
+			strings.TrimSpace(target.Store),
+			strings.TrimSpace(target.Label),
+		}, "\x00")
+		if seenTargets[key] {
+			continue
+		}
+		seenTargets[key] = true
+		counts[manifestSecretTargetScopeLabel(target)]++
+	}
+	return counts
+}
+
+func manifestSecretTargetMatrixLabel(target manifestSecretTarget, counts map[string]int) string {
+	base := manifestSecretTargetScopeLabel(target)
+	if counts[base] <= 1 {
+		return base
+	}
+	subject := manifestSecretTargetShortSubject(target)
+	if subject == "" {
+		return base
+	}
+	return base + ":" + subject
+}
+
+func manifestSecretTargetShortSubject(target manifestSecretTarget) string {
+	label := strings.TrimSpace(target.Label)
+	for _, prefix := range []string{
+		"github repo ",
+		"github org ",
+		"github env ",
+		"aws secrets-manager ",
+		"vault ",
+		"file ",
+		"keychain service ",
+	} {
+		if rest, ok := strings.CutPrefix(strings.ToLower(label), prefix); ok {
+			label = rest
+			break
+		}
+	}
+	if label == "" {
+		label = strings.TrimSpace(target.Store)
+	}
+	label = strings.NewReplacer(" ", "-", "/", "-", ":", "-").Replace(label)
+	if len(label) > 18 { //nolint:mnd
+		label = label[:18]
+	}
+	return strings.Trim(label, "-")
+}
+
+func secretStatusMatrixMark(status SecretStatus) string {
+	switch status.State {
+	case SecretSet:
+		return "✓"
+	case SecretNoAccess:
+		return "!"
+	case SecretFetchError:
+		return "!"
+	case SecretUnconfigured:
+		return "?"
+	default:
+		if status.IsSet {
+			return "✓"
+		}
+		return "○"
+	}
+}
+
+func shortSecretStateLabel(status SecretStatus) string {
+	switch status.State {
+	case SecretSet:
+		return "set"
+	case SecretNoAccess:
+		return "no-access"
+	case SecretFetchError:
+		return "check-failed"
+	case SecretUnconfigured:
+		return "unconfigured"
+	default:
+		if status.IsSet {
+			return "set"
+		}
+		return "unset"
+	}
 }
 
 func manifestSecretTargetsByIndexes(targets []manifestSecretTarget, indexes []int) []manifestSecretTarget {
@@ -688,11 +1093,15 @@ func manifestMultiSelectTitle(scopeLabel string, skipExisting bool) string {
 	return fmt.Sprintf("Select secrets to set for %s (unset selected by default; toggle set secrets to update)", scopeLabel)
 }
 
-func manifestMultiTargetSelectTitle(skipExisting bool) string {
+func manifestSecretMatrixSelectTitle(skipExisting bool, verbose bool) string {
+	mode := "Select secrets to configure (○ unset, ✓ set, ! inaccessible, ? unconfigured)"
 	if skipExisting {
-		return "Select unset secret provider targets (--skip-existing hides existing targets)"
+		mode = "Select secrets with unset targets (--skip-existing hides existing targets)"
 	}
-	return "Select secret provider targets (unset selected by default; toggle set targets to update)"
+	if verbose {
+		mode += " [verbose]"
+	}
+	return mode
 }
 
 func secretStatusByName(statuses []SecretStatus) map[string]SecretStatus {
@@ -951,6 +1360,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 	onlyFlag := fs.String("only", "", "Comma-separated list of secret names to set")
 	allFlag := fs.Bool("all", false, "Set all discovered secrets")
 	skipExisting := fs.Bool("skip-existing", false, "Skip secrets that already have a value in the target scope")
+	verbose := fs.Bool("verbose", false, "Show source files, plugin names, and full provider target details in interactive prompts")
 	var secretFlag multiStringFlag
 	fs.Var(&secretFlag, "secret", "NAME=VALUE literal. Repeatable.")
 	if err := fs.Parse(args); err != nil {
@@ -983,6 +1393,7 @@ func parseManifestSetupFlags(args []string) (*manifestSetupArgs, error) {
 		only:           only,
 		all:            *allFlag,
 		skipExisting:   *skipExisting,
+		verbose:        *verbose,
 	}, nil
 }
 

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -490,6 +490,39 @@ func TestBuildManifestSecretMatrixRowsDisambiguatesDuplicateScopes(t *testing.T)
 	}
 }
 
+func TestBuildManifestSecretMatrixRowsKeepsTruncatedSubjectsUnique(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:  "gh-a:repo",
+			Label:  "github repo GoCodeAlone/repository-with-shared-prefix-alpha",
+			Status: SecretStatus{
+				State: SecretNotSet,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:  "gh-b:repo",
+			Label:  "github repo GoCodeAlone/repository-with-shared-prefix-beta",
+			Status: SecretStatus{
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+	}
+
+	cols, rows, _ := buildManifestSecretMatrixRows(targets, false, false)
+	if len(cols) != 3 {
+		t.Fatalf("cols = %+v, want secret + two disambiguated repo targets", cols)
+	}
+	if cols[1].Title == cols[2].Title {
+		t.Fatalf("truncated duplicate subjects collapsed into one matrix column: %+v", cols)
+	}
+	if rows[0].Cells[1] != "○" || rows[0].Cells[2] != "✓" {
+		t.Fatalf("row = %+v, want per-target statuses retained", rows[0].Cells)
+	}
+}
+
 func TestBuildManifestTargetItemsAreCompactByDefault(t *testing.T) {
 	targets := []manifestSecretTarget{
 		{

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -146,12 +146,16 @@ func TestParseManifestSetupFlagsPreservesAll(t *testing.T) {
 	args, err := parseManifestSetupFlags([]string{
 		"--manifest", "wfctl.yaml",
 		"--all",
+		"--verbose",
 	})
 	if err != nil {
 		t.Fatalf("parseManifestSetupFlags: %v", err)
 	}
 	if !args.all {
 		t.Fatalf("--all was not preserved: %+v", args)
+	}
+	if !args.verbose {
+		t.Fatalf("--verbose was not preserved: %+v", args)
 	}
 }
 
@@ -321,6 +325,322 @@ func TestBuildManifestSecretTargetItemsShowProviderScopes(t *testing.T) {
 	for _, want := range []string{"AWS_ACCESS_KEY_ID", "aws secrets-manager aws-prod", "✗ unset"} {
 		if !strings.Contains(items[2].Label, want) {
 			t.Fatalf("AWS target label %q does not contain %q", items[2].Label, want)
+		}
+	}
+}
+
+func TestManifestSecretTargetScopeLabelUsesProviderDomain(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "GITHUB_TOKEN"}},
+			Store:  "github-repo",
+			Label:  "github repo GoCodeAlone/example",
+		},
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "GITHUB_TOKEN"}},
+			Store:  "github-env:production",
+			Label:  "github env production in GoCodeAlone/example",
+		},
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "DOTENV_TOKEN"}},
+			Store:  "dotenv",
+			Label:  "file .env",
+		},
+	}
+
+	got := []string{
+		manifestSecretTargetScopeLabel(targets[0]),
+		manifestSecretTargetScopeLabel(targets[1]),
+		manifestSecretTargetScopeLabel(targets[2]),
+	}
+	want := []string{"github:repo", "github:env", "file"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scope labels = %v, want %v", got, want)
+	}
+	for _, label := range got[:2] {
+		if strings.Contains(label, "local") {
+			t.Fatalf("github scope label leaked local semantics: %q", label)
+		}
+	}
+}
+
+func TestBuildManifestSecretMatrixRowsSummarizesTargets(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"},
+				Sources:              []string{"config:digitalocean.wfctl.yaml", "plugin:workflow-plugin-digitalocean"},
+			},
+			Store: "github-repo",
+			Label: "github repo GoCodeAlone/example",
+			Status: SecretStatus{
+				Name:  "DIGITALOCEAN_TOKEN",
+				Store: "github-repo",
+				State: SecretNotSet,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "DIGITALOCEAN_TOKEN"},
+				Sources:              []string{"config:digitalocean.wfctl.yaml", "plugin:workflow-plugin-digitalocean"},
+			},
+			Store: "github-org:GoCodeAlone",
+			Label: "github org GoCodeAlone",
+			Status: SecretStatus{
+				Name:  "DIGITALOCEAN_TOKEN",
+				Store: "github-org:GoCodeAlone",
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "HOVER_PASSWORD"},
+				Sources:              []string{"config:hover.wfctl.yaml", "plugin:workflow-plugin-hover"},
+			},
+			Store: "github-repo",
+			Label: "github repo GoCodeAlone/example",
+			Status: SecretStatus{
+				Name:  "HOVER_PASSWORD",
+				Store: "github-repo",
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{
+				PluginRequiredSecret: PluginRequiredSecret{Name: "HOVER_PASSWORD"},
+				Sources:              []string{"config:hover.wfctl.yaml", "plugin:workflow-plugin-hover"},
+			},
+			Store: "github-org:GoCodeAlone",
+			Label: "github org GoCodeAlone",
+			Status: SecretStatus{
+				Name:  "HOVER_PASSWORD",
+				Store: "github-org:GoCodeAlone",
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+	}
+
+	cols, rows, grouped := buildManifestSecretMatrixRows(targets, false, false)
+	if len(cols) != 3 {
+		t.Fatalf("cols = %+v, want secret + 2 scopes", cols)
+	}
+	if cols[1].Title != "github:repo" || cols[2].Title != "github:org" {
+		t.Fatalf("cols = %+v, want github scope headers", cols)
+	}
+	if len(rows) != 2 || len(grouped) != 2 {
+		t.Fatalf("rows=%d grouped=%d, want 2", len(rows), len(grouped))
+	}
+	if rows[0].Cells[0] != "DIGITALOCEAN_TOKEN" || rows[0].Cells[1] != "○" || rows[0].Cells[2] != "✓" {
+		t.Fatalf("first row = %+v", rows[0].Cells)
+	}
+	if !rows[0].Preselected {
+		t.Fatalf("unset row should be preselected: %+v", rows[0])
+	}
+	if rows[1].Preselected {
+		t.Fatalf("all-set row should not be preselected: %+v", rows[1])
+	}
+	for _, cell := range rows[0].Cells {
+		if strings.Contains(cell, "config:") || strings.Contains(cell, "plugin:") || strings.Contains(cell, "GoCodeAlone/example") {
+			t.Fatalf("default matrix row is too verbose: %+v", rows[0].Cells)
+		}
+	}
+
+	_, verboseRows, _ := buildManifestSecretMatrixRows(targets, false, true)
+	if !strings.Contains(strings.Join(verboseRows[0].Cells, " "), "config:digitalocean.wfctl.yaml") {
+		t.Fatalf("verbose row lacks source detail: %+v", verboseRows[0].Cells)
+	}
+}
+
+func TestBuildManifestSecretMatrixRowsDisambiguatesDuplicateScopes(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:  "gh-a:repo",
+			Label:  "github repo GoCodeAlone/app-a",
+			Status: SecretStatus{
+				State: SecretNotSet,
+			},
+		},
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:  "gh-b:repo",
+			Label:  "github repo GoCodeAlone/app-b",
+			Status: SecretStatus{
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+	}
+
+	cols, rows, _ := buildManifestSecretMatrixRows(targets, false, false)
+	if len(cols) != 3 {
+		t.Fatalf("cols = %+v, want secret + two repo targets", cols)
+	}
+	if cols[1].Title == cols[2].Title {
+		t.Fatalf("duplicate compact scopes were not disambiguated: %+v", cols)
+	}
+	if !strings.HasPrefix(cols[1].Title, "github:repo:") || !strings.HasPrefix(cols[2].Title, "github:repo:") {
+		t.Fatalf("cols = %+v, want compact disambiguated github repo columns", cols)
+	}
+	if rows[0].Cells[1] != "○" || rows[0].Cells[2] != "✓" {
+		t.Fatalf("row = %+v, want per-target status preserved", rows[0].Cells)
+	}
+}
+
+func TestBuildManifestTargetItemsAreCompactByDefault(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Store: "github-repo",
+			Label: "github repo GoCodeAlone/gocodealone-dns (inferred from git remote.origin.url)",
+			Status: SecretStatus{
+				State: SecretNotSet,
+			},
+		},
+		{
+			Store: "github-org:GoCodeAlone",
+			Label: "github org GoCodeAlone",
+			Status: SecretStatus{
+				State: SecretSet,
+				IsSet: true,
+			},
+		},
+	}
+
+	items := buildManifestTargetItems(targets, false, false)
+	if len(items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(items))
+	}
+	if items[0].Label != "github:repo  unset" {
+		t.Fatalf("compact label = %q", items[0].Label)
+	}
+	if items[1].Label != "github:org   set" {
+		t.Fatalf("compact label = %q", items[1].Label)
+	}
+	if strings.Contains(items[0].Label, "inferred") || strings.Contains(items[0].Label, "gocodealone-dns") {
+		t.Fatalf("compact target label is too verbose: %q", items[0].Label)
+	}
+
+	verbose := buildManifestTargetItems(targets, false, true)
+	if !strings.Contains(verbose[0].Label, "inferred from git remote.origin.url") {
+		t.Fatalf("verbose target label lacks detail: %q", verbose[0].Label)
+	}
+}
+
+func TestRunManifestSecretTargetSetupWithValuesSupportsPerTargetValues(t *testing.T) {
+	repoProvider := newEngineTestProvider(nil)
+	orgProvider := newEngineTestProvider(nil)
+	targets := []manifestSecretTarget{
+		{
+			Secret:   manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:    "github-repo",
+			Label:    "github repo GoCodeAlone/example",
+			Provider: repoProvider,
+		},
+		{
+			Secret:   manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}},
+			Store:    "github-org:GoCodeAlone",
+			Label:    "github org GoCodeAlone",
+			Provider: orgProvider,
+		},
+	}
+	values := map[string]manifestProvidedSecretValue{
+		manifestSecretTargetKey(targets[0]): {Value: "repo-value", Provided: true},
+		manifestSecretTargetKey(targets[1]): {Value: "org-value", Provided: true},
+	}
+
+	report, err := runManifestSecretTargetSetupWithValues(context.Background(), targets, values, nil, true)
+	if err != nil {
+		t.Fatalf("runManifestSecretTargetSetupWithValues: %v", err)
+	}
+	if repoProvider.data["TOKEN"] != "repo-value" {
+		t.Fatalf("repo value = %q", repoProvider.data["TOKEN"])
+	}
+	if orgProvider.data["TOKEN"] != "org-value" {
+		t.Fatalf("org value = %q", orgProvider.data["TOKEN"])
+	}
+	if len(report.Set) != 2 {
+		t.Fatalf("report.Set = %v", report.Set)
+	}
+}
+
+func TestCollectManifestSecretTargetValuesAllowsDifferentPerTargetValue(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN", Sensitive: true}},
+			Store:  "github-repo",
+			Label:  "github repo GoCodeAlone/example",
+		},
+		{
+			Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN", Sensitive: true}},
+			Store:  "github-org:GoCodeAlone",
+			Label:  "github org GoCodeAlone",
+		},
+	}
+	inputs := []string{"repo-value", "org-value"}
+	confirmCalls := 0
+	values, err := collectManifestSecretTargetValues(targets,
+		func(manifestDiscoveredSecret) (string, bool, error) { return "", false, nil },
+		manifestTargetValuePrompt{
+			input: func(label string, masked bool) (string, error) {
+				if !masked {
+					t.Fatalf("secret prompt was not masked for %q", label)
+				}
+				if !strings.Contains(label, "TOKEN for github:") {
+					t.Fatalf("input label = %q, want target-specific scope", label)
+				}
+				v := inputs[0]
+				inputs = inputs[1:]
+				return v, nil
+			},
+			confirm: func(question string, def bool) (bool, error) {
+				confirmCalls++
+				if !strings.Contains(question, "github:org") || !def {
+					t.Fatalf("confirm question=%q def=%v", question, def)
+				}
+				return false, nil
+			},
+		})
+	if err != nil {
+		t.Fatalf("collectManifestSecretTargetValues: %v", err)
+	}
+	if confirmCalls != 1 {
+		t.Fatalf("confirm calls = %d, want 1", confirmCalls)
+	}
+	if got := values[manifestSecretTargetKey(targets[0])].Value; got != "repo-value" {
+		t.Fatalf("repo value = %q", got)
+	}
+	if got := values[manifestSecretTargetKey(targets[1])].Value; got != "org-value" {
+		t.Fatalf("org value = %q", got)
+	}
+}
+
+func TestCollectManifestSecretTargetValuesUsesPreprovidedValueForAllTargets(t *testing.T) {
+	targets := []manifestSecretTarget{
+		{Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}}, Store: "github-repo"},
+		{Secret: manifestDiscoveredSecret{PluginRequiredSecret: PluginRequiredSecret{Name: "TOKEN"}}, Store: "github-org:GoCodeAlone"},
+	}
+	values, err := collectManifestSecretTargetValues(targets,
+		func(manifestDiscoveredSecret) (string, bool, error) { return "env-value", true, nil },
+		manifestTargetValuePrompt{
+			input: func(string, bool) (string, error) {
+				t.Fatal("input should not be called when value is preprovided")
+				return "", nil
+			},
+			confirm: func(string, bool) (bool, error) {
+				t.Fatal("confirm should not be called when value is preprovided")
+				return false, nil
+			},
+		})
+	if err != nil {
+		t.Fatalf("collectManifestSecretTargetValues: %v", err)
+	}
+	for _, target := range targets {
+		got := values[manifestSecretTargetKey(target)]
+		if !got.Provided || got.Value != "env-value" {
+			t.Fatalf("value for %+v = %+v", target, got)
 		}
 	}
 }

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2565,7 +2565,7 @@ Set secrets declared in the config for a given environment. Automatically select
 
 **Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names.
 
-Manifest-backed interactive setup uses a compact two-stage flow by default:
+Manifest-backed interactive setup uses a compact three-step flow by default:
 
 1. A table lists one row per discovered secret and one column per concrete provider target. Status marks are `○` unset, `✓` set, `!` inaccessible/check failed, and `?` unconfigured.
 2. After selecting secrets, choose the scope/store targets for each selected secret. GitHub targets are explicit GitHub destinations (`github:repo`, `github:env`, `github:org`); local `.env`/file stores appear as file/env targets, not GitHub scopes.

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2563,7 +2563,15 @@ wfctl secrets sync --from staging --to production
 
 Set secrets declared in the config for a given environment. Automatically selects interactive or non-interactive mode based on whether stdin is a TTY. With `--manifest`, discovers secrets from `wfctl.yaml`, `.wfctl-lock.yaml`, installed plugin `required_secrets[]`, and `${ENV_VAR}` references in workflow configs. Repo/env-scoped GitHub setup uses `secrets.config.repo` or `secretStores.<name>.config.repo` when configured; otherwise it infers the repo from `git remote.origin.url` and prints that assumption in the setup target or error.
 
-**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names. Manifest-backed setup prints the selected GitHub target and whether the repo was configured explicitly or inferred, shows discovered provider/config secrets with set/unset status and their sources, and selects only unset secrets by default. Toggle existing secrets to update them, or pass `--all` to preselect every discovered secret.
+**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names.
+
+Manifest-backed interactive setup uses a compact two-stage flow by default:
+
+1. A table lists one row per discovered secret and one column per concrete provider target. Status marks are `○` unset, `✓` set, `!` inaccessible/check failed, and `?` unconfigured.
+2. After selecting secrets, choose the scope/store targets for each selected secret. GitHub targets are explicit GitHub destinations (`github:repo`, `github:env`, `github:org`); local `.env`/file stores appear as file/env targets, not GitHub scopes.
+3. When a secret is selected for multiple targets, enter the first value once, then either reuse it for the other targets or provide a different value per target.
+
+Unset secrets are selected by default. Toggle existing secrets to update them, or pass `--all` to preselect every discovered secret. Pass `--verbose` to include source files, plugin names, and full provider target labels in the interactive rows.
 
 **Non-interactive mode** (auto when stdin is not a TTY, or forced with `--non-interactive` / `--auto-gen-keys`): reads values from the sources below in priority order:
 - `--from-env` — reads `$NAME` for each secret. Recommended for CI; avoids process-table leaks. Secrets whose env var is unset are skipped.
@@ -2595,6 +2603,7 @@ wfctl secrets setup [options]
 | `--all` | `false` | Set all declared secrets; in manifest-backed interactive setup, preselect existing secrets too |
 | `--only` | _(all)_ | Comma-separated list of secret names to set; mutually exclusive with `--all` |
 | `--skip-existing` | `false` | Skip secrets that already have a value in the store |
+| `--verbose` | `false` | In manifest-backed interactive setup, show source files, plugin names, and full provider target details |
 | `--auto-gen-keys` | `false` | Auto-generate random values for config-backed secrets ending in `_KEY`, `_SECRET`, `_TOKEN`, or `_SIGNING`; implies non-interactive; not supported for manifest-backed `wfctl.yaml` setup |
 | `--scope` | `repo` | GitHub scope for plugin or manifest setup: `repo` \| `env` \| `org` |
 | `--org` | _(none)_ | Organization slug for `--scope org` |

--- a/docs/wfctl-secrets-scopes.md
+++ b/docs/wfctl-secrets-scopes.md
@@ -92,14 +92,31 @@ This:
 3. Prompts for each (masked iff `sensitive: true`).
 4. Writes each to the chosen GH scope.
 
-Repo-level setup can discover all provider plugin secrets from `wfctl.yaml` and
-`.wfctl-lock.yaml`:
+Manifest-backed setup can discover all provider plugin secrets from `wfctl.yaml`
+and `.wfctl-lock.yaml`:
 
 ```sh
 wfctl secrets setup --manifest wfctl.yaml \
   --config 'infra/*.yaml,deploy.yaml' \
   --scope org --org GoCodeAlone --from-env
 ```
+
+When `--scope` is omitted and stdin is interactive, manifest-backed setup uses
+configured `secretStores` when present; otherwise it offers concrete GitHub
+targets discovered from repo/org/env settings. The first prompt is a compact
+matrix with one row per secret and one column per target:
+
+| mark | meaning |
+|------|---------|
+| `○` | unset |
+| `✓` | already set |
+| `!` | inaccessible or check failed |
+| `?` | unconfigured |
+
+GitHub columns are only GitHub destinations: `github:repo`, `github:env`, and
+`github:org`. Local `.env`, file, keychain, Vault, and AWS stores appear as
+their own provider targets. Use `--verbose` when you need the source config
+file, plugin name, or full target label in the prompt rows.
 
 Pipe a value list to skip the prompt loop in CI:
 


### PR DESCRIPTION
## Summary
- add a Bubble Tea table-based multiselect prompt for manifest-backed secrets setup
- show a compact secret x provider-target matrix by default, with verbose source/target details behind --verbose
- let users choose scope/store targets per selected secret and reuse or override values per target
- document the new manifest secrets setup flow and provider-target semantics

## Verification
- GOWORK=off go test ./cmd/wfctl/internal/prompt -count=1
- GOWORK=off go test ./cmd/wfctl -run 'Test.*Manifest.*|TestRunSecretsSetupRejectsAutoGenKeysForManifestTarget|TestBuildSecretWriterRepoScope|TestFirstConfigPattern|TestCollectManifestSecretTargetValues' -count=1\n- GOWORK=off go test ./secrets ./cmd/wfctl/internal/prompt -count=1\n- GOWORK=off golangci-lint run --timeout=10m\n- git diff --check\n- GOWORK=off go test ./cmd/wfctl -count=1 -timeout=5m\n- GOWORK=off go test ./... -count=1 -timeout=10m