### PR TITLE
feat(wfctl): quiet plugin install progress

### DIFF
--- a/cmd/wfctl/download_progress.go
+++ b/cmd/wfctl/download_progress.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -12,7 +13,28 @@ import (
 
 const downloadProgressInterval = 2 * time.Second
 
+var downloadProgressQuiet bool
+
+func setDownloadProgressQuiet(quiet bool) func() {
+	previous := downloadProgressQuiet
+	downloadProgressQuiet = previous || quiet
+	return func() {
+		downloadProgressQuiet = previous
+	}
+}
+
+func shouldSuppressDownloadProgress() bool {
+	if downloadProgressQuiet {
+		return true
+	}
+	value := strings.TrimSpace(strings.ToLower(os.Getenv("WFCTL_PLUGIN_INSTALL_QUIET")))
+	return value == "1" || value == "true" || value == "yes" || value == "on"
+}
+
 func readDownloadBodyWithProgress(r io.Reader, total int64) ([]byte, error) {
+	if shouldSuppressDownloadProgress() {
+		return io.ReadAll(r)
+	}
 	var buf bytes.Buffer
 	tracker := newDownloadProgress(os.Stderr, total)
 	if _, err := io.Copy(io.MultiWriter(&buf, tracker), r); err != nil {

--- a/cmd/wfctl/download_progress_test.go
+++ b/cmd/wfctl/download_progress_test.go
@@ -57,7 +57,14 @@ func TestReadDownloadBodyWithProgressCanBeSuppressedByEnv(t *testing.T) {
 }
 
 func TestDownloadProgressQuietFlagScope(t *testing.T) {
+	t.Setenv("WFCTL_PLUGIN_INSTALL_QUIET", "")
 	restore := setDownloadProgressQuiet(true)
+	restored := false
+	defer func() {
+		if !restored {
+			restore()
+		}
+	}()
 	if !shouldSuppressDownloadProgress() {
 		t.Fatal("quiet scope did not suppress download progress")
 	}
@@ -69,6 +76,7 @@ func TestDownloadProgressQuietFlagScope(t *testing.T) {
 		t.Fatalf("readDownloadBodyWithProgress = %q, want quiet", got)
 	}
 	restore()
+	restored = true
 	if shouldSuppressDownloadProgress() {
 		t.Fatal("quiet scope leaked after restore")
 	}

--- a/cmd/wfctl/download_progress_test.go
+++ b/cmd/wfctl/download_progress_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
@@ -41,4 +42,50 @@ func TestDownloadProgressNonTTYUsesLogLines(t *testing.T) {
 	if !strings.Contains(got, "Download progress:") || !strings.Contains(got, "Download complete:") {
 		t.Fatalf("non-TTY progress output = %q, want progress and completion lines", got)
 	}
+}
+
+func TestReadDownloadBodyWithProgressCanBeSuppressedByEnv(t *testing.T) {
+	t.Setenv("WFCTL_PLUGIN_INSTALL_QUIET", "true")
+
+	got, err := readDownloadBodyWithProgress(strings.NewReader("payload"), int64(len("payload")))
+	if err != nil {
+		t.Fatalf("readDownloadBodyWithProgress: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("readDownloadBodyWithProgress = %q, want payload", got)
+	}
+}
+
+func TestDownloadProgressQuietFlagScope(t *testing.T) {
+	restore := setDownloadProgressQuiet(true)
+	if !shouldSuppressDownloadProgress() {
+		t.Fatal("quiet scope did not suppress download progress")
+	}
+	got, err := readDownloadBodyWithProgress(strings.NewReader("quiet"), int64(len("quiet")))
+	if err != nil {
+		t.Fatalf("readDownloadBodyWithProgress: %v", err)
+	}
+	if string(got) != "quiet" {
+		t.Fatalf("readDownloadBodyWithProgress = %q, want quiet", got)
+	}
+	restore()
+	if shouldSuppressDownloadProgress() {
+		t.Fatal("quiet scope leaked after restore")
+	}
+}
+
+func TestReadDownloadBodyWithProgressQuietPropagatesReadErrors(t *testing.T) {
+	restore := setDownloadProgressQuiet(true)
+	defer restore()
+
+	_, err := readDownloadBodyWithProgress(errReader{}, 10)
+	if err == nil {
+		t.Fatal("readDownloadBodyWithProgress returned nil error")
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
 }

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -108,6 +108,7 @@ func runPluginInstall(args []string) error {
 	compatMode := fs.String("compat-mode", "", "Compatibility mode for registry installs: enforce or warn")
 	engineVersion := fs.String("engine-version", "", "Workflow engine version for compatibility resolution")
 	forceCompat := fs.Bool("force", false, "Permit known-failing compatibility evidence while still enforcing checksums")
+	quiet := fs.Bool("quiet", false, "Suppress per-download progress output")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin install [options] [<name>[@<version>]]\n\nInstall a plugin from the registry, a URL, a local directory, or from the lockfile.\n\n  wfctl plugin install <name>              Install latest from registry\n  wfctl plugin install <name>@v1.0.0       Install specific version\n  wfctl plugin install --url <url>          Install from a direct download URL\n  wfctl plugin install --local <dir>        Install from a local build directory\n  wfctl plugin install --from-config <f>    Install all requires.plugins[] from workflow config\n  wfctl plugin install                      Install all plugins from .wfctl-lock.yaml\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -119,6 +120,8 @@ func runPluginInstall(args []string) error {
 	if err := fs.Parse(parsedArgs); err != nil {
 		return err
 	}
+	restoreDownloadProgress := setDownloadProgressQuiet(*quiet)
+	defer restoreDownloadProgress()
 	// Validate flag combinations before doing anything else.
 	if *sha256Flag != "" && *directURL == "" {
 		return fmt.Errorf("--sha256 requires --url (no download URL specified)")
@@ -510,6 +513,7 @@ func runPluginUpdate(args []string) error {
 	engineVersion := fs.String("engine-version", "", "Workflow engine version for compatibility resolution")
 	forceCompat := fs.Bool("force", false, "Permit known-failing compatibility evidence while still enforcing checksums")
 	skipChecksum := fs.Bool("skip-checksum", false, "Skip integrity verification (WARNING: disables supply-chain protection)")
+	quiet := fs.Bool("quiet", false, "Suppress per-download progress output")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin update [options] <name>\n\nUpdate an installed plugin to its latest version.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -517,6 +521,8 @@ func runPluginUpdate(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	restoreDownloadProgress := setDownloadProgressQuiet(*quiet)
+	defer restoreDownloadProgress()
 	if fs.NArg() < 1 {
 		fs.Usage()
 		return fmt.Errorf("plugin name is required")

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -814,6 +814,7 @@ wfctl plugin install [options] <name>[@<version>]
 | `--compat-mode` | `enforce` | Compatibility mode for registry installs: `enforce` or `warn` |
 | `--engine-version` | build version or `WFCTL_ENGINE_VERSION` | Workflow engine version used for compatibility resolution |
 | `--force` | `false` | Permit known-failing or missing required compatibility evidence while still enforcing archive checksums |
+| `--quiet` | `false` | Suppress per-download progress output |
 | `--skip-checksum` | `false` | Skip archive integrity verification. Use only for trusted internal URLs |
 
 ```bash
@@ -821,6 +822,10 @@ wfctl plugin install my-plugin
 wfctl plugin install my-plugin@1.2.0
 wfctl plugin install --data-dir /opt/plugins my-plugin
 ```
+
+Set `WFCTL_PLUGIN_INSTALL_QUIET=1` to suppress download progress in CI without
+changing command arguments. High-level install, checksum, and error messages are
+still emitted.
 
 Registry installs resolve compatibility before selecting a version. Direct URL installs, local installs, GitHub repository fallback, and lockfile installs do not use registry evidence unless they are backed by registry metadata.
 

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -912,6 +912,7 @@ wfctl plugin update [options] <name>
 | `--compat-mode` | `enforce` | Compatibility mode for registry updates: `enforce` or `warn` |
 | `--engine-version` | build version or `WFCTL_ENGINE_VERSION` | Workflow engine version used for compatibility resolution |
 | `--force` | `false` | Permit known-failing or missing required compatibility evidence while still enforcing archive checksums |
+| `--quiet` | `false` | Suppress per-download progress output |
 | `--skip-checksum` | `false` | Skip archive integrity verification. Use only for trusted internal URLs |
 
 #### `plugin remove`

--- a/docs/manual/build-deploy/05-cli-reference.md
+++ b/docs/manual/build-deploy/05-cli-reference.md
@@ -143,6 +143,9 @@ Runs garbage collection and prunes tags beyond `retention.keep_latest`. Preserve
 wfctl plugin install [flags] [<name>[@<version>]]
 ```
 
+Use `--quiet` or `WFCTL_PLUGIN_INSTALL_QUIET=1` in CI to suppress per-download
+progress lines while keeping install status, checksum, and error output.
+
 ### New flag: `--from-config`
 
 ```

--- a/docs/manual/build-deploy/05-cli-reference.md
+++ b/docs/manual/build-deploy/05-cli-reference.md
@@ -143,8 +143,10 @@ Runs garbage collection and prunes tags beyond `retention.keep_latest`. Preserve
 wfctl plugin install [flags] [<name>[@<version>]]
 ```
 
-Use `--quiet` or `WFCTL_PLUGIN_INSTALL_QUIET=1` in CI to suppress per-download
-progress lines while keeping install status, checksum, and error output.
+Use `--quiet` with `wfctl plugin install` or `wfctl plugin update` in CI to
+suppress per-download progress lines while keeping install status, checksum,
+and error output. `WFCTL_PLUGIN_INSTALL_QUIET=1` applies the same suppression
+without changing command arguments.
 
 ### New flag: `--from-config`
 


### PR DESCRIPTION
Fixes #942

## Summary
- add `wfctl plugin install --quiet` and `wfctl plugin update --quiet`
- add `WFCTL_PLUGIN_INSTALL_QUIET=1` for CI without argument changes
- suppress only per-download progress; status, checksum, and error output remain
- document the flag/env var

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestDownloadProgress|TestReadDownloadBodyWithProgress|TestDownloadURL_LargeDirectDownloadEmitsProgress' -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `git diff --check`