### PR TITLE
Preserve provider authority in DNS portfolios

### DIFF
--- a/decisions/0047-dns-delegation-portfolio-authority.md
+++ b/decisions/0047-dns-delegation-portfolio-authority.md
@@ -17,6 +17,8 @@ Populate `Snapshot.Authority` with delegation NS, merged by `(provider, domain)`
 
 **Consumer read model:** `authority` attaches to the registrar's snapshot (provider=hover). To find where a domain is live, match `registrar_nameservers` to a provider; a Hover snapshot whose `registrar_nameservers` point elsewhere carries staging/placeholder records.
 
+**Provider-supplied target authority:** `infra.dns` states may also carry safe provider authority metadata in `outputs.authority` (for example Cloudflare assigned nameservers for a staged zone). `record.FromResourceStates` copies allow-listed keys from that map into `Snapshot.Authority` so a portfolio can show both current registrar delegation and target-provider cutover inputs. This does not change registrar-source semantics: `registrar_nameservers` and `live_nameservers` still come from delegation states when available.
+
 Alternatives rejected:
 - **Side-file (`--format state`)** — splits the catalog into two inconsistent formats.
 - **NS-as-records** — conflates registrar delegation with in-zone NS records.
@@ -29,5 +31,6 @@ Alternatives rejected:
 - 3-repo cascade (workflow engine + hover plugin + gocodealone-dns) + 2 releases (wfctl + hover v0.5.1). Engine change is ~15 lines + tests.
 - Additive schema use — `Authority` was always present (`omitempty`); no schema break, existing portfolio consumers unaffected.
 - A snapshot now distinguishes live (NS point here) from staging/placeholder (NS elsewhere) records.
+- Provider-assigned nameservers can be preserved for DNS zones staged before registrar cutover, avoiding a dashboard-only lookup for cutover inputs.
 - Revertible per-repo by version pins; reverting canonicalize returns portfolios to records-only.
 - DO delegation not captured (DO NS are self-referential; the registrar Hover holds the real delegation) — future-optional, not built.

--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -11,6 +11,8 @@ import (
 // FromResourceStates converts imported IaC state into a canonical Portfolio.
 // Reads each infra.dns ResourceState's records (Outputs preferred, else
 // AppliedConfig), renaming provider-specific value keys to the canonical "value".
+// If an infra.dns state includes provider-supplied authority metadata in
+// Outputs["authority"], safe keys are copied into Snapshot.Authority.
 // Each infra.dns_delegation state populates Snapshot.Authority with
 // registrar_nameservers and live_nameservers for the matching domain.
 // States of other types are silently skipped.
@@ -71,6 +73,7 @@ func FromResourceStates(states []interfaces.ResourceState) Portfolio {
 				}
 				snap.Records = append(snap.Records, recordFromMap(m))
 			}
+			mergeAuthority(snap, st.Outputs["authority"])
 
 		case "infra.dns_delegation":
 			domain := st.ProviderID
@@ -144,6 +147,39 @@ func pickRecords(outputs, appliedConfig map[string]any) []any {
 		return recs
 	}
 	return nil
+}
+
+func mergeAuthority(snap *Snapshot, raw any) {
+	authority, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+	for key, value := range authority {
+		if !authorityAllowList[key] {
+			continue
+		}
+		if snap.Authority == nil {
+			snap.Authority = map[string]any{}
+		}
+		snap.Authority[key] = cloneAuthorityValue(value)
+	}
+}
+
+func cloneAuthorityValue(value any) any {
+	switch v := value.(type) {
+	case []any:
+		cp := make([]any, len(v))
+		copy(cp, v)
+		return cp
+	case []string:
+		cp := make([]any, len(v))
+		for i := range v {
+			cp[i] = v[i]
+		}
+		return cp
+	default:
+		return v
+	}
 }
 
 // recordFromMap converts a provider record map to a canonical Record.

--- a/dns/record/canonicalize_test.go
+++ b/dns/record/canonicalize_test.go
@@ -111,6 +111,46 @@ func TestFromResourceStates_DelegationPopulatesAuthority(t *testing.T) {
 	}
 }
 
+func TestFromResourceStates_DNSStatePreservesProviderAuthority(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{
+			Type:       "infra.dns",
+			Provider:   "cloudflare",
+			ProviderID: "example.com",
+			Outputs: map[string]any{
+				"records": []any{
+					map[string]any{"type": "A", "name": "example.com", "data": "192.0.2.10", "ttl": 300},
+				},
+				"authority": map[string]any{
+					"role":                  "target_authoritative_dns",
+					"dns_host":              "Cloudflare",
+					"name_servers":          []any{"ada.ns.cloudflare.com", "bob.ns.cloudflare.com"},
+					"original_name_servers": []any{"ns1.hover.com", "ns2.hover.com"},
+				},
+			},
+		},
+	}
+	p := record.FromResourceStates(states)
+	if len(p.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot from DNS state; got %d", len(p.Snapshots))
+	}
+	snap := p.Snapshots[0]
+	if snap.Authority == nil {
+		t.Fatal("Authority missing provider-supplied DNS authority")
+	}
+	if got := snap.Authority["role"]; got != "target_authoritative_dns" {
+		t.Fatalf("Authority[role] = %v; want target_authoritative_dns", got)
+	}
+	nameServers, ok := snap.Authority["name_servers"].([]any)
+	if !ok || len(nameServers) != 2 || nameServers[0] != "ada.ns.cloudflare.com" {
+		t.Fatalf("Authority[name_servers] = %#v; want Cloudflare assigned nameservers", snap.Authority["name_servers"])
+	}
+	original, ok := snap.Authority["original_name_servers"].([]any)
+	if !ok || len(original) != 2 || original[0] != "ns1.hover.com" {
+		t.Fatalf("Authority[original_name_servers] = %#v; want previous nameservers", snap.Authority["original_name_servers"])
+	}
+}
+
 func TestFromResourceStates_MergesBothLayersByDomain(t *testing.T) {
 	states := []interfaces.ResourceState{
 		{

--- a/dns/record/sanitize.go
+++ b/dns/record/sanitize.go
@@ -24,6 +24,12 @@ import (
 var authorityAllowList = map[string]bool{
 	"registrar_nameservers": true,
 	"live_nameservers":      true,
+	"role":                  true,
+	"dns_host":              true,
+	"name_servers":          true,
+	"original_name_servers": true,
+	"original_registrar":    true,
+	"original_dnshost":      true,
 }
 
 // Sanitize sets p.Sanitized = true.

--- a/dns/record/sanitize_test.go
+++ b/dns/record/sanitize_test.go
@@ -325,8 +325,8 @@ func TestSanitizePreservesExistingExampleIPs(t *testing.T) {
 }
 
 // TestSanitizeStripsUnknownAuthorityKeys pins that Sanitize removes any key
-// from Snapshot.Authority that is NOT in the allow-list
-// {registrar_nameservers, live_nameservers}, while leaving allowed keys intact.
+// from Snapshot.Authority that is not in the allow-list, while leaving allowed
+// delegation and provider-supplied target-authority keys intact.
 // A nil Authority must not panic, and Records sanitization must still work.
 func TestSanitizeStripsUnknownAuthorityKeys(t *testing.T) {
 	// Snapshot with a non-nil Authority containing both allowed and disallowed keys.
@@ -339,6 +339,12 @@ func TestSanitizeStripsUnknownAuthorityKeys(t *testing.T) {
 				Authority: map[string]any{
 					"registrar_nameservers": []any{"ns1.x"},
 					"live_nameservers":      []any{"ns2.x"},
+					"role":                  "target_authoritative_dns",
+					"dns_host":              "Cloudflare",
+					"name_servers":          []any{"ada.ns.cloudflare.com", "bob.ns.cloudflare.com"},
+					"original_name_servers": []any{"ns1.hover.com"},
+					"original_registrar":    "Hover",
+					"original_dnshost":      "Hover",
 					"secret_token":          "leak",
 					"domain_id":             "12345",
 				},
@@ -389,6 +395,11 @@ func TestSanitizeStripsUnknownAuthorityKeys(t *testing.T) {
 	}
 	if _, found := auth["domain_id"]; found {
 		t.Error("domain_id was NOT removed; it must be stripped by Sanitize")
+	}
+	for _, key := range []string{"role", "dns_host", "name_servers", "original_name_servers", "original_registrar", "original_dnshost"} {
+		if _, found := auth[key]; !found {
+			t.Errorf("%s was removed; provider-supplied authority metadata must remain", key)
+		}
 	}
 
 	// Nil Authority on second snapshot must not panic (verified by reaching here).


### PR DESCRIPTION
## Summary
- fixes `dns/record.FromResourceStates` to preserve allow-listed provider-supplied `outputs.authority` from `infra.dns` states
- extends DNS portfolio sanitization to retain non-secret target-authority keys such as Cloudflare assigned nameservers
- documents the amended `Snapshot.Authority` semantics in ADR 0047

Closes #933.

## Root Cause
Cloudflare emitted assigned zone nameservers in the `infra.dns` state output, but the portfolio canonicalizer only populated `Snapshot.Authority` from `infra.dns_delegation` states. `wfctl infra import-all --format portfolio` therefore dropped the target nameservers needed for Cloudflare zone activation.

## TDD Evidence
With fix absent:
```sh
GOWORK=off go test ./dns/record -run 'TestFromResourceStates_DNSStatePreservesProviderAuthority|TestSanitizeStripsUnknownAuthorityKeys' -count=1
# FAIL: Authority missing provider-supplied DNS authority
# FAIL: provider-supplied authority metadata removed by Sanitize
```

With fix restored:
```sh
GOWORK=off go test ./dns/record -run 'TestFromResourceStates_DNSStatePreservesProviderAuthority|TestSanitizeStripsUnknownAuthorityKeys' -count=1
# ok github.com/GoCodeAlone/workflow/dns/record
```

## Validation
```sh
GOWORK=off go test ./dns/record ./cmd/wfctl -count=1
GOWORK=off go test ./... -count=1
```