### PR TITLE
fix(wfctl): generate Go docs for plugin packages

### DIFF
--- a/cmd/wfctl/docs_generate.go
+++ b/cmd/wfctl/docs_generate.go
@@ -257,9 +257,12 @@ func goListAPIPackages(ctx context.Context, source string) ([]goListPackage, err
 	}
 	dec := json.NewDecoder(bytes.NewReader(out))
 	var packages []goListPackage
-	for dec.More() {
+	for {
 		var pkg goListPackage
 		if err := dec.Decode(&pkg); err != nil {
+			if err == io.EOF {
+				break
+			}
 			return nil, err
 		}
 		if pkg.Name == "main" || len(pkg.GoFiles) == 0 {

--- a/cmd/wfctl/docs_generate.go
+++ b/cmd/wfctl/docs_generate.go
@@ -245,6 +245,31 @@ func goListAPIPackage(ctx context.Context, source, modulePath, pkgRel string) (g
 	return pkg, nil
 }
 
+func goListAPIPackages(ctx context.Context, source string) ([]goListPackage, error) {
+	cmd := exec.CommandContext(ctx, "go", "list", "-json", "./...") // #nosec G204 -- fixed go command.
+	cmd.Dir = source
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	var packages []goListPackage
+	for dec.More() {
+		var pkg goListPackage
+		if err := dec.Decode(&pkg); err != nil {
+			return nil, err
+		}
+		if pkg.Name == "main" || len(pkg.GoFiles) == 0 {
+			continue
+		}
+		packages = append(packages, pkg)
+	}
+	return packages, nil
+}
+
 func parseDocPackage(listPkg goListPackage) (*doc.Package, *token.FileSet, error) {
 	fset := token.NewFileSet()
 	files := make([]*ast.File, 0, len(listPkg.GoFiles))
@@ -403,12 +428,12 @@ func renderRegistryPluginAPIPackages(ctx context.Context, opts docsGenerateAPIOp
 			warnings = append(warnings, fmt.Sprintf("%s %s skipped: %v", manifest.Name, manifest.Version, err))
 			continue
 		}
-		docPkg, err := renderPluginAPIPackage(ctx, checkout, modulePath, manifest)
+		docPkgs, err := renderPluginAPIPackages(ctx, checkout, modulePath, manifest)
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("%s %s skipped: %v", manifest.Name, manifest.Version, err))
 			continue
 		}
-		rendered = append(rendered, docPkg)
+		rendered = append(rendered, docPkgs...)
 	}
 	return rendered, warnings, nil
 }
@@ -481,38 +506,81 @@ func checkoutDocsPluginRepo(ctx context.Context, manifest *RegistryManifest, cac
 	return dest, nil
 }
 
-func renderPluginAPIPackage(ctx context.Context, checkout, modulePath string, manifest *RegistryManifest) (renderedDocsPackage, error) {
-	listPkg, err := goListAPIPackage(ctx, checkout, modulePath, ".")
+func renderPluginAPIPackages(ctx context.Context, checkout, modulePath string, manifest *RegistryManifest) ([]renderedDocsPackage, error) {
+	listPkgs, err := goListAPIPackages(ctx, checkout)
 	if err != nil {
-		return renderedDocsPackage{}, err
+		return nil, err
 	}
-	docPkg, fset, err := parseDocPackage(listPkg)
-	if err != nil {
-		return renderedDocsPackage{}, err
-	}
+	sortPluginAPIPackages(listPkgs, modulePath)
 	slug, err := safeDocsPluginSlug(manifest.Name)
 	if err != nil {
-		return renderedDocsPackage{}, err
+		return nil, err
 	}
-	route := "plugins/" + slug + "/latest/index.md"
-	synopsis := docPkg.Synopsis(docPkg.Doc)
-	if synopsis == "" {
-		synopsis = listPkg.Doc
+	rendered := make([]renderedDocsPackage, 0, len(listPkgs))
+	for i, listPkg := range listPkgs {
+		docPkg, fset, err := parseDocPackage(listPkg)
+		if err != nil {
+			return nil, err
+		}
+		pkgRel := strings.TrimPrefix(listPkg.ImportPath, strings.TrimRight(modulePath, "/"))
+		pkgRel = strings.Trim(pkgRel, "/")
+		route := pluginAPIDocRoute(slug, pkgRel, i == 0)
+		synopsis := docPkg.Synopsis(docPkg.Doc)
+		if synopsis == "" {
+			synopsis = listPkg.Doc
+		}
+		meta := docsAPIPackageMeta{
+			Subject:          "plugin",
+			Name:             manifest.Name,
+			ImportPath:       listPkg.ImportPath,
+			Version:          manifest.Version,
+			GenerationSource: "release",
+			Repository:       manifest.Repository,
+			Path:             route,
+			Synopsis:         synopsis,
+		}
+		rendered = append(rendered, renderedDocsPackage{
+			Meta: meta,
+			Doc:  renderPackageMarkdown(fset, docPkg, meta, pluginSourceLink(manifest.Repository, manifest.Version, pkgRel), nil),
+		})
 	}
-	meta := docsAPIPackageMeta{
-		Subject:          "plugin",
-		Name:             manifest.Name,
-		ImportPath:       listPkg.ImportPath,
-		Version:          manifest.Version,
-		GenerationSource: "release",
-		Repository:       manifest.Repository,
-		Path:             route,
-		Synopsis:         synopsis,
+	if len(rendered) == 0 {
+		return nil, fmt.Errorf("no non-command Go packages found")
 	}
-	return renderedDocsPackage{
-		Meta: meta,
-		Doc:  renderPackageMarkdown(fset, docPkg, meta, pluginSourceLink(manifest.Repository, manifest.Version), nil),
-	}, nil
+	return rendered, nil
+}
+
+func sortPluginAPIPackages(packages []goListPackage, modulePath string) {
+	modulePath = strings.TrimRight(modulePath, "/")
+	sort.SliceStable(packages, func(i, j int) bool {
+		leftRank := pluginAPIPackageRank(packages[i], modulePath)
+		rightRank := pluginAPIPackageRank(packages[j], modulePath)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return packages[i].ImportPath < packages[j].ImportPath
+	})
+}
+
+func pluginAPIPackageRank(pkg goListPackage, modulePath string) int {
+	switch pkg.ImportPath {
+	case modulePath:
+		return 0
+	case modulePath + "/internal":
+		return 1
+	default:
+		if strings.TrimSpace(pkg.Doc) != "" {
+			return 2
+		}
+		return 3
+	}
+}
+
+func pluginAPIDocRoute(slug, pkgRel string, primary bool) string {
+	if primary {
+		return "plugins/" + slug + "/latest/index.md"
+	}
+	return "plugins/" + slug + "/latest/" + strings.Trim(pkgRel, "/") + "/index.md"
 }
 
 func readGoModulePath(path string) (string, error) {
@@ -718,12 +786,16 @@ func compareDocsVersions(left, right string) int {
 	return strings.Compare(left, right)
 }
 
-func pluginSourceLink(repository, version string) string {
+func pluginSourceLink(repository, version, pkgRel string) string {
 	repository = strings.TrimSuffix(strings.TrimSpace(repository), ".git")
 	if repository == "" {
 		return ""
 	}
-	return repository + "/tree/" + version
+	link := repository + "/tree/" + version
+	if pkgRel != "" && pkgRel != "." {
+		link += "/" + strings.Trim(pkgRel, "/")
+	}
+	return link
 }
 
 func docsContainsString(values []string, want string) bool {

--- a/cmd/wfctl/docs_generate_test.go
+++ b/cmd/wfctl/docs_generate_test.go
@@ -196,6 +196,14 @@ func TestDocsGenerateRegistryPlugins(t *testing.T) {
 			t.Fatalf("generated plugin doc missing %q:\n%s", want, doc)
 		}
 	}
+	internalDocPath := filepath.Join(outDir, "plugins", "alpha", "latest", "internal", "index.md")
+	rawInternalDoc, err := os.ReadFile(internalDocPath)
+	if err != nil {
+		t.Fatalf("read generated plugin internal doc: %v", err)
+	}
+	if !strings.Contains(string(rawInternalDoc), "Import path: `github.com/GoCodeAlone/workflow-plugin-alpha/internal`") {
+		t.Fatalf("generated internal plugin doc has wrong import path:\n%s", rawInternalDoc)
+	}
 
 	rawMeta, err := os.ReadFile(filepath.Join(outDir, "versions.json"))
 	if err != nil {
@@ -208,8 +216,15 @@ func TestDocsGenerateRegistryPlugins(t *testing.T) {
 	if got := meta.Versions["plugins/alpha"]; len(got) != 1 || got[0] != "v0.1.0" {
 		t.Fatalf("plugins/alpha versions = %v, want [v0.1.0]", got)
 	}
-	if len(meta.Packages) != 1 || meta.Packages[0].Path != "plugins/alpha/latest/index.md" {
-		t.Fatalf("packages = %+v, want generated alpha plugin route", meta.Packages)
+	if len(meta.Packages) != 2 {
+		t.Fatalf("packages = %+v, want root and internal plugin docs", meta.Packages)
+	}
+	paths := map[string]bool{}
+	for _, pkg := range meta.Packages {
+		paths[pkg.Path] = true
+	}
+	if !paths["plugins/alpha/latest/index.md"] || !paths["plugins/alpha/latest/internal/index.md"] {
+		t.Fatalf("packages = %+v, want generated alpha plugin routes", meta.Packages)
 	}
 	if meta.Packages[0].GenerationSource != "release" {
 		t.Fatalf("plugin generationSource = %q, want release", meta.Packages[0].GenerationSource)
@@ -222,6 +237,72 @@ func TestDocsGenerateRegistryPlugins(t *testing.T) {
 		if !strings.Contains(joinedWarnings, want) {
 			t.Fatalf("warnings missing %q:\n%s", want, joinedWarnings)
 		}
+	}
+}
+
+func TestDocsGenerateRegistryPluginUsesInternalPackageWhenRootHasNoLibrary(t *testing.T) {
+	pluginRepo := createDocsInternalOnlyPluginRepo(t, "github.com/GoCodeAlone/workflow-plugin-provider", "provider", "v0.2.0")
+	registryPath := filepath.Join(t.TempDir(), "registry.json")
+	registry := `{
+  "plugins": [
+    {
+      "name": "workflow-plugin-provider",
+      "version": "v0.2.0",
+      "repository": "https://github.com/GoCodeAlone/workflow-plugin-provider",
+      "source": ` + strconvQuote(pluginRepo) + `
+    }
+  ]
+}`
+	if err := os.WriteFile(registryPath, []byte(registry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	_, err := captureStdout(t, func() error {
+		return runDocsGenerate([]string{
+			"--source", ".",
+			"--out", outDir,
+			"--module", "github.com/GoCodeAlone/workflow",
+			"--version", "v0.75.0",
+			"--registry", registryPath,
+			"--cache-dir", filepath.Join(t.TempDir(), "cache"),
+			"--subjects", "plugins",
+		})
+	})
+	if err != nil {
+		t.Fatalf("docs generate registry plugins: %v", err)
+	}
+
+	docPath := filepath.Join(outDir, "plugins", "provider", "latest", "index.md")
+	rawDoc, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read generated provider doc: %v", err)
+	}
+	doc := string(rawDoc)
+	for _, want := range []string{
+		"# package internal",
+		"Import path: `github.com/GoCodeAlone/workflow-plugin-provider/internal`",
+		"Source: https://github.com/GoCodeAlone/workflow-plugin-provider/tree/v0.2.0/internal",
+		"ProviderClient configures the provider integration.",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("generated internal provider doc missing %q:\n%s", want, doc)
+		}
+	}
+
+	rawMeta, err := os.ReadFile(filepath.Join(outDir, "versions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta docsAPIMetadata
+	if err := json.Unmarshal(rawMeta, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if len(meta.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", meta.Warnings)
+	}
+	if len(meta.Packages) != 1 || meta.Packages[0].Path != "plugins/provider/latest/index.md" {
+		t.Fatalf("packages = %+v, want provider internal package at stable plugin route", meta.Packages)
 	}
 }
 
@@ -341,6 +422,32 @@ func createDocsPluginRepo(t *testing.T, modulePath, packageName, tag string) str
 	}
 	write("go.mod", "module "+modulePath+"\n\ngo 1.26\n")
 	write(packageName+".go", "package "+packageName+"\n\n// PluginName returns the fixture plugin name.\nfunc PluginName() string { return "+strconvQuote(packageName)+" }\n")
+	write("internal/doc.go", "package internal\n\n// InternalClient describes the plugin's internal integration surface.\ntype InternalClient struct{}\n")
+	runDocsTestGit(t, dir, "init")
+	runDocsTestGit(t, dir, "config", "user.email", "docs@example.test")
+	runDocsTestGit(t, dir, "config", "user.name", "Docs Test")
+	runDocsTestGit(t, dir, "add", ".")
+	runDocsTestGit(t, dir, "commit", "-m", "initial")
+	runDocsTestGit(t, dir, "tag", tag)
+	return dir
+}
+
+func createDocsInternalOnlyPluginRepo(t *testing.T, modulePath, packageName, tag string) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module "+modulePath+"\n\ngo 1.26\n")
+	write("cmd/"+packageName+"/main.go", "package main\n\nfunc main() {}\n")
+	write("internal/doc.go", "package internal\n\n// ProviderClient configures the provider integration.\ntype ProviderClient struct{}\n")
 	runDocsTestGit(t, dir, "init")
 	runDocsTestGit(t, dir, "config", "user.email", "docs@example.test")
 	runDocsTestGit(t, dir, "config", "user.name", "Docs Test")


### PR DESCRIPTION
## Summary
- enumerate non-command Go packages in external plugin repos during `wfctl docs generate`
- keep each plugin's primary Go API page at `plugins/<slug>/latest/index.md`, even when the documented package lives under `internal/`
- add regression coverage for multi-package plugins and provider-style repos with no root library package

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestDocsGenerate' -count=1`\n- `GOWORK=off go test ./cmd/wfctl -count=1`\n- `GOWORK=off go build -o /tmp/wfctl-external-plugin-go-docs ./cmd/wfctl`\n- real registry check generated Cloudflare, Namecheap, and GitLab plugin Go docs at stable routes\n- `GOWORK=off go test ./...`