### PR TITLE
feat(wfctl): set app config variables

### DIFF
--- a/cmd/wfctl/vars.go
+++ b/cmd/wfctl/vars.go
@@ -31,10 +31,11 @@ func printVarsUsage() {
 Manage non-secret provider variables and configuration values.
 
 Actions:
-  setup   Configure non-secret variables declared by plugin required_config[]
+  setup   Configure non-secret variables declared by plugin or app config metadata
 
 Examples:
   wfctl vars setup --plugin workflow-plugin-cloudflare --from-env
   wfctl vars setup --plugin workflow-plugin-namecheap --scope env --env production
+  wfctl vars setup --config app.yaml --from-env
 `)
 }

--- a/cmd/wfctl/vars_setup_config.go
+++ b/cmd/wfctl/vars_setup_config.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/module"
+)
+
+type configVariableEntry struct {
+	Name        string
+	Key         string
+	Required    bool
+	Default     string
+	Description string
+}
+
+func collectConfigVariablesFromFile(path string) ([]configVariableEntry, []string, error) {
+	cfg, err := config.LoadFromFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return collectConfigVariables(cfg), collectSensitiveConfigVariables(cfg), nil
+}
+
+func collectConfigVariables(cfg *config.WorkflowConfig) []configVariableEntry {
+	if cfg == nil {
+		return nil
+	}
+	entriesByName := map[string]configVariableEntry{}
+	for _, mod := range cfg.Modules {
+		if mod.Type != "config.provider" || mod.Config == nil {
+			continue
+		}
+		schema, err := schemaEntriesFromConfigProvider(mod)
+		if err != nil {
+			continue
+		}
+		prefixes := envSourcePrefixes(mod.Config)
+		if len(prefixes) == 0 {
+			continue
+		}
+		for key, entry := range schema {
+			if entry.Sensitive || strings.TrimSpace(entry.Env) == "" {
+				continue
+			}
+			for _, prefix := range prefixes {
+				name := prefix + strings.TrimSpace(entry.Env)
+				if name == "" {
+					continue
+				}
+				entriesByName[name] = configVariableEntry{
+					Name:        name,
+					Key:         mod.Name + "." + key,
+					Required:    entry.Required,
+					Default:     entry.Default,
+					Description: entry.Desc,
+				}
+			}
+		}
+	}
+	return sortedConfigVariableEntries(entriesByName)
+}
+
+func collectSensitiveConfigVariables(cfg *config.WorkflowConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	names := map[string]struct{}{}
+	for _, mod := range cfg.Modules {
+		if mod.Type != "config.provider" || mod.Config == nil {
+			continue
+		}
+		schema, err := schemaEntriesFromConfigProvider(mod)
+		if err != nil {
+			continue
+		}
+		prefixes := envSourcePrefixes(mod.Config)
+		if len(prefixes) == 0 {
+			continue
+		}
+		for _, entry := range schema {
+			if !entry.Sensitive || strings.TrimSpace(entry.Env) == "" {
+				continue
+			}
+			for _, prefix := range prefixes {
+				names[prefix+strings.TrimSpace(entry.Env)] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func schemaEntriesFromConfigProvider(mod config.ModuleConfig) (map[string]module.SchemaEntry, error) {
+	raw, ok := mod.Config["schema"].(map[string]any)
+	if !ok || len(raw) == 0 {
+		return nil, fmt.Errorf("config.provider %q has no schema map", mod.Name)
+	}
+	return module.ParseSchema(raw)
+}
+
+func envSourcePrefixes(cfg map[string]any) []string {
+	rawSources, ok := cfg["sources"].([]any)
+	if !ok || len(rawSources) == 0 {
+		return []string{""}
+	}
+	prefixes := map[string]struct{}{}
+	hasEnvSource := false
+	for _, raw := range rawSources {
+		src, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		srcType, _ := src["type"].(string)
+		if srcType != "env" {
+			continue
+		}
+		hasEnvSource = true
+		prefix, _ := src["prefix"].(string)
+		prefixes[prefix] = struct{}{}
+	}
+	if !hasEnvSource {
+		return nil
+	}
+	out := make([]string, 0, len(prefixes))
+	for prefix := range prefixes {
+		out = append(out, prefix)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedConfigVariableEntries(entries map[string]configVariableEntry) []configVariableEntry {
+	out := make([]configVariableEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/cmd/wfctl/vars_setup_config.go
+++ b/cmd/wfctl/vars_setup_config.go
@@ -31,6 +31,8 @@ func collectConfigVariables(cfg *config.WorkflowConfig) ([]configVariableEntry, 
 	}
 	entriesByName := map[string]configVariableEntry{}
 	sensitiveByName := map[string]struct{}{}
+	addVariableConfigEntries(entriesByName, cfg.Vars)
+	addVariableConfigEntries(entriesByName, cfg.Variables)
 	for _, mod := range cfg.Modules {
 		if mod.Type != "config.provider" || mod.Config == nil {
 			continue
@@ -56,6 +58,9 @@ func collectConfigVariables(cfg *config.WorkflowConfig) ([]configVariableEntry, 
 					sensitiveByName[name] = struct{}{}
 					continue
 				}
+				if _, exists := entriesByName[name]; exists {
+					continue
+				}
 				entriesByName[name] = configVariableEntry{
 					Name:        name,
 					Key:         mod.Name + "." + key,
@@ -67,6 +72,28 @@ func collectConfigVariables(cfg *config.WorkflowConfig) ([]configVariableEntry, 
 		}
 	}
 	return sortedConfigVariableEntries(entriesByName), sortedStringSet(sensitiveByName), nil
+}
+
+func addVariableConfigEntries(entries map[string]configVariableEntry, vars *config.VariablesConfig) {
+	if vars == nil {
+		return
+	}
+	for _, entry := range vars.Entries {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			continue
+		}
+		if _, exists := entries[name]; exists {
+			continue
+		}
+		entries[name] = configVariableEntry{
+			Name:        name,
+			Key:         "vars." + name,
+			Required:    entry.Required,
+			Default:     entry.Default,
+			Description: entry.Description,
+		}
+	}
 }
 
 func schemaEntriesFromConfigProvider(mod config.ModuleConfig) (map[string]module.SchemaEntry, error) {

--- a/cmd/wfctl/vars_setup_config.go
+++ b/cmd/wfctl/vars_setup_config.go
@@ -22,33 +22,38 @@ func collectConfigVariablesFromFile(path string) ([]configVariableEntry, []strin
 	if err != nil {
 		return nil, nil, err
 	}
-	return collectConfigVariables(cfg), collectSensitiveConfigVariables(cfg), nil
+	return collectConfigVariables(cfg)
 }
 
-func collectConfigVariables(cfg *config.WorkflowConfig) []configVariableEntry {
+func collectConfigVariables(cfg *config.WorkflowConfig) ([]configVariableEntry, []string, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil, nil
 	}
 	entriesByName := map[string]configVariableEntry{}
+	sensitiveByName := map[string]struct{}{}
 	for _, mod := range cfg.Modules {
 		if mod.Type != "config.provider" || mod.Config == nil {
 			continue
 		}
 		schema, err := schemaEntriesFromConfigProvider(mod)
 		if err != nil {
-			continue
+			return nil, nil, err
 		}
 		prefixes := envSourcePrefixes(mod.Config)
 		if len(prefixes) == 0 {
 			continue
 		}
 		for key, entry := range schema {
-			if entry.Sensitive || strings.TrimSpace(entry.Env) == "" {
+			if strings.TrimSpace(entry.Env) == "" {
 				continue
 			}
 			for _, prefix := range prefixes {
 				name := prefix + strings.TrimSpace(entry.Env)
 				if name == "" {
+					continue
+				}
+				if entry.Sensitive {
+					sensitiveByName[name] = struct{}{}
 					continue
 				}
 				entriesByName[name] = configVariableEntry{
@@ -61,41 +66,7 @@ func collectConfigVariables(cfg *config.WorkflowConfig) []configVariableEntry {
 			}
 		}
 	}
-	return sortedConfigVariableEntries(entriesByName)
-}
-
-func collectSensitiveConfigVariables(cfg *config.WorkflowConfig) []string {
-	if cfg == nil {
-		return nil
-	}
-	names := map[string]struct{}{}
-	for _, mod := range cfg.Modules {
-		if mod.Type != "config.provider" || mod.Config == nil {
-			continue
-		}
-		schema, err := schemaEntriesFromConfigProvider(mod)
-		if err != nil {
-			continue
-		}
-		prefixes := envSourcePrefixes(mod.Config)
-		if len(prefixes) == 0 {
-			continue
-		}
-		for _, entry := range schema {
-			if !entry.Sensitive || strings.TrimSpace(entry.Env) == "" {
-				continue
-			}
-			for _, prefix := range prefixes {
-				names[prefix+strings.TrimSpace(entry.Env)] = struct{}{}
-			}
-		}
-	}
-	out := make([]string, 0, len(names))
-	for name := range names {
-		out = append(out, name)
-	}
-	sort.Strings(out)
-	return out
+	return sortedConfigVariableEntries(entriesByName), sortedStringSet(sensitiveByName), nil
 }
 
 func schemaEntriesFromConfigProvider(mod config.ModuleConfig) (map[string]module.SchemaEntry, error) {
@@ -109,7 +80,7 @@ func schemaEntriesFromConfigProvider(mod config.ModuleConfig) (map[string]module
 func envSourcePrefixes(cfg map[string]any) []string {
 	rawSources, ok := cfg["sources"].([]any)
 	if !ok || len(rawSources) == 0 {
-		return []string{""}
+		return nil
 	}
 	prefixes := map[string]struct{}{}
 	hasEnvSource := false
@@ -132,6 +103,15 @@ func envSourcePrefixes(cfg map[string]any) []string {
 	out := make([]string, 0, len(prefixes))
 	for prefix := range prefixes {
 		out = append(out, prefix)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
 	}
 	sort.Strings(out)
 	return out

--- a/cmd/wfctl/vars_setup_config_test.go
+++ b/cmd/wfctl/vars_setup_config_test.go
@@ -71,6 +71,63 @@ modules:
 	}
 }
 
+func TestCollectConfigVariablesFromTopLevelVars(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deploy.yaml")
+	if err := os.WriteFile(path, []byte(`
+vars:
+  entries:
+    - name: PUBLIC_CLIENT_ID
+      description: OAuth public client ID.
+      required: true
+    - name: OPTIONAL_FLAG
+      default: "false"
+variables:
+  entries:
+    - name: FACEBOOK_APP_ID
+      description: Facebook public app ID.
+    - name: PUBLIC_CLIENT_ID
+      description: Duplicate alias entry should not win.
+modules:
+  - name: app-config
+    type: config.provider
+    config:
+      sources:
+        - type: env
+      schema:
+        google_client_id:
+          env: PUBLIC_CLIENT_ID
+          desc: Schema duplicate should not win over explicit vars entry.
+        secret:
+          env: PRIVATE_SECRET
+          sensitive: true
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	vars, skipped, err := collectConfigVariablesFromFile(path)
+	if err != nil {
+		t.Fatalf("collectConfigVariablesFromFile: %v", err)
+	}
+	byName := map[string]configVariableEntry{}
+	for _, entry := range vars {
+		byName[entry.Name] = entry
+	}
+	for _, name := range []string{"FACEBOOK_APP_ID", "OPTIONAL_FLAG", "PUBLIC_CLIENT_ID"} {
+		if _, ok := byName[name]; !ok {
+			t.Fatalf("missing variable %s in %+v", name, vars)
+		}
+	}
+	if got := byName["PUBLIC_CLIENT_ID"]; !got.Required || got.Key != "vars.PUBLIC_CLIENT_ID" || got.Description != "OAuth public client ID." {
+		t.Fatalf("PUBLIC_CLIENT_ID = %+v", got)
+	}
+	if got := byName["OPTIONAL_FLAG"]; got.Default != "false" {
+		t.Fatalf("OPTIONAL_FLAG = %+v", got)
+	}
+	if len(skipped) != 1 || skipped[0] != "PRIVATE_SECRET" {
+		t.Fatalf("skipped = %+v, want PRIVATE_SECRET", skipped)
+	}
+}
+
 func TestCollectConfigVariablesErrorsOnMalformedSchema(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "app.yaml")
 	if err := os.WriteFile(path, []byte(`

--- a/cmd/wfctl/vars_setup_config_test.go
+++ b/cmd/wfctl/vars_setup_config_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectConfigVariablesFromConfigProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.yaml")
+	if err := os.WriteFile(path, []byte(`
+modules:
+  - name: app-config
+    type: config.provider
+    config:
+      sources:
+        - type: defaults
+        - type: env
+          prefix: APP_
+      schema:
+        public_client_id:
+          env: CLIENT_ID
+          required: true
+          desc: Public OAuth client ID.
+        private_client_secret:
+          env: CLIENT_SECRET
+          sensitive: true
+          desc: OAuth client secret.
+        internal_default:
+          env: INTERNAL_DEFAULT
+          default: local
+          desc: Has a local default.
+        no_env:
+          required: true
+          desc: Not sourced from env.
+  - name: defaults-only
+    type: config.provider
+    config:
+      sources:
+        - type: defaults
+      schema:
+        not_provider_var:
+          env: DEFAULT_ONLY
+          default: value
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	vars, skipped, err := collectConfigVariablesFromFile(path)
+	if err != nil {
+		t.Fatalf("collectConfigVariablesFromFile: %v", err)
+	}
+	if len(vars) != 2 {
+		t.Fatalf("vars = %+v, want 2 non-sensitive env-backed entries", vars)
+	}
+	if vars[0].Name != "APP_CLIENT_ID" || vars[0].Key != "app-config.public_client_id" || !vars[0].Required {
+		t.Fatalf("vars[0] = %+v", vars[0])
+	}
+	if vars[1].Name != "APP_INTERNAL_DEFAULT" || vars[1].Default != "local" {
+		t.Fatalf("vars[1] = %+v", vars[1])
+	}
+	if len(skipped) != 1 || skipped[0] != "APP_CLIENT_SECRET" {
+		t.Fatalf("skipped = %+v, want APP_CLIENT_SECRET", skipped)
+	}
+}
+
+func TestRunVarsSetupConfigOnlySensitiveSkipsWithoutProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.yaml")
+	if err := os.WriteFile(path, []byte(`
+modules:
+  - name: app-config
+    type: config.provider
+    config:
+      sources:
+        - type: env
+      schema:
+        api_token:
+          env: API_TOKEN
+          sensitive: true
+          required: true
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runVarsSetupPluginWithIO([]string{
+		"--config", path,
+		"--non-interactive",
+	}, nil, &out); err != nil {
+		t.Fatalf("runVarsSetupPluginWithIO: %v", err)
+	}
+	if got := out.String(); got == "" || !bytes.Contains(out.Bytes(), []byte("declares no non-secret config variables")) {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}

--- a/cmd/wfctl/vars_setup_config_test.go
+++ b/cmd/wfctl/vars_setup_config_test.go
@@ -43,6 +43,12 @@ modules:
         not_provider_var:
           env: DEFAULT_ONLY
           default: value
+  - name: missing-sources
+    type: config.provider
+    config:
+      schema:
+        not_provider_var:
+          env: MISSING_SOURCES
 `), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -62,6 +68,47 @@ modules:
 	}
 	if len(skipped) != 1 || skipped[0] != "APP_CLIENT_SECRET" {
 		t.Fatalf("skipped = %+v, want APP_CLIENT_SECRET", skipped)
+	}
+}
+
+func TestCollectConfigVariablesErrorsOnMalformedSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.yaml")
+	if err := os.WriteFile(path, []byte(`
+modules:
+  - name: bad-config
+    type: config.provider
+    config:
+      sources:
+        - type: env
+      schema:
+        bad_entry: not-a-map
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := collectConfigVariablesFromFile(path)
+	if err == nil {
+		t.Fatal("expected malformed schema error")
+	}
+}
+
+func TestValuesFromFlagsAndReaderTrimsAndSkipsBlankKeys(t *testing.T) {
+	values, err := valuesFromFlagsAndReader([]string{" FLAG = literal "}, bytes.NewBufferString(`
+ =ignored
+ READER = value
+NO_EQUALS
+`))
+	if err != nil {
+		t.Fatalf("valuesFromFlagsAndReader: %v", err)
+	}
+	if values["FLAG"] != " literal " {
+		t.Fatalf("FLAG = %q", values["FLAG"])
+	}
+	if values["READER"] != "value" {
+		t.Fatalf("READER = %q", values["READER"])
+	}
+	if _, ok := values[""]; ok {
+		t.Fatal("blank key must be skipped")
 	}
 }
 

--- a/cmd/wfctl/vars_setup_plugin.go
+++ b/cmd/wfctl/vars_setup_plugin.go
@@ -52,7 +52,7 @@ Options:
 		if err != nil {
 			return err
 		}
-		return runVarsSetupConfig(*configFile, strings.ToLower(strings.TrimSpace(*scope)), *envName, *org, *orgVisibility, *tokenEnv, values, *fromEnv, *nonInteractive, out)
+		return runVarsSetupConfig(*configFile, strings.ToLower(strings.TrimSpace(*scope)), *envName, *org, *orgVisibility, *tokenEnv, values, *fromEnv, *nonInteractive || in != nil, out)
 	}
 
 	manifest, err := loadPluginManifest(*pluginName, *pluginDir)
@@ -79,17 +79,9 @@ Options:
 		return fmt.Errorf("plugin %q does not declare config target %s:%s", manifest.Name, desc.Provider, desc.Scope)
 	}
 
-	values, err := buildVariableLiteralMap(varFlag)
+	values, err := valuesFromFlagsAndReader(varFlag, in)
 	if err != nil {
 		return err
-	}
-	if in != nil {
-		for _, kv := range readKVLines(in) {
-			k, v, ok := strings.Cut(kv, "=")
-			if ok {
-				values[k] = v
-			}
-		}
 	}
 
 	interactive := in == nil && !*nonInteractive && prompt.CanPrompt()
@@ -173,6 +165,10 @@ func buildVariableLiteralMap(literals []string) (map[string]string, error) {
 		if !found {
 			return nil, fmt.Errorf("--var %q: expected NAME=VALUE format", lit)
 		}
+		k = strings.TrimSpace(k)
+		if k == "" {
+			return nil, fmt.Errorf("--var %q: variable name is required", lit)
+		}
 		values[k] = v
 	}
 	return values, nil
@@ -186,9 +182,14 @@ func valuesFromFlagsAndReader(literals []string, in io.Reader) (map[string]strin
 	if in != nil {
 		for _, kv := range readKVLines(in) {
 			k, v, ok := strings.Cut(kv, "=")
-			if ok {
-				values[k] = v
+			if !ok {
+				continue
 			}
+			k = strings.TrimSpace(k)
+			if k == "" {
+				continue
+			}
+			values[k] = strings.TrimSpace(v)
 		}
 	}
 	return values, nil

--- a/cmd/wfctl/vars_setup_plugin.go
+++ b/cmd/wfctl/vars_setup_plugin.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -19,7 +18,7 @@ func runVarsSetupPlugin(args []string) error {
 
 func runVarsSetupPluginWithIO(args []string, in io.Reader, out io.Writer) error {
 	fs := flag.NewFlagSet("vars setup", flag.ContinueOnError)
-	pluginName := fs.String("plugin", "", "Plugin name (must match a directory under --plugin-dir / $WFCTL_PLUGIN_DIR)")
+	pluginName := fs.String("plugin", "", "Plugin name (must match a directory under --plugin-dir / $WFCTL_PLUGIN_DIR). When omitted, --config is scanned for config.provider env vars.")
 	pluginDir := fs.String("plugin-dir", "", "Plugin install dir (default: $WFCTL_PLUGIN_DIR or ./data/plugins)")
 	scope := fs.String("scope", "repo", "GitHub variable scope: repo | env | org")
 	envName := fs.String("env", "", "Environment name (required with --scope=env)")
@@ -32,11 +31,14 @@ func runVarsSetupPluginWithIO(args []string, in io.Reader, out io.Writer) error 
 	var varFlag multiStringFlag
 	fs.Var(&varFlag, "var", "NAME=VALUE literal. Repeatable.")
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), `Usage: wfctl vars setup --plugin <name> [options]
+		fmt.Fprintf(fs.Output(), `Usage: wfctl vars setup [--plugin <name>] [options]
 
-Set non-secret variables declared by a plugin's plugin.json required_config[] block.
-Sensitive values belong in required_secrets[] and must be configured with
-wfctl secrets setup instead.
+Set non-secret variables declared by either:
+  - a plugin's plugin.json required_config[] block when --plugin is supplied, or
+  - config.provider schema entries with sensitive:false when --plugin is omitted.
+
+Sensitive values belong in required_secrets[] or secrets setup paths and must be
+configured with wfctl secrets setup instead.
 
 Options:
 `)
@@ -46,7 +48,11 @@ Options:
 		return err
 	}
 	if *pluginName == "" {
-		return errors.New("--plugin <name> is required")
+		values, err := valuesFromFlagsAndReader(varFlag, in)
+		if err != nil {
+			return err
+		}
+		return runVarsSetupConfig(*configFile, strings.ToLower(strings.TrimSpace(*scope)), *envName, *org, *orgVisibility, *tokenEnv, values, *fromEnv, *nonInteractive, out)
 	}
 
 	manifest, err := loadPluginManifest(*pluginName, *pluginDir)
@@ -107,6 +113,47 @@ Options:
 	return nil
 }
 
+func runVarsSetupConfig(configFile, scopeStr, envName, org, orgVisibility, tokenEnv string, values map[string]string, fromEnv, nonInteractive bool, out io.Writer) error {
+	entries, skippedSensitive, err := collectConfigVariablesFromFile(configFile)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		fmt.Fprintf(out, "config %q declares no non-secret config variables; nothing to do\n", configFile)
+		if len(skippedSensitive) > 0 {
+			fmt.Fprintf(out, "Skipped sensitive config entries; use wfctl secrets setup for: %s\n", strings.Join(skippedSensitive, ", "))
+		}
+		return nil
+	}
+
+	provider, scopeLabel, err := buildVariableWriter(scopeStr, envName, org, orgVisibility, tokenEnv, configFile)
+	if err != nil {
+		return err
+	}
+
+	interactive := !nonInteractive && prompt.CanPrompt()
+	fmt.Fprintf(out, "Setting up variables from config %q -> %s\n\n", configFile, scopeLabel)
+	if len(skippedSensitive) > 0 {
+		fmt.Fprintf(out, "Sensitive config entries skipped; use wfctl secrets setup for: %s\n\n", strings.Join(skippedSensitive, ", "))
+	}
+	for _, entry := range entries {
+		value, provided, err := configVariableValue(entry, values, fromEnv, interactive)
+		if err != nil {
+			return err
+		}
+		if !provided {
+			fmt.Fprintf(out, "  %s: skipped (no value provided)\n", entry.Name)
+			continue
+		}
+		if err := provider.SetVariable(context.Background(), entry.Name, value); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "  %s: set\n", entry.Name)
+	}
+	fmt.Fprintln(out, "\nAll done.")
+	return nil
+}
+
 func buildVariableWriter(scope, envName, org, visibility, tokenEnv, configFile string) (secrets.VariableProvider, string, error) {
 	p, label, err := buildSecretWriter(scope, envName, org, visibility, tokenEnv, configFile)
 	if err != nil {
@@ -131,6 +178,22 @@ func buildVariableLiteralMap(literals []string) (map[string]string, error) {
 	return values, nil
 }
 
+func valuesFromFlagsAndReader(literals []string, in io.Reader) (map[string]string, error) {
+	values, err := buildVariableLiteralMap(literals)
+	if err != nil {
+		return nil, err
+	}
+	if in != nil {
+		for _, kv := range readKVLines(in) {
+			k, v, ok := strings.Cut(kv, "=")
+			if ok {
+				values[k] = v
+			}
+		}
+	}
+	return values, nil
+}
+
 func pluginConfigValue(cfg PluginRequiredConfig, literals map[string]string, fromEnv, interactive bool) (string, bool, error) {
 	if fromEnv {
 		if v := os.Getenv(cfg.Name); v != "" {
@@ -149,6 +212,32 @@ func pluginConfigValue(cfg PluginRequiredConfig, literals map[string]string, fro
 	}
 	if cfg.Description != "" {
 		label += " - " + cfg.Description
+	}
+	value, err := prompt.Input(label, false)
+	if err != nil {
+		return "", false, err
+	}
+	if value == "" {
+		return "", false, nil
+	}
+	return value, true, nil
+}
+
+func configVariableValue(entry configVariableEntry, literals map[string]string, fromEnv, interactive bool) (string, bool, error) {
+	if fromEnv {
+		if v := os.Getenv(entry.Name); v != "" {
+			return v, true, nil
+		}
+	}
+	if v, ok := literals[entry.Name]; ok {
+		return v, true, nil
+	}
+	if !interactive {
+		return "", false, nil
+	}
+	label := entry.Name
+	if entry.Description != "" {
+		label += " - " + entry.Description
 	}
 	value, err := prompt.Input(label, false)
 	if err != nil {

--- a/cmd/wfctl/vars_setup_plugin.go
+++ b/cmd/wfctl/vars_setup_plugin.go
@@ -35,7 +35,8 @@ func runVarsSetupPluginWithIO(args []string, in io.Reader, out io.Writer) error 
 
 Set non-secret variables declared by either:
   - a plugin's plugin.json required_config[] block when --plugin is supplied, or
-  - config.provider schema entries with sensitive:false when --plugin is omitted.
+  - config vars.entries/variables.entries declarations and config.provider
+    schema entries with sensitive:false when --plugin is omitted.
 
 Sensitive values belong in required_secrets[] or secrets setup paths and must be
 configured with wfctl secrets setup instead.

--- a/config/config.go
+++ b/config/config.go
@@ -158,6 +158,8 @@ type WorkflowConfig struct {
 	CI             *CIConfig                     `json:"ci,omitempty" yaml:"ci,omitempty"`
 	Environments   map[string]*EnvironmentConfig `json:"environments,omitempty" yaml:"environments,omitempty"`
 	Secrets        *SecretsConfig                `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Vars           *VariablesConfig              `json:"vars,omitempty" yaml:"vars,omitempty"`
+	Variables      *VariablesConfig              `json:"variables,omitempty" yaml:"variables,omitempty"`
 	Infra          *InfraConfig                  `json:"infra,omitempty" yaml:"infra,omitempty"`
 	SecretStores   map[string]*SecretStoreConfig `json:"secretStores,omitempty" yaml:"secretStores,omitempty"`
 	Services       map[string]*ServiceConfig     `json:"services,omitempty" yaml:"services,omitempty"`
@@ -456,10 +458,32 @@ func (cfg *WorkflowConfig) processImports(seen map[string]bool) error {
 				existingEntries[e.Name] = struct{}{}
 			}
 		}
+		mergeImportedVariables(&cfg.Vars, impCfg.Vars)
+		mergeImportedVariables(&cfg.Variables, impCfg.Variables)
 	}
 
 	cfg.Imports = nil // clear after processing
 	return nil
+}
+
+func mergeImportedVariables(dst **VariablesConfig, imported *VariablesConfig) {
+	if imported == nil {
+		return
+	}
+	if *dst == nil {
+		*dst = &VariablesConfig{}
+	}
+	existing := make(map[string]struct{}, len((*dst).Entries))
+	for _, entry := range (*dst).Entries {
+		existing[entry.Name] = struct{}{}
+	}
+	for _, entry := range imported.Entries {
+		if _, exists := existing[entry.Name]; exists {
+			continue
+		}
+		(*dst).Entries = append((*dst).Entries, entry)
+		existing[entry.Name] = struct{}{}
+	}
 }
 
 func mergeImportedCI(cfg *WorkflowConfig, imported *CIConfig) {

--- a/config/config_import_test.go
+++ b/config/config_import_test.go
@@ -745,6 +745,76 @@ secrets:
 	}
 }
 
+func TestLoadFromFile_ImportVarsMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	importedYAML := `
+vars:
+  entries:
+    - name: IMPORTED_PUBLIC_ID
+      description: imported
+    - name: SHARED_PUBLIC_ID
+      description: imported shared
+variables:
+  entries:
+    - name: IMPORTED_ALIAS_ID
+      description: imported alias
+`
+	if err := os.WriteFile(filepath.Join(dir, "imported.yaml"), []byte(importedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainYAML := `
+imports:
+  - imported.yaml
+
+vars:
+  entries:
+    - name: MAIN_PUBLIC_ID
+      description: main
+    - name: SHARED_PUBLIC_ID
+      description: main shared
+variables:
+  entries:
+    - name: MAIN_ALIAS_ID
+      description: main alias
+`
+	mainPath := filepath.Join(dir, "main.yaml")
+	if err := os.WriteFile(mainPath, []byte(mainYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromFile(mainPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	varByName := make(map[string]VariableEntry)
+	for _, entry := range cfg.Vars.Entries {
+		if _, exists := varByName[entry.Name]; exists {
+			t.Errorf("duplicate vars entry %q", entry.Name)
+		}
+		varByName[entry.Name] = entry
+	}
+	for _, name := range []string{"MAIN_PUBLIC_ID", "IMPORTED_PUBLIC_ID", "SHARED_PUBLIC_ID"} {
+		if _, ok := varByName[name]; !ok {
+			t.Errorf("expected vars entry %q", name)
+		}
+	}
+	if shared := varByName["SHARED_PUBLIC_ID"]; shared.Description != "main shared" {
+		t.Errorf("expected main-wins vars description, got %q", shared.Description)
+	}
+
+	aliasByName := make(map[string]VariableEntry)
+	for _, entry := range cfg.Variables.Entries {
+		aliasByName[entry.Name] = entry
+	}
+	for _, name := range []string{"MAIN_ALIAS_ID", "IMPORTED_ALIAS_ID"} {
+		if _, ok := aliasByName[name]; !ok {
+			t.Errorf("expected variables entry %q", name)
+		}
+	}
+}
+
 func TestLoadFromFile_ImportCIMerge(t *testing.T) {
 	dir := t.TempDir()
 

--- a/config/merge.go
+++ b/config/merge.go
@@ -18,6 +18,8 @@ func DeepMergeConfigs(base, override *WorkflowConfig) *WorkflowConfig {
 		Pipelines: deepMergeMap(base.Pipelines, override.Pipelines),
 		Platform:  deepMergeMap(base.Platform, override.Platform),
 		Sidecars:  deepMergeSidecars(base.Sidecars, override.Sidecars),
+		Vars:      mergeVariableConfigs(base.Vars, override.Vars, true),
+		Variables: mergeVariableConfigs(base.Variables, override.Variables, true),
 		ConfigDir: base.ConfigDir,
 	}
 	if override.ConfigDir != "" {
@@ -107,6 +109,41 @@ func deepMergeMap(base, override map[string]any) map[string]any {
 	return result
 }
 
+func mergeVariableConfigs(base, override *VariablesConfig, overrideWins bool) *VariablesConfig {
+	if base == nil && override == nil {
+		return nil
+	}
+	if base == nil {
+		return copyVariableConfig(override)
+	}
+	if override == nil {
+		return copyVariableConfig(base)
+	}
+	merged := &VariablesConfig{Entries: append([]VariableEntry(nil), base.Entries...)}
+	index := make(map[string]int, len(merged.Entries))
+	for i, entry := range merged.Entries {
+		index[entry.Name] = i
+	}
+	for _, entry := range override.Entries {
+		if i, exists := index[entry.Name]; exists {
+			if overrideWins {
+				merged.Entries[i] = entry
+			}
+			continue
+		}
+		index[entry.Name] = len(merged.Entries)
+		merged.Entries = append(merged.Entries, entry)
+	}
+	return merged
+}
+
+func copyVariableConfig(cfg *VariablesConfig) *VariablesConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &VariablesConfig{Entries: append([]VariableEntry(nil), cfg.Entries...)}
+}
+
 // MergeConfigs merges a config fragment into the primary config.
 // Modules are appended. Workflows and triggers are merged without
 // overwriting existing keys.
@@ -134,6 +171,9 @@ func MergeConfigs(primary, fragment *WorkflowConfig) {
 			}
 		}
 	}
+
+	primary.Vars = mergeVariableConfigs(primary.Vars, fragment.Vars, false)
+	primary.Variables = mergeVariableConfigs(primary.Variables, fragment.Variables, false)
 
 	// Merge sidecars — deduplicate by name, primary wins
 	if len(fragment.Sidecars) > 0 {

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -143,6 +143,91 @@ func TestDeepMergeConfigs_PipelineOverride(t *testing.T) {
 	}
 }
 
+func TestDeepMergeConfigs_VariablesOverride(t *testing.T) {
+	base := &WorkflowConfig{
+		Vars: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "PUBLIC_CLIENT_ID", Description: "base"},
+			{Name: "BASE_ONLY", Description: "base only"},
+		}},
+		Variables: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "ALIAS_ID", Description: "base alias"},
+		}},
+	}
+	override := &WorkflowConfig{
+		Vars: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "PUBLIC_CLIENT_ID", Description: "override"},
+			{Name: "OVERRIDE_ONLY", Description: "override only"},
+		}},
+		Variables: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "ALIAS_ID", Description: "override alias"},
+		}},
+	}
+
+	result := DeepMergeConfigs(base, override)
+	varsByName := variableEntriesByName(result.Vars)
+	if varsByName["PUBLIC_CLIENT_ID"].Description != "override" {
+		t.Fatalf("PUBLIC_CLIENT_ID = %+v, want override entry", varsByName["PUBLIC_CLIENT_ID"])
+	}
+	if _, ok := varsByName["BASE_ONLY"]; !ok {
+		t.Fatal("BASE_ONLY should be preserved from base")
+	}
+	if _, ok := varsByName["OVERRIDE_ONLY"]; !ok {
+		t.Fatal("OVERRIDE_ONLY should be appended from override")
+	}
+	aliases := variableEntriesByName(result.Variables)
+	if aliases["ALIAS_ID"].Description != "override alias" {
+		t.Fatalf("ALIAS_ID = %+v, want override alias", aliases["ALIAS_ID"])
+	}
+}
+
+func TestMergeConfigs_VariablesPrimaryWins(t *testing.T) {
+	primary := &WorkflowConfig{
+		Vars: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "PUBLIC_CLIENT_ID", Description: "primary"},
+		}},
+		Variables: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "ALIAS_ID", Description: "primary alias"},
+		}},
+	}
+	fragment := &WorkflowConfig{
+		Vars: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "PUBLIC_CLIENT_ID", Description: "fragment"},
+			{Name: "FRAGMENT_ONLY", Description: "fragment only"},
+		}},
+		Variables: &VariablesConfig{Entries: []VariableEntry{
+			{Name: "ALIAS_ID", Description: "fragment alias"},
+			{Name: "ALIAS_FRAGMENT_ONLY", Description: "fragment alias only"},
+		}},
+	}
+
+	MergeConfigs(primary, fragment)
+	varsByName := variableEntriesByName(primary.Vars)
+	if varsByName["PUBLIC_CLIENT_ID"].Description != "primary" {
+		t.Fatalf("PUBLIC_CLIENT_ID = %+v, want primary entry", varsByName["PUBLIC_CLIENT_ID"])
+	}
+	if _, ok := varsByName["FRAGMENT_ONLY"]; !ok {
+		t.Fatal("FRAGMENT_ONLY should be appended from fragment")
+	}
+	aliases := variableEntriesByName(primary.Variables)
+	if aliases["ALIAS_ID"].Description != "primary alias" {
+		t.Fatalf("ALIAS_ID = %+v, want primary alias", aliases["ALIAS_ID"])
+	}
+	if _, ok := aliases["ALIAS_FRAGMENT_ONLY"]; !ok {
+		t.Fatal("ALIAS_FRAGMENT_ONLY should be appended from fragment")
+	}
+}
+
+func variableEntriesByName(cfg *VariablesConfig) map[string]VariableEntry {
+	out := map[string]VariableEntry{}
+	if cfg == nil {
+		return out
+	}
+	for _, entry := range cfg.Entries {
+		out[entry.Name] = entry
+	}
+	return out
+}
+
 func TestDeepMergeConfigs_NestedMapRecursion(t *testing.T) {
 	base := &WorkflowConfig{
 		Workflows: map[string]any{

--- a/config/round_trip_test.go
+++ b/config/round_trip_test.go
@@ -103,3 +103,52 @@ infra:
 		t.Error("after round-trip: Infra.AutoBootstrap: want true, got nil or false")
 	}
 }
+
+func TestWorkflowConfig_RoundTrip_PreservesVars(t *testing.T) {
+	const src = `
+vars:
+  entries:
+    - name: PUBLIC_CLIENT_ID
+      description: OAuth public client ID
+      required: true
+      default: ""
+variables:
+  entries:
+    - name: FACEBOOK_APP_ID
+      description: Facebook public app ID
+`
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "app.yaml")
+	if err := os.WriteFile(srcPath, []byte(src), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	cfg, err := config.LoadFromFile(srcPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	if cfg.Vars == nil || len(cfg.Vars.Entries) != 1 || cfg.Vars.Entries[0].Name != "PUBLIC_CLIENT_ID" {
+		t.Fatalf("cfg.Vars = %+v", cfg.Vars)
+	}
+	if cfg.Variables == nil || len(cfg.Variables.Entries) != 1 || cfg.Variables.Entries[0].Name != "FACEBOOK_APP_ID" {
+		t.Fatalf("cfg.Variables = %+v", cfg.Variables)
+	}
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	roundTripPath := filepath.Join(dir, "roundtrip.yaml")
+	if err := os.WriteFile(roundTripPath, out, 0o600); err != nil {
+		t.Fatalf("write roundtrip: %v", err)
+	}
+	cfg2, err := config.LoadFromFile(roundTripPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile (roundtrip): %v", err)
+	}
+	if cfg2.Vars == nil || len(cfg2.Vars.Entries) != 1 || cfg2.Vars.Entries[0].Name != "PUBLIC_CLIENT_ID" {
+		t.Fatalf("round-trip cfg.Vars = %+v", cfg2.Vars)
+	}
+	if cfg2.Variables == nil || len(cfg2.Variables.Entries) != 1 || cfg2.Variables.Entries[0].Name != "FACEBOOK_APP_ID" {
+		t.Fatalf("round-trip cfg.Variables = %+v", cfg2.Variables)
+	}
+}

--- a/config/variables_config.go
+++ b/config/variables_config.go
@@ -1,0 +1,17 @@
+package config
+
+// VariablesConfig defines non-sensitive configuration values an application
+// expects operators to set in an external variable provider such as GitHub
+// Actions variables. Credential material belongs in SecretsConfig instead.
+type VariablesConfig struct {
+	// Entries lists the non-secret variables this application requires.
+	Entries []VariableEntry `json:"entries,omitempty" yaml:"entries,omitempty"`
+}
+
+// VariableEntry declares a single non-sensitive variable the application needs.
+type VariableEntry struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Default     string `json:"default,omitempty" yaml:"default,omitempty"`
+}

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -2769,18 +2769,22 @@ wfctl vars <action> [options]
 
 #### `vars setup`
 
-Set non-secret variables declared by an installed plugin's
-`plugin.json required_config[]` block. The command uses the same GitHub
-repo/env/org target model as plugin secret setup, but writes to GitHub Actions
-Variables instead of encrypted Actions Secrets. Environment-scoped GitHub
-variables require the named GitHub Actions environment to exist.
+Set non-secret variables declared by either an installed plugin's
+`plugin.json required_config[]` block or an application's `config.provider`
+schema. The command uses the same GitHub repo/env/org target model as plugin
+secret setup, but writes to GitHub Actions Variables instead of encrypted
+Actions Secrets. Environment-scoped GitHub variables require the named GitHub
+Actions environment to exist.
 
 `required_config[]` entries marked `sensitive: true` are rejected; plugin
 authors must model those values in `required_secrets[]` instead.
+For `config.provider` schemas, entries marked `sensitive: true` are skipped and
+should be configured through `wfctl secrets setup` or the app's documented
+secret flow.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--plugin` | _(required)_ | Plugin name or installed plugin directory name |
+| `--plugin` | _(none)_ | Plugin name or installed plugin directory name. When omitted, `--config` is scanned for `config.provider` env-backed schema entries. |
 | `--plugin-dir` | `$WFCTL_PLUGIN_DIR` or `./data/plugins` | Installed plugin directory |
 | `--scope` | `repo` | GitHub variable scope: `repo` \| `env` \| `org` |
 | `--env` | _(none)_ | GitHub Actions environment name for `--scope env` |
@@ -2800,6 +2804,10 @@ CLOUDFLARE_ACCOUNT_ID=abc123 wfctl vars setup \
 # Configure an environment-scoped variable
 NAMECHEAP_CLIENT_IP=203.0.113.10 wfctl vars setup \
   --plugin workflow-plugin-namecheap --scope env --env production --from-env
+
+# Configure non-secret application config.provider env vars
+AUTH_GOOGLE_CLIENT_ID=client-id SMS_AUTH_ENABLED=false wfctl vars setup \
+  --config app.yaml --scope env --env staging --from-env
 ```
 
 ---

--- a/docs/wfctl-secrets-scopes.md
+++ b/docs/wfctl-secrets-scopes.md
@@ -98,6 +98,11 @@ writes GitHub Actions Variables at repo, environment, or organization scope
 instead of encrypted Actions Secrets. A value marked `sensitive: true` is a
 plugin manifest bug and must be moved to `required_secrets[]`.
 
+Applications can use the same variable provider path for non-secret
+`config.provider` schema values. Run `wfctl vars setup --config app.yaml` to
+scan env-backed schema entries where `sensitive: false`; sensitive entries are
+left for the app's secret setup flow.
+
 Manifest-backed setup can discover all provider plugin secrets from `wfctl.yaml`
 and `.wfctl-lock.yaml`:
 


### PR DESCRIPTION
## Summary
- extend `wfctl vars setup` so omitting `--plugin` scans `--config` for env-backed `config.provider` schema entries
- skip sensitive config schema entries and leave them on the secrets setup path
- document plugin and application variable setup flows

## Test Evidence
- RED: before implementation, `GOWORK=off go test ./cmd/wfctl -run TestCollectConfigVariablesFromConfigProvider -count=1` failed with `undefined: collectConfigVariablesFromFile`
- GREEN: `GOWORK=off go test ./cmd/wfctl -run TestCollectConfigVariablesFromConfigProvider -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `GOWORK=off go test ./secrets ./plugin ./cmd/wfctl -count=1`
- `GOWORK=off go run ./cmd/wfctl vars -h`
- `git diff --check`