### PR TITLE
fix(wfctl): render secrets setup prompts plainly

### DIFF
--- a/cmd/wfctl/internal/prompt/confirm.go
+++ b/cmd/wfctl/internal/prompt/confirm.go
@@ -1,7 +1,9 @@
 package prompt
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -20,17 +22,21 @@ func Confirm(question string, def bool) (bool, error) {
 	if def {
 		hint = "Y/n"
 	}
-	m := &confirmModel{question: question, hint: hint, def: def}
-	p := tea.NewProgram(m, tea.WithOutput(out))
-	result, err := p.Run()
+	fmt.Fprintf(out, "%s [%s] ", question, hint)
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
-		return false, fmt.Errorf("prompt confirm: %w", err)
+		return false, err
 	}
-	fm := result.(*confirmModel)
-	if fm.quit {
-		return false, ErrInterrupted
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "":
+		return def, nil
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid confirmation %q", strings.TrimSpace(line))
 	}
-	return fm.answer, nil
 }
 
 type confirmModel struct {

--- a/cmd/wfctl/internal/prompt/input.go
+++ b/cmd/wfctl/internal/prompt/input.go
@@ -1,11 +1,16 @@
 package prompt
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
+	"syscall"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"golang.org/x/term"
 )
 
 // Input prompts the user for a single-line text value. When masked is true
@@ -24,29 +29,21 @@ func InputWithSuggestions(label string, masked bool, suggestions []string) (stri
 		return "", ErrNotInteractive
 	}
 	out, _ := outputWriter()
-	ti := textinput.New()
-	ti.Placeholder = label
-	ti.Focus()
-	if len(suggestions) > 0 {
-		ti.ShowSuggestions = true
-		ti.SetSuggestions(suggestions)
-	}
+	fmt.Fprint(out, label+": ")
 	if masked {
-		ti.EchoMode = textinput.EchoPassword
-		ti.EchoCharacter = '*'
+		value, err := term.ReadPassword(syscall.Stdin)
+		fmt.Fprintln(out)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimRight(string(value), "\r\n"), nil
 	}
-
-	m := &inputModel{label: label, ti: ti}
-	p := tea.NewProgram(m, tea.WithOutput(out))
-	result, err := p.Run()
+	reader := bufio.NewReader(os.Stdin)
+	value, err := reader.ReadString('\n')
 	if err != nil {
-		return "", fmt.Errorf("prompt input: %w", err)
+		return "", err
 	}
-	fm := result.(*inputModel)
-	if fm.quit {
-		return "", ErrInterrupted
-	}
-	return fm.ti.Value(), nil
+	return strings.TrimRight(value, "\r\n"), nil
 }
 
 type inputModel struct {

--- a/cmd/wfctl/internal/prompt/interrupt_test.go
+++ b/cmd/wfctl/internal/prompt/interrupt_test.go
@@ -1,6 +1,8 @@
 package prompt
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -31,5 +33,45 @@ func TestPromptModelsMarkCtrlCAsInterrupted(t *testing.T) {
 	multiSelect.Update(msg)
 	if !multiSelect.quit {
 		t.Fatal("multiSelectModel did not mark ctrl+c as quit")
+	}
+
+	tableMultiSelect := &tableMultiSelectModel{}
+	tableMultiSelect.Update(msg)
+	if !tableMultiSelect.quit {
+		t.Fatal("tableMultiSelectModel did not mark ctrl+c as quit")
+	}
+}
+
+func TestParseIndexSelection(t *testing.T) {
+	got, err := parseIndexSelection("1,3-4,3", 5)
+	if err != nil {
+		t.Fatalf("parseIndexSelection: %v", err)
+	}
+	want := []int{0, 2, 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("indexes = %v, want %v", got, want)
+	}
+
+	if _, err := parseIndexSelection("0", 5); err == nil {
+		t.Fatal("parseIndexSelection accepted out-of-range selection")
+	}
+}
+
+func TestTableMultiSelectModelViewShowsRows(t *testing.T) {
+	m := newTableMultiSelectModel("Pick secrets",
+		[]TableColumn{
+			{Title: "Secret", Width: 24},
+			{Title: "github:repo", Width: 12},
+		},
+		[]TableItem{
+			{Cells: []string{"DIGITALOCEAN_TOKEN", "set"}, Preselected: true},
+			{Cells: []string{"HOVER_PASSWORD", "unset"}},
+		},
+	)
+	view := m.View().Content
+	for _, want := range []string{"Pick secrets", "Secret", "github:repo", "DIGITALOCEAN_TOKEN", "HOVER_PASSWORD", "[x]", "[ ]"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing %q:\n%s", want, view)
+		}
 	}
 }

--- a/cmd/wfctl/internal/prompt/multiselect.go
+++ b/cmd/wfctl/internal/prompt/multiselect.go
@@ -1,7 +1,10 @@
 package prompt
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -17,29 +20,60 @@ func MultiSelect(title string, items []Item) ([]int, error) {
 		return nil, ErrNotInteractive
 	}
 	out, _ := outputWriter()
-	selected := make(map[int]bool, len(items))
-	for i, it := range items {
-		if it.Preselected {
-			selected[i] = true
+	fmt.Fprintln(out, title)
+	defaults := make([]int, 0, len(items))
+	for i, item := range items {
+		mark := " "
+		if item.Preselected {
+			mark = "x"
+			defaults = append(defaults, i)
 		}
+		fmt.Fprintf(out, "  %d. [%s] %s\n", i+1, mark, item.Label)
 	}
-	m := &multiSelectModel{title: title, items: items, selected: selected}
-	p := tea.NewProgram(m, tea.WithOutput(out))
-	result, err := p.Run()
+	fmt.Fprint(out, "Choose numbers/ranges (comma-separated, Enter for defaults): ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
-		return nil, fmt.Errorf("prompt multiselect: %w", err)
+		return nil, err
 	}
-	fm := result.(*multiSelectModel)
-	if fm.quit {
-		return nil, ErrInterrupted
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return defaults, nil
 	}
-	var indices []int
-	for i := range items {
-		if fm.selected[i] {
-			indices = append(indices, i)
+	return parseIndexSelection(line, len(items))
+}
+
+func parseIndexSelection(line string, count int) ([]int, error) {
+	seen := make(map[int]bool)
+	var out []int
+	for _, raw := range strings.Split(line, ",") {
+		part := strings.TrimSpace(raw)
+		if part == "" {
+			continue
+		}
+		startRaw, endRaw, hasRange := strings.Cut(part, "-")
+		start, err := strconv.Atoi(strings.TrimSpace(startRaw))
+		if err != nil {
+			return nil, fmt.Errorf("invalid selection %q", part)
+		}
+		end := start
+		if hasRange {
+			end, err = strconv.Atoi(strings.TrimSpace(endRaw))
+			if err != nil {
+				return nil, fmt.Errorf("invalid selection %q", part)
+			}
+		}
+		if start < 1 || end < start || end > count {
+			return nil, fmt.Errorf("selection %q out of range 1-%d", part, count)
+		}
+		for n := start; n <= end; n++ {
+			idx := n - 1
+			if !seen[idx] {
+				seen[idx] = true
+				out = append(out, idx)
+			}
 		}
 	}
-	return indices, nil
+	return out, nil
 }
 
 type multiSelectModel struct {

--- a/cmd/wfctl/internal/prompt/select.go
+++ b/cmd/wfctl/internal/prompt/select.go
@@ -1,7 +1,10 @@
 package prompt
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -17,17 +20,24 @@ func Select(title string, opts []string) (int, error) {
 		return 0, ErrNotInteractive
 	}
 	out, _ := outputWriter()
-	m := &selectModel{title: title, opts: opts}
-	p := tea.NewProgram(m, tea.WithOutput(out))
-	result, err := p.Run()
+	fmt.Fprintln(out, title)
+	for i, opt := range opts {
+		fmt.Fprintf(out, "  %d. %s\n", i+1, opt)
+	}
+	fmt.Fprint(out, "Choose [1]: ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
-		return 0, fmt.Errorf("prompt select: %w", err)
+		return 0, err
 	}
-	fm := result.(*selectModel)
-	if fm.quit {
-		return 0, ErrInterrupted
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return 0, nil
 	}
-	return fm.cursor, nil
+	idx, err := strconv.Atoi(line)
+	if err != nil || idx < 1 || idx > len(opts) {
+		return 0, fmt.Errorf("invalid selection %q", line)
+	}
+	return idx - 1, nil
 }
 
 // selectModel is the bubbletea model for single selection.

--- a/cmd/wfctl/internal/prompt/table_multiselect.go
+++ b/cmd/wfctl/internal/prompt/table_multiselect.go
@@ -1,10 +1,11 @@
 package prompt
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"strings"
 
-	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
 )
 
@@ -31,22 +32,23 @@ func TableMultiSelect(title string, columns []TableColumn, items []TableItem) ([
 	}
 	out, _ := outputWriter()
 	m := newTableMultiSelectModel(title, columns, items)
-	p := tea.NewProgram(m, tea.WithOutput(out))
-	result, err := p.Run()
+	fmt.Fprint(out, m.View().Content)
+	fmt.Fprint(out, "Choose numbers/ranges (comma-separated, Enter for defaults): ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
-		return nil, fmt.Errorf("prompt table multiselect: %w", err)
+		return nil, err
 	}
-	fm := result.(*tableMultiSelectModel)
-	if fm.quit {
-		return nil, ErrInterrupted
-	}
-	var indices []int
-	for i := range items {
-		if fm.selected[i] {
-			indices = append(indices, i)
+	line = strings.TrimSpace(line)
+	if line == "" {
+		var defaults []int
+		for i, item := range items {
+			if item.Preselected {
+				defaults = append(defaults, i)
+			}
 		}
+		return defaults, nil
 	}
-	return indices, nil
+	return parseIndexSelection(line, len(items))
 }
 
 type tableMultiSelectModel struct {
@@ -54,7 +56,7 @@ type tableMultiSelectModel struct {
 	columns  []TableColumn
 	items    []TableItem
 	selected map[int]bool
-	table    table.Model
+	cursor   int
 	quit     bool
 }
 
@@ -71,12 +73,6 @@ func newTableMultiSelectModel(title string, columns []TableColumn, items []Table
 		items:    items,
 		selected: selected,
 	}
-	m.table = table.New(
-		table.WithColumns(m.tableColumns()),
-		table.WithRows(m.tableRows()),
-		table.WithFocused(true),
-		table.WithHeight(min(max(len(items)+2, 5), 18)), //nolint:mnd
-	)
 	return m
 }
 
@@ -88,53 +84,93 @@ func (m *tableMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			m.quit = true
 			return m, tea.Quit
-		case " ":
-			cursor := m.table.Cursor()
-			if m.selected[cursor] {
-				delete(m.selected, cursor)
-			} else {
-				m.selected[cursor] = true
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
 			}
-			m.table.SetRows(m.tableRows())
+		case "down", "j":
+			if m.cursor < len(m.items)-1 {
+				m.cursor++
+			}
+		case " ":
+			if m.selected[m.cursor] {
+				delete(m.selected, m.cursor)
+			} else {
+				m.selected[m.cursor] = true
+			}
 			return m, nil
 		case "enter":
 			return m, tea.Quit
 		}
 	}
-	var cmd tea.Cmd
-	m.table, cmd = m.table.Update(msg)
-	return m, cmd
+	return m, nil
 }
 
 func (m *tableMultiSelectModel) View() tea.View {
 	var b strings.Builder
 	b.WriteString(titleStyle.Render(m.title))
 	b.WriteString("\n")
-	b.WriteString(m.table.View())
+	b.WriteString(m.headerRow())
+	b.WriteString("\n")
+	b.WriteString(m.separatorRow())
+	b.WriteString("\n")
+	for i, item := range m.items {
+		cursor := "  "
+		if i == m.cursor {
+			cursor = "> "
+		}
+		mark := "[ ]"
+		if m.selected[i] {
+			mark = "[x]"
+		}
+		b.WriteString(cursor)
+		b.WriteString(padTableCell(mark, 3))
+		for colIdx, col := range m.columns {
+			cell := ""
+			if colIdx < len(item.Cells) {
+				cell = item.Cells[colIdx]
+			}
+			b.WriteString(" ")
+			b.WriteString(padTableCell(cell, col.Width))
+		}
+		b.WriteString("\n")
+	}
 	b.WriteString("\n\n(space to toggle, enter to confirm)\n")
 	return tea.NewView(b.String())
 }
 
-func (m *tableMultiSelectModel) tableColumns() []table.Column {
-	cols := make([]table.Column, 0, len(m.columns)+1)
-	cols = append(cols, table.Column{Title: "Set", Width: 3})
+func (m *tableMultiSelectModel) headerRow() string {
+	var b strings.Builder
+	b.WriteString("  ")
+	b.WriteString(padTableCell("Set", 3))
 	for _, col := range m.columns {
-		cols = append(cols, table.Column{Title: col.Title, Width: col.Width})
+		b.WriteString(" ")
+		b.WriteString(padTableCell(col.Title, col.Width))
 	}
-	return cols
+	return b.String()
 }
 
-func (m *tableMultiSelectModel) tableRows() []table.Row {
-	rows := make([]table.Row, 0, len(m.items))
-	for i, item := range m.items {
-		mark := " "
-		if m.selected[i] {
-			mark = "x"
-		}
-		cells := make([]string, 0, len(item.Cells)+1)
-		cells = append(cells, mark)
-		cells = append(cells, item.Cells...)
-		rows = append(rows, table.Row(cells))
+func (m *tableMultiSelectModel) separatorRow() string {
+	var b strings.Builder
+	b.WriteString("  ")
+	b.WriteString(strings.Repeat("-", 3))
+	for _, col := range m.columns {
+		b.WriteString(" ")
+		b.WriteString(strings.Repeat("-", max(col.Width, 1)))
 	}
-	return rows
+	return b.String()
+}
+
+func padTableCell(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > width {
+		if width <= 1 {
+			return s[:width]
+		}
+		return s[:width-1] + "~"
+	}
+	return s + strings.Repeat(" ", width-len(s))
 }


### PR DESCRIPTION
## Summary
- replace renderer-backed prompt entrypoints with plain TTY prompts so secrets setup remains visible under terminal capability edge cases
- keep table-shaped secrets setup output visible and support comma-separated selections/ranges
- preserve Enter-for-default behavior for preselected/default choices

## Verification
- `GOWORK=off go test ./cmd/wfctl/internal/prompt -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestDiscoverManifestSecrets|TestBuildManifestSecretMatrixRows|TestBuildManifestTargetItems|TestRunSecretsSetupRejectsAutoGenKeysForManifestTarget' -count=1`
- `GOWORK=off go test ./cmd/wfctl/internal/prompt ./cmd/wfctl -count=1`
- `GOWORK=off golangci-lint run --timeout=5m ./cmd/wfctl/internal/prompt/... ./cmd/wfctl/...`
- `git diff --check`
- rebuilt wfctl and reproduced `wfctl secrets setup` from `gocodealone-dns`; the secrets table and scope/store target prompts are visible