### PR TITLE
Fix wfctl masked prompt Windows build

### DIFF
--- a/cmd/wfctl/internal/prompt/input.go
+++ b/cmd/wfctl/internal/prompt/input.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -31,7 +30,7 @@ func InputWithSuggestions(label string, masked bool, suggestions []string) (stri
 	out, _ := outputWriter()
 	fmt.Fprint(out, label+": ")
 	if masked {
-		value, err := term.ReadPassword(syscall.Stdin)
+		value, err := term.ReadPassword(int(os.Stdin.Fd()))
 		fmt.Fprintln(out)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## Summary
- use `int(os.Stdin.Fd())` for masked prompt input instead of `syscall.Stdin`
- removes the Windows cross-compile failure seen in the pre-release snapshot workflow

## Verification
- GOWORK=off go test ./cmd/wfctl/internal/prompt -count=1
- GOWORK=off go build ./cmd/wfctl
- GOOS=windows GOARCH=amd64 GOWORK=off go build ./cmd/wfctl
- git diff --check