### PR TITLE
feat(wfctl): add provider variable setup

### DIFF
--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -150,6 +150,7 @@ var commands = map[string]func([]string) error{
 	"override":        runOverride,
 	"test":            runTest,
 	"secrets":         runSecrets,
+	"vars":            runVars,
 	"ports":           runPorts,
 	"security":        runSecurity,
 	"wizard":          runWizard,

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -1421,6 +1421,11 @@ type installedPluginJSON struct {
 	// SecretTargets carries through from the registry manifest so
 	// manifest-backed secrets setup can respect provider-specific target models.
 	SecretTargets []PluginSecretTarget `json:"secret_targets,omitempty"`
+	// RequiredConfig carries through non-secret plugin setup requirements so
+	// `wfctl vars setup --plugin <name>` can configure provider variables.
+	RequiredConfig []PluginRequiredConfig `json:"required_config,omitempty"`
+	// ConfigTargets carries through non-secret variable/config target metadata.
+	ConfigTargets []PluginConfigTarget `json:"config_targets,omitempty"`
 }
 
 type installedPluginCapabilities struct {
@@ -1457,6 +1462,8 @@ func writeInstalledManifest(path string, m *RegistryManifest) error {
 		IaCProvider:     m.IaCProvider,
 		RequiredSecrets: m.RequiredSecrets,
 		SecretTargets:   m.SecretTargets,
+		RequiredConfig:  m.RequiredConfig,
+		ConfigTargets:   m.ConfigTargets,
 	}
 	if m.Capabilities != nil {
 		pj.Capabilities = &installedPluginCapabilities{

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -1239,6 +1239,39 @@ func TestRunPluginUpdateCompatUsesOlderPassingVersion(t *testing.T) {
 	}
 }
 
+func TestWriteInstalledManifestPreservesRequiredConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugin.json")
+	err := writeInstalledManifest(path, &RegistryManifest{
+		Name:        "workflow-plugin-cloudflare",
+		Version:     "v0.1.0",
+		Author:      "GoCodeAlone",
+		Description: "Cloudflare provider",
+		License:     "MIT",
+		RequiredConfig: []PluginRequiredConfig{{
+			Name:        "CLOUDFLARE_ACCOUNT_ID",
+			Key:         "account_id",
+			Description: "Cloudflare account ID",
+		}},
+		ConfigTargets: []PluginConfigTarget{{
+			Provider: "github",
+			Scopes:   []string{"repo", "env", "org"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("writeInstalledManifest: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"required_config"`) {
+		t.Fatalf("installed plugin.json missing required_config:\n%s", string(raw))
+	}
+	if !strings.Contains(string(raw), `"config_targets"`) {
+		t.Fatalf("installed plugin.json missing config_targets:\n%s", string(raw))
+	}
+}
+
 type compatInstallRegistry struct {
 	ConfigPath string
 }
@@ -1439,5 +1472,33 @@ func TestRegistryManifest_UnmarshalPreservesSecretTargets(t *testing.T) {
 	}
 	if m.SecretTargets[0].Provider != "github" || !reflect.DeepEqual(m.SecretTargets[0].Scopes, []string{"repo", "env"}) {
 		t.Errorf("unexpected secret_targets[0]: %+v", m.SecretTargets[0])
+	}
+}
+
+func TestRegistryManifest_UnmarshalPreservesRequiredConfig(t *testing.T) {
+	raw := []byte(`{
+		"name": "workflow-plugin-cloudflare",
+		"version": "0.1.0",
+		"author": "GoCodeAlone",
+		"description": "Cloudflare provider",
+		"type": "external",
+		"tier": "community",
+		"license": "MIT",
+		"required_config": [
+			{"name": "CLOUDFLARE_ACCOUNT_ID", "key": "account_id"}
+		],
+		"config_targets": [
+			{"provider": "github", "scopes": ["repo", "env", "org"]}
+		]
+	}`)
+	var m RegistryManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(m.RequiredConfig) != 1 || m.RequiredConfig[0].Name != "CLOUDFLARE_ACCOUNT_ID" {
+		t.Fatalf("required_config = %+v", m.RequiredConfig)
+	}
+	if len(m.ConfigTargets) != 1 || m.ConfigTargets[0].Provider != "github" {
+		t.Fatalf("config_targets = %+v", m.ConfigTargets)
 	}
 }

--- a/cmd/wfctl/plugin_registry.go
+++ b/cmd/wfctl/plugin_registry.go
@@ -56,6 +56,13 @@ type RegistryManifest struct {
 	// for this plugin's required_secrets[] entries, without hard-coding
 	// GitHub repo/org/env semantics into unrelated providers.
 	SecretTargets []PluginSecretTarget `json:"secret_targets,omitempty"`
+	// RequiredConfig mirrors plugin.json `required_config[]`. These entries are
+	// non-secret provider/application configuration values that should be written
+	// to variable/config stores rather than secret stores.
+	RequiredConfig []PluginRequiredConfig `json:"required_config,omitempty"`
+	// ConfigTargets mirrors plugin.json `config_targets[]`, the non-secret
+	// analog to secret_targets[].
+	ConfigTargets []PluginConfigTarget `json:"config_targets,omitempty"`
 }
 
 // RegistryCapabilities describes what module/step/trigger types a plugin provides.

--- a/cmd/wfctl/publish.go
+++ b/cmd/wfctl/publish.go
@@ -20,21 +20,23 @@ import (
 // registryManifest is the manifest format for the GoCodeAlone/workflow-registry.
 // It differs from plugin.PluginManifest in field names and structure to match the registry schema.
 type registryManifest struct {
-	Name             string                `json:"name"`
-	Version          string                `json:"version"`
-	Author           string                `json:"author"`
-	Description      string                `json:"description"`
-	Source           string                `json:"source,omitempty"`
-	Path             string                `json:"path,omitempty"`
-	Type             string                `json:"type"`
-	Tier             string                `json:"tier"`
-	License          string                `json:"license"`
-	MinEngineVersion string                `json:"minEngineVersion,omitempty"`
-	Keywords         []string              `json:"keywords,omitempty"`
-	Homepage         string                `json:"homepage,omitempty"`
-	Repository       string                `json:"repository,omitempty"`
-	Capabilities     *registryCapabilities `json:"capabilities,omitempty"`
-	Checksums        map[string]string     `json:"checksums,omitempty"`
+	Name             string                 `json:"name"`
+	Version          string                 `json:"version"`
+	Author           string                 `json:"author"`
+	Description      string                 `json:"description"`
+	Source           string                 `json:"source,omitempty"`
+	Path             string                 `json:"path,omitempty"`
+	Type             string                 `json:"type"`
+	Tier             string                 `json:"tier"`
+	License          string                 `json:"license"`
+	MinEngineVersion string                 `json:"minEngineVersion,omitempty"`
+	Keywords         []string               `json:"keywords,omitempty"`
+	Homepage         string                 `json:"homepage,omitempty"`
+	Repository       string                 `json:"repository,omitempty"`
+	Capabilities     *registryCapabilities  `json:"capabilities,omitempty"`
+	Checksums        map[string]string      `json:"checksums,omitempty"`
+	RequiredConfig   []PluginRequiredConfig `json:"required_config,omitempty"`
+	ConfigTargets    []PluginConfigTarget   `json:"config_targets,omitempty"`
 }
 
 // registryCapabilities holds plugin capability declarations for the registry.
@@ -163,19 +165,21 @@ func loadRegistryManifest(path string) (*registryManifest, error) {
 
 // pluginJSONSchema mirrors the internal plugin.PluginManifest for loading plugin.json.
 type pluginJSONSchema struct {
-	Name          string   `json:"name"`
-	Version       string   `json:"version"`
-	Author        string   `json:"author"`
-	Description   string   `json:"description"`
-	License       string   `json:"license"`
-	Tags          []string `json:"tags"`
-	Repository    string   `json:"repository"`
-	Tier          string   `json:"tier"`
-	ModuleTypes   []string `json:"moduleTypes"`
-	StepTypes     []string `json:"stepTypes"`
-	TriggerTypes  []string `json:"triggerTypes"`
-	WorkflowTypes []string `json:"workflowTypes"`
-	WiringHooks   []string `json:"wiringHooks"`
+	Name           string                 `json:"name"`
+	Version        string                 `json:"version"`
+	Author         string                 `json:"author"`
+	Description    string                 `json:"description"`
+	License        string                 `json:"license"`
+	Tags           []string               `json:"tags"`
+	Repository     string                 `json:"repository"`
+	Tier           string                 `json:"tier"`
+	ModuleTypes    []string               `json:"moduleTypes"`
+	StepTypes      []string               `json:"stepTypes"`
+	TriggerTypes   []string               `json:"triggerTypes"`
+	WorkflowTypes  []string               `json:"workflowTypes"`
+	WiringHooks    []string               `json:"wiringHooks"`
+	RequiredConfig []PluginRequiredConfig `json:"required_config"`
+	ConfigTargets  []PluginConfigTarget   `json:"config_targets"`
 }
 
 // loadRegistryManifestFromPluginJSON converts an internal plugin.json to registry format.
@@ -196,15 +200,17 @@ func loadRegistryManifestFromPluginJSON(path, pluginType, pluginTier string) (*r
 	pType := pluginType
 
 	m := &registryManifest{
-		Name:        p.Name,
-		Version:     p.Version,
-		Author:      p.Author,
-		Description: p.Description,
-		License:     p.License,
-		Repository:  p.Repository,
-		Type:        pType,
-		Tier:        tier,
-		Keywords:    p.Tags,
+		Name:           p.Name,
+		Version:        p.Version,
+		Author:         p.Author,
+		Description:    p.Description,
+		License:        p.License,
+		Repository:     p.Repository,
+		Type:           pType,
+		Tier:           tier,
+		Keywords:       p.Tags,
+		RequiredConfig: p.RequiredConfig,
+		ConfigTargets:  p.ConfigTargets,
 	}
 	if hasCapabilities(p) {
 		m.Capabilities = &registryCapabilities{

--- a/cmd/wfctl/publish_test.go
+++ b/cmd/wfctl/publish_test.go
@@ -295,6 +295,37 @@ func TestLoadRegistryManifest_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadRegistryManifestFromPluginJSONPreservesRequiredConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.json")
+	if err := os.WriteFile(path, []byte(`{
+		"name": "workflow-plugin-cloudflare",
+		"version": "0.1.0",
+		"author": "GoCodeAlone",
+		"description": "Cloudflare provider",
+		"license": "MIT",
+		"required_config": [
+			{"name": "CLOUDFLARE_ACCOUNT_ID", "key": "account_id"}
+		],
+		"config_targets": [
+			{"provider": "github", "scopes": ["repo", "env", "org"]}
+		]
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadRegistryManifestFromPluginJSON(path, "external", "community")
+	if err != nil {
+		t.Fatalf("loadRegistryManifestFromPluginJSON: %v", err)
+	}
+	if len(got.RequiredConfig) != 1 || got.RequiredConfig[0].Name != "CLOUDFLARE_ACCOUNT_ID" {
+		t.Fatalf("required_config = %+v", got.RequiredConfig)
+	}
+	if len(got.ConfigTargets) != 1 || got.ConfigTargets[0].Provider != "github" {
+		t.Fatalf("config_targets = %+v", got.ConfigTargets)
+	}
+}
+
 // ---- dry-run integration test ----
 
 func TestRunPublish_DryRun(t *testing.T) {

--- a/cmd/wfctl/secrets_setup_plugin.go
+++ b/cmd/wfctl/secrets_setup_plugin.go
@@ -26,11 +26,29 @@ type PluginRequiredSecret struct {
 	Prompt      string `json:"prompt,omitempty"`
 }
 
+// PluginRequiredConfig mirrors plugin.json `required_config[]` entries for
+// non-secret provider configuration such as account IDs or allowlisted client IPs.
+type PluginRequiredConfig struct {
+	Name        string `json:"name"`
+	Key         string `json:"key,omitempty"`
+	Sensitive   bool   `json:"sensitive,omitempty"`
+	Description string `json:"description,omitempty"`
+	Prompt      string `json:"prompt,omitempty"`
+}
+
 // PluginSecretTarget declares secret storage targets that a plugin supports for
 // its required_secrets[] entries. Provider is a provider domain such as
 // "github", "vault", or "aws-secrets-manager"; Scopes narrows provider-owned
 // namespaces such as GitHub repo/env/org or Vault mount.
 type PluginSecretTarget struct {
+	Provider    string   `json:"provider"`
+	Scopes      []string `json:"scopes,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+// PluginConfigTarget declares variable/config storage targets that a plugin
+// supports for required_config[] entries.
+type PluginConfigTarget struct {
 	Provider    string   `json:"provider"`
 	Scopes      []string `json:"scopes,omitempty"`
 	Description string   `json:"description,omitempty"`
@@ -42,6 +60,8 @@ type pluginManifest struct {
 	Name            string                 `json:"name"`
 	RequiredSecrets []PluginRequiredSecret `json:"required_secrets,omitempty"`
 	SecretTargets   []PluginSecretTarget   `json:"secret_targets,omitempty"`
+	RequiredConfig  []PluginRequiredConfig `json:"required_config,omitempty"`
+	ConfigTargets   []PluginConfigTarget   `json:"config_targets,omitempty"`
 }
 
 // runSecretsSetupPlugin is the entry-point for `wfctl secrets setup

--- a/cmd/wfctl/secrets_setup_plugin_test.go
+++ b/cmd/wfctl/secrets_setup_plugin_test.go
@@ -49,6 +49,63 @@ func TestLoadPluginManifest_HappyPath(t *testing.T) {
 	}
 }
 
+func TestLoadPluginManifest_RequiredConfig(t *testing.T) {
+	dir := t.TempDir()
+	writePluginManifestFile(t, dir, "workflow-plugin-cloudflare", `{
+		"name": "workflow-plugin-cloudflare",
+		"required_secrets": [
+			{"name": "CLOUDFLARE_API_TOKEN", "sensitive": true}
+		],
+		"required_config": [
+			{
+				"name": "CLOUDFLARE_ACCOUNT_ID",
+				"key": "account_id",
+				"sensitive": false,
+				"description": "Cloudflare account ID for account-scoped APIs"
+			}
+		],
+		"config_targets": [
+			{"provider": "github", "scopes": ["repo", "env", "org"]}
+		]
+	}`)
+	m, err := loadPluginManifest("cloudflare", dir)
+	if err != nil {
+		t.Fatalf("loadPluginManifest: %v", err)
+	}
+	if len(m.RequiredConfig) != 1 {
+		t.Fatalf("required_config = %d want 1", len(m.RequiredConfig))
+	}
+	if got := m.RequiredConfig[0]; got.Name != "CLOUDFLARE_ACCOUNT_ID" || got.Key != "account_id" || got.Sensitive {
+		t.Fatalf("required_config[0] = %+v", got)
+	}
+	if len(m.ConfigTargets) != 1 || m.ConfigTargets[0].Provider != "github" {
+		t.Fatalf("config_targets = %+v", m.ConfigTargets)
+	}
+}
+
+func TestRunVarsSetupPluginRejectsSecretConfig(t *testing.T) {
+	dir := t.TempDir()
+	writePluginManifestFile(t, dir, "wp-fake", `{
+		"name": "wp-fake",
+		"required_config": [
+			{"name": "FAKE_TOKEN", "sensitive": true}
+		]
+	}`)
+	var out bytes.Buffer
+	err := runVarsSetupPluginWithIO([]string{
+		"--plugin", "wp-fake",
+		"--plugin-dir", dir,
+		"--scope", "repo",
+		"--config", filepath.Join(t.TempDir(), "missing.yaml"),
+	}, nil, &out)
+	if err == nil {
+		t.Fatal("expected sensitive required_config rejection")
+	}
+	if !strings.Contains(err.Error(), "belongs in required_secrets") {
+		t.Fatalf("error = %v, want required_secrets guidance", err)
+	}
+}
+
 func TestLoadPluginManifest_NormalizedInstallDir(t *testing.T) {
 	dir := t.TempDir()
 	writePluginManifestFile(t, dir, "cloudflare", `{

--- a/cmd/wfctl/vars.go
+++ b/cmd/wfctl/vars.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func runVars(args []string) error {
+	if len(args) < 1 {
+		return varsUsage()
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		printVarsUsage()
+		return flag.ErrHelp
+	case "setup":
+		return runVarsSetupPlugin(args[1:])
+	default:
+		return varsUsage()
+	}
+}
+
+func varsUsage() error {
+	printVarsUsage()
+	return fmt.Errorf("missing or unknown action")
+}
+
+func printVarsUsage() {
+	fmt.Fprintf(flag.CommandLine.Output(), `Usage: wfctl vars <action> [options]
+
+Manage non-secret provider variables and configuration values.
+
+Actions:
+  setup   Configure non-secret variables declared by plugin required_config[]
+
+Examples:
+  wfctl vars setup --plugin workflow-plugin-cloudflare --from-env
+  wfctl vars setup --plugin workflow-plugin-namecheap --scope env --env production
+`)
+}

--- a/cmd/wfctl/vars_setup_plugin.go
+++ b/cmd/wfctl/vars_setup_plugin.go
@@ -28,7 +28,7 @@ func runVarsSetupPluginWithIO(args []string, in io.Reader, out io.Writer) error 
 	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT")
 	configFile := fs.String("config", "app.yaml", "app.yaml/wfctl.yaml used to resolve the github repo when --scope=repo|env")
 	fromEnv := fs.Bool("from-env", false, "Read each variable value from $NAME")
-	nonInteractive := fs.Bool("non-interactive", false, "Do not prompt; require --from-env, --var, or piped KEY=VALUE values")
+	nonInteractive := fs.Bool("non-interactive", false, "Do not prompt; skip entries without --from-env, --var, or piped KEY=VALUE values")
 	var varFlag multiStringFlag
 	fs.Var(&varFlag, "var", "NAME=VALUE literal. Repeatable.")
 	fs.Usage = func() {

--- a/cmd/wfctl/vars_setup_plugin.go
+++ b/cmd/wfctl/vars_setup_plugin.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
+	"github.com/GoCodeAlone/workflow/secrets"
+)
+
+func runVarsSetupPlugin(args []string) error {
+	return runVarsSetupPluginWithIO(args, nil, os.Stdout)
+}
+
+func runVarsSetupPluginWithIO(args []string, in io.Reader, out io.Writer) error {
+	fs := flag.NewFlagSet("vars setup", flag.ContinueOnError)
+	pluginName := fs.String("plugin", "", "Plugin name (must match a directory under --plugin-dir / $WFCTL_PLUGIN_DIR)")
+	pluginDir := fs.String("plugin-dir", "", "Plugin install dir (default: $WFCTL_PLUGIN_DIR or ./data/plugins)")
+	scope := fs.String("scope", "repo", "GitHub variable scope: repo | env | org")
+	envName := fs.String("env", "", "Environment name (required with --scope=env)")
+	org := fs.String("org", "", "Organization slug (required with --scope=org)")
+	orgVisibility := fs.String("visibility", "all", "Org-scope visibility: all | selected | private")
+	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Env var holding the GitHub PAT")
+	configFile := fs.String("config", "app.yaml", "app.yaml/wfctl.yaml used to resolve the github repo when --scope=repo|env")
+	fromEnv := fs.Bool("from-env", false, "Read each variable value from $NAME")
+	nonInteractive := fs.Bool("non-interactive", false, "Do not prompt; require --from-env, --var, or piped KEY=VALUE values")
+	var varFlag multiStringFlag
+	fs.Var(&varFlag, "var", "NAME=VALUE literal. Repeatable.")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage: wfctl vars setup --plugin <name> [options]
+
+Set non-secret variables declared by a plugin's plugin.json required_config[] block.
+Sensitive values belong in required_secrets[] and must be configured with
+wfctl secrets setup instead.
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *pluginName == "" {
+		return errors.New("--plugin <name> is required")
+	}
+
+	manifest, err := loadPluginManifest(*pluginName, *pluginDir)
+	if err != nil {
+		return err
+	}
+	if len(manifest.RequiredConfig) == 0 {
+		fmt.Fprintf(out, "plugin %q declares no required_config[]; nothing to do\n", manifest.Name)
+		return nil
+	}
+	for _, cfg := range manifest.RequiredConfig {
+		if cfg.Sensitive {
+			return fmt.Errorf("required_config %q is marked sensitive; it belongs in required_secrets[]", cfg.Name)
+		}
+	}
+
+	scopeStr := strings.ToLower(strings.TrimSpace(*scope))
+	provider, scopeLabel, err := buildVariableWriter(scopeStr, *envName, *org, *orgVisibility, *tokenEnv, *configFile)
+	if err != nil {
+		return err
+	}
+	if !pluginConfigTargetAllowed(manifest.ConfigTargets, provider) {
+		desc := variableProviderTarget(provider)
+		return fmt.Errorf("plugin %q does not declare config target %s:%s", manifest.Name, desc.Provider, desc.Scope)
+	}
+
+	values, err := buildVariableLiteralMap(varFlag)
+	if err != nil {
+		return err
+	}
+	if in != nil {
+		for _, kv := range readKVLines(in) {
+			k, v, ok := strings.Cut(kv, "=")
+			if ok {
+				values[k] = v
+			}
+		}
+	}
+
+	interactive := in == nil && !*nonInteractive && prompt.CanPrompt()
+	fmt.Fprintf(out, "Setting up variables for plugin %q -> %s\n\n", manifest.Name, scopeLabel)
+
+	for _, cfg := range manifest.RequiredConfig {
+		value, provided, err := pluginConfigValue(cfg, values, *fromEnv, interactive)
+		if err != nil {
+			return err
+		}
+		if !provided {
+			fmt.Fprintf(out, "  %s: skipped (no value provided)\n", cfg.Name)
+			continue
+		}
+		if err := provider.SetVariable(context.Background(), cfg.Name, value); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "  %s: set\n", cfg.Name)
+	}
+	fmt.Fprintln(out, "\nAll done.")
+	return nil
+}
+
+func buildVariableWriter(scope, envName, org, visibility, tokenEnv, configFile string) (secrets.VariableProvider, string, error) {
+	p, label, err := buildSecretWriter(scope, envName, org, visibility, tokenEnv, configFile)
+	if err != nil {
+		return nil, "", err
+	}
+	vars, ok := p.(secrets.VariableProvider)
+	if !ok {
+		return nil, "", fmt.Errorf("provider %q does not support variables", p.Name())
+	}
+	return vars, strings.Replace(label, "secrets", "variables", 1), nil
+}
+
+func buildVariableLiteralMap(literals []string) (map[string]string, error) {
+	values := make(map[string]string, len(literals))
+	for _, lit := range literals {
+		k, v, found := strings.Cut(lit, "=")
+		if !found {
+			return nil, fmt.Errorf("--var %q: expected NAME=VALUE format", lit)
+		}
+		values[k] = v
+	}
+	return values, nil
+}
+
+func pluginConfigValue(cfg PluginRequiredConfig, literals map[string]string, fromEnv, interactive bool) (string, bool, error) {
+	if fromEnv {
+		if v := os.Getenv(cfg.Name); v != "" {
+			return v, true, nil
+		}
+	}
+	if v, ok := literals[cfg.Name]; ok {
+		return v, true, nil
+	}
+	if !interactive {
+		return "", false, nil
+	}
+	label := cfg.Prompt
+	if label == "" {
+		label = cfg.Name
+	}
+	if cfg.Description != "" {
+		label += " - " + cfg.Description
+	}
+	value, err := prompt.Input(label, false)
+	if err != nil {
+		return "", false, err
+	}
+	if value == "" {
+		return "", false, nil
+	}
+	return value, true, nil
+}
+
+func pluginConfigTargetAllowed(allowed []PluginConfigTarget, provider secrets.VariableProvider) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	target := variableProviderTarget(provider)
+	providerName := normalizedSecretTargetProvider(target.Provider)
+	scope := strings.ToLower(strings.TrimSpace(target.Scope))
+	for _, candidate := range allowed {
+		if normalizedSecretTargetProvider(candidate.Provider) != providerName {
+			continue
+		}
+		scopes := normalizedSecretTargetScopes(candidate.Scopes)
+		if len(scopes) == 0 {
+			return true
+		}
+		for _, s := range scopes {
+			if s == scope {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func variableProviderTarget(provider secrets.VariableProvider) secrets.ProviderTarget {
+	if targeter, ok := provider.(interface{ SecretTarget() secrets.ProviderTarget }); ok {
+		return targeter.SecretTarget()
+	}
+	return secrets.ProviderTarget{Provider: provider.Name(), Scope: "default"}
+}

--- a/cmd/wfctl/wfctl.yaml
+++ b/cmd/wfctl/wfctl.yaml
@@ -87,6 +87,8 @@ workflows:
         description: Run Workflow integration tests
       - name: secrets
         description: Manage declared secrets
+      - name: vars
+        description: Manage non-secret provider variables
       - name: ports
         description: Inspect port usage
       - name: security
@@ -273,6 +275,10 @@ pipelines:
     trigger: {type: cli, config: {command: secrets}}
     steps:
       - {name: run, type: step.cli_invoke, config: {command: secrets}}
+  cmd-vars:
+    trigger: {type: cli, config: {command: vars}}
+    steps:
+      - {name: run, type: step.cli_invoke, config: {command: vars}}
   cmd-ports:
     trigger: {type: cli, config: {command: ports}}
     steps:

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2756,6 +2756,54 @@ wfctl secrets setup --manifest wfctl.yaml --config 'infra/*.yaml,deploy.yaml' \
 
 ---
 
+### `vars`
+
+Manage non-secret provider variables and configuration values. Use this for
+values that applications or provider plugins need at runtime but that are not
+credentials, such as a Cloudflare account ID or a Namecheap API client IP.
+Sensitive values still belong in `wfctl secrets`.
+
+```
+wfctl vars <action> [options]
+```
+
+#### `vars setup`
+
+Set non-secret variables declared by an installed plugin's
+`plugin.json required_config[]` block. The command uses the same GitHub
+repo/env/org target model as plugin secret setup, but writes to GitHub Actions
+Variables instead of encrypted Actions Secrets. Environment-scoped GitHub
+variables require the named GitHub Actions environment to exist.
+
+`required_config[]` entries marked `sensitive: true` are rejected; plugin
+authors must model those values in `required_secrets[]` instead.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--plugin` | _(required)_ | Plugin name or installed plugin directory name |
+| `--plugin-dir` | `$WFCTL_PLUGIN_DIR` or `./data/plugins` | Installed plugin directory |
+| `--scope` | `repo` | GitHub variable scope: `repo` \| `env` \| `org` |
+| `--env` | _(none)_ | GitHub Actions environment name for `--scope env` |
+| `--org` | _(none)_ | Organization slug for `--scope org` |
+| `--visibility` | `all` | Org-scope visibility: `all` \| `selected` \| `private` |
+| `--token-env` | `GITHUB_TOKEN` | Env var holding the GitHub PAT |
+| `--config` | `app.yaml` | Config file used to resolve GitHub repo for repo/env scopes |
+| `--from-env` | `false` | Read each variable value from `$NAME` |
+| `--var` | _(none)_ | `NAME=VALUE` literal. Repeatable. |
+| `--non-interactive` | `false` | Do not prompt; skip entries with no provided value |
+
+```bash
+# Configure non-secret provider variables from process env
+CLOUDFLARE_ACCOUNT_ID=abc123 wfctl vars setup \
+  --plugin workflow-plugin-cloudflare --from-env
+
+# Configure an environment-scoped variable
+NAMECHEAP_CLIENT_IP=203.0.113.10 wfctl vars setup \
+  --plugin workflow-plugin-namecheap --scope env --env production --from-env
+```
+
+---
+
 ### `git connect`
 
 Connect a workflow project to a GitHub repository. Writes a `.wfctl.yaml` project file and optionally initializes the git repo.

--- a/docs/iac-dns-providers.md
+++ b/docs/iac-dns-providers.md
@@ -199,6 +199,19 @@ wfctl secrets setup --plugin workflow-plugin-hover \
   --scope env --env production
 ```
 
+Provider values that are not credentials belong in plugin.json
+`required_config[]` and should be configured with `wfctl vars setup`. For
+example, Cloudflare account IDs and Namecheap API client IPs are operational
+configuration, not secrets:
+
+```sh
+CLOUDFLARE_ACCOUNT_ID=abc123 wfctl vars setup \
+  --plugin workflow-plugin-cloudflare --from-env
+
+NAMECHEAP_CLIENT_IP=203.0.113.10 wfctl vars setup \
+  --plugin workflow-plugin-namecheap --from-env
+```
+
 For a repo that already has `wfctl.yaml` and `.wfctl-lock.yaml`, use the
 manifest-driven form to discover all installed provider plugin secrets plus
 `${ENV_VAR}` references in config files:

--- a/docs/wfctl-secrets-scopes.md
+++ b/docs/wfctl-secrets-scopes.md
@@ -92,6 +92,12 @@ This:
 3. Prompts for each (masked iff `sensitive: true`).
 4. Writes each to the chosen GH scope.
 
+Plugins can also declare non-secret setup values in `required_config[]`. Use
+`wfctl vars setup --plugin <name>` for those entries. For GitHub targets, this
+writes GitHub Actions Variables at repo, environment, or organization scope
+instead of encrypted Actions Secrets. A value marked `sensitive: true` is a
+plugin manifest bug and must be moved to `required_secrets[]`.
+
 Manifest-backed setup can discover all provider plugin secrets from `wfctl.yaml`
 and `.wfctl-lock.yaml`:
 

--- a/plugin/manifest.go
+++ b/plugin/manifest.go
@@ -98,6 +98,30 @@ type PluginManifest struct {
 	// MinEngineVersion declares the minimum engine version required to run this plugin.
 	// A semver string without the "v" prefix, e.g. "0.3.30".
 	MinEngineVersion string `json:"minEngineVersion,omitempty" yaml:"minEngineVersion,omitempty"`
+
+	// RequiredConfig declares non-secret provider/application configuration
+	// values needed by the plugin. Sensitive values belong in required_secrets.
+	RequiredConfig []PluginRequiredConfig `json:"required_config,omitempty" yaml:"required_config,omitempty"`
+	// ConfigTargets declares where RequiredConfig values may be stored, such as
+	// GitHub Actions repository, environment, or organization variables.
+	ConfigTargets []PluginConfigTarget `json:"config_targets,omitempty" yaml:"config_targets,omitempty"`
+}
+
+// PluginRequiredConfig is a non-secret setup value required by a plugin.
+type PluginRequiredConfig struct {
+	Name        string `json:"name" yaml:"name"`
+	Key         string `json:"key,omitempty" yaml:"key,omitempty"`
+	Sensitive   bool   `json:"sensitive,omitempty" yaml:"sensitive,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Prompt      string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+}
+
+// PluginConfigTarget is a provider-owned variable/config store supported by a
+// plugin for RequiredConfig values.
+type PluginConfigTarget struct {
+	Provider    string   `json:"provider" yaml:"provider"`
+	Scopes      []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // CapabilityDecl declares a capability relationship for a plugin in the manifest.

--- a/secrets/github_provider.go
+++ b/secrets/github_provider.go
@@ -321,26 +321,35 @@ type ghVariableEntry struct {
 }
 
 func (p *GitHubSecretsProvider) listVariableEntries(ctx context.Context) ([]ghVariableEntry, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.variablesURL(), nil)
-	if err != nil {
-		return nil, err
+	nextURL := p.variablesURL()
+	var entries []ghVariableEntry
+	for nextURL != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		p.setHeaders(req)
+		resp, err := p.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			err := fmt.Errorf("secrets: github list variables: HTTP %d%s", resp.StatusCode, readErrorBody(resp))
+			resp.Body.Close()
+			return nil, err
+		}
+		var result struct {
+			Variables []ghVariableEntry `json:"variables"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("secrets: github list variables decode: %w", err)
+		}
+		resp.Body.Close()
+		entries = append(entries, result.Variables...)
+		nextURL = githubNextLink(resp.Header.Get("Link"))
 	}
-	p.setHeaders(req)
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("secrets: github list variables: HTTP %d%s", resp.StatusCode, readErrorBody(resp))
-	}
-	var result struct {
-		Variables []ghVariableEntry `json:"variables"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("secrets: github list variables decode: %w", err)
-	}
-	return result.Variables, nil
+	return entries, nil
 }
 
 // ListVariables returns metadata for GitHub Actions variables in the configured
@@ -628,18 +637,27 @@ func (p *GitHubSecretsProvider) secretsURL() string {
 }
 
 func (p *GitHubSecretsProvider) variablesURL() string {
+	values := url.Values{}
+	values.Set("per_page", "100")
 	switch p.scope {
 	case GitHubScopeOrg:
-		return fmt.Sprintf("%s/orgs/%s/actions/variables", p.base(), url.PathEscape(p.org))
+		return fmt.Sprintf("%s/orgs/%s/actions/variables?%s", p.base(), url.PathEscape(p.org), values.Encode())
 	case GitHubScopeEnv:
-		return fmt.Sprintf("%s/repos/%s/%s/environments/%s/variables", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(p.env))
+		return fmt.Sprintf("%s/repos/%s/%s/environments/%s/variables?%s", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(p.env), values.Encode())
 	default:
-		return fmt.Sprintf("%s/repos/%s/%s/actions/variables", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo))
+		return fmt.Sprintf("%s/repos/%s/%s/actions/variables?%s", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo), values.Encode())
 	}
 }
 
 func (p *GitHubSecretsProvider) variableURL(key string) string {
-	return p.variablesURL() + "/" + url.PathEscape(key)
+	switch p.scope {
+	case GitHubScopeOrg:
+		return fmt.Sprintf("%s/orgs/%s/actions/variables/%s", p.base(), url.PathEscape(p.org), url.PathEscape(key))
+	case GitHubScopeEnv:
+		return fmt.Sprintf("%s/repos/%s/%s/environments/%s/variables/%s", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(p.env), url.PathEscape(key))
+	default:
+		return fmt.Sprintf("%s/repos/%s/%s/actions/variables/%s", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(key))
+	}
 }
 
 func (p *GitHubSecretsProvider) environmentsURL() string {

--- a/secrets/github_provider.go
+++ b/secrets/github_provider.go
@@ -313,6 +313,158 @@ func (p *GitHubSecretsProvider) StatAll(ctx context.Context) ([]SecretMeta, erro
 	return metas, nil
 }
 
+type ghVariableEntry struct {
+	Name      string    `json:"name"`
+	Value     string    `json:"value"`
+	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (p *GitHubSecretsProvider) listVariableEntries(ctx context.Context) ([]ghVariableEntry, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.variablesURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	p.setHeaders(req)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("secrets: github list variables: HTTP %d%s", resp.StatusCode, readErrorBody(resp))
+	}
+	var result struct {
+		Variables []ghVariableEntry `json:"variables"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("secrets: github list variables decode: %w", err)
+	}
+	return result.Variables, nil
+}
+
+// ListVariables returns metadata for GitHub Actions variables in the configured
+// repo, environment, or organization scope. Returned values are redacted.
+func (p *GitHubSecretsProvider) ListVariables(ctx context.Context) ([]VariableMeta, error) {
+	entries, err := p.listVariableEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	metas := make([]VariableMeta, 0, len(entries))
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			continue
+		}
+		ts := entry.UpdatedAt
+		if ts.IsZero() {
+			ts = entry.CreatedAt
+		}
+		metas = append(metas, VariableMeta{
+			Name:      name,
+			Exists:    true,
+			UpdatedAt: ts,
+		})
+	}
+	return metas, nil
+}
+
+// CheckVariable reports whether a GitHub Actions variable exists without
+// returning its value.
+func (p *GitHubSecretsProvider) CheckVariable(ctx context.Context, key string) (VariableMeta, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return VariableMeta{}, ErrInvalidKey
+	}
+	entries, err := p.listVariableEntries(ctx)
+	if err != nil {
+		return VariableMeta{}, err
+	}
+	for _, entry := range entries {
+		if entry.Name != key {
+			continue
+		}
+		ts := entry.UpdatedAt
+		if ts.IsZero() {
+			ts = entry.CreatedAt
+		}
+		return VariableMeta{Name: key, Exists: true, UpdatedAt: ts}, nil
+	}
+	return VariableMeta{Name: key, Exists: false}, nil
+}
+
+// SetVariable creates or updates a GitHub Actions variable in the configured
+// repo, environment, or organization scope.
+func (p *GitHubSecretsProvider) SetVariable(ctx context.Context, key, value string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ErrInvalidKey
+	}
+	meta, err := p.CheckVariable(ctx, key)
+	if err != nil {
+		return err
+	}
+	method := http.MethodPost
+	targetURL := p.variablesURL()
+	payload := map[string]any{
+		"name":  key,
+		"value": value,
+	}
+	if meta.Exists {
+		method = http.MethodPatch
+		targetURL = p.variableURL(key)
+		delete(payload, "name")
+	}
+	if p.scope == GitHubScopeOrg {
+		payload["visibility"] = string(p.orgVisibility)
+		if p.orgVisibility == OrgVisibilitySelected {
+			payload["selected_repository_ids"] = p.selectedRepoIDs
+		}
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, method, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	p.setHeaders(req)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusNoContent, http.StatusOK:
+		return nil
+	default:
+		return fmt.Errorf("secrets: github set variable %q: HTTP %d%s", key, resp.StatusCode, readErrorBody(resp))
+	}
+}
+
+// DeleteVariable removes a GitHub Actions variable.
+func (p *GitHubSecretsProvider) DeleteVariable(ctx context.Context, key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ErrInvalidKey
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, p.variableURL(key), nil)
+	if err != nil {
+		return err
+	}
+	p.setHeaders(req)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w: %s", ErrNotFound, key)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("secrets: github delete variable %q: HTTP %d%s", key, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
 // CheckAccess implements AccessChecker. It verifies the configured credentials
 // have at least read access by fetching the public key. Errors never contain
 // credential material.
@@ -473,6 +625,21 @@ func (p *GitHubSecretsProvider) secretsURL() string {
 	default: // GitHubScopeRepo
 		return fmt.Sprintf("%s/repos/%s/%s/actions/secrets", p.base(), p.owner, p.repo)
 	}
+}
+
+func (p *GitHubSecretsProvider) variablesURL() string {
+	switch p.scope {
+	case GitHubScopeOrg:
+		return fmt.Sprintf("%s/orgs/%s/actions/variables", p.base(), url.PathEscape(p.org))
+	case GitHubScopeEnv:
+		return fmt.Sprintf("%s/repos/%s/%s/environments/%s/variables", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(p.env))
+	default:
+		return fmt.Sprintf("%s/repos/%s/%s/actions/variables", p.base(), url.PathEscape(p.owner), url.PathEscape(p.repo))
+	}
+}
+
+func (p *GitHubSecretsProvider) variableURL(key string) string {
+	return p.variablesURL() + "/" + url.PathEscape(key)
 }
 
 func (p *GitHubSecretsProvider) environmentsURL() string {

--- a/secrets/github_provider_test.go
+++ b/secrets/github_provider_test.go
@@ -203,6 +203,53 @@ func TestGitHubProvider_EnvVariablesUseEnvironmentVariableEndpoints(t *testing.T
 	}
 }
 
+func TestGitHubProvider_ListVariablesFollowsPagination(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/owner/repo/actions/variables" {
+			http.NotFound(w, r)
+			return
+		}
+		paths = append(paths, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			w.Header().Set("Link", `<https://api.github.com/repos/owner/repo/actions/variables?per_page=100&page=2>; rel="next"`)
+			json.NewEncoder(w).Encode(map[string]any{
+				"variables": []map[string]any{{"name": "FIRST", "value": "redacted"}},
+			})
+		case "2":
+			json.NewEncoder(w).Encode(map[string]any{
+				"variables": []map[string]any{{"name": "SECOND", "value": "redacted"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestGitHubProvider(t, srv)
+	vars, err := p.ListVariables(context.Background())
+	if err != nil {
+		t.Fatalf("ListVariables: %v", err)
+	}
+	if len(vars) != 2 {
+		t.Fatalf("variables = %+v, want 2 entries", vars)
+	}
+	gotNames := []string{vars[0].Name, vars[1].Name}
+	wantNames := []string{"FIRST", "SECOND"}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("names = %v, want %v", gotNames, wantNames)
+	}
+	wantPaths := []string{
+		"/repos/owner/repo/actions/variables?per_page=100",
+		"/repos/owner/repo/actions/variables?per_page=100&page=2",
+	}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("paths = %v, want %v", paths, wantPaths)
+	}
+}
+
 func TestGitHubProvider_ListEnvironments(t *testing.T) {
 	var queries []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/secrets/github_provider_test.go
+++ b/secrets/github_provider_test.go
@@ -136,6 +136,73 @@ func TestGitHubProvider_EnvironmentScopeUsesEnvironmentEndpoints(t *testing.T) {
 	}
 }
 
+func TestGitHubProvider_RepoVariablesUseActionsVariableEndpoints(t *testing.T) {
+	var got []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/actions/variables":
+			json.NewEncoder(w).Encode(map[string]any{
+				"variables": []map[string]any{{"name": "CLOUDFLARE_ACCOUNT_ID", "value": "abc123"}},
+			})
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/actions/variables/CLOUDFLARE_ACCOUNT_ID":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestGitHubProvider(t, srv)
+	vars, err := p.ListVariables(context.Background())
+	if err != nil {
+		t.Fatalf("ListVariables: %v", err)
+	}
+	if len(vars) != 1 || vars[0].Name != "CLOUDFLARE_ACCOUNT_ID" || vars[0].Value != "" || !vars[0].Exists {
+		t.Fatalf("variables = %+v, want redacted existing variable", vars)
+	}
+	if err := p.SetVariable(context.Background(), "CLOUDFLARE_ACCOUNT_ID", "updated"); err != nil {
+		t.Fatalf("SetVariable: %v", err)
+	}
+	want := []string{
+		"GET /repos/owner/repo/actions/variables",
+		"GET /repos/owner/repo/actions/variables",
+		"PATCH /repos/owner/repo/actions/variables/CLOUDFLARE_ACCOUNT_ID",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("requests = %v, want %v", got, want)
+	}
+}
+
+func TestGitHubProvider_EnvVariablesUseEnvironmentVariableEndpoints(t *testing.T) {
+	var got []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/environments/staging/variables":
+			json.NewEncoder(w).Encode(map[string]any{"variables": []map[string]any{}})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/environments/staging/variables":
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestGitHubProvider(t, srv)
+	p.SetEnvironment("staging")
+	if err := p.SetVariable(context.Background(), "NAMECHEAP_CLIENT_IP", "203.0.113.10"); err != nil {
+		t.Fatalf("SetVariable: %v", err)
+	}
+	want := []string{
+		"GET /repos/owner/repo/environments/staging/variables",
+		"POST /repos/owner/repo/environments/staging/variables",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("requests = %v, want %v", got, want)
+	}
+}
+
 func TestGitHubProvider_ListEnvironments(t *testing.T) {
 	var queries []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -56,6 +56,28 @@ type ProviderEnvironment struct {
 	Source   string
 }
 
+// VariableMeta is presence + freshness for one non-secret configuration
+// variable. Value is intentionally optional and callers should usually leave it
+// empty in status displays; provider variables are not credentials, but they can
+// still carry operational details that do not belong in logs.
+type VariableMeta struct {
+	Name      string
+	Value     string
+	Exists    bool
+	UpdatedAt time.Time
+}
+
+// VariableProvider is the provider-side analog to Provider for non-sensitive
+// setup values such as GitHub Actions variables. It must not be used for
+// credential material; sensitive plugin requirements belong in Provider.
+type VariableProvider interface {
+	Name() string
+	SetVariable(ctx context.Context, key, value string) error
+	DeleteVariable(ctx context.Context, key string) error
+	ListVariables(ctx context.Context) ([]VariableMeta, error)
+	CheckVariable(ctx context.Context, key string) (VariableMeta, error)
+}
+
 // EnvironmentManager is optional: providers implement it when they can inspect
 // and create environment-like namespaces used by scoped secrets.
 //


### PR DESCRIPTION
## Summary
- add non-secret provider variable metadata with plugin required_config/config_targets support
- implement GitHub Actions variable provider support for repo/env/org scopes
- add wfctl vars setup --plugin for non-secret provider config
- document secrets vs variables split for DNS providers

Closes #911.

## Verification
- GOWORK=off go test ./secrets ./plugin ./cmd/wfctl -count=1
- GOWORK=off go run ./cmd/wfctl vars -h
- git diff --check