### PR TITLE
Add wfctl DNS intent reconcile

### DIFF
--- a/cmd/wfctl/dns.go
+++ b/cmd/wfctl/dns.go
@@ -12,6 +12,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	dnsIntentRunValidate   = runValidate
+	dnsIntentRunInfraPlan  = runInfraPlan
+	dnsIntentRunInfraApply = runInfraApply
+)
+
 func runDNS(args []string) error {
 	if len(args) < 1 {
 		return dnsUsage()
@@ -45,6 +51,8 @@ func runDNSIntent(args []string) error {
 	switch args[0] {
 	case "compile":
 		return runDNSIntentCompile(args[1:])
+	case "reconcile":
+		return runDNSIntentReconcile(args[1:])
 	case "-h", "--help", "help":
 		_ = dnsIntentUsage()
 		return flag.ErrHelp
@@ -58,6 +66,7 @@ func dnsIntentUsage() error {
 
 Subcommands:
   compile   Compile domain intent JSON and DNS portfolio exports
+  reconcile Compile, validate, and plan/apply domain intent
 `)
 	return fmt.Errorf("missing or unknown subcommand")
 }
@@ -75,6 +84,113 @@ func runDNSIntentCompile(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	bundle, err := compileDNSIntentBundle(intentPath, portfolioCSV, domain, outputPath, reportPath, bundlePath, stateDir)
+	if err != nil {
+		return err
+	}
+	if bundle.Report.BlockedDomains > 0 {
+		return fmt.Errorf("%d domain(s) blocked", bundle.Report.BlockedDomains)
+	}
+	return nil
+}
+
+func runDNSIntentReconcile(args []string) error {
+	fs := flag.NewFlagSet("dns intent reconcile", flag.ContinueOnError)
+	var opts dnsIntentReconcileOptions
+	fs.StringVar(&opts.intentPath, "intent", "domains.json", "Domain intent JSON file")
+	fs.StringVar(&opts.portfolioCSV, "portfolio", "zones/*.portfolio.json", "Comma-separated DNS portfolio JSON paths or globs")
+	fs.StringVar(&opts.domain, "domain", "", "Optional single domain to reconcile")
+	fs.StringVar(&opts.outputPath, "output", "infra/domain-reconcile.generated.wfctl.yaml", "Generated wfctl config path")
+	fs.StringVar(&opts.reportPath, "report", "reports/domain-reconcile-report.json", "Generated JSON report path")
+	fs.StringVar(&opts.bundlePath, "bundle", "", "Optional combined JSON bundle path")
+	fs.StringVar(&opts.stateDir, "state-dir", ".state/domain-intent/", "Filesystem state directory for generated iac.state")
+	fs.StringVar(&opts.planPath, "plan-output", "reports/domain-reconcile-plan.json", "Generated infra plan JSON path")
+	fs.StringVar(&opts.pluginDir, "plugin-dir", "", "Plugin directory passed to validate/plan/apply")
+	fs.StringVar(&opts.mode, "mode", "plan", "Reconcile mode: plan or apply")
+	fs.BoolVar(&opts.autoApprove, "auto-approve", false, "Pass --auto-approve to infra apply (required with --mode apply)")
+	fs.BoolVar(&opts.allowEmpty, "allow-empty", false, "Allow intent with zero generated actions")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return runDNSIntentReconcileWithOptions(opts)
+}
+
+type dnsIntentReconcileOptions struct {
+	intentPath   string
+	portfolioCSV string
+	domain       string
+	outputPath   string
+	reportPath   string
+	bundlePath   string
+	stateDir     string
+	planPath     string
+	pluginDir    string
+	mode         string
+	autoApprove  bool
+	allowEmpty   bool
+}
+
+func runDNSIntentReconcileWithOptions(opts dnsIntentReconcileOptions) error {
+	switch opts.mode {
+	case "plan":
+	case "apply":
+		if !opts.autoApprove {
+			return fmt.Errorf("--mode apply requires --auto-approve")
+		}
+	default:
+		return fmt.Errorf("unsupported reconcile mode %q (want plan or apply)", opts.mode)
+	}
+	bundle, err := compileDNSIntentBundle(
+		opts.intentPath,
+		opts.portfolioCSV,
+		opts.domain,
+		opts.outputPath,
+		opts.reportPath,
+		opts.bundlePath,
+		opts.stateDir,
+	)
+	if err != nil {
+		return err
+	}
+	if bundle.Report.ActionCount == 0 && !opts.allowEmpty {
+		return fmt.Errorf("domain intent produced no actions; use --allow-empty to accept a no-op")
+	}
+	validateArgs := []string{"--allow-no-entry-points"}
+	if opts.pluginDir != "" {
+		validateArgs = append(validateArgs, "--plugin-dir", opts.pluginDir)
+	}
+	validateArgs = append(validateArgs, opts.outputPath)
+	if err := dnsIntentRunValidate(validateArgs); err != nil {
+		return fmt.Errorf("validate generated domain intent config: %w", err)
+	}
+	planArgs := []string{"--config", opts.outputPath}
+	if opts.pluginDir != "" {
+		planArgs = append(planArgs, "--plugin-dir", opts.pluginDir)
+	}
+	if opts.planPath != "" {
+		planArgs = append(planArgs, "--output", opts.planPath)
+	}
+	if err := dnsIntentRunInfraPlan(planArgs); err != nil {
+		return fmt.Errorf("plan domain intent: %w", err)
+	}
+	switch opts.mode {
+	case "plan":
+		return nil
+	case "apply":
+		applyArgs := []string{"--config", opts.outputPath, "--auto-approve"}
+		if opts.pluginDir != "" {
+			applyArgs = append(applyArgs, "--plugin-dir", opts.pluginDir)
+		}
+		if err := dnsIntentRunInfraApply(applyArgs); err != nil {
+			return fmt.Errorf("apply domain intent: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported reconcile mode %q (want plan or apply)", opts.mode)
+	}
+}
+
+func compileDNSIntentBundle(intentPath, portfolioCSV, domain, outputPath, reportPath, bundlePath, stateDir string) (*intent.Bundle, error) {
 	portfolios := splitDNSIntentCSV(portfolioCSV)
 	bundle, err := intent.Compile(intent.Options{
 		IntentPath:     intentPath,
@@ -83,33 +199,38 @@ func runDNSIntentCompile(args []string) error {
 		StateDir:       stateDir,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	configBytes, err := yaml.Marshal(bundle.Config)
 	if err != nil {
-		return fmt.Errorf("marshal generated config: %w", err)
+		return nil, fmt.Errorf("marshal generated config: %w", err)
 	}
 	reportBytes, err := json.MarshalIndent(bundle.Report, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal report: %w", err)
+		return nil, fmt.Errorf("marshal report: %w", err)
 	}
 	reportBytes = append(reportBytes, '\n')
 	if err := writeFileCreatingParents(outputPath, configBytes); err != nil {
-		return err
+		return nil, err
 	}
 	if err := writeFileCreatingParents(reportPath, reportBytes); err != nil {
-		return err
+		return nil, err
 	}
 	if bundlePath != "" {
 		bundleBytes, err := json.MarshalIndent(bundle, "", "  ")
 		if err != nil {
-			return fmt.Errorf("marshal bundle: %w", err)
+			return nil, fmt.Errorf("marshal bundle: %w", err)
 		}
 		bundleBytes = append(bundleBytes, '\n')
 		if err := writeFileCreatingParents(bundlePath, bundleBytes); err != nil {
-			return err
+			return nil, err
 		}
 	}
+	printDNSIntentSummary(bundle)
+	return bundle, nil
+}
+
+func printDNSIntentSummary(bundle *intent.Bundle) {
 	for i := range bundle.Report.Domains {
 		domainReport := &bundle.Report.Domains[i]
 		if len(domainReport.Blockers) == 0 {
@@ -123,10 +244,6 @@ func runDNSIntentCompile(args []string) error {
 			fmt.Printf("%s: blocked: %s\n", domainReport.Domain, strings.Join(domainReport.Blockers, "; "))
 		}
 	}
-	if bundle.Report.BlockedDomains > 0 {
-		return fmt.Errorf("%d domain(s) blocked", bundle.Report.BlockedDomains)
-	}
-	return nil
 }
 
 func writeFileCreatingParents(path string, data []byte) error {

--- a/cmd/wfctl/dns_test.go
+++ b/cmd/wfctl/dns_test.go
@@ -44,36 +44,7 @@ func TestRunDNSIntentHelpReturnsFlagErrHelp(t *testing.T) {
 
 func TestRunDNSIntentCompileWritesConfigAndReport(t *testing.T) {
 	dir := t.TempDir()
-	intentPath := filepath.Join(dir, "domains.json")
-	if err := os.WriteFile(intentPath, []byte(`{
-  "schema": "workflow.domain-intent.v1",
-  "domains": {
-    "example.com": {
-      "registrar": "hover",
-      "dns_host": "cloudflare",
-      "stage_dns": true,
-      "nameserver_cutover": false,
-      "records_policy": "preserve_cloudflare"
-    }
-  }
-}`), 0o644); err != nil {
-		t.Fatalf("write intent: %v", err)
-	}
-	portfolioPath := filepath.Join(dir, "portfolio.json")
-	if err := os.WriteFile(portfolioPath, []byte(`{
-  "schema": "workflow.dns-portfolio.export.v1",
-  "snapshots": [
-    {
-      "id": "cf-example-com",
-      "provider": "cloudflare",
-      "domain": "example.com",
-      "authority": {"name_servers": ["a.ns.cloudflare.com", "b.ns.cloudflare.com"]},
-      "records": [{"type": "A", "name": "@", "value": "192.0.2.10", "ttl": 30}]
-    }
-  ]
-}`), 0o644); err != nil {
-		t.Fatalf("write portfolio: %v", err)
-	}
+	intentPath, portfolioPath := writeDNSIntentFixture(t, dir, false)
 	outputPath := filepath.Join(dir, "out.yaml")
 	reportPath := filepath.Join(dir, "report.json")
 	if err := runDNS([]string{"intent", "compile",
@@ -137,5 +108,149 @@ func TestRunDNSIntentCompileWritesConfigAndReport(t *testing.T) {
 	}
 	if report.Schema != "workflow.domain-intent.report.v1" || report.BlockedDomains != 0 || report.ActionCount != 1 {
 		t.Fatalf("bad report: %+v", report)
+	}
+}
+
+func TestRunDNSIntentReconcilePlansGeneratedConfig(t *testing.T) {
+	dir := t.TempDir()
+	intentPath, portfolioPath := writeDNSIntentFixture(t, dir, false)
+	outputPath := filepath.Join(dir, "out.yaml")
+	reportPath := filepath.Join(dir, "report.json")
+	planPath := filepath.Join(dir, "plan.json")
+	var validateArgs, planArgs, applyArgs []string
+	restore := stubDNSIntentLifecycle(t, &validateArgs, &planArgs, &applyArgs)
+	defer restore()
+
+	if err := runDNS([]string{"intent", "reconcile",
+		"--intent", intentPath,
+		"--portfolio", portfolioPath,
+		"--output", outputPath,
+		"--report", reportPath,
+		"--plan-output", planPath,
+		"--plugin-dir", "data/plugins",
+	}); err != nil {
+		t.Fatalf("runDNS intent reconcile: %v", err)
+	}
+	assertStringSliceEqual(t, validateArgs, []string{"--allow-no-entry-points", "--plugin-dir", "data/plugins", outputPath})
+	assertStringSliceEqual(t, planArgs, []string{"--config", outputPath, "--plugin-dir", "data/plugins", "--output", planPath})
+	if applyArgs != nil {
+		t.Fatalf("apply args = %v, want nil for plan mode", applyArgs)
+	}
+	if _, err := os.Stat(reportPath); err != nil {
+		t.Fatalf("report not written: %v", err)
+	}
+}
+
+func TestRunDNSIntentReconcileApplyRequiresAutoApprove(t *testing.T) {
+	var validateArgs, planArgs, applyArgs []string
+	restore := stubDNSIntentLifecycle(t, &validateArgs, &planArgs, &applyArgs)
+	defer restore()
+
+	err := runDNS([]string{"intent", "reconcile", "--mode", "apply"})
+	if err == nil || !strings.Contains(err.Error(), "--mode apply requires --auto-approve") {
+		t.Fatalf("error = %v, want auto approve requirement", err)
+	}
+	if validateArgs != nil || planArgs != nil || applyArgs != nil {
+		t.Fatalf("lifecycle was called before rejecting apply: validate=%v plan=%v apply=%v", validateArgs, planArgs, applyArgs)
+	}
+}
+
+func TestRunDNSIntentReconcileAppliesGeneratedConfig(t *testing.T) {
+	dir := t.TempDir()
+	intentPath, portfolioPath := writeDNSIntentFixture(t, dir, false)
+	outputPath := filepath.Join(dir, "out.yaml")
+	reportPath := filepath.Join(dir, "report.json")
+	var validateArgs, planArgs, applyArgs []string
+	restore := stubDNSIntentLifecycle(t, &validateArgs, &planArgs, &applyArgs)
+	defer restore()
+
+	if err := runDNS([]string{"intent", "reconcile",
+		"--intent", intentPath,
+		"--portfolio", portfolioPath,
+		"--output", outputPath,
+		"--report", reportPath,
+		"--mode", "apply",
+		"--auto-approve",
+		"--plugin-dir", "data/plugins",
+	}); err != nil {
+		t.Fatalf("runDNS intent reconcile apply: %v", err)
+	}
+	assertStringSliceEqual(t, validateArgs, []string{"--allow-no-entry-points", "--plugin-dir", "data/plugins", outputPath})
+	assertStringSliceEqual(t, planArgs, []string{"--config", outputPath, "--plugin-dir", "data/plugins", "--output", "reports/domain-reconcile-plan.json"})
+	assertStringSliceEqual(t, applyArgs, []string{"--config", outputPath, "--auto-approve", "--plugin-dir", "data/plugins"})
+}
+
+func writeDNSIntentFixture(t *testing.T, dir string, nameserverCutover bool) (string, string) {
+	t.Helper()
+	intentPath := filepath.Join(dir, "domains.json")
+	cutover := "false"
+	if nameserverCutover {
+		cutover = "true"
+	}
+	if err := os.WriteFile(intentPath, []byte(`{
+  "schema": "workflow.domain-intent.v1",
+  "domains": {
+    "example.com": {
+      "registrar": "hover",
+      "dns_host": "cloudflare",
+      "stage_dns": true,
+      "nameserver_cutover": `+cutover+`,
+      "records_policy": "preserve_cloudflare"
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+	portfolioPath := filepath.Join(dir, "portfolio.json")
+	if err := os.WriteFile(portfolioPath, []byte(`{
+  "schema": "workflow.dns-portfolio.export.v1",
+  "snapshots": [
+    {
+      "id": "cf-example-com",
+      "provider": "cloudflare",
+      "domain": "example.com",
+      "authority": {"name_servers": ["a.ns.cloudflare.com", "b.ns.cloudflare.com"]},
+      "records": [{"type": "A", "name": "@", "value": "192.0.2.10", "ttl": 30}]
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write portfolio: %v", err)
+	}
+	return intentPath, portfolioPath
+}
+
+func stubDNSIntentLifecycle(t *testing.T, validateArgs, planArgs, applyArgs *[]string) func() {
+	t.Helper()
+	oldValidate := dnsIntentRunValidate
+	oldPlan := dnsIntentRunInfraPlan
+	oldApply := dnsIntentRunInfraApply
+	dnsIntentRunValidate = func(args []string) error {
+		*validateArgs = append([]string(nil), args...)
+		return nil
+	}
+	dnsIntentRunInfraPlan = func(args []string) error {
+		*planArgs = append([]string(nil), args...)
+		return nil
+	}
+	dnsIntentRunInfraApply = func(args []string) error {
+		*applyArgs = append([]string(nil), args...)
+		return nil
+	}
+	return func() {
+		dnsIntentRunValidate = oldValidate
+		dnsIntentRunInfraPlan = oldPlan
+		dnsIntentRunInfraApply = oldApply
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("args length = %d, want %d\ngot  %v\nwant %v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q\ngot  %v\nwant %v", i, got[i], want[i], got, want)
+		}
 	}
 }

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -1840,6 +1840,36 @@ Useful flags:
 | `--bundle` | _(none)_ | Optional combined JSON bundle path. |
 | `--state-dir` | `.state/domain-intent/` | Generated filesystem IaC state directory. |
 
+#### `dns intent reconcile`
+
+Compile domain intent, validate the generated infra-only config, and run the
+normal infra plan/apply lifecycle:
+
+```sh
+wfctl dns intent reconcile \
+  --intent domains.json \
+  --portfolio 'zones/*.portfolio.json' \
+  --domain example.com \
+  --plugin-dir data/plugins \
+  --mode plan
+```
+
+The command is a wrapper around `dns intent compile`, `wfctl validate
+--allow-no-entry-points`, and `wfctl infra plan`. With `--mode apply
+--auto-approve`, it runs `wfctl infra apply` after a successful plan. Reports
+and generated config files are written with the same defaults as `compile`;
+`--plan-output` defaults to `reports/domain-reconcile-plan.json`.
+
+Useful flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--mode` | `plan` | `plan` writes/prints the infra plan; `apply` also applies changes. |
+| `--auto-approve` | `false` | Required with `--mode apply`; passed through to `infra apply`. |
+| `--plugin-dir` | _(default resolution)_ | Plugin directory passed to validate/plan/apply. |
+| `--plan-output` | `reports/domain-reconcile-plan.json` | Generated infra plan JSON path. |
+| `--allow-empty` | `false` | Allow intent that compiles to zero actions. |
+
 **Protected-resource gate:**
 
 Resources annotated `protected: true` cannot be replaced or deleted by `infra apply` without an explicit per-resource opt-in. When a plan would replace or delete a protected resource, `wfctl` aborts before any provider dispatch and prints the full set of blockers in one pass with a copy-paste-ready flag value:

--- a/docs/iac-dns-providers.md
+++ b/docs/iac-dns-providers.md
@@ -288,3 +288,23 @@ Unsupported provider pairs and unsafe discard requests are reported as blockers
 and cause the command to exit non-zero. Provider plugins still own the actual
 apply behavior; the compiler only removes repository-local glue for producing
 the concrete IaC resources and report.
+
+For CI and operator workflows that want wfctl to drive the first lifecycle
+steps, use `wfctl dns intent reconcile`:
+
+```sh
+wfctl dns intent reconcile \
+  --intent domains.json \
+  --portfolio 'zones/*.portfolio.json' \
+  --domain example.com \
+  --plugin-dir data/plugins \
+  --mode plan
+```
+
+`reconcile` compiles the intent, validates the generated infra-only config with
+the correct no-entry-points setting, and runs `wfctl infra plan`. With
+`--mode apply --auto-approve`, it runs `wfctl infra apply` after the plan. The
+command preserves the generated config, report, optional bundle, and plan JSON
+paths so CI can upload them as artifacts. Provider-specific preflight and
+post-apply verification still belong in the consuming workflow until wfctl grows
+first-class provider-aware verification.


### PR DESCRIPTION
## Summary
- add `wfctl dns intent reconcile` to compile, validate, and drive infra plan/apply from domain intent
- validate generated infra-only configs with `--allow-no-entry-points` internally
- document the new operator command in the wfctl and DNS provider guides

Closes #938.

## Validation
- `GOWORK=off go test ./cmd/wfctl -run 'TestRunDNS' -count=1`\n- `GOWORK=off go test ./cmd/wfctl -run TestRunDNSIntentReconcilePlansGeneratedConfig -count=1`\n- `GOWORK=off go test ./cmd/wfctl -count=1`\n- `git diff --check`