### PR TITLE
fix(dns): canonicalize portfolio ordering

### DIFF
--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -154,7 +154,7 @@ func recordLess(a, b Record) bool {
 	if less, ok := optionalIntLess(a.Flags, b.Flags); ok {
 		return less
 	}
-	if strings.ToLower(a.Tag) != strings.ToLower(b.Tag) {
+	if !strings.EqualFold(a.Tag, b.Tag) {
 		return strings.ToLower(a.Tag) < strings.ToLower(b.Tag)
 	}
 	return a.Tag < b.Tag

--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -130,7 +130,9 @@ func canonicalizeSnapshot(snap *Snapshot) {
 func recordLess(a, b Record) bool {
 	for _, cmp := range []struct{ a, b string }{
 		{strings.ToUpper(a.Type), strings.ToUpper(b.Type)},
+		{a.Type, b.Type},
 		{strings.ToLower(a.Name), strings.ToLower(b.Name)},
+		{a.Name, b.Name},
 		{strings.ToLower(a.Value), strings.ToLower(b.Value)},
 		{a.Value, b.Value},
 	} {

--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -113,9 +113,115 @@ func FromResourceStates(states []interfaces.ResourceState) Portfolio {
 	})
 
 	for _, k := range order {
-		p.Snapshots = append(p.Snapshots, *snapByKey[k])
+		snap := *snapByKey[k]
+		canonicalizeSnapshot(&snap)
+		p.Snapshots = append(p.Snapshots, snap)
 	}
 	return p
+}
+
+func canonicalizeSnapshot(snap *Snapshot) {
+	sort.SliceStable(snap.Records, func(i, j int) bool {
+		return recordLess(snap.Records[i], snap.Records[j])
+	})
+	sortAuthorityStringSlices(snap.Authority)
+}
+
+func recordLess(a, b Record) bool {
+	for _, cmp := range []struct{ a, b string }{
+		{strings.ToUpper(a.Type), strings.ToUpper(b.Type)},
+		{strings.ToLower(a.Name), strings.ToLower(b.Name)},
+		{strings.ToLower(a.Value), strings.ToLower(b.Value)},
+		{a.Value, b.Value},
+	} {
+		if cmp.a == cmp.b {
+			continue
+		}
+		return cmp.a < cmp.b
+	}
+	if a.TTL != b.TTL {
+		return a.TTL < b.TTL
+	}
+	if less, ok := optionalIntLess(a.Priority, b.Priority); ok {
+		return less
+	}
+	if less, ok := optionalIntLess(a.Port, b.Port); ok {
+		return less
+	}
+	if less, ok := optionalIntLess(a.Weight, b.Weight); ok {
+		return less
+	}
+	if less, ok := optionalIntLess(a.Flags, b.Flags); ok {
+		return less
+	}
+	if strings.ToLower(a.Tag) != strings.ToLower(b.Tag) {
+		return strings.ToLower(a.Tag) < strings.ToLower(b.Tag)
+	}
+	return a.Tag < b.Tag
+}
+
+func optionalIntLess(a, b *int) (bool, bool) {
+	switch {
+	case a == nil && b == nil:
+		return false, false
+	case a == nil:
+		return true, true
+	case b == nil:
+		return false, true
+	case *a != *b:
+		return *a < *b, true
+	default:
+		return false, false
+	}
+}
+
+func sortAuthorityStringSlices(authority map[string]any) {
+	for _, key := range []string{
+		"registrar_nameservers",
+		"live_nameservers",
+		"name_servers",
+		"original_name_servers",
+	} {
+		value, ok := authority[key]
+		if !ok {
+			continue
+		}
+		if sorted, ok := sortedStringAnySlice(value); ok {
+			authority[key] = sorted
+		}
+	}
+}
+
+func sortedStringAnySlice(value any) ([]any, bool) {
+	var values []string
+	switch v := value.(type) {
+	case []any:
+		values = make([]string, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, false
+			}
+			values[i] = s
+		}
+	case []string:
+		values = append([]string(nil), v...)
+	default:
+		return nil, false
+	}
+	sort.SliceStable(values, func(i, j int) bool {
+		li := strings.ToLower(values[i])
+		lj := strings.ToLower(values[j])
+		if li == lj {
+			return values[i] < values[j]
+		}
+		return li < lj
+	})
+	out := make([]any, len(values))
+	for i := range values {
+		out[i] = values[i]
+	}
+	return out, true
 }
 
 // sanitizeDomainForID converts a domain string into an ID-safe slug:

--- a/dns/record/canonicalize_test.go
+++ b/dns/record/canonicalize_test.go
@@ -326,6 +326,8 @@ func TestFromResourceStatesCanonicalizesRecordAndAuthorityOrder(t *testing.T) {
 					map[string]any{"type": "TXT", "name": "z", "address": "last", "ttl": 300},
 					map[string]any{"type": "MX", "name": "@", "address": "mail.example.com.", "ttl": 300, "priority": 10},
 					map[string]any{"type": "TXT", "name": "_dmarc", "address": "v=DMARC1; p=none", "ttl": 300},
+					map[string]any{"type": "A", "name": "www", "address": "192.0.2.12", "ttl": 300},
+					map[string]any{"type": "A", "name": "WWW", "address": "192.0.2.11", "ttl": 300},
 					map[string]any{"type": "A", "name": "@", "address": "192.0.2.10", "ttl": 300},
 				},
 				"authority": map[string]any{
@@ -356,6 +358,8 @@ func TestFromResourceStatesCanonicalizesRecordAndAuthorityOrder(t *testing.T) {
 	}
 	wantRecords := []string{
 		"A @ 192.0.2.10",
+		"A WWW 192.0.2.11",
+		"A www 192.0.2.12",
 		"MX @ mail.example.com.",
 		"TXT _dmarc v=DMARC1; p=none",
 		"TXT z last",

--- a/dns/record/canonicalize_test.go
+++ b/dns/record/canonicalize_test.go
@@ -1,6 +1,7 @@
 package record_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/dns/record"
@@ -311,5 +312,70 @@ func TestFromResourceStatesOmitsAbsentOptionalFields(t *testing.T) {
 	if r.Priority != nil || r.Port != nil || r.Weight != nil || r.Flags != nil {
 		t.Errorf("absent optional fields should stay nil; got priority=%v port=%v weight=%v flags=%v",
 			r.Priority, r.Port, r.Weight, r.Flags)
+	}
+}
+
+func TestFromResourceStatesCanonicalizesRecordAndAuthorityOrder(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{
+			Type:       "infra.dns",
+			Provider:   "namecheap",
+			ProviderID: "example.com",
+			Outputs: map[string]any{
+				"records": []any{
+					map[string]any{"type": "TXT", "name": "z", "address": "last", "ttl": 300},
+					map[string]any{"type": "MX", "name": "@", "address": "mail.example.com.", "ttl": 300, "priority": 10},
+					map[string]any{"type": "TXT", "name": "_dmarc", "address": "v=DMARC1; p=none", "ttl": 300},
+					map[string]any{"type": "A", "name": "@", "address": "192.0.2.10", "ttl": 300},
+				},
+				"authority": map[string]any{
+					"name_servers":          []any{"z.ns.example.com", "A.ns.example.com"},
+					"original_name_servers": []string{"ns2.hover.com", "ns1.hover.com"},
+				},
+			},
+		},
+		{
+			Type:       "infra.dns_delegation",
+			Provider:   "namecheap",
+			ProviderID: "example.com",
+			Outputs: map[string]any{
+				"registrar_nameservers": []any{"ns2.registrar.example", "ns1.registrar.example"},
+				"live_nameservers":      []any{"ns2.live.example", "ns1.live.example"},
+			},
+		},
+	}
+
+	p := record.FromResourceStates(states)
+	if len(p.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot; got %d", len(p.Snapshots))
+	}
+
+	gotRecords := make([]string, len(p.Snapshots[0].Records))
+	for i, r := range p.Snapshots[0].Records {
+		gotRecords[i] = r.Type + " " + r.Name + " " + r.Value
+	}
+	wantRecords := []string{
+		"A @ 192.0.2.10",
+		"MX @ mail.example.com.",
+		"TXT _dmarc v=DMARC1; p=none",
+		"TXT z last",
+	}
+	if !reflect.DeepEqual(gotRecords, wantRecords) {
+		t.Fatalf("records order = %#v; want %#v", gotRecords, wantRecords)
+	}
+
+	for key, want := range map[string][]any{
+		"name_servers":          {"A.ns.example.com", "z.ns.example.com"},
+		"original_name_servers": {"ns1.hover.com", "ns2.hover.com"},
+		"registrar_nameservers": {"ns1.registrar.example", "ns2.registrar.example"},
+		"live_nameservers":      {"ns1.live.example", "ns2.live.example"},
+	} {
+		got, ok := p.Snapshots[0].Authority[key].([]any)
+		if !ok {
+			t.Fatalf("Authority[%s] = %#v; want []any", key, p.Snapshots[0].Authority[key])
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Authority[%s] = %#v; want %#v", key, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- sort DNS portfolio records before JSON export
- sort nameserver authority arrays before JSON export
- add regression coverage for record and authority ordering

## Verification
- GOWORK=off go test ./dns/record -count=1
- GOWORK=off go test ./cmd/wfctl ./dns/record -count=1

This reduces order-only churn in provider import PRs for Hover, Namecheap, Cloudflare, and DigitalOcean DNS catalogs.