### PR TITLE
fix(wfctl): list registry sync assets via GitHub API

### DIFF
--- a/cmd/wfctl/plugin_registry_sync.go
+++ b/cmd/wfctl/plugin_registry_sync.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,17 +265,16 @@ func normalizeRepo(repoURL string) string {
 }
 
 func ghReleaseLatestTag(ghRepo string) (string, error) {
-	cmd := exec.Command("gh", "release", "view", "--repo", ghRepo, "--json", "tagName", "-q", ".tagName") // #nosec G204 -- ghRepo is from trusted committed manifest
-	out, err := cmd.Output()
+	release, err := fetchGitHubReleaseMetadata("repos/" + escapedGitHubRepoPath(ghRepo) + "/releases/latest")
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(release.TagName), nil
 }
 
 func releaseExists(ghRepo, tag string) bool {
-	cmd := exec.Command("gh", "release", "view", tag, "--repo", ghRepo, "--json", "tagName") // #nosec G204 -- ghRepo+tag from trusted manifest
-	return cmd.Run() == nil
+	_, err := githubReleaseByTag(ghRepo, tag)
+	return err == nil
 }
 
 type releaseAsset struct {
@@ -282,30 +285,74 @@ type releaseAsset struct {
 	SHA256 string `json:"sha256,omitempty"`
 }
 
+type githubReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type githubReleaseMetadata struct {
+	TagName string               `json:"tag_name"`
+	Assets  []githubReleaseAsset `json:"assets"`
+}
+
+func escapedGitHubRepoPath(ghRepo string) string {
+	owner, repo, ok := strings.Cut(ghRepo, "/")
+	if !ok {
+		return neturl.PathEscape(ghRepo)
+	}
+	return neturl.PathEscape(owner) + "/" + neturl.PathEscape(repo)
+}
+
+func githubReleaseByTag(ghRepo, tag string) (*githubReleaseMetadata, error) {
+	return fetchGitHubReleaseMetadata("repos/" + escapedGitHubRepoPath(ghRepo) + "/releases/tags/" + neturl.PathEscape(tag))
+}
+
+func fetchGitHubReleaseMetadata(apiPath string) (*githubReleaseMetadata, error) {
+	apiURL := strings.TrimRight(gitHubAPIBaseURL, "/") + "/" + strings.TrimLeft(apiPath, "/")
+	ctx, cancel := context.WithTimeout(context.Background(), gitHubReleaseMetadataTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil) //nolint:gosec // URL is built from trusted repo/tag metadata.
+	if err != nil {
+		return nil, err
+	}
+	if tok := gitHubToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "wfctl/"+version)
+
+	resp, err := gitHubAPIClient.Do(req)
+	if err != nil {
+		closeResponseBody(resp)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("GitHub releases API: HTTP %d for %s: %s", resp.StatusCode, apiPath, strings.TrimSpace(string(body)))
+	}
+	var release githubReleaseMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode GitHub release response: %w", err)
+	}
+	return &release, nil
+}
+
 // releaseDownloads returns the platform release-asset list for a tag, in the
 // shape the registry's manifest.json expects. Matches the bash
 // release_downloads helper.
 func releaseDownloads(ghRepo, tag string) ([]releaseAsset, error) {
-	cmd := exec.Command("gh", "release", "view", tag, "--repo", ghRepo, "--json", "assets") // #nosec G204 -- ghRepo+tag from trusted manifest
-	out, err := cmd.Output()
+	release, err := githubReleaseByTag(ghRepo, tag)
 	if err != nil {
 		return nil, err
 	}
-	var resp struct {
-		Assets []struct {
-			Name string `json:"name"`
-			URL  string `json:"url"`
-		} `json:"assets"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return nil, err
-	}
-	checksums, err := releaseChecksums(ghRepo, tag)
+	checksums, err := releaseChecksumsFromMetadata(release)
 	if err != nil {
 		return nil, err
 	}
 	var assets []releaseAsset
-	for _, a := range resp.Assets {
+	for _, a := range release.Assets {
 		goos, goarch, ok := releaseAssetPlatform(a.Name)
 		if !ok {
 			continue
@@ -314,7 +361,7 @@ func releaseDownloads(ghRepo, tag string) ([]releaseAsset, error) {
 			Name:   a.Name,
 			OS:     goos,
 			Arch:   goarch,
-			URL:    a.URL,
+			URL:    a.BrowserDownloadURL,
 			SHA256: checksums[a.Name],
 		})
 	}
@@ -322,16 +369,28 @@ func releaseDownloads(ghRepo, tag string) ([]releaseAsset, error) {
 }
 
 func releaseChecksums(ghRepo, tag string) (map[string]string, error) {
-	cmd := exec.Command("gh", "release", "download", tag, "--repo", ghRepo, "--pattern", "checksums.txt", "--output", "-") // #nosec G204 -- ghRepo+tag from trusted manifest
-	out, err := cmd.CombinedOutput()
+	release, err := githubReleaseByTag(ghRepo, tag)
 	if err != nil {
-		msg := strings.ToLower(string(out))
-		if strings.Contains(msg, "no assets match") || strings.Contains(msg, "no matching assets") || strings.Contains(msg, "not found") {
-			return map[string]string{}, nil
-		}
-		return nil, fmt.Errorf("download checksums.txt: %w: %s", err, strings.TrimSpace(string(out)))
+		return nil, err
 	}
-	return parseReleaseChecksums(string(out)), nil
+	return releaseChecksumsFromMetadata(release)
+}
+
+func releaseChecksumsFromMetadata(release *githubReleaseMetadata) (map[string]string, error) {
+	for _, asset := range release.Assets {
+		if asset.Name != "checksums.txt" {
+			continue
+		}
+		if asset.BrowserDownloadURL == "" {
+			return nil, fmt.Errorf("checksums.txt has empty browser_download_url")
+		}
+		data, err := downloadURL(asset.BrowserDownloadURL)
+		if err != nil {
+			return nil, fmt.Errorf("download checksums.txt: %w", err)
+		}
+		return parseReleaseChecksums(string(data)), nil
+	}
+	return map[string]string{}, nil
 }
 
 func parseReleaseChecksums(text string) map[string]string {

--- a/cmd/wfctl/plugin_registry_sync.go
+++ b/cmd/wfctl/plugin_registry_sync.go
@@ -368,14 +368,6 @@ func releaseDownloads(ghRepo, tag string) ([]releaseAsset, error) {
 	return assets, nil
 }
 
-func releaseChecksums(ghRepo, tag string) (map[string]string, error) {
-	release, err := githubReleaseByTag(ghRepo, tag)
-	if err != nil {
-		return nil, err
-	}
-	return releaseChecksumsFromMetadata(release)
-}
-
 func releaseChecksumsFromMetadata(release *githubReleaseMetadata) (map[string]string, error) {
 	for _, asset := range release.Assets {
 		if asset.Name != "checksums.txt" {

--- a/cmd/wfctl/plugin_registry_sync.go
+++ b/cmd/wfctl/plugin_registry_sync.go
@@ -325,7 +325,7 @@ func fetchGitHubReleaseMetadata(apiPath string) (*githubReleaseMetadata, error) 
 	resp, err := gitHubAPIClient.Do(req)
 	if err != nil {
 		closeResponseBody(resp)
-		return nil, err
+		return nil, fmt.Errorf("GitHub releases API request %s: %w", apiPath, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/cmd/wfctl/plugin_registry_sync_test.go
+++ b/cmd/wfctl/plugin_registry_sync_test.go
@@ -6,6 +6,9 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -504,6 +507,71 @@ func TestPluginRegistrySync_LocateExtractedBinary(t *testing.T) {
 
 	if _, err := locateRegistrySyncBinary(dir, "missing-plugin"); err == nil {
 		t.Fatal("expected missing binary error")
+	}
+}
+
+func TestPluginRegistrySync_ReleaseDownloadsUsesGitHubREST(t *testing.T) {
+	oldBaseURL := gitHubAPIBaseURL
+	oldClient := gitHubAPIClient
+	t.Cleanup(func() {
+		gitHubAPIBaseURL = oldBaseURL
+		gitHubAPIClient = oldClient
+	})
+	t.Setenv("RELEASES_TOKEN", "test-token")
+
+	var sawAuth bool
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer test-token" {
+			sawAuth = true
+		}
+		switch r.URL.Path {
+		case "/repos/owner/repo/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[]}`)
+		case "/repos/owner/repo/releases/tags/v1.2.3":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+				"tag_name":"v1.2.3",
+				"assets":[
+					{"name":"checksums.txt","browser_download_url":"%s/checksums.txt"},
+					{"name":"workflow-plugin-foo-linux-amd64.tar.gz","browser_download_url":"%s/workflow-plugin-foo-linux-amd64.tar.gz"},
+					{"name":"notes.txt","browser_download_url":"%s/notes.txt"}
+				]
+			}`, srv.URL, srv.URL, srv.URL)
+		case "/checksums.txt":
+			fmt.Fprintln(w, strings.Repeat("a", 64)+"  workflow-plugin-foo-linux-amd64.tar.gz")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	gitHubAPIBaseURL = srv.URL
+	gitHubAPIClient = srv.Client()
+
+	latest, err := ghReleaseLatestTag("owner/repo")
+	if err != nil {
+		t.Fatalf("ghReleaseLatestTag: %v", err)
+	}
+	if latest != "v1.2.3" {
+		t.Fatalf("latest tag = %q, want v1.2.3", latest)
+	}
+	if !releaseExists("owner/repo", "v1.2.3") {
+		t.Fatal("releaseExists returned false for REST-backed release")
+	}
+	downloads, err := releaseDownloads("owner/repo", "v1.2.3")
+	if err != nil {
+		t.Fatalf("releaseDownloads: %v", err)
+	}
+	if len(downloads) != 1 {
+		t.Fatalf("downloads len = %d, want 1: %#v", len(downloads), downloads)
+	}
+	got := downloads[0]
+	if got.OS != "linux" || got.Arch != "amd64" || got.URL != srv.URL+"/workflow-plugin-foo-linux-amd64.tar.gz" || got.SHA256 != strings.Repeat("a", 64) {
+		t.Fatalf("download = %#v", got)
+	}
+	if !sawAuth {
+		t.Fatal("GitHub API request did not include RELEASES_TOKEN bearer auth")
 	}
 }
 

--- a/cmd/wfctl/plugin_registry_sync_test.go
+++ b/cmd/wfctl/plugin_registry_sync_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -519,11 +520,11 @@ func TestPluginRegistrySync_ReleaseDownloadsUsesGitHubREST(t *testing.T) {
 	})
 	t.Setenv("RELEASES_TOKEN", "test-token")
 
-	var sawAuth bool
+	var sawAuth atomic.Bool
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer test-token" {
-			sawAuth = true
+			sawAuth.Store(true)
 		}
 		switch r.URL.Path {
 		case "/repos/owner/repo/releases/latest":
@@ -570,7 +571,7 @@ func TestPluginRegistrySync_ReleaseDownloadsUsesGitHubREST(t *testing.T) {
 	if got.OS != "linux" || got.Arch != "amd64" || got.URL != srv.URL+"/workflow-plugin-foo-linux-amd64.tar.gz" || got.SHA256 != strings.Repeat("a", 64) {
 		t.Fatalf("download = %#v", got)
 	}
-	if !sawAuth {
+	if !sawAuth.Load() {
 		t.Fatal("GitHub API request did not include RELEASES_TOKEN bearer auth")
 	}
 }


### PR DESCRIPTION
## Summary
- replace `gh release view/download` calls in `wfctl plugin registry-sync` release metadata paths with GitHub REST API calls using Go stdlib HTTP
- reuse existing GitHub token precedence (`RELEASES_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`) and checksum download handling
- add an httptest-backed regression test for latest tag, release existence, asset listing, and checksum attachment

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestPluginRegistrySync_(ReleaseDownloadsUsesGitHubREST|ApplyFixIncludesDownloadChecksums|ApplyFixPropagatesDownloadErrors)'`
- `GOWORK=off GH_TOKEN=$(gh auth token) go run ./cmd/wfctl plugin registry-sync --plugin payments --registry-dir /Users/jon/workspace/workflow-registry/.worktrees/provider-sync-wfctl-current` reported the expected dry-run mismatch instead of `list release downloads` failure
- `GOWORK=off go test ./cmd/wfctl`
- `git diff --check`