### PR TITLE
fix(wfctl): use interactive multiselect prompts

### DIFF
--- a/cmd/wfctl/internal/prompt/interrupt_test.go
+++ b/cmd/wfctl/internal/prompt/interrupt_test.go
@@ -42,6 +42,59 @@ func TestPromptModelsMarkCtrlCAsInterrupted(t *testing.T) {
 	}
 }
 
+func TestPromptModelsMarkEscAsInterrupted(t *testing.T) {
+	msg := tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape})
+
+	multiSelect := &multiSelectModel{}
+	multiSelect.Update(msg)
+	if !multiSelect.quit {
+		t.Fatal("multiSelectModel did not mark esc as quit")
+	}
+
+	tableMultiSelect := &tableMultiSelectModel{}
+	tableMultiSelect.Update(msg)
+	if !tableMultiSelect.quit {
+		t.Fatal("tableMultiSelectModel did not mark esc as quit")
+	}
+}
+
+func TestMultiSelectModelSelectedIndexes(t *testing.T) {
+	m := newMultiSelectModel("Pick", []Item{
+		{Label: "set", Preselected: true},
+		{Label: "unset"},
+	})
+
+	if got, want := m.selectedIndexes(), []int{0}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected indexes = %v, want %v", got, want)
+	}
+
+	m.Update(tea.KeyPressMsg(tea.Key{Text: "j", Code: 'j'}))
+	m.Update(tea.KeyPressMsg(tea.Key{Text: " ", Code: ' '}))
+	if got, want := m.selectedIndexes(), []int{0, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected indexes after toggle = %v, want %v", got, want)
+	}
+}
+
+func TestTableMultiSelectModelSelectedIndexes(t *testing.T) {
+	m := newTableMultiSelectModel("Pick",
+		[]TableColumn{{Title: "Secret", Width: 12}},
+		[]TableItem{
+			{Cells: []string{"A"}, Preselected: true},
+			{Cells: []string{"B"}},
+		},
+	)
+
+	if got, want := m.selectedIndexes(), []int{0}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected indexes = %v, want %v", got, want)
+	}
+
+	m.Update(tea.KeyPressMsg(tea.Key{Text: "j", Code: 'j'}))
+	m.Update(tea.KeyPressMsg(tea.Key{Text: " ", Code: ' '}))
+	if got, want := m.selectedIndexes(), []int{0, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected indexes after toggle = %v, want %v", got, want)
+	}
+}
+
 func TestParseIndexSelection(t *testing.T) {
 	got, err := parseIndexSelection("1,3-4,3", 5)
 	if err != nil {
@@ -72,6 +125,11 @@ func TestTableMultiSelectModelViewShowsRows(t *testing.T) {
 	for _, want := range []string{"Pick secrets", "Secret", "github:repo", "DIGITALOCEAN_TOKEN", "HOVER_PASSWORD", "[x]", "[ ]"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
+		}
+	}
+	for _, notWant := range []string{"Choose numbers/ranges", "Set "} {
+		if strings.Contains(view, notWant) {
+			t.Fatalf("view contains stale prompt text %q:\n%s", notWant, view)
 		}
 	}
 }

--- a/cmd/wfctl/internal/prompt/multiselect.go
+++ b/cmd/wfctl/internal/prompt/multiselect.go
@@ -1,9 +1,7 @@
 package prompt
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -20,26 +18,18 @@ func MultiSelect(title string, items []Item) ([]int, error) {
 		return nil, ErrNotInteractive
 	}
 	out, _ := outputWriter()
-	fmt.Fprintln(out, title)
-	defaults := make([]int, 0, len(items))
-	for i, item := range items {
-		mark := " "
-		if item.Preselected {
-			mark = "x"
-			defaults = append(defaults, i)
-		}
-		fmt.Fprintf(out, "  %d. [%s] %s\n", i+1, mark, item.Label)
-	}
-	fmt.Fprint(out, "Choose numbers/ranges (comma-separated, Enter for defaults): ")
-	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	finalModel, err := tea.NewProgram(newMultiSelectModel(title, items), tea.WithOutput(out)).Run()
 	if err != nil {
 		return nil, err
 	}
-	line = strings.TrimSpace(line)
-	if line == "" {
-		return defaults, nil
+	m, ok := finalModel.(*multiSelectModel)
+	if !ok {
+		return nil, fmt.Errorf("prompt: unexpected multiselect model %T", finalModel)
 	}
-	return parseIndexSelection(line, len(items))
+	if m.interrupted {
+		return nil, ErrInterrupted
+	}
+	return m.selectedIndexes(), nil
 }
 
 func parseIndexSelection(line string, count int) ([]int, error) {
@@ -77,11 +67,12 @@ func parseIndexSelection(line string, count int) ([]int, error) {
 }
 
 type multiSelectModel struct {
-	title    string
-	items    []Item
-	cursor   int
-	selected map[int]bool
-	quit     bool
+	title       string
+	items       []Item
+	cursor      int
+	selected    map[int]bool
+	quit        bool
+	interrupted bool
 }
 
 var (
@@ -89,13 +80,28 @@ var (
 	uncheckStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 )
 
+func newMultiSelectModel(title string, items []Item) *multiSelectModel {
+	selected := make(map[int]bool, len(items))
+	for i, item := range items {
+		if item.Preselected {
+			selected[i] = true
+		}
+	}
+	return &multiSelectModel{
+		title:    title,
+		items:    items,
+		selected: selected,
+	}
+}
+
 func (m *multiSelectModel) Init() tea.Cmd { return nil }
 
 func (m *multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyPressMsg); ok {
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c", "esc", "q":
 			m.quit = true
+			m.interrupted = true
 			return m, tea.Quit
 		case "up", "k":
 			if m.cursor > 0 {
@@ -105,7 +111,10 @@ func (m *multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.items)-1 {
 				m.cursor++
 			}
-		case " ":
+		case " ", "space":
+			if len(m.items) == 0 {
+				return m, nil
+			}
 			if m.selected[m.cursor] {
 				delete(m.selected, m.cursor)
 			} else {
@@ -116,6 +125,16 @@ func (m *multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m *multiSelectModel) selectedIndexes() []int {
+	selected := make([]int, 0, len(m.selected))
+	for i := range m.items {
+		if m.selected[i] {
+			selected = append(selected, i)
+		}
+	}
+	return selected
 }
 
 func (m *multiSelectModel) View() tea.View {
@@ -133,6 +152,6 @@ func (m *multiSelectModel) View() tea.View {
 		}
 		b.WriteString(cursor + check + " " + it.Label + "\n")
 	}
-	b.WriteString("\n(space to toggle, enter to confirm)\n")
+	b.WriteString("\n(up/down move, space toggles, enter confirms, esc cancels)\n")
 	return tea.NewView(b.String())
 }

--- a/cmd/wfctl/internal/prompt/table_multiselect.go
+++ b/cmd/wfctl/internal/prompt/table_multiselect.go
@@ -1,13 +1,13 @@
 package prompt
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 )
+
+const tableSelectColumnWidth = 4
 
 // TableColumn describes a column in a table-based prompt.
 type TableColumn struct {
@@ -31,33 +31,28 @@ func TableMultiSelect(title string, columns []TableColumn, items []TableItem) ([
 		return nil, ErrNotInteractive
 	}
 	out, _ := outputWriter()
-	m := newTableMultiSelectModel(title, columns, items)
-	fmt.Fprint(out, m.View().Content)
-	fmt.Fprint(out, "Choose numbers/ranges (comma-separated, Enter for defaults): ")
-	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	finalModel, err := tea.NewProgram(newTableMultiSelectModel(title, columns, items), tea.WithOutput(out)).Run()
 	if err != nil {
 		return nil, err
 	}
-	line = strings.TrimSpace(line)
-	if line == "" {
-		var defaults []int
-		for i, item := range items {
-			if item.Preselected {
-				defaults = append(defaults, i)
-			}
-		}
-		return defaults, nil
+	m, ok := finalModel.(*tableMultiSelectModel)
+	if !ok {
+		return nil, fmt.Errorf("prompt: unexpected table multiselect model %T", finalModel)
 	}
-	return parseIndexSelection(line, len(items))
+	if m.interrupted {
+		return nil, ErrInterrupted
+	}
+	return m.selectedIndexes(), nil
 }
 
 type tableMultiSelectModel struct {
-	title    string
-	columns  []TableColumn
-	items    []TableItem
-	selected map[int]bool
-	cursor   int
-	quit     bool
+	title       string
+	columns     []TableColumn
+	items       []TableItem
+	selected    map[int]bool
+	cursor      int
+	quit        bool
+	interrupted bool
 }
 
 func newTableMultiSelectModel(title string, columns []TableColumn, items []TableItem) *tableMultiSelectModel {
@@ -81,8 +76,9 @@ func (m *tableMultiSelectModel) Init() tea.Cmd { return nil }
 func (m *tableMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyPressMsg); ok {
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c", "esc", "q":
 			m.quit = true
+			m.interrupted = true
 			return m, tea.Quit
 		case "up", "k":
 			if m.cursor > 0 {
@@ -92,7 +88,10 @@ func (m *tableMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.items)-1 {
 				m.cursor++
 			}
-		case " ":
+		case " ", "space":
+			if len(m.items) == 0 {
+				return m, nil
+			}
 			if m.selected[m.cursor] {
 				delete(m.selected, m.cursor)
 			} else {
@@ -104,6 +103,16 @@ func (m *tableMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m *tableMultiSelectModel) selectedIndexes() []int {
+	selected := make([]int, 0, len(m.selected))
+	for i := range m.items {
+		if m.selected[i] {
+			selected = append(selected, i)
+		}
+	}
+	return selected
 }
 
 func (m *tableMultiSelectModel) View() tea.View {
@@ -124,7 +133,7 @@ func (m *tableMultiSelectModel) View() tea.View {
 			mark = "[x]"
 		}
 		b.WriteString(cursor)
-		b.WriteString(padTableCell(mark, 3))
+		b.WriteString(padTableCell(mark, tableSelectColumnWidth))
 		for colIdx, col := range m.columns {
 			cell := ""
 			if colIdx < len(item.Cells) {
@@ -135,14 +144,14 @@ func (m *tableMultiSelectModel) View() tea.View {
 		}
 		b.WriteString("\n")
 	}
-	b.WriteString("\n\n(space to toggle, enter to confirm)\n")
+	b.WriteString("\n\n(up/down move, space toggles, enter confirms, esc cancels)\n")
 	return tea.NewView(b.String())
 }
 
 func (m *tableMultiSelectModel) headerRow() string {
 	var b strings.Builder
 	b.WriteString("  ")
-	b.WriteString(padTableCell("Set", 3))
+	b.WriteString(padTableCell("Pick", tableSelectColumnWidth))
 	for _, col := range m.columns {
 		b.WriteString(" ")
 		b.WriteString(padTableCell(col.Title, col.Width))
@@ -153,7 +162,7 @@ func (m *tableMultiSelectModel) headerRow() string {
 func (m *tableMultiSelectModel) separatorRow() string {
 	var b strings.Builder
 	b.WriteString("  ")
-	b.WriteString(strings.Repeat("-", 3))
+	b.WriteString(strings.Repeat("-", tableSelectColumnWidth))
 	for _, col := range m.columns {
 		b.WriteString(" ")
 		b.WriteString(strings.Repeat("-", max(col.Width, 1)))


### PR DESCRIPTION
## Summary
- Run `MultiSelect` and `TableMultiSelect` through their Bubble Tea models instead of printing a static view plus numeric input.
- Return `prompt.ErrInterrupted` for Escape/Ctrl+C/q cancel paths.
- Handle Bubble Tea v2's `space` key string for toggling selections.
- Rename the table selection column from `Set` to `Pick` and remove stale numeric prompt wording from the view.

## Verification
- `GOWORK=off go test ./cmd/wfctl/internal/prompt ./cmd/wfctl -count=1`