### PR TITLE
[codex] Decouple plugin SDK contracts

### DIFF
--- a/plugin/external/contract/handshake.go
+++ b/plugin/external/contract/handshake.go
@@ -1,0 +1,25 @@
+// Package contract contains host/plugin shared types that must stay free of
+// workflow host runtime dependencies.
+package contract
+
+import goplugin "github.com/GoCodeAlone/go-plugin"
+
+const (
+	// ProtocolVersion is the plugin protocol version.
+	// Increment this when making breaking changes to the gRPC interface.
+	ProtocolVersion = 1
+
+	// MagicCookieKey is the environment variable used for the handshake.
+	MagicCookieKey = "WORKFLOW_PLUGIN"
+
+	// MagicCookieValue is the expected value for the handshake cookie.
+	MagicCookieValue = "workflow-external-plugin-v1"
+)
+
+// Handshake is the shared handshake configuration between host and plugins.
+// Both the host client and plugin server must use identical values.
+var Handshake = goplugin.HandshakeConfig{
+	ProtocolVersion:  ProtocolVersion,
+	MagicCookieKey:   MagicCookieKey,
+	MagicCookieValue: MagicCookieValue,
+}

--- a/plugin/external/contract/ui_manifest.go
+++ b/plugin/external/contract/ui_manifest.go
@@ -1,0 +1,72 @@
+package contract
+
+// UIManifest describes the UI contribution of a go-plugin UI plugin.
+// Place this as "ui.json" in the plugin directory alongside "plugin.json".
+//
+// # Directory Layout
+//
+//	plugins/
+//	  my-ui-plugin/
+//	    my-ui-plugin  (binary, required for API handlers; optional for asset-only plugins)
+//	    plugin.json   (gRPC plugin manifest; required when binary is present)
+//	    ui.json       (UI manifest: nav items and asset location)
+//	    assets/       (static files: HTML, CSS, JS, images, etc.)
+//	      index.html
+//	      main.js
+//
+// # Asset Versioning
+//
+// Include a version hash in asset filenames (e.g. main.abc123.js) and
+// reference them from index.html so browsers pick up new files after
+// hot-deploy.
+//
+// # Hot-Reload
+//
+// After updating assets or ui.json, call:
+//
+//	POST /api/v1/plugins/ui/{name}/reload
+//
+// This re-reads the manifest and serves the new files without restarting the
+// workflow engine.
+//
+// # Hot-Deploy
+//
+// Replace the plugin binary and/or assets directory with the new version,
+// then call the reload endpoint above.
+type UIManifest struct {
+	// Name is the plugin identifier. Must match the plugin directory name.
+	Name string `json:"name"`
+	// Version is the plugin version string (e.g. "1.0.0").
+	Version string `json:"version"`
+	// Description is a short human-readable description of the plugin.
+	Description string `json:"description,omitempty"`
+	// NavItems declares navigation entries contributed to the admin UI.
+	NavItems []UINavItem `json:"navItems,omitempty"`
+	// AssetDir is the subdirectory within the plugin directory that holds
+	// static assets. Defaults to "assets" when empty.
+	AssetDir string `json:"assetDir,omitempty"`
+}
+
+// UINavItem describes a single entry in the admin UI navigation sidebar.
+type UINavItem struct {
+	// ID is the unique page identifier (e.g. "my-plugin-dashboard").
+	ID string `json:"id"`
+	// Label is the human-readable navigation label shown in the sidebar.
+	Label string `json:"label"`
+	// Icon is an emoji or icon token rendered alongside the label.
+	Icon string `json:"icon,omitempty"`
+	// Category groups navigation entries:
+	//   "global"   - always visible top-level entries
+	//   "workflow" - shown only when a workflow is open
+	//   "plugin"   - plugin-contributed entries (default)
+	//   "tools"    - administrative tooling entries
+	Category string `json:"category,omitempty"`
+	// Order controls the sort position within the category (lower = higher up).
+	Order int `json:"order,omitempty"`
+	// RequiredRole is the minimum role needed to see this page
+	// (e.g. "viewer", "editor", "admin", "operator").
+	RequiredRole string `json:"requiredRole,omitempty"`
+	// RequiredPermission is a specific permission key required to see this page
+	// (e.g. "plugins.manage").
+	RequiredPermission string `json:"requiredPermission,omitempty"`
+}

--- a/plugin/external/handshake.go
+++ b/plugin/external/handshake.go
@@ -4,24 +4,21 @@ package external
 
 import (
 	goplugin "github.com/GoCodeAlone/go-plugin"
+	"github.com/GoCodeAlone/workflow/plugin/external/contract"
 )
 
 const (
 	// ProtocolVersion is the plugin protocol version.
 	// Increment this when making breaking changes to the gRPC interface.
-	ProtocolVersion = 1
+	ProtocolVersion = contract.ProtocolVersion
 
 	// MagicCookieKey is the environment variable used for the handshake.
-	MagicCookieKey = "WORKFLOW_PLUGIN"
+	MagicCookieKey = contract.MagicCookieKey
 
 	// MagicCookieValue is the expected value for the handshake cookie.
-	MagicCookieValue = "workflow-external-plugin-v1"
+	MagicCookieValue = contract.MagicCookieValue
 )
 
 // Handshake is the shared handshake configuration between host and plugins.
 // Both the host (client) and plugin (server) must use identical values.
-var Handshake = goplugin.HandshakeConfig{
-	ProtocolVersion:  ProtocolVersion,
-	MagicCookieKey:   MagicCookieKey,
-	MagicCookieValue: MagicCookieValue,
-}
+var Handshake = goplugin.HandshakeConfig(contract.Handshake)

--- a/plugin/external/handshake.go
+++ b/plugin/external/handshake.go
@@ -2,10 +2,7 @@
 // External plugins run as separate processes communicating over gRPC via hashicorp/go-plugin.
 package external
 
-import (
-	goplugin "github.com/GoCodeAlone/go-plugin"
-	"github.com/GoCodeAlone/workflow/plugin/external/contract"
-)
+import "github.com/GoCodeAlone/workflow/plugin/external/contract"
 
 const (
 	// ProtocolVersion is the plugin protocol version.
@@ -21,4 +18,4 @@ const (
 
 // Handshake is the shared handshake configuration between host and plugins.
 // Both the host (client) and plugin (server) must use identical values.
-var Handshake = goplugin.HandshakeConfig(contract.Handshake)
+var Handshake = contract.Handshake

--- a/plugin/external/sdk/iacserver.go
+++ b/plugin/external/sdk/iacserver.go
@@ -631,8 +631,8 @@ func ServeIaCPlugin(provider any, opts IaCServeOptions) {
 }
 
 // resolveServeHandshake returns the goplugin handshake to use for an IaC
-// plugin. Defaults to the canonical wfctl<->plugin
-// handshake) when the caller did not supply a PluginInfo OR supplied
+// plugin. Defaults to the canonical wfctl<->plugin handshake when the
+// caller did not supply a PluginInfo OR supplied
 // the zero-valued HandshakeConfig. Returns an error when the caller
 // supplied a PARTIAL override (any non-zero field but missing
 // MagicCookieKey or MagicCookieValue) — partial overrides produce a

--- a/plugin/external/sdk/iacserver.go
+++ b/plugin/external/sdk/iacserver.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	pluginpkg "github.com/GoCodeAlone/workflow/plugin"
-	ext "github.com/GoCodeAlone/workflow/plugin/external"
+	"github.com/GoCodeAlone/workflow/plugin/external/contract"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 )
 
@@ -355,12 +355,12 @@ func (b *iacPluginServiceBridge) GetManifest(_ context.Context, _ *emptypb.Empty
 // IaCServeOptions configures the IaC plugin gRPC server entrypoint.
 //
 // Plugin authors typically zero-value this; ServeIaCPlugin then uses the
-// canonical host<->plugin handshake (ext.Handshake). The struct exists as
+// canonical host<->plugin handshake. The struct exists as
 // a forward-extension point so future metadata fields (PluginInfo) can be
 // added without breaking the API.
 type IaCServeOptions struct {
 	// PluginInfo overrides the default handshake/metadata. When nil,
-	// ServeIaCPlugin uses ext.Handshake (the canonical wfctl<->plugin
+	// ServeIaCPlugin uses the canonical wfctl<->plugin
 	// handshake — required for compatibility with the workflow host).
 	PluginInfo *PluginInfo
 
@@ -547,7 +547,7 @@ func (p *mapBackedProvider) CreateTypedStep(typeName, name string, config *anypb
 // breaking the IaCServeOptions API.
 type PluginInfo struct {
 	// HandshakeConfig is the go-plugin handshake. Plugin authors should
-	// leave this zero-valued to inherit ext.Handshake — the host (wfctl)
+	// leave this zero-valued to inherit the host (wfctl)
 	// and plugin MUST agree on the cookie + protocol version, so override
 	// only when implementing a non-workflow host.
 	HandshakeConfig goplugin.HandshakeConfig
@@ -631,7 +631,7 @@ func ServeIaCPlugin(provider any, opts IaCServeOptions) {
 }
 
 // resolveServeHandshake returns the goplugin handshake to use for an IaC
-// plugin. Defaults to ext.Handshake (the canonical wfctl<->plugin
+// plugin. Defaults to the canonical wfctl<->plugin
 // handshake) when the caller did not supply a PluginInfo OR supplied
 // the zero-valued HandshakeConfig. Returns an error when the caller
 // supplied a PARTIAL override (any non-zero field but missing
@@ -648,13 +648,13 @@ func ServeIaCPlugin(provider any, opts IaCServeOptions) {
 // without invoking goplugin.Serve's blocking loop.
 func resolveServeHandshake(opts IaCServeOptions) (goplugin.HandshakeConfig, error) {
 	if opts.PluginInfo == nil {
-		return ext.Handshake, nil
+		return contract.Handshake, nil
 	}
 	hs := opts.PluginInfo.HandshakeConfig
 	if hs == (goplugin.HandshakeConfig{}) {
 		// Zero value: caller supplied PluginInfo{} but no handshake
 		// override. Treat identically to opts.PluginInfo == nil.
-		return ext.Handshake, nil
+		return contract.Handshake, nil
 	}
 	if hs.MagicCookieKey == "" || hs.MagicCookieValue == "" {
 		return goplugin.HandshakeConfig{}, fmt.Errorf(
@@ -662,7 +662,7 @@ func resolveServeHandshake(opts IaCServeOptions) (goplugin.HandshakeConfig, erro
 				"override (MagicCookieKey=%q MagicCookieValue=%q "+
 				"ProtocolVersion=%d): both MagicCookieKey AND "+
 				"MagicCookieValue MUST be set when overriding the default "+
-				"ext.Handshake — leave the whole struct zero-valued to "+
+				"canonical handshake - leave the whole struct zero-valued to "+
 				"inherit the canonical wfctl<->plugin handshake",
 			hs.MagicCookieKey, hs.MagicCookieValue, hs.ProtocolVersion,
 		)

--- a/plugin/external/sdk/import_graph_test.go
+++ b/plugin/external/sdk/import_graph_test.go
@@ -1,0 +1,40 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSDKImportGraphDoesNotDependOnHostRuntime(t *testing.T) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-f", "{{.ImportPath}}", "github.com/GoCodeAlone/workflow/plugin/external/sdk")
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("go list timed out: %v\n%s", ctx.Err(), out)
+	}
+	if err != nil {
+		t.Fatalf("go list failed: %v\n%s", err, out)
+	}
+
+	forbidden := []string{
+		"github.com/GoCodeAlone/workflow/module",
+		"github.com/docker/docker",
+	}
+	for _, dep := range strings.Fields(string(out)) {
+		for _, prefix := range forbidden {
+			if dep == prefix || strings.HasPrefix(dep, prefix+"/") {
+				t.Fatalf("SDK import graph includes host runtime dependency %q", dep)
+			}
+		}
+	}
+}

--- a/plugin/external/sdk/serve.go
+++ b/plugin/external/sdk/serve.go
@@ -7,7 +7,7 @@ import (
 
 	goplugin "github.com/GoCodeAlone/go-plugin"
 	pluginpkg "github.com/GoCodeAlone/workflow/plugin"
-	ext "github.com/GoCodeAlone/workflow/plugin/external"
+	"github.com/GoCodeAlone/workflow/plugin/external/contract"
 	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
 	"google.golang.org/grpc"
 )
@@ -95,7 +95,7 @@ func Serve(provider PluginProvider, opts ...ServeOption) {
 	}
 
 	goplugin.Serve(&goplugin.ServeConfig{
-		HandshakeConfig: ext.Handshake,
+		HandshakeConfig: contract.Handshake,
 		GRPCServer:      goplugin.DefaultGRPCServer,
 		Plugins: goplugin.PluginSet{
 			"plugin": &servePlugin{server: server},
@@ -126,7 +126,7 @@ func (p *servePlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, _ *g
 
 // writeUIManifestIfAbsent writes m to "ui.json" in the current working
 // directory only when that file does not already exist.
-func writeUIManifestIfAbsent(m ext.UIManifest) {
+func writeUIManifestIfAbsent(m UIManifest) {
 	const filename = "ui.json"
 	if _, err := os.Stat(filename); err == nil {
 		return // file already exists — do not overwrite

--- a/plugin/external/sdk/ui_provider.go
+++ b/plugin/external/sdk/ui_provider.go
@@ -1,6 +1,9 @@
 package sdk
 
-import ext "github.com/GoCodeAlone/workflow/plugin/external"
+import "github.com/GoCodeAlone/workflow/plugin/external/contract"
+
+type UIManifest = contract.UIManifest
+type UINavItem = contract.UINavItem
 
 // UIProvider is an optional interface that PluginProvider implementations can
 // satisfy to declare UI assets and navigation contributions.
@@ -12,11 +15,9 @@ import ext "github.com/GoCodeAlone/workflow/plugin/external"
 //
 // # Type aliases
 //
-// The UI manifest types (UIManifest, UINavItem) are defined in the
-// github.com/GoCodeAlone/workflow/plugin/external package so that both the
-// host engine and plugin processes share the same type definitions without
-// introducing an import cycle.
+// The UI manifest types are aliases for the shared contract package so plugins
+// can use the SDK without importing host-side external plugin adapters.
 type UIProvider interface {
 	// UIManifest returns the UI manifest for this plugin.
-	UIManifest() ext.UIManifest
+	UIManifest() UIManifest
 }

--- a/plugin/external/ui_manifest.go
+++ b/plugin/external/ui_manifest.go
@@ -1,5 +1,7 @@
 package external
 
+import "github.com/GoCodeAlone/workflow/plugin/external/contract"
+
 // UIManifest describes the UI contribution of a go-plugin UI plugin.
 // Place this as "ui.json" in the plugin directory alongside "plugin.json".
 //
@@ -33,40 +35,7 @@ package external
 //
 // Replace the plugin binary and/or assets directory with the new version,
 // then call the reload endpoint above.
-type UIManifest struct {
-	// Name is the plugin identifier. Must match the plugin directory name.
-	Name string `json:"name"`
-	// Version is the plugin version string (e.g. "1.0.0").
-	Version string `json:"version"`
-	// Description is a short human-readable description of the plugin.
-	Description string `json:"description,omitempty"`
-	// NavItems declares navigation entries contributed to the admin UI.
-	NavItems []UINavItem `json:"navItems,omitempty"`
-	// AssetDir is the subdirectory within the plugin directory that holds
-	// static assets. Defaults to "assets" when empty.
-	AssetDir string `json:"assetDir,omitempty"`
-}
+type UIManifest = contract.UIManifest
 
 // UINavItem describes a single entry in the admin UI navigation sidebar.
-type UINavItem struct {
-	// ID is the unique page identifier (e.g. "my-plugin-dashboard").
-	ID string `json:"id"`
-	// Label is the human-readable navigation label shown in the sidebar.
-	Label string `json:"label"`
-	// Icon is an emoji or icon token rendered alongside the label.
-	Icon string `json:"icon,omitempty"`
-	// Category groups navigation entries:
-	//   "global"   – always visible top-level entries
-	//   "workflow" – shown only when a workflow is open
-	//   "plugin"   – plugin-contributed entries (default)
-	//   "tools"    – administrative tooling entries
-	Category string `json:"category,omitempty"`
-	// Order controls the sort position within the category (lower = higher up).
-	Order int `json:"order,omitempty"`
-	// RequiredRole is the minimum role needed to see this page
-	// (e.g. "viewer", "editor", "admin", "operator").
-	RequiredRole string `json:"requiredRole,omitempty"`
-	// RequiredPermission is a specific permission key required to see this page
-	// (e.g. "plugins.manage").
-	RequiredPermission string `json:"requiredPermission,omitempty"`
-}
+type UINavItem = contract.UINavItem


### PR DESCRIPTION
## Summary

- moves the external plugin handshake and UI manifest structs into a dependency-light contract package
- keeps plugin/external aliases for compatibility with existing host and plugin code
- updates the plugin SDK to use the contract package directly so plugin binaries do not inherit host runtime imports
- adds an import-graph regression test blocking workflow/module and Docker from the SDK dependency graph

## Root Cause

Hover imports the workflow plugin SDK. The SDK imported plugin/external for Handshake and UIManifest, but plugin/external also contains host adapters that import workflow/module. That made SDK consumers inherit Docker transitively through module even though plugins do not use Docker.

## Verification

- GOWORK=off go list -deps github.com/GoCodeAlone/workflow/plugin/external/sdk | rg 'github.com/GoCodeAlone/workflow/module|github.com/docker/docker' || true
- GOWORK=off go test ./plugin/external/...
- GOWORK=off go test ./plugin/... ./module/...
- GOWORK=off go test ./...
- git diff --check
