### PR TITLE
fix(wfctl): stop secrets setup on cancelled value entry

### DIFF
--- a/cmd/wfctl/secrets_setup_interactive.go
+++ b/cmd/wfctl/secrets_setup_interactive.go
@@ -116,7 +116,6 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 		}
 	}
 
-	var promptErr error
 	valuer := func(d setupDecl) (string, bool, error) {
 		label := d.name
 		if d.description != "" {
@@ -124,9 +123,6 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 		}
 		v, err := prompt.Input(label, d.sensitive)
 		if err != nil {
-			if errors.Is(err, prompt.ErrNotInteractive) || errors.Is(err, prompt.ErrCancelled) {
-				promptErr = err
-			}
 			return "", false, err
 		}
 		if v == "" {
@@ -141,13 +137,6 @@ func runSecretsSetupInteractive(ctx context.Context, a *interactiveSetupArgs, ou
 	}
 
 	report, err := runSetupDeclsByStore(ctx, cfg, selectedDecls, valuer, auditFn, false)
-	// If a prompt.Input hit a non-TTY mid-flow, surface ErrNotInteractive so the
-	// caller's fallback triggers. The engine runs with stopOnErr=false, so it
-	// returns (report, nil) even when the valuer reported ErrNotInteractive —
-	// hence this check must run regardless of err.
-	if promptErr != nil {
-		return promptErr
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/wfctl/secrets_setup_interactive.go
+++ b/cmd/wfctl/secrets_setup_interactive.go
@@ -303,6 +303,9 @@ func runSetupDeclsByStore(ctx context.Context, cfg *config.WorkflowConfig, decls
 		value, provided, err := valuer(decl)
 		if err != nil {
 			report.Failed = append(report.Failed, decl.name)
+			if errors.Is(err, prompt.ErrCancelled) || errors.Is(err, prompt.ErrNotInteractive) {
+				return report, err
+			}
 			if stopOnError {
 				return report, err
 			}

--- a/cmd/wfctl/secrets_setup_interactive_test.go
+++ b/cmd/wfctl/secrets_setup_interactive_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/GoCodeAlone/workflow/cmd/wfctl/internal/prompt"
 	"github.com/GoCodeAlone/workflow/config"
 )
 
@@ -198,6 +200,41 @@ func TestQueryDeclStatuses(t *testing.T) {
 	}
 	if byName["B"].IsSet {
 		t.Error("B should be unset")
+	}
+}
+
+func TestRunSetupDeclsByStoreStopsOnPromptCancellation(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.WorkflowConfig{
+		SecretStores: map[string]*config.SecretStoreConfig{
+			"localfs": {Provider: "file", Config: map[string]any{"path": tmp}},
+		},
+	}
+	decls := []setupDecl{
+		{name: "FIRST_SECRET", store: "localfs"},
+		{name: "SECOND_SECRET", store: "localfs"},
+	}
+	asked := []string{}
+	valuer := func(d setupDecl) (string, bool, error) {
+		asked = append(asked, d.name)
+		if d.name == "FIRST_SECRET" {
+			return "", false, prompt.ErrCancelled
+		}
+		return "must-not-be-written", true, nil
+	}
+
+	report, err := runSetupDeclsByStore(context.Background(), cfg, decls, valuer, nil, false)
+	if !errors.Is(err, prompt.ErrCancelled) {
+		t.Fatalf("error = %v, want ErrCancelled", err)
+	}
+	if got, want := strings.Join(asked, ","), "FIRST_SECRET"; got != want {
+		t.Fatalf("prompted secrets = %q, want %q", got, want)
+	}
+	if len(report.Set) != 0 {
+		t.Fatalf("set secrets after cancellation = %v, want none", report.Set)
+	}
+	if len(report.Failed) != 1 || report.Failed[0] != "FIRST_SECRET" {
+		t.Fatalf("failed secrets = %v, want FIRST_SECRET only", report.Failed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop the secrets setup engine immediately when value entry returns prompt cancellation/non-interactive errors
- add regression coverage for cancellation after selected secrets reach the value-entry stage
- prevent prompting/writing later selected secrets after a user cancels the current value prompt

Closes #907.

## Verification
- `GOWORK=off go test ./cmd/wfctl/internal/prompt -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestRunSetupDeclsByStoreStopsOnPromptCancellation|Test.*Secrets|TestRunSecretsSetup|TestPrompt|TestWizard' -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `GOWORK=off golangci-lint run --timeout=5m ./cmd/wfctl/...`
- `git diff --check`

## Regression Proof
With fix absent and the new test present:

```text
$ GOWORK=off go test ./cmd/wfctl -run TestRunSetupDeclsByStoreStopsOnPromptCancellation -count=1
--- FAIL: TestRunSetupDeclsByStoreStopsOnPromptCancellation (0.00s)
    secrets_setup_interactive_test.go:228: error = <nil>, want ErrCancelled
FAIL
```

With fix restored:

```text
$ GOWORK=off go test ./cmd/wfctl -run TestRunSetupDeclsByStoreStopsOnPromptCancellation -count=1
ok  	github.com/GoCodeAlone/workflow/cmd/wfctl	1.076s
```
