### PR TITLE
fix(wfctl): preserve import-all cloud IDs

### DIFF
--- a/cmd/wfctl/infra_import_all.go
+++ b/cmd/wfctl/infra_import_all.go
@@ -239,7 +239,14 @@ func buildResourceStateFromImport(zoneName, cloudID, resourceType, providerType 
 		Name: resourceType + "/" + sanitizeImportedZoneName(zoneName),
 		Type: resourceType,
 	}
-	return resourceStateFromImportedState(spec, providerType, imported, cloudID)
+	state, err := resourceStateFromImportedState(spec, providerType, imported, cloudID)
+	if err != nil {
+		return interfaces.ResourceState{}, err
+	}
+	if cloudID != "" {
+		state.ProviderID = cloudID
+	}
+	return state, nil
 }
 
 // sanitizeImportedZoneName converts a zone identifier (typically a FQDN like

--- a/cmd/wfctl/infra_import_all.go
+++ b/cmd/wfctl/infra_import_all.go
@@ -224,8 +224,9 @@ func runInfraImportAllWithDeps(ctx context.Context, provider interfaces.IaCProvi
 // importing zones that may not yet be declared.
 //
 // Reuses resourceStateFromImportedState (workflow/cmd/wfctl/infra.go:1198)
-// for ProviderID resolution + AppliedConfig hashing + timestamp normalization
-// so the synthesized state matches the single-resource import path exactly.
+// for AppliedConfig hashing + timestamp normalization, then restores the
+// enumerated cloudID as ProviderID so portfolio exports group by domain even
+// when a provider import returns an opaque durable ID in outputs/applied config.
 func buildResourceStateFromImport(zoneName, cloudID, resourceType, providerType string, imported *interfaces.ResourceState) (interfaces.ResourceState, error) {
 	// Prefix the sanitized zone name with the resource type so that importing
 	// two different types (e.g. infra.dns and infra.dns_delegation) for the

--- a/cmd/wfctl/infra_import_all_format_test.go
+++ b/cmd/wfctl/infra_import_all_format_test.go
@@ -205,6 +205,33 @@ func TestBuildResourceStateFromImport_TypeNamespacedID(t *testing.T) {
 	}
 }
 
+func TestBuildResourceStateFromImport_PreservesEnumeratedCloudID(t *testing.T) {
+	imported := &interfaces.ResourceState{
+		ProviderID: "opaque-zone-id",
+		Type:       "infra.dns",
+		Outputs: map[string]any{
+			"domain":  "example.com",
+			"zone_id": "opaque-zone-id",
+		},
+		AppliedConfig: map[string]any{
+			"domain":  "example.com",
+			"zone_id": "opaque-zone-id",
+		},
+	}
+
+	state, err := buildResourceStateFromImport("example.com", "example.com", "infra.dns", "cloudflare", imported)
+	if err != nil {
+		t.Fatalf("buildResourceStateFromImport: %v", err)
+	}
+
+	if state.ProviderID != "example.com" {
+		t.Fatalf("ProviderID = %q; want enumerated cloudID example.com", state.ProviderID)
+	}
+	if state.Outputs["zone_id"] != "opaque-zone-id" {
+		t.Fatalf("zone_id output = %v; want opaque-zone-id", state.Outputs["zone_id"])
+	}
+}
+
 // TestDumpPortfolio_MergesDnsAndDelegationForSameDomain pins the end-to-end
 // portfolio merge contract (CRITICAL-1 class): when BOTH an infra.dns state
 // and an infra.dns_delegation state for the same domain are present in the

--- a/cmd/wfctl/infra_import_all_format_test.go
+++ b/cmd/wfctl/infra_import_all_format_test.go
@@ -230,6 +230,9 @@ func TestBuildResourceStateFromImport_PreservesEnumeratedCloudID(t *testing.T) {
 	if state.Outputs["zone_id"] != "opaque-zone-id" {
 		t.Fatalf("zone_id output = %v; want opaque-zone-id", state.Outputs["zone_id"])
 	}
+	if state.AppliedConfig["zone_id"] != "opaque-zone-id" {
+		t.Fatalf("zone_id applied config = %v; want opaque-zone-id", state.AppliedConfig["zone_id"])
+	}
 }
 
 // TestDumpPortfolio_MergesDnsAndDelegationForSameDomain pins the end-to-end


### PR DESCRIPTION
## Summary
- preserve the enumerated `cloudID` as saved state `ProviderID` in `wfctl infra import-all`
- retain provider-returned opaque IDs in outputs/applied config
- add a regression test for Cloudflare-style opaque provider IDs

Fixes #929

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestBuildResourceStateFromImport|TestDumpPortfolio_MergesDnsAndDelegationForSameDomain|TestRunInfraImportAllWithDeps_dispatch' -count=1`\n- `GOWORK=off go test ./cmd/wfctl -count=1`