### PR TITLE
Preserve delegation nameserver string slices

### DIFF
--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -88,13 +88,11 @@ func FromResourceStates(states []interfaces.ResourceState) Portfolio {
 			snap := getOrCreate(st.Provider, domain)
 			for _, nsKey := range []string{"registrar_nameservers", "live_nameservers"} {
 				if v, ok := st.Outputs[nsKey]; ok {
-					if slice, ok := v.([]any); ok {
-						cp := make([]any, len(slice))
-						copy(cp, slice)
+					if slice, ok := sortedStringAnySlice(v); ok {
 						if snap.Authority == nil {
 							snap.Authority = map[string]any{}
 						}
-						snap.Authority[nsKey] = cp
+						snap.Authority[nsKey] = slice
 					}
 				}
 			}

--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -88,11 +88,11 @@ func FromResourceStates(states []interfaces.ResourceState) Portfolio {
 			snap := getOrCreate(st.Provider, domain)
 			for _, nsKey := range []string{"registrar_nameservers", "live_nameservers"} {
 				if v, ok := st.Outputs[nsKey]; ok {
-					if slice, ok := sortedStringAnySlice(v); ok {
+					if cloned, ok := cloneNameserverAuthorityValue(v); ok {
 						if snap.Authority == nil {
 							snap.Authority = map[string]any{}
 						}
-						snap.Authority[nsKey] = slice
+						snap.Authority[nsKey] = cloned
 					}
 				}
 			}
@@ -285,6 +285,15 @@ func cloneAuthorityValue(value any) any {
 		return cp
 	default:
 		return v
+	}
+}
+
+func cloneNameserverAuthorityValue(value any) (any, bool) {
+	switch value.(type) {
+	case []any, []string:
+		return cloneAuthorityValue(value), true
+	default:
+		return nil, false
 	}
 }
 

--- a/dns/record/canonicalize_test.go
+++ b/dns/record/canonicalize_test.go
@@ -152,6 +152,31 @@ func TestFromResourceStates_DNSStatePreservesProviderAuthority(t *testing.T) {
 	}
 }
 
+func TestFromResourceStates_DelegationAcceptsStringSlices(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{
+			Type:       "infra.dns_delegation",
+			Provider:   "namecheap",
+			ProviderID: "example.com",
+			Outputs: map[string]any{
+				"registrar_nameservers": []string{"dns1.registrar-servers.com", "dns2.registrar-servers.com"},
+			},
+		},
+	}
+	p := record.FromResourceStates(states)
+	if len(p.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot from delegation state; got %d", len(p.Snapshots))
+	}
+	ns, ok := p.Snapshots[0].Authority["registrar_nameservers"]
+	if !ok {
+		t.Fatalf("Authority missing registrar_nameservers")
+	}
+	nsSlice, ok := ns.([]any)
+	if !ok || len(nsSlice) != 2 || nsSlice[0] != "dns1.registrar-servers.com" || nsSlice[1] != "dns2.registrar-servers.com" {
+		t.Fatalf("registrar_nameservers = %#v, want two nameservers", ns)
+	}
+}
+
 func TestFromResourceStates_MergesBothLayersByDomain(t *testing.T) {
 	states := []interfaces.ResourceState{
 		{


### PR DESCRIPTION
## Summary
- accept []string delegation nameserver outputs when building DNS portfolios
- reuse existing authority slice normalization/sorting
- add regression coverage for Namecheap infra.dns_delegation imports

## Verification
- GOWORK=off go test ./dns/record -run 'Delegation|FromResourceStates' -count=1
- GOWORK=off go test ./cmd/wfctl -run 'ImportAll|DumpPortfolio|Delegation' -count=1
- GOWORK=off go test ./...