### PR TITLE
[codex] Print wfctl apply action failures

### DIFF
--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -617,15 +617,40 @@ func wireApplyProgressIntoHooks(hooks *wfctlhelpers.ApplyPlanHooks, actions []in
 		}
 		return prior(ctx, action)
 	}
-	hooks.OnActionComplete = func(_ context.Context, action interfaces.PlanAction, outcome interfaces.ActionOutcome) {
+	priorComplete := hooks.OnActionComplete
+	hooks.OnActionComplete = func(ctx context.Context, action interfaces.PlanAction, outcome interfaces.ActionOutcome) {
+		if priorComplete != nil {
+			priorComplete(ctx, action, outcome)
+		}
 		if outcome.Status == interfaces.ActionStatusSuccess {
 			return
 		}
 		detail := outcome.Error
 		if detail == "" {
-			detail = fmt.Sprintf("status %d", outcome.Status)
+			detail = applyActionStatusLabel(outcome.Status)
 		}
 		fmt.Printf("  ✗ %s (%s): %s\n", action.Resource.Name, action.Resource.Type, detail)
+	}
+}
+
+func applyActionStatusLabel(status interfaces.ActionStatus) string {
+	switch status {
+	case interfaces.ActionStatusUnspecified:
+		return "unspecified"
+	case interfaces.ActionStatusSuccess:
+		return "success"
+	case interfaces.ActionStatusError:
+		return "error"
+	case interfaces.ActionStatusDeleteFailed:
+		return "delete failed"
+	case interfaces.ActionStatusCompensated:
+		return "compensated"
+	case interfaces.ActionStatusCompensationFailed:
+		return "compensation failed"
+	case interfaces.ActionStatusSkipped:
+		return "skipped"
+	default:
+		return fmt.Sprintf("status %d", status)
 	}
 }
 

--- a/cmd/wfctl/infra_apply.go
+++ b/cmd/wfctl/infra_apply.go
@@ -617,6 +617,16 @@ func wireApplyProgressIntoHooks(hooks *wfctlhelpers.ApplyPlanHooks, actions []in
 		}
 		return prior(ctx, action)
 	}
+	hooks.OnActionComplete = func(_ context.Context, action interfaces.PlanAction, outcome interfaces.ActionOutcome) {
+		if outcome.Status == interfaces.ActionStatusSuccess {
+			return
+		}
+		detail := outcome.Error
+		if detail == "" {
+			detail = fmt.Sprintf("status %d", outcome.Status)
+		}
+		fmt.Printf("  ✗ %s (%s): %s\n", action.Resource.Name, action.Resource.Type, detail)
+	}
 }
 
 func statePersistenceHooks(

--- a/cmd/wfctl/infra_apply_v2_test.go
+++ b/cmd/wfctl/infra_apply_v2_test.go
@@ -186,6 +186,43 @@ func TestApplyWithProviderAndStore_PrintsActionFailureProgress(t *testing.T) {
 	}
 }
 
+func TestWireApplyProgressIntoHooks_ChainsActionCompleteAndLabelsEmptyErrors(t *testing.T) {
+	action := interfaces.PlanAction{
+		Action:   "create",
+		Resource: interfaces.ResourceSpec{Name: "skip-me", Type: "infra.test"},
+	}
+	var priorCalls int
+	hooks := wfctlhelpers.ApplyPlanHooks{
+		OnActionComplete: func(context.Context, interfaces.PlanAction, interfaces.ActionOutcome) {
+			priorCalls++
+		},
+	}
+	wireApplyProgressIntoHooks(&hooks, []interfaces.PlanAction{action})
+
+	stdout, err := captureStdout(t, func() error {
+		hooks.OnActionComplete(context.Background(), action, interfaces.ActionOutcome{
+			ActionIndex: 0,
+			Status:      interfaces.ActionStatusSuccess,
+		})
+		hooks.OnActionComplete(context.Background(), action, interfaces.ActionOutcome{
+			ActionIndex: 0,
+			Status:      interfaces.ActionStatusSkipped,
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("capture stdout: %v", err)
+	}
+
+	if priorCalls != 2 {
+		t.Fatalf("prior OnActionComplete calls = %d, want 2", priorCalls)
+	}
+	want := "  ✗ skip-me (infra.test): skipped\n"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing readable skipped label %q:\n%s", want, stdout)
+	}
+}
+
 // TestApplyWithProviderAndStore_V1FallsThroughToProviderApply +
 // TestApplyWithProviderAndStore_V1Path_DeclarerReturnsEmpty +
 // v1RecordingProvider stub were deleted per workflow#699 — v1 dispatch

--- a/cmd/wfctl/infra_apply_v2_test.go
+++ b/cmd/wfctl/infra_apply_v2_test.go
@@ -143,6 +143,49 @@ func TestApplyWithProviderAndStore_PrintsActionStartProgress(t *testing.T) {
 	}
 }
 
+func TestApplyWithProviderAndStore_PrintsActionFailureProgress(t *testing.T) {
+	v2Provider := &v2DriverProvider{driver: &createOutputDriver{}}
+
+	origCompute := computeInfraPlan
+	computeInfraPlan = func(context.Context, interfaces.IaCProvider, []interfaces.ResourceSpec, []interfaces.ResourceState) (interfaces.IaCPlan, error) {
+		return interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+			Action:   "create",
+			Resource: interfaces.ResourceSpec{Name: "bad", Type: "infra.test"},
+		}}}, nil
+	}
+	t.Cleanup(func() { computeInfraPlan = origCompute })
+
+	origApply := applyV2ApplyPlanWithHooksFn
+	applyV2ApplyPlanWithHooksFn = func(ctx context.Context, _ interfaces.IaCProvider, plan *interfaces.IaCPlan, hooks wfctlhelpers.ApplyPlanHooks) (*interfaces.ApplyResult, error) {
+		action := plan.Actions[0]
+		if hooks.OnBeforeAction != nil {
+			if err := hooks.OnBeforeAction(ctx, action); err != nil {
+				return nil, err
+			}
+		}
+		outcome := interfaces.ActionOutcome{ActionIndex: 0, Status: interfaces.ActionStatusError, Error: "create failed"}
+		if hooks.OnActionComplete != nil {
+			hooks.OnActionComplete(ctx, action, outcome)
+		}
+		return &interfaces.ApplyResult{
+			Actions: []interfaces.ActionOutcome{outcome},
+			Errors:  []interfaces.ActionError{{Resource: "bad", Action: "create", Error: "create failed"}},
+		}, nil
+	}
+	t.Cleanup(func() { applyV2ApplyPlanWithHooksFn = origApply })
+
+	stdout, err := captureStdout(t, func() error {
+		return applyWithProviderAndStore(t.Context(), v2Provider, "stub", nil, nil, nil, io.Discard, "test", "", nil)
+	})
+	if err == nil {
+		t.Fatal("expected aggregate apply error, got nil")
+	}
+	want := "  ✗ bad (infra.test): create failed\n"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing failure progress %q:\n%s", want, stdout)
+	}
+}
+
 // TestApplyWithProviderAndStore_V1FallsThroughToProviderApply +
 // TestApplyWithProviderAndStore_V1Path_DeclarerReturnsEmpty +
 // v1RecordingProvider stub were deleted per workflow#699 — v1 dispatch

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -328,7 +328,14 @@ func applyPlanWithEnvProviderAndHooks(
 				}
 				result.Actions = append(result.Actions, outcome)
 				if hooks.OnActionComplete != nil {
-					hooks.OnActionComplete(ctx, action, outcome)
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Printf("warning: OnActionComplete panicked for %s/%s: %v", action.Resource.Type, action.Resource.Name, r)
+							}
+						}()
+						hooks.OnActionComplete(ctx, action, outcome)
+					}()
 				}
 			}()
 

--- a/iac/wfctlhelpers/apply.go
+++ b/iac/wfctlhelpers/apply.go
@@ -110,6 +110,11 @@ type ApplyPlanHooks struct {
 	OnBeforeAction    func(context.Context, interfaces.PlanAction) error
 	OnResourceApplied func(context.Context, interfaces.ResourceDriver, interfaces.PlanAction, interfaces.ResourceOutput) error
 	OnResourceDeleted func(context.Context, interfaces.PlanAction) error
+	// OnActionComplete fires after every PlanAction reaches a terminal
+	// outcome and the corresponding ActionOutcome has been appended to the
+	// ApplyResult. It is observational only: unlike mutation/persistence
+	// hooks above, it cannot alter apply control flow.
+	OnActionComplete func(context.Context, interfaces.PlanAction, interfaces.ActionOutcome)
 	// OnPlanComplete fires once after the per-action loop reaches its
 	// natural success-exit return at the end of
 	// applyPlanWithEnvProviderAndHooks, i.e., when the outer function is
@@ -315,12 +320,16 @@ func applyPlanWithEnvProviderAndHooks(
 				if iterErr != nil {
 					errStr = iterErr.Error()
 				}
-				result.Actions = append(result.Actions, interfaces.ActionOutcome{
+				outcome := interfaces.ActionOutcome{
 					//nolint:gosec // ActionIndex is loop counter bound by len(plan.Actions); G115 false positive.
 					ActionIndex: uint32(i),
 					Status:      iterStatus,
 					Error:       errStr,
-				})
+				}
+				result.Actions = append(result.Actions, outcome)
+				if hooks.OnActionComplete != nil {
+					hooks.OnActionComplete(ctx, action, outcome)
+				}
 			}()
 
 			// Honor cancellation at the loop boundary. Drivers should also

--- a/iac/wfctlhelpers/apply_hooks_test.go
+++ b/iac/wfctlhelpers/apply_hooks_test.go
@@ -84,6 +84,26 @@ func TestApplyPlanWithHooks_CallsOnActionCompleteForFailure(t *testing.T) {
 	}
 }
 
+func TestApplyPlanWithHooks_OnActionCompletePanicDoesNotAbortApply(t *testing.T) {
+	provider := &hookProvider{driver: &hookOrderingDriver{}}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+		Action:   "create",
+		Resource: interfaces.ResourceSpec{Name: "ok", Type: "infra.test"},
+	}}}
+
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{
+		OnActionComplete: func(context.Context, interfaces.PlanAction, interfaces.ActionOutcome) {
+			panic("observer failed")
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPlanWithHooks: %v", err)
+	}
+	if len(result.Actions) != 1 || result.Actions[0].Status != interfaces.ActionStatusSuccess {
+		t.Fatalf("result.Actions = %#v, want one successful outcome", result.Actions)
+	}
+}
+
 func TestApplyPlanWithHooks_DefaultReplaceDeleteHookRunsBeforeCreateFailure(t *testing.T) {
 	driver := &replaceDeleteHookDriver{}
 	provider := &hookProvider{driver: driver}

--- a/iac/wfctlhelpers/apply_hooks_test.go
+++ b/iac/wfctlhelpers/apply_hooks_test.go
@@ -52,6 +52,38 @@ func TestApplyPlanWithHooks_PersistsBeforeLaterAction(t *testing.T) {
 	}
 }
 
+func TestApplyPlanWithHooks_CallsOnActionCompleteForFailure(t *testing.T) {
+	driver := &hookOrderingDriver{
+		create: func(interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+			return nil, errors.New("create failed")
+		},
+	}
+	provider := &hookProvider{driver: driver}
+	plan := &interfaces.IaCPlan{Actions: []interfaces.PlanAction{{
+		Action:   "create",
+		Resource: interfaces.ResourceSpec{Name: "bad", Type: "infra.test"},
+	}}}
+
+	var observed []interfaces.ActionOutcome
+	result, err := ApplyPlanWithHooks(t.Context(), provider, plan, ApplyPlanHooks{
+		OnActionComplete: func(_ context.Context, _ interfaces.PlanAction, outcome interfaces.ActionOutcome) {
+			observed = append(observed, outcome)
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPlanWithHooks: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("result.Errors len = %d, want 1", len(result.Errors))
+	}
+	if len(observed) != 1 {
+		t.Fatalf("OnActionComplete calls = %d, want 1", len(observed))
+	}
+	if observed[0].Status != interfaces.ActionStatusError || !strings.Contains(observed[0].Error, "create failed") {
+		t.Fatalf("observed outcome = %#v, want error outcome with create failure", observed[0])
+	}
+}
+
 func TestApplyPlanWithHooks_DefaultReplaceDeleteHookRunsBeforeCreateFailure(t *testing.T) {
 	driver := &replaceDeleteHookDriver{}
 	provider := &hookProvider{driver: driver}


### PR DESCRIPTION
## Summary

Adds an observational `ApplyPlanHooks.OnActionComplete` callback and wires `wfctl infra apply` progress output to print failed or skipped actions as soon as each action reaches a terminal outcome.

This closes the logging gap seen during Cloudflare staging: wfctl could print `-> [n/N] ...` for later actions while earlier per-action driver failures were only visible in the final aggregate error.

## Validation

- `GOWORK=off go test ./iac/wfctlhelpers -run TestApplyPlanWithHooks_CallsOnActionCompleteForFailure -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestApplyWithProviderAndStore_PrintsAction(Start|Failure)Progress' -count=1`
- `GOWORK=off go test ./iac/wfctlhelpers ./cmd/wfctl -count=1`

## TDD Evidence

Red:

```text
$ GOWORK=off go test ./cmd/wfctl -run TestApplyWithProviderAndStore_PrintsActionFailureProgress -count=1
FAIL: stdout missing failure progress "  ✗ bad (infra.test): create failed\n"
```

Green:

```text
$ GOWORK=off go test ./cmd/wfctl -run TestApplyWithProviderAndStore_PrintsActionFailureProgress -count=1
ok github.com/GoCodeAlone/workflow/cmd/wfctl
```

Invariant proof with print wiring temporarily removed:

```text
FAIL: stdout missing failure progress "  ✗ bad (infra.test): create failed\n"
```
