### PR TITLE
feat(wfctl): add plugin secret target metadata

### DIFF
--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -1418,6 +1418,9 @@ type installedPluginJSON struct {
 	// reporting "declares no required_secrets[]" even when the
 	// upstream manifest declared it.
 	RequiredSecrets []PluginRequiredSecret `json:"required_secrets,omitempty"`
+	// SecretTargets carries through from the registry manifest so
+	// manifest-backed secrets setup can respect provider-specific target models.
+	SecretTargets []PluginSecretTarget `json:"secret_targets,omitempty"`
 }
 
 type installedPluginCapabilities struct {
@@ -1453,6 +1456,7 @@ func writeInstalledManifest(path string, m *RegistryManifest) error {
 		Type:            m.Type,
 		IaCProvider:     m.IaCProvider,
 		RequiredSecrets: m.RequiredSecrets,
+		SecretTargets:   m.SecretTargets,
 	}
 	if m.Capabilities != nil {
 		pj.Capabilities = &installedPluginCapabilities{

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -1343,6 +1344,10 @@ func TestWriteInstalledManifest_PreservesRequiredSecrets(t *testing.T) {
 			{Name: "HOVER_USERNAME", Sensitive: false, Description: "Hover username", Prompt: "Hover username"},
 			{Name: "HOVER_PASSWORD", Sensitive: true, Description: "Hover password"},
 		},
+		SecretTargets: []PluginSecretTarget{
+			{Provider: "github", Scopes: []string{"repo", "env"}},
+			{Provider: "vault", Scopes: []string{"mount"}},
+		},
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.json")
@@ -1366,11 +1371,20 @@ func TestWriteInstalledManifest_PreservesRequiredSecrets(t *testing.T) {
 	if !pj.RequiredSecrets[1].Sensitive {
 		t.Errorf("required_secrets[1].sensitive = false; want true (HOVER_PASSWORD)")
 	}
+	if len(pj.SecretTargets) != 2 {
+		t.Fatalf("secret_targets len = %d, want 2", len(pj.SecretTargets))
+	}
+	if pj.SecretTargets[0].Provider != "github" || !reflect.DeepEqual(pj.SecretTargets[0].Scopes, []string{"repo", "env"}) {
+		t.Errorf("unexpected secret_targets[0]: %+v", pj.SecretTargets[0])
+	}
 	// Also assert the raw JSON contains the field — guards against a
 	// future installedPluginJSON refactor that adds Sensitive omitempty
 	// or otherwise hides the field at marshal time.
 	if !strings.Contains(string(raw), "\"required_secrets\":") {
 		t.Errorf("installed plugin.json missing required_secrets[] key:\n%s", string(raw))
+	}
+	if !strings.Contains(string(raw), "\"secret_targets\":") {
+		t.Errorf("installed plugin.json missing secret_targets[] key:\n%s", string(raw))
 	}
 }
 
@@ -1399,5 +1413,31 @@ func TestRegistryManifest_UnmarshalPreservesRequiredSecrets(t *testing.T) {
 	}
 	if m.RequiredSecrets[1].Name != "Y" || !m.RequiredSecrets[1].Sensitive {
 		t.Errorf("unexpected required_secrets[1]: %+v", m.RequiredSecrets[1])
+	}
+}
+
+func TestRegistryManifest_UnmarshalPreservesSecretTargets(t *testing.T) {
+	src := `{
+		"name": "workflow-plugin-github",
+		"version": "0.2.0",
+		"author": "GoCodeAlone",
+		"description": "test",
+		"type": "external",
+		"tier": "community",
+		"license": "MIT",
+		"secret_targets": [
+			{"provider": "github", "scopes": ["repo", "env"], "description": "GitHub Actions secrets"},
+			{"provider": "vault", "scopes": ["mount"]}
+		]
+	}`
+	var m RegistryManifest
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(m.SecretTargets) != 2 {
+		t.Fatalf("secret_targets len = %d, want 2", len(m.SecretTargets))
+	}
+	if m.SecretTargets[0].Provider != "github" || !reflect.DeepEqual(m.SecretTargets[0].Scopes, []string{"repo", "env"}) {
+		t.Errorf("unexpected secret_targets[0]: %+v", m.SecretTargets[0])
 	}
 }

--- a/cmd/wfctl/plugin_registry.go
+++ b/cmd/wfctl/plugin_registry.go
@@ -51,6 +51,11 @@ type RegistryManifest struct {
 	// would be silently dropped at unmarshal time even when the
 	// upstream manifest declared it.
 	RequiredSecrets []PluginRequiredSecret `json:"required_secrets,omitempty"`
+	// SecretTargets mirrors plugin.json `secret_targets[]`. It tells
+	// manifest-backed secrets setup which provider-owned targets are appropriate
+	// for this plugin's required_secrets[] entries, without hard-coding
+	// GitHub repo/org/env semantics into unrelated providers.
+	SecretTargets []PluginSecretTarget `json:"secret_targets,omitempty"`
 }
 
 // RegistryCapabilities describes what module/step/trigger types a plugin provides.

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -1429,6 +1429,9 @@ func addDiscoveredSecretWithStoreHintAndTargets(secretsByName map[string]*manife
 }
 
 func mergePluginSecretTargets(existing []PluginSecretTarget, incoming []PluginSecretTarget) []PluginSecretTarget {
+	if len(incoming) == 0 {
+		return existing
+	}
 	out := append([]PluginSecretTarget(nil), existing...)
 	seen := make(map[string]bool, len(out)+len(incoming))
 	for _, target := range out {

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -22,8 +22,9 @@ var manifestEnvRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
 type manifestDiscoveredSecret struct {
 	PluginRequiredSecret
-	Sources   []string
-	StoreHint string
+	Sources       []string
+	StoreHint     string
+	SecretTargets []PluginSecretTarget
 }
 
 type manifestSecretTarget struct {
@@ -617,6 +618,9 @@ func queryManifestSecretTargets(ctx context.Context, secrets []manifestDiscovere
 			if secret.StoreHint != "" && provider.Store != secret.StoreHint && !strings.HasPrefix(provider.Store, secret.StoreHint+":") {
 				continue
 			}
+			if secret.StoreHint == "" && !manifestSecretTargetAllowed(secret, provider) {
+				continue
+			}
 			state, err := provider.Provider.Check(ctx, secret.Name)
 			status := SecretStatus{
 				Name:  secret.Name,
@@ -637,6 +641,37 @@ func queryManifestSecretTargets(ctx context.Context, secrets []manifestDiscovere
 		}
 	}
 	return targets
+}
+
+func manifestSecretTargetAllowed(secret manifestDiscoveredSecret, provider manifestSecretTargetProvider) bool {
+	if len(secret.SecretTargets) == 0 {
+		return true
+	}
+	target := manifestSecretTargetProviderDescriptor(provider.Provider)
+	providerName := normalizedSecretTargetProvider(target.Provider)
+	scope := strings.ToLower(strings.TrimSpace(target.Scope))
+	for _, allowed := range secret.SecretTargets {
+		if normalizedSecretTargetProvider(allowed.Provider) != providerName {
+			continue
+		}
+		scopes := normalizedSecretTargetScopes(allowed.Scopes)
+		if len(scopes) == 0 {
+			return true
+		}
+		for _, allowedScope := range scopes {
+			if allowedScope == scope {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func manifestSecretTargetProviderDescriptor(provider SecretsProvider) secrets.ProviderTarget {
+	if targeter, ok := provider.(interface{ SecretTarget() secrets.ProviderTarget }); ok {
+		return targeter.SecretTarget()
+	}
+	return secrets.ProviderTarget{Scope: "default"}
 }
 
 func runManifestSecretTargetSetup(ctx context.Context, targets []manifestSecretTarget, valuer func(manifestDiscoveredSecret) (string, bool, error), audit func(string, string), stopOnError bool) (setupReport, error) {
@@ -829,7 +864,7 @@ func discoverManifestSecrets(manifestPath, lockfilePath, pluginDir, configPatter
 			if strings.TrimSpace(required.Name) == "" {
 				continue
 			}
-			addDiscoveredSecret(secretsByName, required, "plugin:"+sourceName)
+			addDiscoveredSecretWithTargets(secretsByName, required, "plugin:"+sourceName, manifest.SecretTargets)
 		}
 	}
 	configFiles, err := expandConfigPatterns(configPatterns)
@@ -1358,7 +1393,15 @@ func addDiscoveredSecret(secretsByName map[string]*manifestDiscoveredSecret, req
 	addDiscoveredSecretWithStoreHint(secretsByName, required, source, "")
 }
 
+func addDiscoveredSecretWithTargets(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source string, targets []PluginSecretTarget) {
+	addDiscoveredSecretWithStoreHintAndTargets(secretsByName, required, source, "", targets)
+}
+
 func addDiscoveredSecretWithStoreHint(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source, storeHint string) {
+	addDiscoveredSecretWithStoreHintAndTargets(secretsByName, required, source, storeHint, nil)
+}
+
+func addDiscoveredSecretWithStoreHintAndTargets(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source, storeHint string, targets []PluginSecretTarget) {
 	name := strings.TrimSpace(required.Name)
 	if name == "" {
 		return
@@ -1375,6 +1418,7 @@ func addDiscoveredSecretWithStoreHint(secretsByName map[string]*manifestDiscover
 	if storeHint != "" && secret.StoreHint == "" {
 		secret.StoreHint = storeHint
 	}
+	secret.SecretTargets = mergePluginSecretTargets(secret.SecretTargets, targets)
 	secret.Sensitive = secret.Sensitive || required.Sensitive || isSecretSensitive(name)
 	for _, existing := range secret.Sources {
 		if existing == source {
@@ -1383,6 +1427,58 @@ func addDiscoveredSecretWithStoreHint(secretsByName map[string]*manifestDiscover
 	}
 	secret.Sources = append(secret.Sources, source)
 	sort.Strings(secret.Sources)
+}
+
+func mergePluginSecretTargets(existing []PluginSecretTarget, incoming []PluginSecretTarget) []PluginSecretTarget {
+	out := append([]PluginSecretTarget(nil), existing...)
+	seen := make(map[string]bool, len(out)+len(incoming))
+	for _, target := range out {
+		seen[pluginSecretTargetKey(target)] = true
+	}
+	for _, target := range incoming {
+		target.Provider = normalizedSecretTargetProvider(target.Provider)
+		target.Scopes = normalizedSecretTargetScopes(target.Scopes)
+		if target.Provider == "" {
+			continue
+		}
+		key := pluginSecretTargetKey(target)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, target)
+	}
+	return out
+}
+
+func pluginSecretTargetKey(target PluginSecretTarget) string {
+	return normalizedSecretTargetProvider(target.Provider) + "\x00" + strings.Join(normalizedSecretTargetScopes(target.Scopes), ",")
+}
+
+func normalizedSecretTargetProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "github-actions", "github_action", "github-actions-secrets":
+		return "github"
+	case "aws", "aws-sm":
+		return "aws-secrets-manager"
+	default:
+		return strings.ToLower(strings.TrimSpace(provider))
+	}
+}
+
+func normalizedSecretTargetScopes(scopes []string) []string {
+	out := make([]string, 0, len(scopes))
+	seen := map[string]bool{}
+	for _, scope := range scopes {
+		scope = strings.ToLower(strings.TrimSpace(scope))
+		if scope == "" || seen[scope] {
+			continue
+		}
+		seen[scope] = true
+		out = append(out, scope)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func sortedManifestSecrets(secretsByName map[string]*manifestDiscoveredSecret) []manifestDiscoveredSecret {

--- a/cmd/wfctl/secrets_setup_manifest.go
+++ b/cmd/wfctl/secrets_setup_manifest.go
@@ -738,7 +738,8 @@ func collectManifestSecretTargetValues(targets []manifestSecretTarget, fallback 
 	}
 	values := make(map[string]manifestProvidedSecretValue, len(targets))
 	groups := groupManifestSecretTargets(targets)
-	for _, group := range groups {
+	for groupIdx := range groups {
+		group := &groups[groupIdx]
 		if fallback != nil {
 			value, provided, err := fallback(group.Secret)
 			if err != nil {
@@ -1056,7 +1057,8 @@ func buildManifestSecretMatrixRows(targets []manifestSecretTarget, includeExisti
 	}
 
 	rows := make([]prompt.TableItem, 0, len(groups))
-	for _, group := range groups {
+	for groupIdx := range groups {
+		group := &groups[groupIdx]
 		cells := []string{group.Secret.Name}
 		if verbose {
 			cells = append(cells, strings.Join(group.Secret.Sources, ", "))
@@ -1120,7 +1122,8 @@ func manifestSecretMatrixScopes(targets []manifestSecretTarget, labels map[strin
 
 func manifestSecretNameColumnWidth(groups []manifestSecretTargetGroup) int {
 	width := len("Secret")
-	for _, group := range groups {
+	for groupIdx := range groups {
+		group := &groups[groupIdx]
 		width = max(width, len(group.Secret.Name))
 	}
 	return min(max(width+1, 18), 36) //nolint:mnd
@@ -1387,10 +1390,6 @@ func discoverManifestPlugins(manifestPath, lockfilePath string) ([]string, error
 	}
 	sort.Strings(plugins)
 	return plugins, nil
-}
-
-func addDiscoveredSecret(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source string) {
-	addDiscoveredSecretWithStoreHint(secretsByName, required, source, "")
 }
 
 func addDiscoveredSecretWithTargets(secretsByName map[string]*manifestDiscoveredSecret, required PluginRequiredSecret, source string, targets []PluginSecretTarget) {

--- a/cmd/wfctl/secrets_setup_manifest_test.go
+++ b/cmd/wfctl/secrets_setup_manifest_test.go
@@ -1043,6 +1043,89 @@ func TestQueryManifestSecretTargetsHonorsSecretStoreHint(t *testing.T) {
 	}
 }
 
+func TestQueryManifestSecretTargetsFiltersByPluginTargetCapabilities(t *testing.T) {
+	discovered := []manifestDiscoveredSecret{
+		{
+			PluginRequiredSecret: PluginRequiredSecret{Name: "GITHUB_APP_PRIVATE_KEY"},
+			SecretTargets: []PluginSecretTarget{
+				{Provider: "github", Scopes: []string{"repo", "env"}},
+			},
+		},
+		{
+			PluginRequiredSecret: PluginRequiredSecret{Name: "VAULT_TOKEN"},
+			SecretTargets: []PluginSecretTarget{
+				{Provider: "vault", Scopes: []string{"mount"}},
+			},
+		},
+	}
+	providers := []manifestSecretTargetProvider{
+		{
+			Store:    "github-repo",
+			Label:    "github repo GoCodeAlone/workflow",
+			Provider: targetEngineTestProvider{engineTestProvider: newEngineTestProvider(nil), target: secrets.ProviderTarget{Provider: "github", Scope: "repo"}},
+		},
+		{
+			Store:    "github-org",
+			Label:    "github org GoCodeAlone",
+			Provider: targetEngineTestProvider{engineTestProvider: newEngineTestProvider(nil), target: secrets.ProviderTarget{Provider: "github", Scope: "org"}},
+		},
+		{
+			Store:    "vault-prod",
+			Label:    "vault prod",
+			Provider: targetEngineTestProvider{engineTestProvider: newEngineTestProvider(nil), target: secrets.ProviderTarget{Provider: "vault", Scope: "mount"}},
+		},
+	}
+
+	targets := queryManifestSecretTargets(context.Background(), discovered, providers)
+	if len(targets) != 2 {
+		t.Fatalf("targets = %+v, want github repo + vault only", targets)
+	}
+	if targets[0].Secret.Name != "GITHUB_APP_PRIVATE_KEY" || targets[0].Store != "github-repo" {
+		t.Fatalf("first target = %+v, want GitHub repo", targets[0])
+	}
+	if targets[1].Secret.Name != "VAULT_TOKEN" || targets[1].Store != "vault-prod" {
+		t.Fatalf("second target = %+v, want Vault", targets[1])
+	}
+}
+
+func TestQueryManifestSecretTargetsStoreHintOverridesPluginTargets(t *testing.T) {
+	discovered := []manifestDiscoveredSecret{
+		{
+			PluginRequiredSecret: PluginRequiredSecret{Name: "SHARED_TOKEN"},
+			StoreHint:            "vault-prod",
+			SecretTargets: []PluginSecretTarget{
+				{Provider: "github", Scopes: []string{"repo"}},
+			},
+		},
+	}
+	providers := []manifestSecretTargetProvider{
+		{
+			Store:    "github-repo",
+			Label:    "github repo GoCodeAlone/workflow",
+			Provider: targetEngineTestProvider{engineTestProvider: newEngineTestProvider(nil), target: secrets.ProviderTarget{Provider: "github", Scope: "repo"}},
+		},
+		{
+			Store:    "vault-prod",
+			Label:    "vault prod",
+			Provider: targetEngineTestProvider{engineTestProvider: newEngineTestProvider(nil), target: secrets.ProviderTarget{Provider: "vault", Scope: "mount"}},
+		},
+	}
+
+	targets := queryManifestSecretTargets(context.Background(), discovered, providers)
+	if len(targets) != 1 || targets[0].Store != "vault-prod" {
+		t.Fatalf("targets = %+v, want explicit vault store hint", targets)
+	}
+}
+
+type targetEngineTestProvider struct {
+	*engineTestProvider
+	target secrets.ProviderTarget
+}
+
+func (p targetEngineTestProvider) SecretTarget() secrets.ProviderTarget {
+	return p.target
+}
+
 func TestRunManifestSecretTargetSetupWritesEachSelectedProvider(t *testing.T) {
 	repoProvider := newEngineTestProvider(nil)
 	orgProvider := newEngineTestProvider(nil)

--- a/cmd/wfctl/secrets_setup_plugin.go
+++ b/cmd/wfctl/secrets_setup_plugin.go
@@ -26,11 +26,22 @@ type PluginRequiredSecret struct {
 	Prompt      string `json:"prompt,omitempty"`
 }
 
+// PluginSecretTarget declares secret storage targets that a plugin supports for
+// its required_secrets[] entries. Provider is a provider domain such as
+// "github", "vault", or "aws-secrets-manager"; Scopes narrows provider-owned
+// namespaces such as GitHub repo/env/org or Vault mount.
+type PluginSecretTarget struct {
+	Provider    string   `json:"provider"`
+	Scopes      []string `json:"scopes,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
 // pluginManifest is the slice of plugin.json this command actually
 // reads. Other fields are ignored.
 type pluginManifest struct {
 	Name            string                 `json:"name"`
 	RequiredSecrets []PluginRequiredSecret `json:"required_secrets,omitempty"`
+	SecretTargets   []PluginSecretTarget   `json:"secret_targets,omitempty"`
 }
 
 // runSecretsSetupPlugin is the entry-point for `wfctl secrets setup


### PR DESCRIPTION
## Summary
- add plugin.json/registry `secret_targets[]` metadata for provider-owned secret store targets
- preserve `secret_targets[]` through registry install into installed plugin manifests
- filter manifest-backed `wfctl secrets setup` target rows by plugin-declared provider/scope metadata while preserving explicit YAML store hints

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestWriteInstalledManifest_PreservesRequiredSecrets|TestQueryManifestSecretTargets|TestRegistryManifest_UnmarshalPreserves|TestDiscoverManifestSecrets' -count=1`
- `GOWORK=off go test ./cmd/wfctl ./secrets -count=1`
- downstream plugin manifests validated with `jq empty`
