### PR TITLE
[codex] Add DNS intent compiler

### DIFF
--- a/cmd/wfctl/dns.go
+++ b/cmd/wfctl/dns.go
@@ -20,7 +20,8 @@ func runDNS(args []string) error {
 	case "intent":
 		return runDNSIntent(args[1:])
 	case "-h", "--help", "help":
-		return dnsUsage()
+		_ = dnsUsage()
+		return flag.ErrHelp
 	default:
 		return fmt.Errorf("dns: unknown subcommand %q", args[0])
 	}
@@ -45,7 +46,8 @@ func runDNSIntent(args []string) error {
 	case "compile":
 		return runDNSIntentCompile(args[1:])
 	case "-h", "--help", "help":
-		return dnsIntentUsage()
+		_ = dnsIntentUsage()
+		return flag.ErrHelp
 	default:
 		return fmt.Errorf("dns intent: unknown subcommand %q", args[0])
 	}

--- a/cmd/wfctl/dns.go
+++ b/cmd/wfctl/dns.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/dns/intent"
+	"gopkg.in/yaml.v3"
+)
+
+func runDNS(args []string) error {
+	if len(args) < 1 {
+		return dnsUsage()
+	}
+	switch args[0] {
+	case "intent":
+		return runDNSIntent(args[1:])
+	case "-h", "--help", "help":
+		return dnsUsage()
+	default:
+		return fmt.Errorf("dns: unknown subcommand %q", args[0])
+	}
+}
+
+func dnsUsage() error {
+	fmt.Fprintf(flag.CommandLine.Output(), `Usage: wfctl dns <subcommand> [flags]
+
+DNS orchestration helpers.
+
+Subcommands:
+  intent   Compile domain intent into infra resources and reports
+`)
+	return fmt.Errorf("missing or unknown subcommand")
+}
+
+func runDNSIntent(args []string) error {
+	if len(args) < 1 {
+		return dnsIntentUsage()
+	}
+	switch args[0] {
+	case "compile":
+		return runDNSIntentCompile(args[1:])
+	case "-h", "--help", "help":
+		return dnsIntentUsage()
+	default:
+		return fmt.Errorf("dns intent: unknown subcommand %q", args[0])
+	}
+}
+
+func dnsIntentUsage() error {
+	fmt.Fprintf(flag.CommandLine.Output(), `Usage: wfctl dns intent <subcommand> [flags]
+
+Subcommands:
+  compile   Compile domain intent JSON and DNS portfolio exports
+`)
+	return fmt.Errorf("missing or unknown subcommand")
+}
+
+func runDNSIntentCompile(args []string) error {
+	fs := flag.NewFlagSet("dns intent compile", flag.ContinueOnError)
+	var intentPath, portfolioCSV, domain, outputPath, reportPath, bundlePath, stateDir string
+	fs.StringVar(&intentPath, "intent", "domains.json", "Domain intent JSON file")
+	fs.StringVar(&portfolioCSV, "portfolio", "zones/*.portfolio.json", "Comma-separated DNS portfolio JSON paths or globs")
+	fs.StringVar(&domain, "domain", "", "Optional single domain to compile")
+	fs.StringVar(&outputPath, "output", "infra/domain-reconcile.generated.wfctl.yaml", "Generated wfctl config path")
+	fs.StringVar(&reportPath, "report", "reports/domain-reconcile-report.json", "Generated JSON report path")
+	fs.StringVar(&bundlePath, "bundle", "", "Optional combined JSON bundle path")
+	fs.StringVar(&stateDir, "state-dir", ".state/domain-intent/", "Filesystem state directory for generated iac.state")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	portfolios := splitDNSIntentCSV(portfolioCSV)
+	bundle, err := intent.Compile(intent.Options{
+		IntentPath:     intentPath,
+		PortfolioGlobs: portfolios,
+		DomainFilter:   domain,
+		StateDir:       stateDir,
+	})
+	if err != nil {
+		return err
+	}
+	configBytes, err := yaml.Marshal(bundle.Config)
+	if err != nil {
+		return fmt.Errorf("marshal generated config: %w", err)
+	}
+	reportBytes, err := json.MarshalIndent(bundle.Report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	reportBytes = append(reportBytes, '\n')
+	if err := writeFileCreatingParents(outputPath, configBytes); err != nil {
+		return err
+	}
+	if err := writeFileCreatingParents(reportPath, reportBytes); err != nil {
+		return err
+	}
+	if bundlePath != "" {
+		bundleBytes, err := json.MarshalIndent(bundle, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal bundle: %w", err)
+		}
+		bundleBytes = append(bundleBytes, '\n')
+		if err := writeFileCreatingParents(bundlePath, bundleBytes); err != nil {
+			return err
+		}
+	}
+	for _, domainReport := range bundle.Report.Domains {
+		if len(domainReport.Blockers) == 0 {
+			actionTypes := make([]string, 0, len(domainReport.Actions))
+			for _, action := range domainReport.Actions {
+				actionTypes = append(actionTypes, action.Type)
+			}
+			fmt.Printf("%s: %s\n", domainReport.Domain, strings.Join(actionTypes, ","))
+		} else {
+			fmt.Printf("%s: blocked: %s\n", domainReport.Domain, strings.Join(domainReport.Blockers, "; "))
+		}
+	}
+	if bundle.Report.BlockedDomains > 0 {
+		return fmt.Errorf("%d domain(s) blocked", bundle.Report.BlockedDomains)
+	}
+	return nil
+}
+
+func writeFileCreatingParents(path string, data []byte) error {
+	if path == "" || path == "-" {
+		_, err := os.Stdout.Write(data)
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %q: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}
+
+func splitDNSIntentCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/cmd/wfctl/dns.go
+++ b/cmd/wfctl/dns.go
@@ -108,10 +108,12 @@ func runDNSIntentCompile(args []string) error {
 			return err
 		}
 	}
-	for _, domainReport := range bundle.Report.Domains {
+	for i := range bundle.Report.Domains {
+		domainReport := &bundle.Report.Domains[i]
 		if len(domainReport.Blockers) == 0 {
 			actionTypes := make([]string, 0, len(domainReport.Actions))
-			for _, action := range domainReport.Actions {
+			for j := range domainReport.Actions {
+				action := &domainReport.Actions[j]
 				actionTypes = append(actionTypes, action.Type)
 			}
 			fmt.Printf("%s: %s\n", domainReport.Domain, strings.Join(actionTypes, ","))
@@ -130,10 +132,10 @@ func writeFileCreatingParents(path string, data []byte) error {
 		_, err := os.Stdout.Write(data)
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("create parent directory for %q: %w", path, err)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write %q: %w", path, err)
 	}
 	return nil

--- a/cmd/wfctl/dns_test.go
+++ b/cmd/wfctl/dns_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestRunDNSRegistered(t *testing.T) {
+	if _, ok := commands["dns"]; !ok {
+		t.Fatal("dns command not registered")
+	}
+	embedded := string(wfctlConfigBytes)
+	for _, want := range []string{"name: dns", "command: dns"} {
+		if !strings.Contains(embedded, want) {
+			t.Fatalf("embedded wfctl config missing %q", want)
+		}
+	}
+}
+
+func TestRunDNSIntentCompileWritesConfigAndReport(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := filepath.Join(dir, "domains.json")
+	if err := os.WriteFile(intentPath, []byte(`{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "example.com": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "stage_dns": true,
+      "nameserver_cutover": false,
+      "records_policy": "preserve_cloudflare"
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+	portfolioPath := filepath.Join(dir, "portfolio.json")
+	if err := os.WriteFile(portfolioPath, []byte(`{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [
+    {
+      "id": "cf-example-com",
+      "provider": "cloudflare",
+      "domain": "example.com",
+      "authority": {"name_servers": ["a.ns.cloudflare.com", "b.ns.cloudflare.com"]},
+      "records": [{"type": "A", "name": "@", "value": "192.0.2.10", "ttl": 30}]
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write portfolio: %v", err)
+	}
+	outputPath := filepath.Join(dir, "out.yaml")
+	reportPath := filepath.Join(dir, "report.json")
+	if err := runDNS([]string{"intent", "compile",
+		"--intent", intentPath,
+		"--portfolio", portfolioPath,
+		"--output", outputPath,
+		"--report", reportPath,
+	}); err != nil {
+		t.Fatalf("runDNS intent compile: %v", err)
+	}
+
+	cfgData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output config: %v", err)
+	}
+	var cfg struct {
+		Modules []struct {
+			Name   string         `yaml:"name"`
+			Type   string         `yaml:"type"`
+			Config map[string]any `yaml:"config"`
+		} `yaml:"modules"`
+	}
+	if err := yaml.Unmarshal(cfgData, &cfg); err != nil {
+		t.Fatalf("parse output config: %v\n%s", err, cfgData)
+	}
+	if len(cfg.Modules) != 3 {
+		t.Fatalf("module count = %d, want provider+state+dns: %#v", len(cfg.Modules), cfg.Modules)
+	}
+	var foundDNS bool
+	for _, module := range cfg.Modules {
+		if module.Name == "cf-example-com" {
+			foundDNS = true
+			if module.Type != "infra.dns" {
+				t.Fatalf("dns module type = %q", module.Type)
+			}
+			records, ok := module.Config["records"].([]any)
+			if !ok || len(records) != 1 {
+				t.Fatalf("records = %#v, want one record", module.Config["records"])
+			}
+			rec, ok := records[0].(map[string]any)
+			if !ok || rec["ttl"] != 60 {
+				t.Fatalf("record = %#v, want ttl normalized to 60", records[0])
+			}
+		}
+	}
+	if !foundDNS {
+		t.Fatalf("generated config missing cf-example-com: %#v", cfg.Modules)
+	}
+
+	reportData, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report struct {
+		Schema         string `json:"schema"`
+		BlockedDomains int    `json:"blocked_domains"`
+		ActionCount    int    `json:"action_count"`
+	}
+	if err := json.Unmarshal(reportData, &report); err != nil {
+		t.Fatalf("parse report: %v\n%s", err, reportData)
+	}
+	if report.Schema != "workflow.domain-intent.report.v1" || report.BlockedDomains != 0 || report.ActionCount != 1 {
+		t.Fatalf("bad report: %+v", report)
+	}
+}

--- a/cmd/wfctl/dns_test.go
+++ b/cmd/wfctl/dns_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +21,24 @@ func TestRunDNSRegistered(t *testing.T) {
 		if !strings.Contains(embedded, want) {
 			t.Fatalf("embedded wfctl config missing %q", want)
 		}
+	}
+}
+
+func TestRunDNSHelpReturnsFlagErrHelp(t *testing.T) {
+	if err := runDNS([]string{"--help"}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("wfctl dns --help error = %v, want flag.ErrHelp", err)
+	}
+	if err := runDNS([]string{}); err == nil || errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("wfctl dns without subcommand should be a usage error, not help: %v", err)
+	}
+}
+
+func TestRunDNSIntentHelpReturnsFlagErrHelp(t *testing.T) {
+	if err := runDNS([]string{"intent", "--help"}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("wfctl dns intent --help error = %v, want flag.ErrHelp", err)
+	}
+	if err := runDNS([]string{"intent"}); err == nil || errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("wfctl dns intent without subcommand should be a usage error, not help: %v", err)
 	}
 }
 

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -141,6 +141,7 @@ var commands = map[string]func([]string) error{
 	"modernize":       runModernize,
 	"expr-migrate":    runExprMigrate,
 	"infra":           runInfra,
+	"dns":             runDNS,
 	"dns-policy":      runDNSPolicy,
 	"docs":            runDocs,
 	"editor-schemas":  runEditorSchemas,

--- a/cmd/wfctl/wfctl.yaml
+++ b/cmd/wfctl/wfctl.yaml
@@ -69,6 +69,8 @@ workflows:
         description: Convert Go template expressions to expr syntax
       - name: infra
         description: Manage infrastructure lifecycle
+      - name: dns
+        description: DNS orchestration helpers
       - name: dns-policy
         description: Manage cross-provider DNS ownership policy (show/set/transfer-ownership/drift)
       - name: docs
@@ -241,6 +243,10 @@ pipelines:
     trigger: {type: cli, config: {command: infra}}
     steps:
       - {name: run, type: step.cli_invoke, config: {command: infra}}
+  cmd-dns:
+    trigger: {type: cli, config: {command: dns}}
+    steps:
+      - {name: run, type: step.cli_invoke, config: {command: dns}}
   cmd-dns-policy:
     trigger: {type: cli, config: {command: dns-policy}}
     steps:

--- a/dns/intent/compiler.go
+++ b/dns/intent/compiler.go
@@ -101,7 +101,11 @@ func Compile(opts Options) (*Bundle, error) {
 	domainFilter := normalizeDomain(opts.DomainFilter)
 	domainMap := make(map[string]DomainIntent, len(intentDoc.Domains))
 	for domain, cfg := range intentDoc.Domains {
-		domainMap[normalizeDomain(domain)] = cfg
+		normalized := normalizeDomain(domain)
+		if _, exists := domainMap[normalized]; exists {
+			return nil, fmt.Errorf("duplicate domain intent after normalization: %s", normalized)
+		}
+		domainMap[normalized] = cfg
 	}
 	if domainFilter != "" {
 		cfg, ok := domainMap[domainFilter]
@@ -204,6 +208,15 @@ func reconcileDomain(domain string, cfg DomainIntent, snapshots []record.Snapsho
 	}
 	if cfg.NameserverCutover && registrar != "hover" {
 		blockers = append(blockers, fmt.Sprintf("registrar %q nameserver cutover is not supported yet", registrar))
+	}
+	if cfg.NameserverCutover && len(cfg.ExpectedCurrentNameservers) > 0 {
+		expected := normalizeNameservers(cfg.ExpectedCurrentNameservers)
+		current, ok := currentRegistrarNameservers(group, registrar)
+		if !ok {
+			blockers = append(blockers, "expected_current_nameservers provided but registrar nameservers are unavailable; import registrar delegation first")
+		} else if !equalStringSlices(current, expected) {
+			blockers = append(blockers, fmt.Sprintf("current registrar nameservers %q did not match expected %q", strings.Join(current, ","), strings.Join(expected, ",")))
+		}
 	}
 
 	plan := recordPlan{}
@@ -400,8 +413,9 @@ func selectSource(group []record.Snapshot) (record.Snapshot, bool) {
 func sourceRank(snapshot record.Snapshot, group []record.Snapshot) int {
 	provider := strings.ToLower(snapshot.Provider)
 	authorityProvider := nameserverProvider(snapshot)
+	groupAuthorityProvider := currentAuthorityProvider(group)
 	switch {
-	case provider == "cloudflare":
+	case provider == "cloudflare" && groupAuthorityProvider == "cloudflare":
 		return 0
 	case authorityProvider != "" && provider == authorityProvider:
 		return 1
@@ -415,9 +429,20 @@ func sourceRank(snapshot record.Snapshot, group []record.Snapshot) int {
 		return 3
 	case provider == "hover":
 		return 4
+	case provider == "cloudflare":
+		return 5
 	default:
 		return 9
 	}
+}
+
+func currentAuthorityProvider(group []record.Snapshot) string {
+	for _, snapshot := range group {
+		if provider := nameserverProvider(snapshot); provider != "" {
+			return provider
+		}
+	}
+	return ""
 }
 
 func hoverDelegatesTo(group []record.Snapshot, provider string) bool {
@@ -471,6 +496,33 @@ func stringSliceFromAuthority(authority map[string]any, key string) []string {
 	default:
 		return nil
 	}
+}
+
+func currentRegistrarNameservers(group []record.Snapshot, registrar string) ([]string, bool) {
+	if registrar == "" {
+		return nil, false
+	}
+	snapshot, ok := firstSnapshotByProvider(group, registrar)
+	if !ok {
+		return nil, false
+	}
+	current := normalizeNameservers(stringSliceFromAuthority(snapshot.Authority, "registrar_nameservers"))
+	if len(current) == 0 {
+		current = normalizeNameservers(stringSliceFromAuthority(snapshot.Authority, "live_nameservers"))
+	}
+	return current, len(current) > 0
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func parkedHoverRecords(records []record.Record) bool {

--- a/dns/intent/compiler.go
+++ b/dns/intent/compiler.go
@@ -1,0 +1,588 @@
+package intent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/dns/record"
+)
+
+const (
+	SchemaV1       = "workflow.domain-intent.v1"
+	LegacySchemaV1 = "gocodealone.domain-intent.v1"
+	ReportSchemaV1 = "workflow.domain-intent.report.v1"
+)
+
+type Document struct {
+	Schema  string                  `json:"schema" yaml:"schema"`
+	Domains map[string]DomainIntent `json:"domains" yaml:"domains"`
+}
+
+type DomainIntent struct {
+	Registrar                  string   `json:"registrar" yaml:"registrar"`
+	DNSHost                    string   `json:"dns_host" yaml:"dns_host"`
+	StageDNS                   *bool    `json:"stage_dns,omitempty" yaml:"stage_dns,omitempty"`
+	NameserverCutover          bool     `json:"nameserver_cutover" yaml:"nameserver_cutover"`
+	RecordsPolicy              string   `json:"records_policy" yaml:"records_policy"`
+	ExpectedCurrentNameservers []string `json:"expected_current_nameservers,omitempty" yaml:"expected_current_nameservers,omitempty"`
+	AllowDiscardNonparked      bool     `json:"allow_discard_nonparked,omitempty" yaml:"allow_discard_nonparked,omitempty"`
+}
+
+type Options struct {
+	IntentPath     string
+	PortfolioGlobs []string
+	DomainFilter   string
+	StateDir       string
+}
+
+type Bundle struct {
+	Config config.WorkflowConfig `json:"config" yaml:"config"`
+	Report Report                `json:"report" yaml:"report"`
+}
+
+type Report struct {
+	Schema         string         `json:"schema" yaml:"schema"`
+	Domains        []DomainReport `json:"domains" yaml:"domains"`
+	BlockedDomains int            `json:"blocked_domains" yaml:"blocked_domains"`
+	ActionCount    int            `json:"action_count" yaml:"action_count"`
+}
+
+type DomainReport struct {
+	Domain                string   `json:"domain" yaml:"domain"`
+	Registrar             string   `json:"registrar" yaml:"registrar"`
+	DNSHost               string   `json:"dns_host" yaml:"dns_host"`
+	CloudflareNameservers []string `json:"cloudflare_nameservers" yaml:"cloudflare_nameservers"`
+	RecordsPolicy         string   `json:"records_policy" yaml:"records_policy"`
+	Actions               []Action `json:"actions" yaml:"actions"`
+	Blockers              []string `json:"blockers" yaml:"blockers"`
+}
+
+type Action struct {
+	Type                       string   `json:"type" yaml:"type"`
+	Provider                   string   `json:"provider" yaml:"provider"`
+	Resource                   string   `json:"resource" yaml:"resource"`
+	RecordCount                *int     `json:"record_count,omitempty" yaml:"record_count,omitempty"`
+	ManageUnlisted             *bool    `json:"manage_unlisted,omitempty" yaml:"manage_unlisted,omitempty"`
+	RecordsPolicy              string   `json:"records_policy,omitempty" yaml:"records_policy,omitempty"`
+	DesiredNameservers         []string `json:"desired_nameservers,omitempty" yaml:"desired_nameservers,omitempty"`
+	ExpectedCurrentNameservers []string `json:"expected_current_nameservers,omitempty" yaml:"expected_current_nameservers,omitempty"`
+}
+
+type recordPlan struct {
+	records        []map[string]any
+	manageUnlisted bool
+	blockers       []string
+}
+
+func Compile(opts Options) (*Bundle, error) {
+	if opts.IntentPath == "" {
+		return nil, fmt.Errorf("intent path required")
+	}
+	if len(opts.PortfolioGlobs) == 0 {
+		return nil, fmt.Errorf("at least one portfolio path or glob is required")
+	}
+	if opts.StateDir == "" {
+		opts.StateDir = ".state/domain-intent/"
+	}
+	intentDoc, err := loadDocument(opts.IntentPath)
+	if err != nil {
+		return nil, err
+	}
+	snapshots, err := loadSnapshots(opts.PortfolioGlobs)
+	if err != nil {
+		return nil, err
+	}
+	domainFilter := normalizeDomain(opts.DomainFilter)
+	domainMap := make(map[string]DomainIntent, len(intentDoc.Domains))
+	for domain, cfg := range intentDoc.Domains {
+		domainMap[normalizeDomain(domain)] = cfg
+	}
+	if domainFilter != "" {
+		cfg, ok := domainMap[domainFilter]
+		if !ok {
+			return nil, fmt.Errorf("domain %s not found in intent", domainFilter)
+		}
+		domainMap = map[string]DomainIntent{domainFilter: cfg}
+	}
+
+	domains := make([]string, 0, len(domainMap))
+	for domain := range domainMap {
+		domains = append(domains, domain)
+	}
+	sort.Strings(domains)
+
+	results := make([]compileResult, 0, len(domains))
+	for _, domain := range domains {
+		results = append(results, reconcileDomain(domain, domainMap[domain], snapshots))
+	}
+
+	return buildBundle(results, opts.StateDir), nil
+}
+
+func loadDocument(path string) (*Document, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read intent %q: %w", path, err)
+	}
+	var doc Document
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse intent %q: %w", path, err)
+	}
+	if doc.Schema != SchemaV1 && doc.Schema != LegacySchemaV1 {
+		return nil, fmt.Errorf("unsupported intent schema: %s", doc.Schema)
+	}
+	if len(doc.Domains) == 0 {
+		return nil, fmt.Errorf("intent has no domains")
+	}
+	return &doc, nil
+}
+
+func loadSnapshots(globs []string) ([]record.Snapshot, error) {
+	var files []string
+	for _, pattern := range globs {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("portfolio glob %q: %w", pattern, err)
+		}
+		if len(matches) == 0 {
+			if _, statErr := os.Stat(pattern); statErr == nil {
+				matches = []string{pattern}
+			}
+		}
+		files = append(files, matches...)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no portfolio files matched")
+	}
+	sort.Strings(files)
+	var snapshots []record.Snapshot
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("read portfolio %q: %w", file, err)
+		}
+		var p record.Portfolio
+		if err := json.Unmarshal(data, &p); err != nil {
+			return nil, fmt.Errorf("parse portfolio %q: %w", file, err)
+		}
+		if err := p.Validate(); err != nil {
+			return nil, fmt.Errorf("portfolio %q: %w", file, err)
+		}
+		snapshots = append(snapshots, p.Snapshots...)
+	}
+	return snapshots, nil
+}
+
+type compileResult struct {
+	report  DomainReport
+	modules []config.ModuleConfig
+}
+
+func reconcileDomain(domain string, cfg DomainIntent, snapshots []record.Snapshot) compileResult {
+	group := snapshotsForDomain(snapshots, domain)
+	cfSnapshot, _ := firstSnapshotByProvider(group, "cloudflare")
+	cfNameservers := normalizeNameservers(stringSliceFromAuthority(cfSnapshot.Authority, "name_servers"))
+	desiredDNSHost := strings.ToLower(strings.TrimSpace(cfg.DNSHost))
+	registrar := strings.ToLower(strings.TrimSpace(cfg.Registrar))
+	recordsPolicy := cfg.RecordsPolicy
+	if recordsPolicy == "" {
+		recordsPolicy = "preserve_authoritative"
+	}
+
+	blockers := []string{}
+	if desiredDNSHost == "cloudflare" && len(cfNameservers) == 0 {
+		blockers = append(blockers, "Cloudflare authority.name_servers missing; stage/import Cloudflare zone first")
+	}
+	if desiredDNSHost != "cloudflare" {
+		blockers = append(blockers, fmt.Sprintf("dns_host %q is not supported yet", desiredDNSHost))
+	}
+	if cfg.NameserverCutover && registrar != "hover" {
+		blockers = append(blockers, fmt.Sprintf("registrar %q nameserver cutover is not supported yet", registrar))
+	}
+
+	plan := recordPlan{}
+	if stageDNS(cfg) {
+		plan = planRecords(domain, cfg, recordsPolicy, group, cfSnapshot)
+		blockers = append(blockers, plan.blockers...)
+	}
+
+	report := DomainReport{
+		Domain:                domain,
+		Registrar:             registrar,
+		DNSHost:               desiredDNSHost,
+		CloudflareNameservers: cfNameservers,
+		RecordsPolicy:         recordsPolicy,
+		Blockers:              blockers,
+	}
+	if len(blockers) > 0 {
+		return compileResult{report: report}
+	}
+
+	var modules []config.ModuleConfig
+	if stageDNS(cfg) {
+		resource := resourceName("cf", domain)
+		report.Actions = append(report.Actions, Action{
+			Type:           "stage_dns",
+			Provider:       "cloudflare",
+			Resource:       resource,
+			RecordCount:    intPtr(len(plan.records)),
+			ManageUnlisted: boolPtr(plan.manageUnlisted),
+			RecordsPolicy:  recordsPolicy,
+		})
+		modules = append(modules, config.ModuleConfig{
+			Name: resource,
+			Type: "infra.dns",
+			Config: map[string]any{
+				"provider":        "cloudflare",
+				"account_id":      "${CLOUDFLARE_ACCOUNT_ID}",
+				"domain":          domain,
+				"manage_unlisted": plan.manageUnlisted,
+				"records":         plan.records,
+			},
+		})
+	}
+	if cfg.NameserverCutover {
+		resource := resourceName("hover-delegation", domain)
+		expected := normalizeNameservers(cfg.ExpectedCurrentNameservers)
+		report.Actions = append(report.Actions, Action{
+			Type:                       "set_nameservers",
+			Provider:                   "hover",
+			Resource:                   resource,
+			DesiredNameservers:         cfNameservers,
+			ExpectedCurrentNameservers: expected,
+		})
+		modules = append(modules, config.ModuleConfig{
+			Name: resource,
+			Type: "infra.dns_delegation",
+			Config: map[string]any{
+				"provider":    "hover",
+				"domain":      domain,
+				"nameservers": cfNameservers,
+			},
+		})
+	}
+	return compileResult{report: report, modules: modules}
+}
+
+func buildBundle(results []compileResult, stateDir string) *Bundle {
+	var modules []config.ModuleConfig
+	needCloudflare := false
+	needHover := false
+	report := Report{Schema: ReportSchemaV1}
+	for _, result := range results {
+		report.Domains = append(report.Domains, result.report)
+		if len(result.report.Blockers) > 0 {
+			report.BlockedDomains++
+		}
+		report.ActionCount += len(result.report.Actions)
+		for _, action := range result.report.Actions {
+			switch action.Provider {
+			case "cloudflare":
+				needCloudflare = true
+			case "hover":
+				needHover = true
+			}
+		}
+	}
+	if needCloudflare {
+		modules = append(modules, config.ModuleConfig{
+			Name: "cloudflare",
+			Type: "iac.provider",
+			Config: map[string]any{
+				"provider":   "cloudflare",
+				"api_token":  "${CLOUDFLARE_API_TOKEN}",
+				"account_id": "${CLOUDFLARE_ACCOUNT_ID}",
+			},
+		})
+	}
+	if needHover {
+		modules = append(modules, config.ModuleConfig{
+			Name: "hover",
+			Type: "iac.provider",
+			Config: map[string]any{
+				"provider":            "hover",
+				"username":            "${HOVER_USERNAME}",
+				"password":            "${HOVER_PASSWORD}",
+				"totp_secret":         "${HOVER_TOTP_SECRET}",
+				"browser_profile_dir": "${HOVER_BROWSER_PROFILE_DIR}",
+				"browser_headless":    true,
+				"browser_download":    true,
+			},
+		})
+	}
+	modules = append(modules, config.ModuleConfig{
+		Name: "iac-state",
+		Type: "iac.state",
+		Config: map[string]any{
+			"backend":   "filesystem",
+			"directory": stateDir,
+		},
+	})
+	for _, result := range results {
+		modules = append(modules, result.modules...)
+	}
+	return &Bundle{
+		Config: config.WorkflowConfig{Modules: modules},
+		Report: report,
+	}
+}
+
+func planRecords(domain string, cfg DomainIntent, policy string, group []record.Snapshot, cfSnapshot record.Snapshot) recordPlan {
+	hoverSnapshot, hasHover := firstSnapshotByProvider(group, "hover")
+	switch policy {
+	case "discard_parked":
+		if hasHover && parkedHoverRecords(hoverSnapshot.Records) {
+			return recordPlan{records: []map[string]any{}, manageUnlisted: true}
+		}
+		if cfg.AllowDiscardNonparked {
+			return recordPlan{records: []map[string]any{}, manageUnlisted: true}
+		}
+		return recordPlan{blockers: []string{"records_policy discard_parked requested but Hover records do not match parked-record pattern"}}
+	case "preserve_authoritative":
+		if selected, ok := selectSource(group); ok {
+			return recordPlan{records: cloudflareRecords(domain, selected.Records)}
+		}
+		return recordPlan{blockers: []string{"no portfolio snapshot available for records"}}
+	case "preserve_cloudflare":
+		if cfSnapshot.Provider != "" {
+			return recordPlan{records: cloudflareRecords(domain, cfSnapshot.Records)}
+		}
+		return recordPlan{blockers: []string{"records_policy preserve_cloudflare requested but no Cloudflare snapshot exists"}}
+	default:
+		return recordPlan{blockers: []string{fmt.Sprintf("unsupported records_policy %q", policy)}}
+	}
+}
+
+func stageDNS(cfg DomainIntent) bool {
+	if cfg.StageDNS == nil {
+		return true
+	}
+	return *cfg.StageDNS
+}
+
+func snapshotsForDomain(snapshots []record.Snapshot, domain string) []record.Snapshot {
+	var out []record.Snapshot
+	for _, snapshot := range snapshots {
+		if normalizeDomain(snapshot.Domain) == domain {
+			out = append(out, snapshot)
+		}
+	}
+	return out
+}
+
+func firstSnapshotByProvider(snapshots []record.Snapshot, provider string) (record.Snapshot, bool) {
+	for _, snapshot := range snapshots {
+		if strings.EqualFold(snapshot.Provider, provider) {
+			return snapshot, true
+		}
+	}
+	return record.Snapshot{}, false
+}
+
+func selectSource(group []record.Snapshot) (record.Snapshot, bool) {
+	if len(group) == 0 {
+		return record.Snapshot{}, false
+	}
+	sort.SliceStable(group, func(i, j int) bool {
+		return sourceRank(group[i], group) < sourceRank(group[j], group)
+	})
+	return group[0], true
+}
+
+func sourceRank(snapshot record.Snapshot, group []record.Snapshot) int {
+	provider := strings.ToLower(snapshot.Provider)
+	authorityProvider := nameserverProvider(snapshot)
+	switch {
+	case provider == "cloudflare":
+		return 0
+	case authorityProvider != "" && provider == authorityProvider:
+		return 1
+	case provider == "digitalocean" && hoverDelegatesTo(group, "digitalocean"):
+		return 1
+	case provider == "namecheap":
+		return 2
+	case provider == "hover" && authorityProvider == "hover":
+		return 2
+	case provider == "digitalocean":
+		return 3
+	case provider == "hover":
+		return 4
+	default:
+		return 9
+	}
+}
+
+func hoverDelegatesTo(group []record.Snapshot, provider string) bool {
+	for _, snapshot := range group {
+		if strings.EqualFold(snapshot.Provider, "hover") && nameserverProvider(snapshot) == provider {
+			return true
+		}
+	}
+	return false
+}
+
+func nameserverProvider(snapshot record.Snapshot) string {
+	ns := normalizeNameservers(append(
+		stringSliceFromAuthority(snapshot.Authority, "live_nameservers"),
+		stringSliceFromAuthority(snapshot.Authority, "registrar_nameservers")...,
+	))
+	for _, value := range ns {
+		switch {
+		case strings.Contains(value, "cloudflare.com"):
+			return "cloudflare"
+		case strings.Contains(value, "digitalocean.com"):
+			return "digitalocean"
+		case strings.Contains(value, "hover.com"):
+			return "hover"
+		case strings.Contains(value, "registrar-servers.com"):
+			return "namecheap"
+		}
+	}
+	return ""
+}
+
+func stringSliceFromAuthority(authority map[string]any, key string) []string {
+	if authority == nil {
+		return nil
+	}
+	raw, ok := authority[key]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func parkedHoverRecords(records []record.Record) bool {
+	if len(records) == 0 {
+		return false
+	}
+	for _, rec := range records {
+		recType := strings.ToUpper(rec.Type)
+		name := strings.ToLower(defaultName(rec.Name))
+		value := strings.TrimSuffix(strings.ToLower(rec.Value), ".")
+		priority := 0
+		if rec.Priority != nil {
+			priority = *rec.Priority
+		}
+		switch recType {
+		case "A":
+			if (name != "@" && name != "*") || value != "216.40.34.41" {
+				return false
+			}
+		case "CNAME":
+			if name != "mail" || value != "mail.hover.com.cust.hostedemail.com" {
+				return false
+			}
+		case "MX":
+			if name != "@" || !strings.HasSuffix(value, "mx.hover.com.cust.hostedemail.com") || (priority != 0 && priority != 10) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func cloudflareRecords(domain string, records []record.Record) []map[string]any {
+	out := make([]map[string]any, 0, len(records))
+	for _, rec := range records {
+		recType := strings.ToUpper(rec.Type)
+		if !supportedCloudflareType(recType) {
+			continue
+		}
+		name := defaultName(rec.Name)
+		normalizedName := normalizeDomain(name)
+		if recType == "NS" && (name == "@" || normalizedName == domain) {
+			continue
+		}
+		data := rec.Value
+		if recType == "CNAME" || recType == "MX" || recType == "NS" || recType == "SRV" {
+			data = strings.TrimSuffix(data, ".")
+		}
+		ttl := rec.TTL
+		if ttl == 1 {
+			ttl = 1
+		} else if ttl < 60 {
+			ttl = 60
+		}
+		item := map[string]any{
+			"type": recType,
+			"name": name,
+			"data": data,
+			"ttl":  ttl,
+		}
+		if (recType == "MX" || recType == "SRV") && rec.Priority != nil {
+			item["priority"] = *rec.Priority
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func supportedCloudflareType(recType string) bool {
+	switch recType {
+	case "A", "AAAA", "CAA", "CNAME", "MX", "NS", "SRV", "TXT":
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultName(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "@"
+	}
+	return name
+}
+
+func normalizeNameservers(values []string) []string {
+	seen := map[string]bool{}
+	for _, value := range values {
+		ns := normalizeDomain(value)
+		if ns != "" {
+			seen[ns] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for ns := range seen {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeDomain(value string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(value)), ".")
+}
+
+var resourceNamePattern = regexp.MustCompile(`[^a-z0-9]+`)
+
+func resourceName(prefix, domain string) string {
+	slug := resourceNamePattern.ReplaceAllString(normalizeDomain(domain), "-")
+	slug = strings.Trim(slug, "-")
+	return prefix + "-" + slug
+}
+
+func intPtr(v int) *int { return &v }
+
+func boolPtr(v bool) *bool { return &v }

--- a/dns/intent/compiler.go
+++ b/dns/intent/compiler.go
@@ -275,13 +275,15 @@ func buildBundle(results []compileResult, stateDir string) *Bundle {
 	needCloudflare := false
 	needHover := false
 	report := Report{Schema: ReportSchemaV1}
-	for _, result := range results {
+	for i := range results {
+		result := &results[i]
 		report.Domains = append(report.Domains, result.report)
 		if len(result.report.Blockers) > 0 {
 			report.BlockedDomains++
 		}
 		report.ActionCount += len(result.report.Actions)
-		for _, action := range result.report.Actions {
+		for j := range result.report.Actions {
+			action := &result.report.Actions[j]
 			switch action.Provider {
 			case "cloudflare":
 				needCloudflare = true
@@ -294,7 +296,7 @@ func buildBundle(results []compileResult, stateDir string) *Bundle {
 		modules = append(modules, config.ModuleConfig{
 			Name: "cloudflare",
 			Type: "iac.provider",
-			Config: map[string]any{
+			Config: map[string]any{ //nolint:gosec // Values are env placeholders, not literal credentials.
 				"provider":   "cloudflare",
 				"api_token":  "${CLOUDFLARE_API_TOKEN}",
 				"account_id": "${CLOUDFLARE_ACCOUNT_ID}",
@@ -305,7 +307,7 @@ func buildBundle(results []compileResult, stateDir string) *Bundle {
 		modules = append(modules, config.ModuleConfig{
 			Name: "hover",
 			Type: "iac.provider",
-			Config: map[string]any{
+			Config: map[string]any{ //nolint:gosec // Values are env placeholders, not literal credentials.
 				"provider":            "hover",
 				"username":            "${HOVER_USERNAME}",
 				"password":            "${HOVER_PASSWORD}",
@@ -324,8 +326,8 @@ func buildBundle(results []compileResult, stateDir string) *Bundle {
 			"directory": stateDir,
 		},
 	})
-	for _, result := range results {
-		modules = append(modules, result.modules...)
+	for i := range results {
+		modules = append(modules, results[i].modules...)
 	}
 	return &Bundle{
 		Config: config.WorkflowConfig{Modules: modules},

--- a/dns/intent/compiler.go
+++ b/dns/intent/compiler.go
@@ -437,10 +437,17 @@ func sourceRank(snapshot record.Snapshot, group []record.Snapshot) int {
 }
 
 func currentAuthorityProvider(group []record.Snapshot) string {
+	providers := map[string]bool{}
 	for _, snapshot := range group {
 		if provider := nameserverProvider(snapshot); provider != "" {
-			return provider
+			providers[provider] = true
 		}
+	}
+	if len(providers) != 1 {
+		return ""
+	}
+	for provider := range providers {
+		return provider
 	}
 	return ""
 }

--- a/dns/intent/compiler_test.go
+++ b/dns/intent/compiler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/dns/record"
 )
 
 func TestCompileDiscardParkedProducesCloudflareAndHoverResources(t *testing.T) {
@@ -224,6 +225,32 @@ func TestCompilePreserveAuthoritativeIgnoresStagedCloudflareByDefault(t *testing
 	}
 	if records[0]["data"] != "192.0.2.44" {
 		t.Fatalf("record data = %#v, want authoritative Hover value", records[0]["data"])
+	}
+}
+
+func TestCurrentAuthorityProviderIsOrderIndependent(t *testing.T) {
+	group := []record.Snapshot{
+		{
+			Provider: "cloudflare",
+			Domain:   "example.com",
+			Authority: map[string]any{
+				"name_servers": []any{"a.ns.cloudflare.com", "b.ns.cloudflare.com"},
+			},
+		},
+		{
+			Provider: "hover",
+			Domain:   "example.com",
+			Authority: map[string]any{
+				"registrar_nameservers": []any{"ns1.hover.com", "ns2.hover.com"},
+			},
+		},
+	}
+	reversed := []record.Snapshot{group[1], group[0]}
+	if got := currentAuthorityProvider(group); got != "hover" {
+		t.Fatalf("currentAuthorityProvider(group) = %q, want hover", got)
+	}
+	if got := currentAuthorityProvider(reversed); got != "hover" {
+		t.Fatalf("currentAuthorityProvider(reversed) = %q, want hover", got)
 	}
 }
 

--- a/dns/intent/compiler_test.go
+++ b/dns/intent/compiler_test.go
@@ -3,6 +3,7 @@ package intent
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -117,6 +118,112 @@ func TestCompileDiscardParkedBlocksNonParkedRecords(t *testing.T) {
 	}
 	if len(bundle.Report.Domains[0].Blockers) == 0 {
 		t.Fatalf("expected blockers: %+v", bundle.Report.Domains[0])
+	}
+}
+
+func TestCompileRejectsDuplicateNormalizedDomains(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := writeTestFile(t, dir, "domains.json", `{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "Example.COM": {"registrar": "hover", "dns_host": "cloudflare"},
+    "example.com.": {"registrar": "hover", "dns_host": "cloudflare"}
+  }
+}`)
+	portfolioPath := writeTestFile(t, dir, "portfolio.json", `{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [{"id": "cf", "provider": "cloudflare", "domain": "example.com", "authority": {"name_servers": ["a.ns.cloudflare.com"]}}]
+}`)
+
+	_, err := Compile(Options{IntentPath: intentPath, PortfolioGlobs: []string{portfolioPath}})
+	if err == nil || !strings.Contains(err.Error(), "duplicate domain intent") {
+		t.Fatalf("expected duplicate normalized domain error; got %v", err)
+	}
+}
+
+func TestCompileBlocksExpectedCurrentNameserverMismatch(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := writeTestFile(t, dir, "domains.json", `{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "example.com": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "nameserver_cutover": true,
+      "expected_current_nameservers": ["ns1.hover.com", "ns2.hover.com"]
+    }
+  }
+}`)
+	portfolioPath := writeTestFile(t, dir, "portfolio.json", `{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [
+    {"id": "cf", "provider": "cloudflare", "domain": "example.com", "authority": {"name_servers": ["a.ns.cloudflare.com", "b.ns.cloudflare.com"]}},
+    {"id": "hover", "provider": "hover", "domain": "example.com", "authority": {"registrar_nameservers": ["ns1.digitalocean.com", "ns2.digitalocean.com"]}}
+  ]
+}`)
+
+	bundle, err := Compile(Options{IntentPath: intentPath, PortfolioGlobs: []string{portfolioPath}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if bundle.Report.BlockedDomains != 1 {
+		t.Fatalf("blocked domains = %d, want 1", bundle.Report.BlockedDomains)
+	}
+	got := strings.Join(bundle.Report.Domains[0].Blockers, "\n")
+	if !strings.Contains(got, "did not match expected") {
+		t.Fatalf("expected nameserver mismatch blocker; got %q", got)
+	}
+	if len(bundle.Config.Modules) != 1 {
+		t.Fatalf("blocked compile should only emit state module; got %+v", bundle.Config.Modules)
+	}
+}
+
+func TestCompilePreserveAuthoritativeIgnoresStagedCloudflareByDefault(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := writeTestFile(t, dir, "domains.json", `{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "example.com": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "stage_dns": true
+    }
+  }
+}`)
+	portfolioPath := writeTestFile(t, dir, "portfolio.json", `{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [
+    {
+      "id": "cf",
+      "provider": "cloudflare",
+      "domain": "example.com",
+      "authority": {"name_servers": ["a.ns.cloudflare.com", "b.ns.cloudflare.com"]},
+      "records": []
+    },
+    {
+      "id": "hover",
+      "provider": "hover",
+      "domain": "example.com",
+      "authority": {"registrar_nameservers": ["ns1.hover.com", "ns2.hover.com"]},
+      "records": [{"type": "A", "name": "@", "value": "192.0.2.44", "ttl": 900}]
+    }
+  ]
+}`)
+
+	bundle, err := Compile(Options{IntentPath: intentPath, PortfolioGlobs: []string{portfolioPath}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got := moduleByName(bundle.Config.Modules, "cf-example-com")
+	if got == nil {
+		t.Fatalf("missing generated Cloudflare module: %+v", bundle.Config.Modules)
+	}
+	records, ok := got.Config["records"].([]map[string]any)
+	if !ok || len(records) != 1 {
+		t.Fatalf("records = %#v, want one authoritative Hover record", got.Config["records"])
+	}
+	if records[0]["data"] != "192.0.2.44" {
+		t.Fatalf("record data = %#v, want authoritative Hover value", records[0]["data"])
 	}
 }
 

--- a/dns/intent/compiler_test.go
+++ b/dns/intent/compiler_test.go
@@ -1,0 +1,151 @@
+package intent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/config"
+)
+
+func TestCompileDiscardParkedProducesCloudflareAndHoverResources(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := writeTestFile(t, dir, "domains.json", `{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "Example.COM.": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "stage_dns": true,
+      "nameserver_cutover": true,
+      "records_policy": "discard_parked",
+      "expected_current_nameservers": ["ns3.hover.com.", "ns1.hover.com", "ns2.hover.com"]
+    }
+  }
+}`)
+	portfolioPath := writeTestFile(t, dir, "portfolio.json", `{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [
+    {
+      "id": "cf-example-com",
+      "provider": "cloudflare",
+      "domain": "example.com",
+      "authority": {"name_servers": ["ZOE.NS.CLOUDFLARE.COM.", "adam.ns.cloudflare.com"]}
+    },
+    {
+      "id": "hover-example-com",
+      "provider": "hover",
+      "domain": "example.com",
+      "authority": {"registrar_nameservers": ["ns1.hover.com", "ns2.hover.com", "ns3.hover.com"]},
+      "records": [
+        {"type": "A", "name": "@", "value": "216.40.34.41", "ttl": 900},
+        {"type": "A", "name": "*", "value": "216.40.34.41", "ttl": 900},
+        {"type": "MX", "name": "@", "value": "10 mx.hover.com.cust.hostedemail.com", "ttl": 900},
+        {"type": "CNAME", "name": "mail", "value": "mail.hover.com.cust.hostedemail.com", "ttl": 900}
+      ]
+    }
+  ]
+}`)
+
+	bundle, err := Compile(Options{IntentPath: intentPath, PortfolioGlobs: []string{portfolioPath}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if bundle.Report.BlockedDomains != 0 {
+		t.Fatalf("blocked domains = %d; report=%+v", bundle.Report.BlockedDomains, bundle.Report)
+	}
+	if bundle.Report.ActionCount != 2 {
+		t.Fatalf("action count = %d, want 2", bundle.Report.ActionCount)
+	}
+	got := moduleByName(bundle.Config.Modules, "cf-example-com")
+	if got == nil {
+		t.Fatalf("missing cloudflare DNS module: %+v", bundle.Config.Modules)
+	}
+	if got.Type != "infra.dns" {
+		t.Fatalf("cloudflare module type = %q", got.Type)
+	}
+	if got.Config["manage_unlisted"] != true {
+		t.Fatalf("manage_unlisted = %#v, want true", got.Config["manage_unlisted"])
+	}
+	records, ok := got.Config["records"].([]map[string]any)
+	if !ok || len(records) != 0 {
+		t.Fatalf("records = %#v, want empty []map[string]any", got.Config["records"])
+	}
+	delegation := moduleByName(bundle.Config.Modules, "hover-delegation-example-com")
+	if delegation == nil || delegation.Type != "infra.dns_delegation" {
+		t.Fatalf("missing hover delegation module: %+v", bundle.Config.Modules)
+	}
+	nameservers, ok := delegation.Config["nameservers"].([]string)
+	if !ok {
+		t.Fatalf("nameservers type = %T", delegation.Config["nameservers"])
+	}
+	wantNS := []string{"adam.ns.cloudflare.com", "zoe.ns.cloudflare.com"}
+	if !equalStrings(nameservers, wantNS) {
+		t.Fatalf("nameservers = %v, want %v", nameservers, wantNS)
+	}
+}
+
+func TestCompileDiscardParkedBlocksNonParkedRecords(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := writeTestFile(t, dir, "domains.json", `{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "example.com": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "records_policy": "discard_parked"
+    }
+  }
+}`)
+	portfolioPath := writeTestFile(t, dir, "portfolio.json", `{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [
+    {"id": "cf", "provider": "cloudflare", "domain": "example.com", "authority": {"name_servers": ["a.ns.cloudflare.com", "b.ns.cloudflare.com"]}},
+    {"id": "hover", "provider": "hover", "domain": "example.com", "records": [{"type": "MX", "name": "@", "value": "mail.protonmail.ch", "ttl": 900}]}
+  ]
+}`)
+
+	bundle, err := Compile(Options{IntentPath: intentPath, PortfolioGlobs: []string{portfolioPath}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if bundle.Report.BlockedDomains != 1 {
+		t.Fatalf("blocked domains = %d, want 1", bundle.Report.BlockedDomains)
+	}
+	if bundle.Report.ActionCount != 0 {
+		t.Fatalf("action count = %d, want 0", bundle.Report.ActionCount)
+	}
+	if len(bundle.Report.Domains[0].Blockers) == 0 {
+		t.Fatalf("expected blockers: %+v", bundle.Report.Domains[0])
+	}
+}
+
+func moduleByName(modules []config.ModuleConfig, name string) *config.ModuleConfig {
+	for i := range modules {
+		if modules[i].Name == name {
+			return &modules[i]
+		}
+	}
+	return nil
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func writeTestFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -1810,6 +1810,36 @@ wfctl infra apply [-c CONFIG] [--env ENV] [--auto-approve] [--plan FILE]
 
 Generic ownership checks do not replace authentication or provider IAM. They are a pre-dispatch safety gate to avoid accidental cross-owner mutation where provider plugins can read/write ownership metadata. DNS resources are excluded from this generic gate and continue to use `wfctl dns-policy`.
 
+#### `dns intent compile`
+
+Compile declarative domain intent into concrete DNS IaC resources:
+
+```sh
+wfctl dns intent compile \
+  --intent domains.json \
+  --portfolio 'zones/*.portfolio.json' \
+  --output infra/domain-reconcile.generated.wfctl.yaml \
+  --report reports/domain-reconcile-report.json
+```
+
+The command reads `workflow.domain-intent.v1` JSON plus DNS portfolio exports
+from `wfctl infra import-all --format portfolio`. It writes a normal wfctl
+config containing `infra.dns` and `infra.dns_delegation` resources, plus a JSON
+report with per-domain actions and blockers. It exits non-zero when any domain
+is blocked.
+
+Useful flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--intent` | `domains.json` | Domain intent JSON file. |
+| `--portfolio` | `zones/*.portfolio.json` | Comma-separated portfolio paths or globs. |
+| `--domain` | _(all)_ | Compile one domain from the intent file. |
+| `--output` | `infra/domain-reconcile.generated.wfctl.yaml` | Generated wfctl config path. |
+| `--report` | `reports/domain-reconcile-report.json` | Generated JSON report path. |
+| `--bundle` | _(none)_ | Optional combined JSON bundle path. |
+| `--state-dir` | `.state/domain-intent/` | Generated filesystem IaC state directory. |
+
 **Protected-resource gate:**
 
 Resources annotated `protected: true` cannot be replaced or deleted by `infra apply` without an explicit per-resource opt-in. When a plan would replace or delete a protected resource, `wfctl` aborts before any provider dispatch and prints the full set of blockers in one pass with a copy-paste-ready flag value:

--- a/docs/iac-dns-providers.md
+++ b/docs/iac-dns-providers.md
@@ -235,3 +235,56 @@ The full DNS provider plan (Namecheap + Hover + dyndns + scoped
 secret-set) is tracked in `docs/plans/2026-05-20-dns-providers.md`
 (workflow#735) — caveman SPEC format with 20 tasks, 16 constraints,
 18 invariants.
+
+## Domain Intent Compiler
+
+Use `wfctl dns intent compile` when a domain migration spans hosted DNS and a
+registrar delegation provider. The command reads a domain intent file plus one
+or more `wfctl infra import-all --format portfolio` DNS catalog exports, then
+emits ordinary `infra.dns` and `infra.dns_delegation` resources plus a JSON
+report.
+
+```sh
+wfctl dns intent compile \
+  --intent domains.json \
+  --portfolio 'zones/*.portfolio.json' \
+  --domain example.com \
+  --output infra/domain-reconcile.generated.wfctl.yaml \
+  --report reports/domain-reconcile-report.json
+```
+
+Intent file shape:
+
+```json
+{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "example.com": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "stage_dns": true,
+      "nameserver_cutover": true,
+      "records_policy": "preserve_authoritative",
+      "expected_current_nameservers": ["ns1.hover.com", "ns2.hover.com"]
+    }
+  }
+}
+```
+
+Supported first increment:
+
+- `dns_host: cloudflare` creates or updates `infra.dns` resources from the
+  selected portfolio records and Cloudflare-assigned nameservers.
+- `registrar: hover` with `nameserver_cutover: true` creates
+  `infra.dns_delegation` resources targeting the Cloudflare nameservers.
+- `records_policy: preserve_authoritative` chooses the current authoritative
+  source when available.
+- `records_policy: preserve_cloudflare` keeps the existing Cloudflare snapshot.
+- `records_policy: discard_parked` emits an empty managed Cloudflare zone only
+  when Hover records match the known parking pattern, unless
+  `allow_discard_nonparked` is explicitly set.
+
+Unsupported provider pairs and unsafe discard requests are reported as blockers
+and cause the command to exit non-zero. Provider plugins still own the actual
+apply behavior; the compiler only removes repository-local glue for producing
+the concrete IaC resources and report.


### PR DESCRIPTION
## Summary

Adds a first-class `wfctl dns intent compile` command that turns domain intent plus DNS portfolio exports into concrete wfctl IaC config and a JSON action/blocker report. This moves the gocodealone-dns reconciliation generator pattern into workflow so DNS migrations do not require repo-local shell/JQ glue.

The first increment supports Cloudflare hosted DNS staging, Hover delegation cutover resources, `preserve_authoritative`, `preserve_cloudflare`, and guarded `discard_parked` record policy. Unsupported provider pairs and unsafe discard requests fail closed as report blockers.

Closes #935.

## Validation

- `GOWORK=off go test ./dns/intent ./cmd/wfctl -run 'TestCompile|TestRunDNS' -count=1`
- `GOWORK=off go test ./dns/intent -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestRunDNS|TestRunDNSPolicy|TestHelpFlagDoesNotLeakEngineError' -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestRunDNS|TestRunDNSPolicy|Test.*Command|Test.*Registered' -count=1`
- `GOWORK=off go test ./dns/... ./cmd/wfctl -count=1`
- Real-data compile: `GOWORK=off go run ./cmd/wfctl dns intent compile --intent /Users/<name>/workspace/gocodealone-dns/domains.json --portfolio '/Users/<name>/workspace/gocodealone-dns/zones/*.portfolio.json' --domain buymywishlist.net --output /tmp/wfctl-domain.yaml --report /tmp/wfctl-domain-report.json --bundle /tmp/wfctl-domain-bundle.json`
- Generated config validation with installed plugins: `GOWORK=off go run ./cmd/wfctl validate --allow-no-entry-points --plugin-dir /Users/<name>/workspace/gocodealone-dns/data/plugins /tmp/wfctl-domain.yaml`