### PR TITLE
feat(wfctl): audit plugin release workflows

### DIFF
--- a/cigen/render_gha.go
+++ b/cigen/render_gha.go
@@ -9,7 +9,7 @@ const (
 	githubActionsCheckoutRef = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
 	githubActionsScriptRef   = "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0"
 	// #nosec G101 -- action commit SHA, not a credential.
-	githubActionsSetupWfctlRef = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+	githubActionsSetupWfctlRef = "GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1"
 )
 
 // RenderGitHubActions generates GitHub Actions workflow YAML files from a CIPlan.

--- a/cigen/render_gha_test.go
+++ b/cigen/render_gha_test.go
@@ -77,7 +77,7 @@ func TestRenderGitHubActions_PinsActionSHAs(t *testing.T) {
 
 	for _, want := range []string{
 		"actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
-		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
+		"GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1",
 		"actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0",
 	} {
 		if !strings.Contains(content, want) {

--- a/cmd/wfctl/ci_init_test.go
+++ b/cmd/wfctl/ci_init_test.go
@@ -15,7 +15,7 @@ func TestGenerateGHABootstrap_NoConfig(t *testing.T) {
 	if !strings.Contains(content, "wfctl ci run --phase build,test") {
 		t.Error("expected wfctl ci run --phase build,test in output")
 	}
-	if !strings.Contains(content, "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1") {
+	if !strings.Contains(content, "GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1") {
 		t.Error("expected SHA-pinned setup-wfctl action in output")
 	}
 }

--- a/cmd/wfctl/ci_test.go
+++ b/cmd/wfctl/ci_test.go
@@ -40,7 +40,7 @@ func TestGenerateGitHubActions(t *testing.T) {
 
 	markers := []string{
 		"actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
-		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
+		"GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1",
 		"wfctl infra plan",
 		"permissions",
 	}

--- a/cmd/wfctl/generate.go
+++ b/cmd/wfctl/generate.go
@@ -52,7 +52,7 @@ const (
 	githubActionsSetupGoRef   = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"
 	githubActionsSetupNodeRef = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
 	// #nosec G101 -- action commit SHA, not a credential.
-	githubActionsSetupWfctlRef        = "GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1"
+	githubActionsSetupWfctlRef        = "GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1"
 	githubActionsDockerLoginRef       = "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3"
 	githubActionsDockerSetupBuildxRef = "docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0"
 	githubActionsDockerBuildPushRef   = "docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0"

--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -46,6 +46,8 @@ func runPlugin(args []string) error {
 		return runPluginAudit(subArgs)
 	case "validate-contract":
 		return runPluginValidateContract(subArgs)
+	case "release-workflow":
+		return runPluginReleaseWorkflow(subArgs)
 	case "verify-capabilities":
 		return runPluginVerifyCapabilities(subArgs)
 	case "registry-sync":
@@ -86,6 +88,7 @@ Subcommands:
   validate Validate a plugin manifest from the registry or a local file
   audit    Audit a single plugin source directory
   validate-contract  Validate a plugin source directory against the release contract (workflow#758)
+  release-workflow  Audit/fix plugin release workflow wfctl installation
   verify-capabilities  Spawn plugin binary, verify runtime GetManifest matches plugin.json
   registry-sync  Sync registry manifest versions/capabilities from upstream release tags; subcommands: core, readme (workflow#762)
   conformance Run executable plugin/host conformance checks

--- a/cmd/wfctl/plugin_release_workflow.go
+++ b/cmd/wfctl/plugin_release_workflow.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type releaseWorkflowFinding struct {
+	Code    string
+	Message string
+}
+
+func runPluginReleaseWorkflow(args []string) error {
+	fs := flag.NewFlagSet("plugin release-workflow", flag.ContinueOnError)
+	path := fs.String("path", ".github/workflows/release.yml", "release workflow path")
+	fix := fs.Bool("fix", false, "rewrite known stale wfctl install patterns")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage: wfctl plugin release-workflow [options]
+
+Audit a plugin release workflow for stale wfctl installation patterns. The
+preferred release gate path is the SHA-pinned GoCodeAlone/setup-wfctl action
+with its default latest wfctl resolution.
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(*path)
+	if err != nil {
+		return fmt.Errorf("read release workflow: %w", err)
+	}
+	updated, findings, changed := auditReleaseWorkflow(string(data), *fix)
+	if len(findings) == 0 {
+		fmt.Printf("release workflow OK: %s\n", *path)
+		return nil
+	}
+	for _, finding := range findings {
+		fmt.Printf("%s: %s\n", finding.Code, finding.Message)
+	}
+	if !*fix {
+		return fmt.Errorf("release workflow has %d issue(s); rerun with --fix", len(findings))
+	}
+	if changed {
+		if err := os.WriteFile(*path, []byte(updated), 0o600); err != nil {
+			return fmt.Errorf("write release workflow: %w", err)
+		}
+		fmt.Printf("release workflow updated: %s\n", *path)
+	} else {
+		fmt.Printf("release workflow unchanged: %s\n", *path)
+	}
+	return nil
+}
+
+func auditReleaseWorkflow(content string, fix bool) (string, []releaseWorkflowFinding, bool) {
+	findings := releaseWorkflowFindings(content)
+	if !fix || len(findings) == 0 {
+		return content, findings, false
+	}
+	updated := normalizeSetupWfctlAction(content)
+	updated = replaceManualWfctlInstallSteps(updated)
+	updated = normalizeWfctlBinaryInvocations(updated)
+	updated = normalizeSetupWfctlVersionInput(updated)
+	return updated, findings, updated != content
+}
+
+func releaseWorkflowFindings(content string) []releaseWorkflowFinding {
+	var findings []releaseWorkflowFinding
+	if strings.Contains(content, "workflow/releases/download/v") || strings.Contains(content, "/wfctl-bin/wfctl") {
+		findings = append(findings, releaseWorkflowFinding{
+			Code:    "manual-wfctl-install",
+			Message: "release workflow installs a hardcoded wfctl binary instead of using setup-wfctl",
+		})
+	}
+	if regexp.MustCompile(`GoCodeAlone/setup-wfctl@v[0-9]+`).MatchString(content) {
+		findings = append(findings, releaseWorkflowFinding{
+			Code:    "unpinned-setup-wfctl",
+			Message: "setup-wfctl action uses a mutable major ref instead of a pinned SHA",
+		})
+	}
+	if regexp.MustCompile(`version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+`).MatchString(content) ||
+		regexp.MustCompile(`version:\s*v[0-9]+\.[0-9]+\.[0-9]+`).MatchString(content) {
+		findings = append(findings, releaseWorkflowFinding{
+			Code:    "pinned-wfctl-version",
+			Message: "setup-wfctl pins an explicit wfctl release; use latest unless a workflow documents a compatibility reason",
+		})
+	}
+	if !strings.Contains(content, "GoCodeAlone/setup-wfctl@") {
+		findings = append(findings, releaseWorkflowFinding{
+			Code:    "missing-setup-wfctl",
+			Message: "release workflow does not use the setup-wfctl action",
+		})
+	}
+	return findings
+}
+
+func normalizeSetupWfctlAction(content string) string {
+	re := regexp.MustCompile(`GoCodeAlone/setup-wfctl@[^\s#]+(?:\s*#\s*v1)?`)
+	return re.ReplaceAllString(content, githubActionsSetupWfctlRef)
+}
+
+func replaceManualWfctlInstallSteps(content string) string {
+	lines := strings.SplitAfter(content, "\n")
+	var out []string
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		if !strings.Contains(line, "- name: Install wfctl ") {
+			out = append(out, line)
+			i++
+			continue
+		}
+		indent := line[:strings.Index(line, "- name:")]
+		out = append(out,
+			indent+"- name: Setup wfctl\n",
+			indent+"  uses: "+githubActionsSetupWfctlRef+"\n",
+		)
+		i++
+		for i < len(lines) {
+			next := lines[i]
+			if strings.HasPrefix(next, indent+"- name:") || strings.HasPrefix(next, indent+"- uses:") {
+				break
+			}
+			i++
+		}
+	}
+	return strings.Join(out, "")
+}
+
+func normalizeWfctlBinaryInvocations(content string) string {
+	replacements := map[string]string{
+		`"${{ runner.temp }}/wfctl-bin/wfctl"`: `wfctl`,
+		`${{ runner.temp }}/wfctl-bin/wfctl`:   "wfctl",
+		`"${RUNNER_TEMP}/wfctl-bin/wfctl"`:     `wfctl`,
+		`${RUNNER_TEMP}/wfctl-bin/wfctl`:       "wfctl",
+	}
+	for old, replacement := range replacements {
+		content = strings.ReplaceAll(content, old, replacement)
+	}
+	content = regexp.MustCompile(`run:\s*"?wfctl ([^"\n]+)"`).ReplaceAllString(content, `run: wfctl $1`)
+	return content
+}
+
+func normalizeSetupWfctlVersionInput(content string) string {
+	reInline := regexp.MustCompile(`with:\s*\{\s*version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+['"]?\s*\}`)
+	content = reInline.ReplaceAllString(content, "with: { version: latest }")
+	reBlock := regexp.MustCompile(`version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+['"]?`)
+	return reBlock.ReplaceAllString(content, "version: latest")
+}

--- a/cmd/wfctl/plugin_release_workflow.go
+++ b/cmd/wfctl/plugin_release_workflow.go
@@ -114,7 +114,13 @@ func replaceManualWfctlInstallSteps(content string) string {
 			i++
 			continue
 		}
-		indent := line[:strings.Index(line, "- name:")]
+		nameIndex := strings.Index(line, "- name:")
+		if nameIndex < 0 {
+			out = append(out, line)
+			i++
+			continue
+		}
+		indent := line[:nameIndex]
 		out = append(out,
 			indent+"- name: Setup wfctl\n",
 			indent+"  uses: "+githubActionsSetupWfctlRef+"\n",

--- a/cmd/wfctl/plugin_release_workflow.go
+++ b/cmd/wfctl/plugin_release_workflow.go
@@ -46,6 +46,13 @@ Options:
 	if !*fix {
 		return fmt.Errorf("release workflow has %d issue(s); rerun with --fix", len(findings))
 	}
+	remainingFindings := releaseWorkflowFindings(updated)
+	if len(remainingFindings) > 0 {
+		for _, finding := range remainingFindings {
+			fmt.Printf("remaining %s: %s\n", finding.Code, finding.Message)
+		}
+		return fmt.Errorf("release workflow still has %d issue(s) after --fix", len(remainingFindings))
+	}
 	if changed {
 		if err := os.WriteFile(*path, []byte(updated), 0o600); err != nil {
 			return fmt.Errorf("write release workflow: %w", err)
@@ -83,8 +90,7 @@ func releaseWorkflowFindings(content string) []releaseWorkflowFinding {
 			Message: "setup-wfctl action uses a mutable major ref instead of a pinned SHA",
 		})
 	}
-	if regexp.MustCompile(`version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+`).MatchString(content) ||
-		regexp.MustCompile(`version:\s*v[0-9]+\.[0-9]+\.[0-9]+`).MatchString(content) {
+	if setupWfctlVersionInputPinned(content) {
 		findings = append(findings, releaseWorkflowFinding{
 			Code:    "pinned-wfctl-version",
 			Message: "setup-wfctl pins an explicit wfctl release; use latest unless a workflow documents a compatibility reason",
@@ -109,7 +115,7 @@ func replaceManualWfctlInstallSteps(content string) string {
 	var out []string
 	for i := 0; i < len(lines); {
 		line := lines[i]
-		if !strings.Contains(line, "- name: Install wfctl ") {
+		if !manualWfctlInstallStepName(line) {
 			out = append(out, line)
 			i++
 			continue
@@ -152,8 +158,42 @@ func normalizeWfctlBinaryInvocations(content string) string {
 }
 
 func normalizeSetupWfctlVersionInput(content string) string {
-	reInline := regexp.MustCompile(`with:\s*\{\s*version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+['"]?\s*\}`)
-	content = reInline.ReplaceAllString(content, "with: { version: latest }")
-	reBlock := regexp.MustCompile(`version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+['"]?`)
-	return reBlock.ReplaceAllString(content, "version: latest")
+	lines := strings.SplitAfter(content, "\n")
+	var out []string
+	inSetupStep := false
+	setupIndent := ""
+	versionRe := regexp.MustCompile(`version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+['"]?`)
+	inlineRe := regexp.MustCompile(`with:\s*\{\s*version:\s*['"]?v[0-9]+\.[0-9]+\.[0-9]+['"]?\s*\}`)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- ") {
+			inSetupStep = false
+			stepIndex := strings.Index(line, "- ")
+			if stepIndex < 0 {
+				setupIndent = ""
+			} else {
+				setupIndent = line[:stepIndex]
+			}
+		} else if setupIndent != "" && !strings.HasPrefix(line, setupIndent+" ") && strings.TrimSpace(line) != "" {
+			inSetupStep = false
+		}
+		if strings.Contains(line, "GoCodeAlone/setup-wfctl@") {
+			inSetupStep = true
+		}
+		if inSetupStep {
+			line = inlineRe.ReplaceAllString(line, "with: { version: latest }")
+			line = versionRe.ReplaceAllString(line, "version: latest")
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "")
+}
+
+func manualWfctlInstallStepName(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return regexp.MustCompile(`^- name:\s*Install wfctl(\s+.*)?$`).MatchString(trimmed)
+}
+
+func setupWfctlVersionInputPinned(content string) bool {
+	return normalizeSetupWfctlVersionInput(content) != content
 }

--- a/cmd/wfctl/plugin_release_workflow_test.go
+++ b/cmd/wfctl/plugin_release_workflow_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAuditReleaseWorkflowFindsManualInstall(t *testing.T) {
+	content := staleReleaseWorkflowFixture()
+	_, findings, changed := auditReleaseWorkflow(content, false)
+	if changed {
+		t.Fatal("audit without fix should not change content")
+	}
+	assertReleaseWorkflowFinding(t, findings, "manual-wfctl-install")
+	assertReleaseWorkflowFinding(t, findings, "missing-setup-wfctl")
+}
+
+func TestAuditReleaseWorkflowFixesManualInstall(t *testing.T) {
+	content := staleReleaseWorkflowFixture()
+	updated, findings, changed := auditReleaseWorkflow(content, true)
+	if len(findings) == 0 {
+		t.Fatal("expected findings")
+	}
+	if !changed {
+		t.Fatal("expected fixed content to change")
+	}
+	for _, forbidden := range []string{
+		"workflow/releases/download/v0.63.2",
+		"Install wfctl v0.63.2",
+		"runner.temp }}/wfctl-bin/wfctl",
+	} {
+		if strings.Contains(updated, forbidden) {
+			t.Fatalf("fixed workflow still contains %q:\n%s", forbidden, updated)
+		}
+	}
+	if !strings.Contains(updated, "uses: "+githubActionsSetupWfctlRef) {
+		t.Fatalf("fixed workflow missing pinned setup-wfctl action:\n%s", updated)
+	}
+	if !strings.Contains(updated, "run: wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} .") {
+		t.Fatalf("fixed workflow missing wfctl validation command:\n%s", updated)
+	}
+}
+
+func TestAuditReleaseWorkflowNormalizesSetupAction(t *testing.T) {
+	content := `name: Release
+jobs:
+  release:
+    steps:
+      - uses: GoCodeAlone/setup-wfctl@v1
+        with: { version: v0.61.0 }
+      - run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
+`
+	updated, findings, changed := auditReleaseWorkflow(content, true)
+	assertReleaseWorkflowFinding(t, findings, "unpinned-setup-wfctl")
+	assertReleaseWorkflowFinding(t, findings, "pinned-wfctl-version")
+	if !changed {
+		t.Fatal("expected fixed content to change")
+	}
+	if !strings.Contains(updated, githubActionsSetupWfctlRef) {
+		t.Fatalf("fixed workflow missing pinned action:\n%s", updated)
+	}
+	if strings.Contains(updated, "version: v0.61.0") {
+		t.Fatalf("fixed workflow kept stale version:\n%s", updated)
+	}
+}
+
+func TestRunPluginReleaseWorkflowFixWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "release.yml")
+	if err := os.WriteFile(path, []byte(staleReleaseWorkflowFixture()), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := runPluginReleaseWorkflow([]string{"--path", path}); err == nil {
+		t.Fatal("expected audit without --fix to fail")
+	}
+	if err := runPluginReleaseWorkflow([]string{"--path", path, "--fix"}); err != nil {
+		t.Fatalf("runPluginReleaseWorkflow --fix: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixed workflow: %v", err)
+	}
+	if !strings.Contains(string(data), githubActionsSetupWfctlRef) {
+		t.Fatalf("fixed file missing setup-wfctl action:\n%s", data)
+	}
+}
+
+func assertReleaseWorkflowFinding(t *testing.T, findings []releaseWorkflowFinding, code string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Code == code {
+			return
+		}
+	}
+	t.Fatalf("finding %q not found in %#v", code, findings)
+}
+
+func staleReleaseWorkflowFixture() string {
+	return `name: Release
+jobs:
+  release:
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install wfctl v0.63.2
+        run: |
+          mkdir -p "${RUNNER_TEMP}/wfctl-bin"
+          curl -sSfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -o "${RUNNER_TEMP}/wfctl-bin/wfctl" \
+            "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
+          chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
+      - name: Validate plugin contract for publish (pre-build)
+        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} ."
+      - uses: goreleaser/goreleaser-action@v7
+`
+}

--- a/cmd/wfctl/plugin_release_workflow_test.go
+++ b/cmd/wfctl/plugin_release_workflow_test.go
@@ -43,6 +43,21 @@ func TestAuditReleaseWorkflowFixesManualInstall(t *testing.T) {
 	}
 }
 
+func TestAuditReleaseWorkflowFixesManualInstallWithoutVersionSuffix(t *testing.T) {
+	content := strings.Replace(staleReleaseWorkflowFixture(), "Install wfctl v0.63.2", "Install wfctl", 1)
+	updated, findings, changed := auditReleaseWorkflow(content, true)
+	assertReleaseWorkflowFinding(t, findings, "manual-wfctl-install")
+	if !changed {
+		t.Fatal("expected fixed content to change")
+	}
+	if strings.Contains(updated, "Install wfctl") || strings.Contains(updated, "workflow/releases/download/v0.63.2") {
+		t.Fatalf("fixed workflow kept stale install block:\n%s", updated)
+	}
+	if remaining := releaseWorkflowFindings(updated); len(remaining) != 0 {
+		t.Fatalf("fixed workflow still has findings: %#v\n%s", remaining, updated)
+	}
+}
+
 func TestAuditReleaseWorkflowNormalizesSetupAction(t *testing.T) {
 	content := `name: Release
 jobs:
@@ -63,6 +78,30 @@ jobs:
 	}
 	if strings.Contains(updated, "version: v0.61.0") {
 		t.Fatalf("fixed workflow kept stale version:\n%s", updated)
+	}
+}
+
+func TestAuditReleaseWorkflowDoesNotRewriteUnrelatedVersionInputs(t *testing.T) {
+	content := `name: Release
+jobs:
+  release:
+    steps:
+      - uses: GoCodeAlone/setup-wfctl@v1
+      - uses: example/tool-action@v1
+        with:
+          version: v2.3.4
+      - run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
+`
+	updated, findings, changed := auditReleaseWorkflow(content, true)
+	assertReleaseWorkflowFinding(t, findings, "unpinned-setup-wfctl")
+	if !changed {
+		t.Fatal("expected setup-wfctl ref to change")
+	}
+	if !strings.Contains(updated, "version: v2.3.4") {
+		t.Fatalf("unrelated version input was rewritten:\n%s", updated)
+	}
+	if strings.Contains(updated, "GoCodeAlone/setup-wfctl@v1") {
+		t.Fatalf("setup-wfctl ref was not normalized:\n%s", updated)
 	}
 }
 

--- a/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/plugin/.github/workflows/release.yml.tmpl
@@ -14,7 +14,7 @@ jobs:
         with:
           go-version: '1.26.4'
       - name: Setup wfctl
-        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+        uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - name: Validate release contract before packaging
         run: wfctl plugin validate-contract --for-publish --tag "${{ "{{" }} github.ref_name {{ "}}" }}" .
       - name: Build plugin binaries

--- a/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
+++ b/cmd/wfctl/templates/ui-plugin/.github/workflows/release.yml.tmpl
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '24'
       - name: Setup wfctl
-        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+        uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - name: Build UI
         run: |
           cd ui && npm ci && npm run build && cd ..

--- a/docs/PLUGIN_RELEASE_GATES.md
+++ b/docs/PLUGIN_RELEASE_GATES.md
@@ -68,7 +68,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
       - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
-        with: { version: v0.61.0 }
 
       # 1. Pre-build gate: static contract + tag format
       - name: Validate plugin contract for publish (pre-build)
@@ -97,6 +96,16 @@ jobs:
 ```
 
 Malformed tag → step 1 fails. Stale capabilities or missing ldflag → step 1 fails. Goreleaser mis-writing the tarball plugin.json → step 3 fails. None of these promote the release to public.
+
+`setup-wfctl` defaults to the latest released Workflow CLI and logs the
+resolved version before download. Do not hand-roll `curl` downloads or pin a
+specific wfctl version in plugin release workflows unless the workflow documents
+a compatibility reason. Audit existing release workflows with:
+
+```
+wfctl plugin release-workflow
+wfctl plugin release-workflow --fix
+```
 
 ## What got deleted
 

--- a/docs/PLUGIN_RELEASE_GATES.md
+++ b/docs/PLUGIN_RELEASE_GATES.md
@@ -67,7 +67,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
 
       # 1. Pre-build gate: static contract + tag format
       - name: Validate plugin contract for publish (pre-build)

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -684,6 +684,23 @@ wfctl plugin docs <plugin-dir>
 wfctl plugin docs ./my-plugin/
 ```
 
+#### `plugin release-workflow`
+
+Audit a plugin release workflow for stale wfctl installation patterns. The
+preferred release-gate path is the SHA-pinned `GoCodeAlone/setup-wfctl` action
+with its default `latest` wfctl resolution. Use `--fix` to rewrite known
+hand-rolled install blocks and mutable setup-wfctl refs.
+
+```
+wfctl plugin release-workflow
+wfctl plugin release-workflow --path .github/workflows/release.yml --fix
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--path` | `.github/workflows/release.yml` | Release workflow to audit |
+| `--fix` | `false` | Rewrite known stale wfctl install patterns |
+
 #### `plugin test`
 
 Run a plugin through its full lifecycle in a test harness.

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -3009,7 +3009,7 @@ Plugin CI should generate evidence with the released artifact, then update the r
 ```yaml
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-  - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+  - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
     with:
       version: v0.51.2
   - run: wfctl plugin conformance --mode typed-iac --artifact dist/plugin.tar.gz --engine-version v0.51.2 --format json --output evidence.json

--- a/docs/manual/build-deploy/03-ci-deploy-environments.md
+++ b/docs/manual/build-deploy/03-ci-deploy-environments.md
@@ -76,7 +76,7 @@ deploy-staging:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-    - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+    - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
     - run: wfctl ci run --phase deploy --env staging
 ```
 
@@ -97,7 +97,7 @@ repair-staging-migrations:
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-    - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+    - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
     - run: |
         wfctl migrate repair-dirty --config infra.yaml --env staging \
           --database app-db \

--- a/docs/tutorials/deploy-pipeline.md
+++ b/docs/tutorials/deploy-pipeline.md
@@ -356,21 +356,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase build,test
   deploy-staging:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase deploy --env staging
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase deploy --env prod
 ```
 
@@ -414,7 +414,7 @@ Reference the SHA in your deploy jobs via the `IMAGE_SHA` environment variable (
     needs: [build-image]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase deploy --env staging
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
@@ -454,7 +454,7 @@ Change `deploy-prod.needs` from `[build-test]` to `[deploy-staging]`. This makes
     needs: [build-image]           # waits for image push
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase deploy --env staging
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
@@ -465,7 +465,7 @@ Change `deploy-prod.needs` from `[build-test]` to `[deploy-staging]`. This makes
     needs: [deploy-staging]        # auto-promotes after staging succeeds
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase deploy --env prod
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
@@ -509,7 +509,7 @@ When `requireApproval: true`, `wfctl ci init` emits `environment: prod` in the g
     environment: prod              # GitHub waits for environment protection approval
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+      - uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - run: wfctl ci run --phase deploy --env prod
 ```
 

--- a/plugin/sdk/generator.go
+++ b/plugin/sdk/generator.go
@@ -654,7 +654,7 @@ jobs:
         with:
           go-version: '%s'
       - name: Setup wfctl
-        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
+        uses: GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1
       - name: Validate release contract before packaging
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
       - name: Run GoReleaser

--- a/plugin/sdk/generator_test.go
+++ b/plugin/sdk/generator_test.go
@@ -477,7 +477,7 @@ func TestTemplateGeneratorReleaseWorkflowUsesContractGateAndCurrentActions(t *te
 	}
 	content := string(data)
 	for _, want := range []string{
-		"GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1",
+		"GoCodeAlone/setup-wfctl@526e23ee7d3cae9ba8ba09d87090879e04c7aab2 # v1",
 		"wfctl plugin validate-contract --for-publish --tag \"${{ github.ref_name }}\" .",
 		"goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2",
 		"version: '~> v2'",


### PR DESCRIPTION
Closes #921.\n\n## Summary\n- add wfctl plugin release-workflow audit/fix command\n- normalize stale manual wfctl installs to the pinned setup-wfctl action\n- update release gate docs to rely on setup-wfctl latest resolution\n\n## Verification\n- GOWORK=off go test ./cmd/wfctl\n- wfctl ci validate --platform github_actions against cloudflare/namecheap/hover migrated release workflows