### PR TITLE
Merge nested DNS delegation authority

### DIFF
--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -13,8 +13,9 @@ import (
 // AppliedConfig), renaming provider-specific value keys to the canonical "value".
 // If an infra.dns state includes provider-supplied authority metadata in
 // Outputs["authority"], safe keys are copied into Snapshot.Authority.
-// Each infra.dns_delegation state populates Snapshot.Authority with
-// registrar_nameservers and live_nameservers for the matching domain.
+// Each infra.dns_delegation state populates Snapshot.Authority for the matching
+// domain from safe Outputs["authority"] keys, plus top-level
+// registrar_nameservers and live_nameservers values when present.
 // States of other types are silently skipped.
 //
 // Snapshots are grouped by (Provider, Domain) so that infra.dns and

--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -86,6 +86,7 @@ func FromResourceStates(states []interfaces.ResourceState) Portfolio {
 				continue
 			}
 			snap := getOrCreate(st.Provider, domain)
+			mergeAuthority(snap, st.Outputs["authority"])
 			for _, nsKey := range []string{"registrar_nameservers", "live_nameservers"} {
 				if v, ok := st.Outputs[nsKey]; ok {
 					if cloned, ok := cloneNameserverAuthorityValue(v); ok {

--- a/dns/record/canonicalize_test.go
+++ b/dns/record/canonicalize_test.go
@@ -177,6 +177,35 @@ func TestFromResourceStates_DelegationAcceptsStringSlices(t *testing.T) {
 	}
 }
 
+func TestFromResourceStates_DelegationAcceptsNestedAuthority(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{
+			Type:       "infra.dns_delegation",
+			Provider:   "namecheap",
+			ProviderID: "example.com",
+			Outputs: map[string]any{
+				"nameservers": []string{"dns1.registrar-servers.com", "dns2.registrar-servers.com"},
+				"authority": map[string]any{
+					"registrar":             "Namecheap",
+					"registrar_nameservers": []string{"dns1.registrar-servers.com", "dns2.registrar-servers.com"},
+				},
+			},
+		},
+	}
+	p := record.FromResourceStates(states)
+	if len(p.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot from delegation state; got %d", len(p.Snapshots))
+	}
+	ns, ok := p.Snapshots[0].Authority["registrar_nameservers"]
+	if !ok {
+		t.Fatalf("Authority missing registrar_nameservers")
+	}
+	nsSlice, ok := ns.([]any)
+	if !ok || len(nsSlice) != 2 || nsSlice[0] != "dns1.registrar-servers.com" || nsSlice[1] != "dns2.registrar-servers.com" {
+		t.Fatalf("registrar_nameservers = %#v, want two nameservers", ns)
+	}
+}
+
 func TestFromResourceStates_MergesBothLayersByDomain(t *testing.T) {
 	states := []interfaces.ResourceState{
 		{


### PR DESCRIPTION
## Summary
- merge allow-listed `outputs.authority` data from `infra.dns_delegation` states
- preserve existing top-level `registrar_nameservers` / `live_nameservers` behavior
- add regression coverage for Namecheap delegation output shape

## Verification
- red proof: `GOWORK=off go test ./dns/record -run TestFromResourceStates_DelegationAcceptsNestedAuthority -count=1` failed before the fix with missing registrar_nameservers
- `GOWORK=off go test ./dns/record -run 'Delegation|FromResourceStates' -count=1`\n- `GOWORK=off go test ./cmd/wfctl -run 'ImportAll|DumpPortfolio|Delegation' -count=1`\n- `GOWORK=off go test ./...`\n