### PR TITLE
fix(wfctl): sync missing registry downloads

### DIFF
--- a/cmd/wfctl/plugin_registry_sync.go
+++ b/cmd/wfctl/plugin_registry_sync.go
@@ -578,7 +578,7 @@ func isKnownArch(s string) bool {
 func downloadsMatchVersion(raw map[string]any, version string) bool {
 	downloadsRaw, _ := raw["downloads"].([]any)
 	if len(downloadsRaw) == 0 {
-		// External plugin manifests need platform downloads so installs can
+		// Non-core plugin manifests need platform downloads so installs can
 		// resolve checksum-pinned release assets. Treat missing downloads as
 		// drift even when the manifest version already matches the latest tag.
 		return false

--- a/cmd/wfctl/plugin_registry_sync.go
+++ b/cmd/wfctl/plugin_registry_sync.go
@@ -578,9 +578,10 @@ func isKnownArch(s string) bool {
 func downloadsMatchVersion(raw map[string]any, version string) bool {
 	downloadsRaw, _ := raw["downloads"].([]any)
 	if len(downloadsRaw) == 0 {
-		// No downloads → trivially match (registry handles empty download
-		// lists by leaving manifest version as-is).
-		return true
+		// External plugin manifests need platform downloads so installs can
+		// resolve checksum-pinned release assets. Treat missing downloads as
+		// drift even when the manifest version already matches the latest tag.
+		return false
 	}
 	wantSubstr := "/releases/download/v" + version + "/"
 	for _, dl := range downloadsRaw {

--- a/cmd/wfctl/plugin_registry_sync_test.go
+++ b/cmd/wfctl/plugin_registry_sync_test.go
@@ -76,10 +76,10 @@ func TestPluginRegistrySync_NormalizeRepo(t *testing.T) {
 // TestPluginRegistrySync_DownloadsMatchVersion verifies the downloads-vs-version
 // invariant the bash script enforces (sync-versions.sh:46-58).
 func TestPluginRegistrySync_DownloadsMatchVersion(t *testing.T) {
-	t.Run("empty downloads OK", func(t *testing.T) {
+	t.Run("empty downloads rejected", func(t *testing.T) {
 		raw := map[string]any{}
-		if !downloadsMatchVersion(raw, "1.2.3") {
-			t.Error("empty downloads should match (no URLs to verify)")
+		if downloadsMatchVersion(raw, "1.2.3") {
+			t.Error("empty downloads should be treated as drift so --fix can populate release assets")
 		}
 	})
 	t.Run("matching URLs OK", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat missing registry manifest downloads as drift in `wfctl plugin registry-sync`
- lets `--fix` populate checksum-pinned release assets even when the manifest version already matches latest
- updates the regression test for the empty-download case

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestPluginRegistrySync_(DownloadsMatchVersion|ApplyFixIncludesDownloadChecksums|ReleaseDownloadsUsesGitHubAPI)'`
- `GOWORK=off go test ./cmd/wfctl`
- `git diff --check`

This was found while adding the external `workflow-plugin-gitlab` registry entry: the manifest was already on `1.1.1`, but `registry-sync --fix` skipped download population because empty downloads were considered matching.