### PR TITLE
Stream external plugin stderr

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -226,7 +226,7 @@ If a plugin process crashes (segfault, panic, OOM kill), the engine detects the 
 
 1. Marks the plugin as "unloaded"
 2. Returns errors for any in-flight requests to that plugin's types
-3. Logs the failure with the plugin's stderr output
+3. Streams plugin stderr with `[external-plugins] plugin "<name>" stderr:` prefixes so failure diagnostics are visible in operator logs
 4. The engine continues running; other plugins and built-in types are unaffected
 
 Crashed plugins can be reloaded via the API (`POST /api/v1/plugins/external/{name}/reload`).

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -226,7 +226,7 @@ If a plugin process crashes (segfault, panic, OOM kill), the engine detects the 
 
 1. Marks the plugin as "unloaded"
 2. Returns errors for any in-flight requests to that plugin's types
-3. Streams plugin stderr with `[external-plugins] plugin "<name>" stderr:` prefixes so failure diagnostics are visible in operator logs
+3. Streams plugin stderr with `plugin "<name>" stderr:` entries so failure diagnostics are visible in operator logs; the default manager logger also prepends `[external-plugins]`
 4. The engine continues running; other plugins and built-in types are unaffected
 
 Crashed plugins can be reloaded via the API (`POST /api/v1/plugins/external/{name}/reload`).

--- a/docs/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -723,7 +723,7 @@ Check the plugin's `GetStepTypes()` / `GetModuleTypes()` / `GetTriggerTypes()` r
 
 ### Plugin crashes during execution
 
-Check the engine logs for `[plugin]` entries. The engine captures plugin stdout/stderr. If the plugin process exits unexpectedly, the `RemoteStep` or `RemoteModule` proxy will return a gRPC connection error.
+Check the engine logs for `[external-plugins]` entries. Plugin stderr is streamed with `plugin "<name>" stderr:` prefixes so progress and diagnostics remain visible in CI logs. If the plugin process exits unexpectedly, the `RemoteStep` or `RemoteModule` proxy will return a gRPC connection error.
 
 ### Data conversion errors
 

--- a/docs/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -723,7 +723,7 @@ Check the plugin's `GetStepTypes()` / `GetModuleTypes()` / `GetTriggerTypes()` r
 
 ### Plugin crashes during execution
 
-Check the engine logs for `[external-plugins]` entries. Plugin stderr is streamed with `plugin "<name>" stderr:` prefixes so progress and diagnostics remain visible in CI logs. If the plugin process exits unexpectedly, the `RemoteStep` or `RemoteModule` proxy will return a gRPC connection error.
+Check the engine logs for `plugin "<name>" stderr:` entries. The default external-plugin logger also adds an `[external-plugins]` prefix, but callers may supply a custom logger. Plugin stderr is streamed so progress and diagnostics remain visible in CI logs. If the plugin process exits unexpectedly, the `RemoteStep` or `RemoteModule` proxy will return a gRPC connection error.
 
 ### Data conversion errors
 

--- a/plugin/external/manager.go
+++ b/plugin/external/manager.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	goplugin "github.com/GoCodeAlone/go-plugin"
@@ -164,11 +165,14 @@ func (m *ExternalPluginManager) startPluginLocked(name string) (*pluginLaunch, e
 	// which may not be writable (e.g. /app owned by root, process runs as nonroot).
 	cmd := exec.Command(binaryPath) //nolint:gosec // G204: plugin binary path is from trusted data/plugins directory
 	cmd.Dir = pluginDir
+	pluginStderr := newPluginStderrForwarder(name, m.logger)
 
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  Handshake,
 		Plugins:          goplugin.PluginSet{"plugin": &GRPCPlugin{CallbackServer: m.callbackServer}},
 		Cmd:              cmd,
+		Stderr:           pluginStderr,
+		SyncStderr:       pluginStderr,
 		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
 	})
 
@@ -199,6 +203,31 @@ func (m *ExternalPluginManager) startPluginLocked(name string) (*pluginLaunch, e
 	}
 
 	return &pluginLaunch{client: client, adapter: adapter}, nil
+}
+
+type pluginStderrForwarder struct {
+	name   string
+	logger *log.Logger
+	mu     sync.Mutex
+}
+
+func newPluginStderrForwarder(name string, logger *log.Logger) *pluginStderrForwarder {
+	return &pluginStderrForwarder{name: name, logger: logger}
+}
+
+func (w *pluginStderrForwarder) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	text := strings.ReplaceAll(string(p), "\r\n", "\n")
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		w.logger.Printf("plugin %q stderr: %s", w.name, line)
+	}
+	return len(p), nil
 }
 
 // UnloadPlugin stops the named plugin subprocess and removes it from the internal map.

--- a/plugin/external/manager.go
+++ b/plugin/external/manager.go
@@ -209,6 +209,7 @@ type pluginStderrForwarder struct {
 	name   string
 	logger *log.Logger
 	mu     sync.Mutex
+	buf    string
 }
 
 func newPluginStderrForwarder(name string, logger *log.Logger) *pluginStderrForwarder {
@@ -219,8 +220,10 @@ func (w *pluginStderrForwarder) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	text := strings.ReplaceAll(string(p), "\r\n", "\n")
-	for _, line := range strings.Split(text, "\n") {
+	w.buf += string(p)
+	lines := strings.Split(w.buf, "\n")
+	w.buf = lines[len(lines)-1]
+	for _, line := range lines[:len(lines)-1] {
 		line = strings.TrimRight(line, "\r")
 		if strings.TrimSpace(line) == "" {
 			continue

--- a/plugin/external/manager_test.go
+++ b/plugin/external/manager_test.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"bytes"
 	"errors"
 	"log"
 	"os"
@@ -10,6 +11,33 @@ import (
 
 	goplugin "github.com/GoCodeAlone/go-plugin"
 )
+
+func TestPluginStderrForwarderPrefixesPluginLines(t *testing.T) {
+	var out bytes.Buffer
+	logger := log.New(&out, "[external-plugins] ", 0)
+	forwarder := newPluginStderrForwarder("hover", logger)
+
+	n, err := forwarder.Write([]byte("first line\nsecond line\r\n\nthird line"))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len("first line\nsecond line\r\n\nthird line") {
+		t.Fatalf("Write returned n=%d, want %d", n, len("first line\nsecond line\r\n\nthird line"))
+	}
+	got := out.String()
+	for _, want := range []string{
+		`[external-plugins] plugin "hover" stderr: first line`,
+		`[external-plugins] plugin "hover" stderr: second line`,
+		`[external-plugins] plugin "hover" stderr: third line`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("forwarded stderr missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `stderr: `+"\n") {
+		t.Fatalf("forwarded stderr should skip blank lines:\n%s", got)
+	}
+}
 
 func TestExternalPluginManagerStoresCallbackServer(t *testing.T) {
 	manager := NewExternalPluginManager(t.TempDir(), log.Default())

--- a/plugin/external/manager_test.go
+++ b/plugin/external/manager_test.go
@@ -17,12 +17,22 @@ func TestPluginStderrForwarderPrefixesPluginLines(t *testing.T) {
 	logger := log.New(&out, "[external-plugins] ", 0)
 	forwarder := newPluginStderrForwarder("hover", logger)
 
-	n, err := forwarder.Write([]byte("first line\nsecond line\r\n\nthird line"))
+	n, err := forwarder.Write([]byte("first line\nsecond line\r\n\nthird"))
 	if err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	if n != len("first line\nsecond line\r\n\nthird line") {
-		t.Fatalf("Write returned n=%d, want %d", n, len("first line\nsecond line\r\n\nthird line"))
+	if n != len("first line\nsecond line\r\n\nthird") {
+		t.Fatalf("Write returned n=%d, want %d", n, len("first line\nsecond line\r\n\nthird"))
+	}
+	if strings.Contains(out.String(), "third") {
+		t.Fatalf("forwarded stderr should not emit partial line:\n%s", out.String())
+	}
+	n, err = forwarder.Write([]byte(" line\n"))
+	if err != nil {
+		t.Fatalf("Write continuation: %v", err)
+	}
+	if n != len(" line\n") {
+		t.Fatalf("Write continuation returned n=%d, want %d", n, len(" line\n"))
 	}
 	got := out.String()
 	for _, want := range []string{


### PR DESCRIPTION
## Summary
- forward external plugin stderr through the existing `[external-plugins]` logger
- prefix forwarded lines with the plugin name
- document visible plugin stderr diagnostics

## Why
Live DNS migration runs need provider diagnostics from Hover. Today plugin stderr is reduced to go-plugin TRACE chunk-length logs, which hides the actionable provider output during CI runs.

## Verification
- `GOWORK=off go test ./plugin/external -run 'TestPluginStderrForwarderPrefixesPluginLines|TestExternalPluginManager' -count=1`\n- `GOWORK=off go test ./plugin/external ./cmd/wfctl -run 'TestPlugin|TestExternalPlugin|Test.*Plugin' -count=1`\n- `git diff --check`