### PR TITLE
fix(wfctl): normalize prompt cancellation

### DIFF
--- a/cmd/wfctl/confirm.go
+++ b/cmd/wfctl/confirm.go
@@ -18,7 +18,7 @@ func confirmAction(question string, def bool, out io.Writer, confirm func(string
 	}
 	ok, err := confirm(question, def)
 	if err != nil {
-		if isPromptCancelled(err) || errors.Is(err, prompt.ErrNotInteractive) {
+		if isPromptCancelled(err) {
 			if out != nil {
 				fmt.Fprintln(out, "Cancelled.")
 			}

--- a/cmd/wfctl/confirm.go
+++ b/cmd/wfctl/confirm.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
+)
+
+func isPromptCancelled(err error) bool {
+	return errors.Is(err, prompt.ErrCancelled)
+}
+
+func confirmAction(question string, def bool, out io.Writer, confirm func(string, bool) (bool, error)) (bool, error) {
+	if confirm == nil {
+		confirm = prompt.Confirm
+	}
+	ok, err := confirm(question, def)
+	if err != nil {
+		if isPromptCancelled(err) || errors.Is(err, prompt.ErrNotInteractive) {
+			if out != nil {
+				fmt.Fprintln(out, "Cancelled.")
+			}
+			return false, nil
+		}
+		return false, err
+	}
+	if !ok && out != nil {
+		fmt.Fprintln(out, "Cancelled.")
+	}
+	return ok, nil
+}

--- a/cmd/wfctl/confirm_test.go
+++ b/cmd/wfctl/confirm_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
+)
+
+func TestConfirmActionTreatsPromptCancelAsCleanAbort(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmAction("Proceed?", true, &out, func(string, bool) (bool, error) {
+		return false, prompt.ErrCancelled
+	})
+	if err != nil {
+		t.Fatalf("confirmAction returned error for prompt cancel: %v", err)
+	}
+	if ok {
+		t.Fatal("confirmAction should not approve a cancelled prompt")
+	}
+	if got := out.String(); !strings.Contains(got, "Cancelled.") {
+		t.Fatalf("cancel output = %q, want Cancelled.", got)
+	}
+}
+
+func TestConfirmActionTreatsNonInteractiveAsCleanAbort(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmAction("Proceed?", false, &out, func(string, bool) (bool, error) {
+		return false, prompt.ErrNotInteractive
+	})
+	if err != nil {
+		t.Fatalf("confirmAction returned error for non-interactive prompt: %v", err)
+	}
+	if ok {
+		t.Fatal("confirmAction should not approve a non-interactive prompt")
+	}
+	if got := out.String(); !strings.Contains(got, "Cancelled.") {
+		t.Fatalf("cancel output = %q, want Cancelled.", got)
+	}
+}
+
+func TestConfirmActionPropagatesUnexpectedPromptError(t *testing.T) {
+	want := errors.New("terminal unavailable")
+	var out bytes.Buffer
+	ok, err := confirmAction("Proceed?", false, &out, func(string, bool) (bool, error) {
+		return false, want
+	})
+	if ok {
+		t.Fatal("confirmAction should not approve on prompt error")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("confirmAction error = %v, want %v", err, want)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected output on prompt error: %q", out.String())
+	}
+}
+
+func TestConfirmActionTreatsNoAnswerAsCleanAbort(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmAction("Proceed?", false, &out, func(string, bool) (bool, error) {
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("confirmAction returned error for no answer: %v", err)
+	}
+	if ok {
+		t.Fatal("confirmAction should not approve a no answer")
+	}
+	if got := out.String(); !strings.Contains(got, "Cancelled.") {
+		t.Fatalf("cancel output = %q, want Cancelled.", got)
+	}
+}
+
+func TestConfirmActionReturnsPromptAnswer(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmAction("Proceed?", true, &out, func(question string, def bool) (bool, error) {
+		if question != "Proceed?" || !def {
+			t.Fatalf("question=%q def=%v", question, def)
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("confirmAction: %v", err)
+	}
+	if !ok {
+		t.Fatal("confirmAction should return true when prompt approves")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected output on approval: %q", out.String())
+	}
+}

--- a/cmd/wfctl/confirm_test.go
+++ b/cmd/wfctl/confirm_test.go
@@ -25,19 +25,19 @@ func TestConfirmActionTreatsPromptCancelAsCleanAbort(t *testing.T) {
 	}
 }
 
-func TestConfirmActionTreatsNonInteractiveAsCleanAbort(t *testing.T) {
+func TestConfirmActionPropagatesNonInteractivePromptError(t *testing.T) {
 	var out bytes.Buffer
 	ok, err := confirmAction("Proceed?", false, &out, func(string, bool) (bool, error) {
 		return false, prompt.ErrNotInteractive
 	})
-	if err != nil {
-		t.Fatalf("confirmAction returned error for non-interactive prompt: %v", err)
-	}
 	if ok {
 		t.Fatal("confirmAction should not approve a non-interactive prompt")
 	}
-	if got := out.String(); !strings.Contains(got, "Cancelled.") {
-		t.Fatalf("cancel output = %q, want Cancelled.", got)
+	if !errors.Is(err, prompt.ErrNotInteractive) {
+		t.Fatalf("confirmAction error = %v, want ErrNotInteractive", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected output on non-interactive error: %q", out.String())
 	}
 }
 

--- a/cmd/wfctl/deploy.go
+++ b/cmd/wfctl/deploy.go
@@ -918,7 +918,7 @@ Options:
 	}
 
 	if !*yes {
-		ok, err := confirmAction("Apply these changes?", false, os.Stdout, nil)
+		ok, err := confirmAction("Apply these changes?", false, os.Stderr, nil)
 		if err != nil {
 			return fmt.Errorf("confirm deployment: %w", err)
 		}

--- a/cmd/wfctl/deploy.go
+++ b/cmd/wfctl/deploy.go
@@ -918,10 +918,12 @@ Options:
 	}
 
 	if !*yes {
-		fmt.Printf("Apply these changes? [y/N] ")
-		var answer string
-		if _, scanErr := fmt.Scanln(&answer); scanErr != nil || (answer != "y" && answer != "Y" && answer != "yes") {
-			return fmt.Errorf("deployment cancelled")
+		ok, err := confirmAction("Apply these changes?", false, os.Stdout, nil)
+		if err != nil {
+			return fmt.Errorf("confirm deployment: %w", err)
+		}
+		if !ok {
+			return nil
 		}
 	}
 	if err := runDirectMigrationDeployGuard(cfg, *target); err != nil {

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -1398,13 +1398,11 @@ func runInfraApply(args []string) error {
 	}
 
 	if !*autoApprove {
-		fmt.Printf("Apply infrastructure changes from %s? [y/N]: ", cfgFile)
-		var answer string
-		if _, err := fmt.Scanln(&answer); err != nil {
-			return fmt.Errorf("reading input: %w", err)
+		ok, err := confirmAction("Apply infrastructure changes from "+cfgFile+"?", false, os.Stdout, nil)
+		if err != nil {
+			return fmt.Errorf("confirm apply: %w", err)
 		}
-		if !strings.EqualFold(answer, "y") && !strings.EqualFold(answer, "yes") {
-			fmt.Println("Cancelled.")
+		if !ok {
 			return nil
 		}
 	}
@@ -1792,13 +1790,11 @@ func runInfraDestroy(args []string) error {
 	}
 
 	if !*autoApprove {
-		fmt.Printf("DESTROY all infrastructure defined in %s? This cannot be undone. [y/N]: ", cfgFile)
-		var answer string
-		if _, err := fmt.Scanln(&answer); err != nil {
-			return fmt.Errorf("reading input: %w", err)
+		ok, err := confirmAction("DESTROY all infrastructure defined in "+cfgFile+"? This cannot be undone.", false, os.Stdout, nil)
+		if err != nil {
+			return fmt.Errorf("confirm destroy: %w", err)
 		}
-		if !strings.EqualFold(answer, "y") && !strings.EqualFold(answer, "yes") {
-			fmt.Println("Cancelled.")
+		if !ok {
 			return nil
 		}
 	}

--- a/cmd/wfctl/infra.go
+++ b/cmd/wfctl/infra.go
@@ -1398,7 +1398,7 @@ func runInfraApply(args []string) error {
 	}
 
 	if !*autoApprove {
-		ok, err := confirmAction("Apply infrastructure changes from "+cfgFile+"?", false, os.Stdout, nil)
+		ok, err := confirmAction("Apply infrastructure changes from "+cfgFile+"?", false, os.Stderr, nil)
 		if err != nil {
 			return fmt.Errorf("confirm apply: %w", err)
 		}
@@ -1790,7 +1790,7 @@ func runInfraDestroy(args []string) error {
 	}
 
 	if !*autoApprove {
-		ok, err := confirmAction("DESTROY all infrastructure defined in "+cfgFile+"? This cannot be undone.", false, os.Stdout, nil)
+		ok, err := confirmAction("DESTROY all infrastructure defined in "+cfgFile+"? This cannot be undone.", false, os.Stderr, nil)
 		if err != nil {
 			return fmt.Errorf("confirm destroy: %w", err)
 		}

--- a/cmd/wfctl/infra_derive.go
+++ b/cmd/wfctl/infra_derive.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/config/yamledit"
 	"github.com/GoCodeAlone/workflow/iac/derive"
@@ -167,30 +168,14 @@ func resolveDeriveProviderInteractive(cfg *config.WorkflowConfig, provider, envN
 	case 1:
 		return choices[0], nil
 	}
-	if nonInteractive || !stdinIsTerminal() {
+	if nonInteractive || !prompt.CanPrompt() {
 		return "", fmt.Errorf("multiple iac providers available %v; pass --provider", choices)
 	}
-	fmt.Fprintln(os.Stderr, "Select IaC provider for derived modules:")
-	for i, choice := range choices {
-		fmt.Fprintf(os.Stderr, "  %d) %s\n", i+1, choice)
-	}
-	fmt.Fprint(os.Stderr, "Provider: ")
-	var selected int
-	if _, err := fmt.Fscan(os.Stdin, &selected); err != nil {
-		return "", fmt.Errorf("read provider selection: %w", err)
-	}
-	if selected < 1 || selected > len(choices) {
-		return "", fmt.Errorf("invalid provider selection %d", selected)
-	}
-	return choices[selected-1], nil
-}
-
-func stdinIsTerminal() bool {
-	info, err := os.Stdin.Stat()
+	selected, err := prompt.Select("Select IaC provider for derived modules", choices)
 	if err != nil {
-		return false
+		return "", err
 	}
-	return info.Mode()&os.ModeCharDevice != 0
+	return choices[selected], nil
 }
 
 func (a *typedIaCAdapter) RequirementMapper() pb.IaCProviderRequirementMapperClient {

--- a/cmd/wfctl/infra_prune.go
+++ b/cmd/wfctl/infra_prune.go
@@ -233,11 +233,12 @@ func runInfraPrune(args []string, provider pruneProvider, w io.Writer) int {
 	}
 
 	if !nonInteractive {
-		fmt.Fprintf(w, "\nProceed? (y/N): ")
-		var ans string
-		_, _ = fmt.Scanln(&ans)
-		if ans != "y" && ans != "Y" {
-			fmt.Fprintln(w, "Aborted.")
+		ok, err := confirmAction("Proceed?", false, w, nil)
+		if err != nil {
+			fmt.Fprintf(w, "prune: confirm: %v\n", err)
+			return 1
+		}
+		if !ok {
 			return 0
 		}
 	}

--- a/cmd/wfctl/infra_rotate_and_prune.go
+++ b/cmd/wfctl/infra_rotate_and_prune.go
@@ -596,11 +596,12 @@ func runPreRotationPrune(ctx context.Context, provider pruneProvider, resourceTy
 	}
 
 	if !nonInteractive {
-		fmt.Fprintf(w, "\nProceed with pre-rotation prune? (y/N): ")
-		var ans string
-		_, _ = fmt.Scanln(&ans)
-		if ans != "y" && ans != "Y" {
-			fmt.Fprintln(w, "Aborted (no rotation attempted; no state mutated).")
+		ok, err := confirmAction("Proceed with pre-rotation prune?", false, w, nil)
+		if err != nil {
+			fmt.Fprintf(w, "rotate-and-prune: confirm: %v\n", err)
+			return 1
+		}
+		if !ok {
 			return 1
 		}
 	}

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -253,6 +253,10 @@ func main() {
 		}
 		if entry := registry.LookupCLICommand(cmd); entry != nil {
 			if err := DispatchCLICommand(entry, os.Args[1:]); err != nil {
+				if isPromptCancelled(err) {
+					fmt.Fprintln(os.Stderr, "Cancelled.")
+					os.Exit(0)
+				}
 				fmt.Fprintf(os.Stderr, "error: %v\n", err) //nolint:gosec // G705
 				os.Exit(1)
 			}
@@ -277,6 +281,10 @@ func main() {
 	if dispatchErr != nil {
 		// If the user requested help, exit cleanly without printing the engine error.
 		if isHelpRequested(dispatchErr) {
+			os.Exit(0)
+		}
+		if isPromptCancelled(dispatchErr) {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
 			os.Exit(0)
 		}
 		// The handler already printed routing errors (unknown/missing command).

--- a/cmd/wfctl/main_test.go
+++ b/cmd/wfctl/main_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/schema"
 )
 
@@ -49,6 +50,21 @@ func TestHelpFlagDoesNotLeakEngineError(t *testing.T) {
 	wrapped := fmt.Errorf("pipeline failed: %w", flag.ErrHelp)
 	if !isHelpRequested(wrapped) {
 		t.Error("isHelpRequested should return true for wrapped flag.ErrHelp")
+	}
+}
+
+func TestIsPromptCancelledUnwrapsPromptCancellation(t *testing.T) {
+	if !isPromptCancelled(prompt.ErrCancelled) {
+		t.Fatal("prompt.ErrCancelled should be classified as user cancellation")
+	}
+	if !isPromptCancelled(fmt.Errorf("wrapped: %w", prompt.ErrCancelled)) {
+		t.Fatal("wrapped prompt.ErrCancelled should be classified as user cancellation")
+	}
+	if isPromptCancelled(flag.ErrHelp) {
+		t.Fatal("flag.ErrHelp must not be classified as prompt cancellation")
+	}
+	if isPromptCancelled(nil) {
+		t.Fatal("nil must not be classified as prompt cancellation")
 	}
 }
 

--- a/cmd/wfctl/secrets_detect.go
+++ b/cmd/wfctl/secrets_detect.go
@@ -15,10 +15,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/secrets"
 	"github.com/mattn/go-isatty"
-	"golang.org/x/term"
 )
 
 // secretFieldPatterns are field name substrings that indicate a secret value.
@@ -205,17 +205,11 @@ Options:
 		}
 		secretValue = strings.TrimRight(string(b), "\n")
 	case isatty.IsTerminal(os.Stdin.Fd()): // interactive: masked prompt
-		fmt.Fprintf(os.Stderr, "Value for %s: ", name)
-		fd, err := stdinFileDescriptor()
+		value, err := prompt.Input("Value for "+name, true)
 		if err != nil {
 			return err
 		}
-		b, err := term.ReadPassword(fd)
-		if err != nil {
-			return fmt.Errorf("read password: %w", err)
-		}
-		fmt.Fprintln(os.Stderr)
-		secretValue = string(b)
+		secretValue = value
 	default:
 		return fmt.Errorf("must provide --value, --from-file, or run interactively (TTY)")
 	}
@@ -511,15 +505,6 @@ func parseGitHubOrgVisibility(s string) (secrets.GitHubOrgVisibility, error) {
 	default:
 		return "", fmt.Errorf("invalid visibility %q (must be all|selected|private)", s)
 	}
-}
-
-func stdinFileDescriptor() (int, error) {
-	fd := os.Stdin.Fd()
-	maxInt := int(^uint(0) >> 1)
-	if fd > uintptr(maxInt) {
-		return 0, fmt.Errorf("stdin file descriptor %d exceeds supported int range", fd)
-	}
-	return int(fd), nil //nolint:gosec // fd is range-checked before conversion.
 }
 
 // secretListJSONEntry is the JSON output shape for a single secret in --json mode.

--- a/cmd/wfctl/secrets_detect.go
+++ b/cmd/wfctl/secrets_detect.go
@@ -18,7 +18,6 @@ import (
 	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/config"
 	"github.com/GoCodeAlone/workflow/secrets"
-	"github.com/mattn/go-isatty"
 )
 
 // secretFieldPatterns are field name substrings that indicate a secret value.
@@ -204,7 +203,7 @@ Options:
 			return fmt.Errorf("read secret value: %w", err)
 		}
 		secretValue = strings.TrimRight(string(b), "\n")
-	case isatty.IsTerminal(os.Stdin.Fd()): // interactive: masked prompt
+	case prompt.CanPrompt(): // interactive: masked prompt
 		value, err := prompt.Input("Value for "+name, true)
 		if err != nil {
 			return err

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2348,7 +2348,7 @@ wfctl ci generate [options]
 | `--phase-config-alias` | _(relativized real path)_ | Logical repo-relative path for the prereq config in generated CI steps |
 | `--interactive` | `false` | Force the interactive wizard even when `--platform` is set |
 
-When `--platform` is absent and stdin is a TTY, an interactive wizard runs to select the platform and other choices. When stdin is not a TTY and `--platform` is also absent, the command fails with a clear error.
+When `--platform` is absent and stdin is a TTY, an interactive wizard runs to select the platform and other choices. Press `Esc` or `Ctrl+C` to cancel the prompt cleanly. When stdin is not a TTY and `--platform` is also absent, the command fails with a clear error.
 
 **Examples:**
 
@@ -2571,7 +2571,7 @@ wfctl secrets set --provider keychain --service buymywishlist STRIPE_SECRET_KEY
 | `--provider` | _(from config)_ | Ad-hoc provider override: `keychain`, `env`, `aws` |
 | `--service` | _(none)_ | Service name / prefix for the selected provider |
 
-When no `--value` or `--from-file` is given and stdin is a TTY, the value is prompted with hidden input (`read -s` style).
+When no `--value` or `--from-file` is given and stdin is a TTY, the value is prompted with hidden input. Press `Esc` or `Ctrl+C` to cancel without setting the secret.
 
 #### `secrets get`
 
@@ -2688,7 +2688,7 @@ Set secrets declared in the config for a given environment. Automatically select
 
 Manifest-backed setup treats static YAML environment declarations as desired provider environments. Top-level `environments`, `ci.deploy.environments`, `platform.environment`, and literal `secretStores.<name>.config.environment` values become environment-scoped targets when the backing provider supports them. Runtime placeholders such as `${WORKFLOW_ENV}` are not treated as literal target names. Missing provider environments fail non-interactive setup; interactive setup asks before creating them.
 
-**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names.
+**Interactive mode** (default when stdin is a TTY): lists each declared secret with its current set/unset status, presents a multi-select to choose which secrets to set, prompts to pick a store when none is configured (resolves via `--store` > `secrets.defaultStore` > single-store auto-select > interactive pick), and collects values with masked terminal input for sensitive names. Press `Esc` or `Ctrl+C` at any prompt to cancel cleanly.
 
 Manifest-backed interactive setup uses a compact three-step flow by default:
 

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
-	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.81.1
@@ -267,6 +266,7 @@ require (
 	golang.org/x/arch v0.28.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260608224507-4308a22a1bab // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab // indirect


### PR DESCRIPTION
## Summary
- treat shared prompt cancellation as a clean CLI abort instead of `error: prompt: cancelled`
- route raw interactive confirmations through the shared prompt package so Esc/Ctrl-C works consistently
- switch `wfctl secrets set` hidden input and `infra derive` provider selection to shared prompt widgets
- document Esc/Ctrl-C cancellation in the wfctl reference

## Verification
- GOWORK=off go test ./cmd/wfctl -run 'Test(IsPromptCancelledUnwrapsPromptCancellation|ConfirmAction|PromptModelsMark|TableMultiSelectModelViewShowsRows|CollectManifestSecretTargetValues|Wizard.*Cancel)' -count=1\n- GOWORK=off go test ./cmd/wfctl -count=1\n- git diff --check\n- raw prompt audit: no fmt.Scanln, Fscan(os.Stdin), ReadPassword, stdinFileDescriptor, or bufio.NewReader(os.Stdin) remain under cmd/wfctl\n- GOWORK=off go test ./...\n\n## TDD note\nThe new cancellation tests failed before implementation with missing `confirmAction`/`isPromptCancelled`; after the implementation and prompt migrations, focused and repository-wide tests pass.