### PR TITLE
fix(wfctl): print apply action progress

### DIFF
--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -459,6 +459,7 @@ func applyWithProviderAndStore(ctx context.Context, provider interfaces.IaCProvi
 	// goes through wfctlhelpers.ApplyPlanWithHooks (Replace + drift
 	// postcondition + IaCProviderFinalizer fan-out).
 	hooks := statePersistenceHooks(store, secretsProvider, provider, providerType, plan.ID, hydratedOut)
+	wireApplyProgressIntoHooks(&hooks, plan.Actions)
 	wireDNSGateIntoHooks(&hooks, provider)
 	wireOwnershipGateIntoHooks(&hooks, provider)
 	result, err := applyV2ApplyPlanWithHooksFn(ctx, provider, &plan, hooks)
@@ -599,6 +600,23 @@ func infraHealthTargets(specs []interfaces.ResourceSpec, current []interfaces.Re
 
 func shouldWaitForInfraHealth(spec interfaces.ResourceSpec) bool {
 	return spec.Type == "infra.container_service"
+}
+
+func wireApplyProgressIntoHooks(hooks *wfctlhelpers.ApplyPlanHooks, actions []interfaces.PlanAction) {
+	if hooks == nil || len(actions) == 0 {
+		return
+	}
+	total := len(actions)
+	nextIndex := 0
+	prior := hooks.OnBeforeAction
+	hooks.OnBeforeAction = func(ctx context.Context, action interfaces.PlanAction) error {
+		nextIndex++
+		fmt.Printf("  -> [%d/%d] %s %s (%s)\n", nextIndex, total, action.Action, action.Resource.Name, action.Resource.Type)
+		if prior == nil {
+			return nil
+		}
+		return prior(ctx, action)
+	}
 }
 
 func statePersistenceHooks(
@@ -1576,6 +1594,7 @@ func applyPrecomputedPlanWithStore(ctx context.Context, plan interfaces.IaCPlan,
 	fmt.Printf("  Plan: %d action(s) to execute.\n", len(plan.Actions))
 	// v2 is the only supported dispatch per ADR 0024 + workflow#699.
 	hooks := statePersistenceHooks(store, secretsProvider, provider, providerType, plan.ID, hydratedOut)
+	wireApplyProgressIntoHooks(&hooks, plan.Actions)
 	wireDNSGateIntoHooks(&hooks, provider)
 	wireOwnershipGateIntoHooks(&hooks, provider)
 	result, err := applyV2ApplyPlanWithHooksFn(ctx, provider, &plan, hooks)

--- a/cmd/wfctl/infra_apply_v2_test.go
+++ b/cmd/wfctl/infra_apply_v2_test.go
@@ -582,7 +582,7 @@ type createOutputDriver struct {
 	iactest.NoopDriver
 }
 
-func (createOutputDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+func (*createOutputDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-" + spec.Name}, nil
 }
 

--- a/cmd/wfctl/infra_apply_v2_test.go
+++ b/cmd/wfctl/infra_apply_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -105,6 +106,40 @@ func TestApplyWithProviderAndStore_V2RoutesThroughWfctlhelpers(t *testing.T) {
 	}
 	if !v2Called.Load() {
 		t.Error("wfctlhelpers.ApplyPlan was not invoked despite manifest declaring v2")
+	}
+}
+
+func TestApplyWithProviderAndStore_PrintsActionStartProgress(t *testing.T) {
+	v2Provider := &v2DriverProvider{driver: &createOutputDriver{}}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(context.Context, interfaces.IaCProvider, []interfaces.ResourceSpec, []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{
+			{Action: "create", Resource: interfaces.ResourceSpec{Name: "first", Type: "infra.test"}},
+			{Action: "create", Resource: interfaces.ResourceSpec{Name: "second", Type: "infra.test"}},
+		}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	stdout, err := captureStdout(t, func() error {
+		return applyWithProviderAndStore(t.Context(), v2Provider, "stub", nil, nil, nil, io.Discard, "test", "", nil)
+	})
+	if err != nil {
+		t.Fatalf("applyWithProviderAndStore: %v", err)
+	}
+
+	start := "  -> [1/2] create first (infra.test)\n"
+	done := "  \u2713 first (infra.test)\n"
+	if !strings.Contains(stdout, start) {
+		t.Fatalf("stdout missing action start progress %q:\n%s", start, stdout)
+	}
+	startIndex := strings.Index(stdout, start)
+	doneIndex := strings.Index(stdout, done)
+	if doneIndex < 0 {
+		t.Fatalf("stdout missing completion line %q:\n%s", done, stdout)
+	}
+	if startIndex > doneIndex {
+		t.Fatalf("action start should print before completion; stdout:\n%s", stdout)
 	}
 }
 
@@ -541,6 +576,14 @@ type v2DriverProvider struct {
 
 func (p *v2DriverProvider) ResourceDriver(string) (interfaces.ResourceDriver, error) {
 	return p.driver, nil
+}
+
+type createOutputDriver struct {
+	iactest.NoopDriver
+}
+
+func (createOutputDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "id-" + spec.Name}, nil
 }
 
 type v2ImmediatePersistDriver struct {


### PR DESCRIPTION
## Summary
- print a plain start line before each wfctl infra apply action: `-> [n/total] action name (type)`
- wire the progress line into both live-diff apply and precomputed-plan apply
- add a regression test proving the start line appears before the existing completion line

## Why
Long CI applies can sit inside one GitHub Actions step while `gh run view --log` refuses to return in-progress logs. The existing completion lines only identify resources after they finish; this identifies the current in-flight action in the browser live log and any captured transcript.

## Verification
- `GOWORK=off go test ./cmd/wfctl -run TestApplyWithProviderAndStore_PrintsActionStartProgress -count=1`
- invariant proof with production progress change reverted: focused test failed with missing `-> [1/2] create first (infra.test)` line
- `GOWORK=off go test ./cmd/wfctl -count=1`
