### PR TITLE
[codex] Remove Docker SDK dependency

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -52,15 +52,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.16.2 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
-	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set/v2 v2.9.0 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v28.5.2+incompatible // indirect
-	github.com/docker/go-connections v0.7.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
@@ -135,7 +129,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
@@ -145,8 +138,6 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/oklog/run v1.2.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/example/go.sum
+++ b/example/go.sum
@@ -143,8 +143,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
-github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
 github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -418,8 +416,6 @@ github.com/moby/moby/client v0.4.1 h1:DMQgisVoMkmMs7fp3ROSdiBnoAu8+vo3GggFl06M/w
 github.com/moby/moby/client v0.4.1/go.mod h1:z52C9O2POPOsnxZAy//WtKcQ32P+jT/NGeXu/7nfjGQ=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
-github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
-github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=
 github.com/moby/sys/sequential v0.7.0/go.mod h1:NfSTAp6V3fw4tmkD62PEcOKeZKquXT8VKCkf7aVR79o=
 github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
@@ -436,8 +432,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
-github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -787,8 +781,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
-gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 k8s.io/api v0.36.1 h1:XbL/EMj8K2aJpJtePmqUyQMsM0D4QI2pvl7YKJ20FTY=
 k8s.io/api v0.36.1/go.mod h1:KOWo4ey3TINlXjeHVuwB3i+tXXnu+UcwFBHlI/9dvEo=
 k8s.io/apimachinery v0.36.1 h1:G63Gjx2W+q0YD+72Vo8oY0nDnePVwnuzTmmy5ENrVSA=

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/IBM/sarama v1.47.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/cucumber/godog v0.15.1
-	github.com/docker/docker v28.5.2+incompatible
 	github.com/expr-lang/expr v1.17.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/github/copilot-sdk/go v0.3.0
@@ -114,16 +113,11 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.16.2 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
-	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
 	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set/v2 v2.9.0 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.7.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
@@ -202,11 +196,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
@@ -215,8 +206,6 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/oklog/run v1.2.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/petermattis/goid v0.0.0-20260226131333-17d1149c6ac6 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
@@ -273,7 +262,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gotest.tools/v3 v3.5.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
-github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
 github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -506,8 +504,6 @@ github.com/moby/moby/client v0.4.1 h1:DMQgisVoMkmMs7fp3ROSdiBnoAu8+vo3GggFl06M/w
 github.com/moby/moby/client v0.4.1/go.mod h1:z52C9O2POPOsnxZAy//WtKcQ32P+jT/NGeXu/7nfjGQ=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
-github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
-github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=
 github.com/moby/sys/sequential v0.7.0/go.mod h1:NfSTAp6V3fw4tmkD62PEcOKeZKquXT8VKCkf7aVR79o=
 github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
@@ -524,8 +520,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
-github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
@@ -922,8 +916,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
-gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 k8s.io/api v0.36.1 h1:XbL/EMj8K2aJpJtePmqUyQMsM0D4QI2pvl7YKJ20FTY=
 k8s.io/api v0.36.1/go.mod h1:KOWo4ey3TINlXjeHVuwB3i+tXXnu+UcwFBHlI/9dvEo=
 k8s.io/apimachinery v0.36.1 h1:G63Gjx2W+q0YD+72Vo8oY0nDnePVwnuzTmmy5ENrVSA=

--- a/module/pipeline_step_docker_build.go
+++ b/module/pipeline_step_docker_build.go
@@ -1,11 +1,8 @@
 package module
 
 import (
-	"archive/tar"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,7 +112,7 @@ func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*Ste
 	}
 	args = append(args, contextPath)
 
-	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd := exec.CommandContext(ctx, "docker", args...) // #nosec G204,G702 - workflow docker_build intentionally executes user-configured Docker CLI args.
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("docker_build step %q: build failed: %w: %s", s.name, err, string(out))
@@ -150,105 +147,9 @@ func readDockerIIDFile(path string) string {
 }
 
 func inspectDockerImageID(ctx context.Context, ref string) string {
-	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", ref).Output()
+	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", ref).Output() // #nosec G204,G702 - ref is the configured image tag passed to Docker.
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
-}
-
-// createBuildContext creates a tar archive of the build context directory.
-func createBuildContext(contextPath string) (io.Reader, error) {
-	absPath, err := filepath.Abs(contextPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve context path: %w", err)
-	}
-
-	info, err := os.Stat(absPath)
-	if err != nil {
-		return nil, fmt.Errorf("context path %q does not exist: %w", absPath, err)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("context path %q is not a directory", absPath)
-	}
-
-	pr, pw := io.Pipe()
-	go func() {
-		pw.CloseWithError(archiveDirectory(absPath, pw))
-	}()
-
-	return pr, nil
-}
-
-// archiveDirectory creates a tar archive of a directory and writes it to w.
-func archiveDirectory(dir string, w io.Writer) error {
-	tw := tar.NewWriter(w)
-	defer tw.Close()
-
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		relPath, err := filepath.Rel(dir, path)
-		if err != nil {
-			return err
-		}
-
-		// Use forward slashes for tar paths
-		relPath = filepath.ToSlash(relPath)
-
-		header, err := tar.FileInfoHeader(info, "")
-		if err != nil {
-			return err
-		}
-		header.Name = relPath
-
-		if err := tw.WriteHeader(header); err != nil {
-			return err
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		_, err = io.Copy(tw, f)
-		return err
-	})
-}
-
-// parseBuildOutput reads the Docker build JSON stream and extracts the image ID.
-func parseBuildOutput(r io.Reader) (string, error) {
-	decoder := json.NewDecoder(r)
-	var imageID string
-
-	for {
-		var msg struct {
-			Stream string `json:"stream"`
-			Aux    struct {
-				ID string `json:"ID"`
-			} `json:"aux"`
-			Error string `json:"error"`
-		}
-		if err := decoder.Decode(&msg); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return "", fmt.Errorf("failed to parse build output: %w", err)
-		}
-		if msg.Error != "" {
-			return "", fmt.Errorf("build error: %s", msg.Error)
-		}
-		if msg.Aux.ID != "" {
-			imageID = msg.Aux.ID
-		}
-	}
-
-	return imageID, nil
 }

--- a/module/pipeline_step_docker_build.go
+++ b/module/pipeline_step_docker_build.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoCodeAlone/modular"
-	"github.com/docker/docker/api/types/build"
-	dockerclient "github.com/docker/docker/client"
 )
 
 // DockerBuildStep builds a Docker image from a context directory and Dockerfile.
@@ -79,40 +79,38 @@ func NewDockerBuildStepFactory() StepFactory {
 // Name returns the step name.
 func (s *DockerBuildStep) Name() string { return s.name }
 
-// Execute builds a Docker image using the Docker SDK.
+// Execute builds a Docker image using the Docker CLI.
 func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*StepResult, error) {
-	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if _, err := exec.LookPath("docker"); err != nil {
+		return nil, fmt.Errorf("docker_build step %q: docker CLI not found: %w", s.name, err)
+	}
+
+	args := []string{"build", "--rm", "-f", s.dockerfile}
+	for _, tag := range s.tags {
+		args = append(args, "-t", tag)
+	}
+	for key, value := range s.buildArgs {
+		arg := key + "="
+		if value != nil {
+			arg += *value
+		}
+		args = append(args, "--build-arg", arg)
+	}
+	for _, ref := range s.cacheFrom {
+		args = append(args, "--cache-from", ref)
+	}
+	args = append(args, s.contextPath)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("docker_build step %q: failed to create Docker client: %w", s.name, err)
-	}
-	defer cli.Close()
-
-	// Create a tar of the build context directory
-	buildCtx, err := createBuildContext(s.contextPath)
-	if err != nil {
-		return nil, fmt.Errorf("docker_build step %q: failed to create build context: %w", s.name, err)
+		return nil, fmt.Errorf("docker_build step %q: build failed: %w: %s", s.name, err, string(out))
 	}
 
-	opts := build.ImageBuildOptions{
-		Tags:       s.tags,
-		Dockerfile: s.dockerfile,
-		BuildArgs:  s.buildArgs,
-		CacheFrom:  s.cacheFrom,
-		Remove:     true,
+	imageID := ""
+	if len(s.tags) > 0 {
+		imageID = inspectDockerImageID(ctx, s.tags[0])
 	}
-
-	resp, err := cli.ImageBuild(ctx, buildCtx, opts)
-	if err != nil {
-		return nil, fmt.Errorf("docker_build step %q: build failed: %w", s.name, err)
-	}
-	defer resp.Body.Close()
-
-	// Read the build output to completion and extract the image ID
-	imageID, err := parseBuildOutput(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("docker_build step %q: %w", s.name, err)
-	}
-
 	return &StepResult{
 		Output: map[string]any{
 			"image_id": imageID,
@@ -120,6 +118,14 @@ func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*Ste
 			"context":  s.contextPath,
 		},
 	}, nil
+}
+
+func inspectDockerImageID(ctx context.Context, ref string) string {
+	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", ref).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // createBuildContext creates a tar archive of the build context directory.

--- a/module/pipeline_step_docker_build.go
+++ b/module/pipeline_step_docker_build.go
@@ -85,7 +85,21 @@ func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*Ste
 		return nil, fmt.Errorf("docker_build step %q: docker CLI not found: %w", s.name, err)
 	}
 
-	args := []string{"build", "--rm", "-f", s.dockerfile}
+	contextPath, err := filepath.Abs(s.contextPath)
+	if err != nil {
+		return nil, fmt.Errorf("docker_build step %q: resolve context path: %w", s.name, err)
+	}
+	dockerfile := s.dockerfilePath(contextPath)
+
+	iidFile, err := os.CreateTemp("", "workflow-docker-build-iid-*")
+	if err != nil {
+		return nil, fmt.Errorf("docker_build step %q: create iidfile: %w", s.name, err)
+	}
+	iidPath := iidFile.Name()
+	_ = iidFile.Close()
+	defer os.Remove(iidPath)
+
+	args := []string{"build", "--rm", "--iidfile", iidPath, "-f", dockerfile}
 	for _, tag := range s.tags {
 		args = append(args, "-t", tag)
 	}
@@ -99,7 +113,7 @@ func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*Ste
 	for _, ref := range s.cacheFrom {
 		args = append(args, "--cache-from", ref)
 	}
-	args = append(args, s.contextPath)
+	args = append(args, contextPath)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	out, err := cmd.CombinedOutput()
@@ -107,8 +121,8 @@ func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*Ste
 		return nil, fmt.Errorf("docker_build step %q: build failed: %w: %s", s.name, err, string(out))
 	}
 
-	imageID := ""
-	if len(s.tags) > 0 {
+	imageID := readDockerIIDFile(iidPath)
+	if imageID == "" && len(s.tags) > 0 {
 		imageID = inspectDockerImageID(ctx, s.tags[0])
 	}
 	return &StepResult{
@@ -118,6 +132,21 @@ func (s *DockerBuildStep) Execute(ctx context.Context, _ *PipelineContext) (*Ste
 			"context":  s.contextPath,
 		},
 	}, nil
+}
+
+func (s *DockerBuildStep) dockerfilePath(absContextPath string) string {
+	if filepath.IsAbs(s.dockerfile) {
+		return s.dockerfile
+	}
+	return filepath.Join(absContextPath, s.dockerfile)
+}
+
+func readDockerIIDFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func inspectDockerImageID(ctx context.Context, ref string) string {

--- a/module/pipeline_step_docker_build_test.go
+++ b/module/pipeline_step_docker_build_test.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -64,5 +65,35 @@ func TestDockerBuildStep_BuildArgs(t *testing.T) {
 	args := step.(*DockerBuildStep).buildArgs
 	if v, ok := args["VERSION"]; !ok || *v != "1.0" {
 		t.Errorf("expected build_arg VERSION=1.0, got %v", args)
+	}
+}
+
+func TestDockerBuildStep_DockerfilePathRelativeToContext(t *testing.T) {
+	step, err := NewDockerBuildStepFactory()("build", map[string]any{
+		"context":    "app",
+		"dockerfile": "deploy/Dockerfile",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := step.(*DockerBuildStep).dockerfilePath("/repo/app")
+	want := filepath.Join("/repo/app", "deploy", "Dockerfile")
+	if got != want {
+		t.Fatalf("expected dockerfile path %q, got %q", want, got)
+	}
+}
+
+func TestDockerBuildStep_DockerfilePathKeepsAbsolutePath(t *testing.T) {
+	step, err := NewDockerBuildStepFactory()("build", map[string]any{
+		"context":    "app",
+		"dockerfile": "/tmp/Dockerfile",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := step.(*DockerBuildStep).dockerfilePath("/repo/app"); got != "/tmp/Dockerfile" {
+		t.Fatalf("expected absolute dockerfile path to be preserved, got %q", got)
 	}
 }

--- a/module/pipeline_step_docker_push.go
+++ b/module/pipeline_step_docker_push.go
@@ -1,12 +1,13 @@
 package module
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
+	"strings"
 
 	"github.com/GoCodeAlone/modular"
 )
@@ -61,7 +62,7 @@ func (s *DockerPushStep) Execute(ctx context.Context, _ *PipelineContext) (*Step
 	}
 
 	// Read push output to completion and extract the digest
-	digest, err := parsePushOutput(bytes.NewReader(out))
+	digest, err := parsePushOutput(strings.NewReader(string(out)))
 	if err != nil {
 		return nil, fmt.Errorf("docker_push step %q: %w", s.name, err)
 	}
@@ -76,9 +77,27 @@ func (s *DockerPushStep) Execute(ctx context.Context, _ *PipelineContext) (*Step
 	}, nil
 }
 
+var dockerPushDigestPattern = regexp.MustCompile(`(?i)\bdigest:\s*([a-z0-9_+.-]+:[a-f0-9]+)\b`)
+
 // parsePushOutput reads the Docker push JSON stream and extracts the digest.
 func parsePushOutput(r io.Reader) (string, error) {
-	decoder := json.NewDecoder(r)
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return "", nil
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		match := dockerPushDigestPattern.FindStringSubmatch(trimmed)
+		if len(match) == 2 {
+			return match[1], nil
+		}
+		return "", nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
 	var digest string
 
 	for {

--- a/module/pipeline_step_docker_push.go
+++ b/module/pipeline_step_docker_push.go
@@ -79,7 +79,7 @@ func (s *DockerPushStep) Execute(ctx context.Context, _ *PipelineContext) (*Step
 
 var dockerPushDigestPattern = regexp.MustCompile(`(?i)\bdigest:\s*([a-z0-9_+.-]+:[a-f0-9]+)\b`)
 
-// parsePushOutput reads the Docker push JSON stream and extracts the digest.
+// parsePushOutput extracts the digest from Docker CLI text output or a JSON stream.
 func parsePushOutput(r io.Reader) (string, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/module/pipeline_step_docker_push.go
+++ b/module/pipeline_step_docker_push.go
@@ -55,7 +55,7 @@ func (s *DockerPushStep) Execute(ctx context.Context, _ *PipelineContext) (*Step
 		ref = s.registry + "/" + s.image
 	}
 
-	cmd := exec.CommandContext(ctx, "docker", "push", ref)
+	cmd := exec.CommandContext(ctx, "docker", "push", ref) // #nosec G204,G702 - workflow docker_push intentionally pushes the configured image reference.
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("docker_push step %q: push failed: %w: %s", s.name, err, string(out))

--- a/module/pipeline_step_docker_push.go
+++ b/module/pipeline_step_docker_push.go
@@ -1,14 +1,14 @@
 package module
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os/exec"
 
 	"github.com/GoCodeAlone/modular"
-	"github.com/docker/docker/api/types/image"
-	dockerclient "github.com/docker/docker/client"
 )
 
 // DockerPushStep pushes a Docker image to a remote registry.
@@ -42,13 +42,11 @@ func NewDockerPushStepFactory() StepFactory {
 // Name returns the step name.
 func (s *DockerPushStep) Name() string { return s.name }
 
-// Execute pushes the image to the configured registry.
+// Execute pushes the image to the configured registry using the Docker CLI.
 func (s *DockerPushStep) Execute(ctx context.Context, _ *PipelineContext) (*StepResult, error) {
-	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
-	if err != nil {
-		return nil, fmt.Errorf("docker_push step %q: failed to create Docker client: %w", s.name, err)
+	if _, err := exec.LookPath("docker"); err != nil {
+		return nil, fmt.Errorf("docker_push step %q: docker CLI not found: %w", s.name, err)
 	}
-	defer cli.Close()
 
 	// Determine the full image reference
 	ref := s.image
@@ -56,16 +54,14 @@ func (s *DockerPushStep) Execute(ctx context.Context, _ *PipelineContext) (*Step
 		ref = s.registry + "/" + s.image
 	}
 
-	opts := image.PushOptions{}
-
-	reader, err := cli.ImagePush(ctx, ref, opts)
+	cmd := exec.CommandContext(ctx, "docker", "push", ref)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("docker_push step %q: push failed: %w", s.name, err)
+		return nil, fmt.Errorf("docker_push step %q: push failed: %w: %s", s.name, err, string(out))
 	}
-	defer reader.Close()
 
 	// Read push output to completion and extract the digest
-	digest, err := parsePushOutput(reader)
+	digest, err := parsePushOutput(bytes.NewReader(out))
 	if err != nil {
 		return nil, fmt.Errorf("docker_push step %q: %w", s.name, err)
 	}

--- a/module/pipeline_step_docker_push_test.go
+++ b/module/pipeline_step_docker_push_test.go
@@ -36,3 +36,34 @@ func TestDockerPushStep_MinimalConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestParsePushOutput_TextDigest(t *testing.T) {
+	digest, err := parsePushOutput(strings.NewReader("latest: digest: sha256:00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff size: 856\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if digest != "sha256:00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff" {
+		t.Fatalf("unexpected digest %q", digest)
+	}
+}
+
+func TestParsePushOutput_JSONDigest(t *testing.T) {
+	digest, err := parsePushOutput(strings.NewReader(`{"status":"pushed"}
+{"aux":{"Digest":"sha256:ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if digest != "sha256:ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100" {
+		t.Fatalf("unexpected digest %q", digest)
+	}
+}
+
+func TestParsePushOutput_JSONError(t *testing.T) {
+	_, err := parsePushOutput(strings.NewReader(`{"error":"denied"}`))
+	if err == nil {
+		t.Fatal("expected push error")
+	}
+	if !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/sandbox/docker.go
+++ b/sandbox/docker.go
@@ -4,17 +4,14 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 	"time"
-
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
 )
 
 // Mount describes a bind mount from host to container.
@@ -27,7 +24,7 @@ type Mount struct {
 // SandboxConfig holds configuration for a Docker sandbox execution environment.
 type SandboxConfig struct {
 	// Profile is the security profile name that produced this config ("strict",
-	// "standard", "permissive"). It is informational — it does not affect local
+	// "standard", "permissive"). It is informational - it does not affect local
 	// Docker execution but is forwarded to remote runners so they can apply their
 	// own profile clamping (ADR 0019).
 	Profile     string            `yaml:"profile,omitempty"`
@@ -89,15 +86,33 @@ type ExecResult struct {
 	Stderr   string
 }
 
-// DockerSandbox wraps the Docker Engine SDK to execute commands in isolated containers.
+type hostConfig struct {
+	Memory         int64
+	NanoCPUs       int64
+	Mounts         []hostMount
+	NetworkMode    string
+	SecurityOpt    []string
+	CapAdd         []string
+	CapDrop        []string
+	ReadonlyRootfs bool
+	PidsLimit      *int64
+	Tmpfs          map[string]string
+}
+
+type hostMount struct {
+	Source   string
+	Target   string
+	ReadOnly bool
+}
+
+// DockerSandbox wraps the Docker CLI to execute commands in isolated containers.
 type DockerSandbox struct {
-	client      *client.Client
 	config      SandboxConfig
 	containerID string // set by CreateContainer, used by CopyIn/CopyOut/RemoveContainer
 }
 
 // NewDockerSandbox creates a new DockerSandbox with the given configuration.
-// It initializes a Docker client using environment variables (DOCKER_HOST, etc.).
+// It requires the Docker CLI to be present on PATH.
 func NewDockerSandbox(config SandboxConfig) (*DockerSandbox, error) {
 	if config.Image == "" {
 		return nil, fmt.Errorf("sandbox: image is required")
@@ -107,15 +122,11 @@ func NewDockerSandbox(config SandboxConfig) (*DockerSandbox, error) {
 		config.Timeout = 10 * time.Minute
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return nil, fmt.Errorf("sandbox: failed to create Docker client: %w", err)
+	if _, err := exec.LookPath("docker"); err != nil {
+		return nil, fmt.Errorf("sandbox: docker CLI not found: %w", err)
 	}
 
-	return &DockerSandbox{
-		client: cli,
-		config: config,
-	}, nil
+	return &DockerSandbox{config: config}, nil
 }
 
 // Exec creates a container, runs the given command, captures output, and removes the container.
@@ -127,72 +138,14 @@ func (s *DockerSandbox) Exec(ctx context.Context, cmd []string) (*ExecResult, er
 	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
 	defer cancel()
 
-	// Pull image if not present locally
 	if err := s.ensureImage(ctx); err != nil {
 		return nil, fmt.Errorf("sandbox: failed to pull image: %w", err)
 	}
 
-	// Build container config
-	containerConfig := &container.Config{
-		Image:      s.config.Image,
-		Cmd:        cmd,
-		Env:        s.buildEnv(),
-		WorkingDir: s.config.WorkDir,
-	}
-	if s.config.User != "" {
-		containerConfig.User = s.config.User
-	}
-
-	hostConfig := s.buildHostConfig()
-
-	// Create container
-	resp, err := s.client.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
-	if err != nil {
-		return nil, fmt.Errorf("sandbox: failed to create container: %w", err)
-	}
-	containerID := resp.ID
-
-	// Always remove the container when done
-	defer func() {
-		removeCtx, removeCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer removeCancel()
-		_ = s.client.ContainerRemove(removeCtx, containerID, container.RemoveOptions{Force: true})
-	}()
-
-	// Start container
-	if err := s.client.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
-		return nil, fmt.Errorf("sandbox: failed to start container: %w", err)
-	}
-
-	// Wait for container to finish
-	statusCh, errCh := s.client.ContainerWait(ctx, containerID, container.WaitConditionNotRunning)
-	var exitCode int
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return nil, fmt.Errorf("sandbox: error waiting for container: %w", err)
-		}
-	case status := <-statusCh:
-		exitCode = int(status.StatusCode)
-	case <-ctx.Done():
-		// Timeout: stop the container
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-		_ = s.client.ContainerStop(stopCtx, containerID, container.StopOptions{})
-		return nil, fmt.Errorf("sandbox: execution timed out after %s", s.config.Timeout)
-	}
-
-	// Capture stdout/stderr
-	stdout, stderr, err := s.getLogs(ctx, containerID)
-	if err != nil {
-		return nil, fmt.Errorf("sandbox: failed to capture logs: %w", err)
-	}
-
-	return &ExecResult{
-		ExitCode: exitCode,
-		Stdout:   stdout,
-		Stderr:   stderr,
-	}, nil
+	args := append([]string{"run", "--rm"}, s.dockerRunArgs()...)
+	args = append(args, s.config.Image)
+	args = append(args, cmd...)
+	return runDockerResult(ctx, args)
 }
 
 // CopyIn copies a file from the host into the active container.
@@ -204,31 +157,28 @@ func (s *DockerSandbox) CopyIn(ctx context.Context, srcPath, destPath string) er
 	return s.copyToContainer(ctx, s.containerID, srcPath, destPath)
 }
 
-// CopyOut copies a file out of the active container. Returns a ReadCloser with the file contents.
+// CopyOut copies a file out of the active container. Returns a ReadCloser with
+// a tar archive containing the file contents, matching Docker copy semantics.
 // Call CreateContainer first to set the active container ID.
 func (s *DockerSandbox) CopyOut(ctx context.Context, srcPath string) (io.ReadCloser, error) {
 	if s.containerID == "" {
 		return nil, fmt.Errorf("sandbox: CopyOut requires an active container; call CreateContainer first")
 	}
-	reader, _, err := s.client.CopyFromContainer(ctx, s.containerID, srcPath)
-	if err != nil {
-		return nil, fmt.Errorf("sandbox: CopyOut %q: %w", srcPath, err)
-	}
-	return reader, nil
+	return s.copyFromContainer(ctx, s.containerID, srcPath)
 }
 
-// CreateContainer creates and starts a container, storing its ID for use with CopyIn/CopyOut.
+// CreateContainer creates a container, storing its ID for use with CopyIn/CopyOut.
 // Call RemoveContainer when done to clean up.
 func (s *DockerSandbox) CreateContainer(ctx context.Context, cmd []string) error {
-	hostConfig := s.buildHostConfig()
-	resp, err := s.client.ContainerCreate(ctx, &container.Config{
-		Image: s.config.Image,
-		Cmd:   cmd,
-	}, hostConfig, nil, nil, "")
+	args := append([]string{"create"}, s.dockerRunArgs()...)
+	args = append(args, s.config.Image)
+	args = append(args, cmd...)
+
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
 	if err != nil {
 		return fmt.Errorf("sandbox: create container: %w", err)
 	}
-	s.containerID = resp.ID
+	s.containerID = strings.TrimSpace(string(out))
 	return nil
 }
 
@@ -239,7 +189,7 @@ func (s *DockerSandbox) RemoveContainer(ctx context.Context) error {
 	}
 	id := s.containerID
 	s.containerID = ""
-	return s.client.ContainerRemove(ctx, id, container.RemoveOptions{Force: true})
+	return exec.CommandContext(ctx, "docker", "rm", "-f", id).Run()
 }
 
 // ExecInContainer creates a container, copies files in, runs the command, and allows file extraction.
@@ -256,109 +206,63 @@ func (s *DockerSandbox) ExecInContainer(ctx context.Context, cmd []string, copyI
 		return nil, nil, fmt.Errorf("sandbox: failed to pull image: %w", err)
 	}
 
-	containerConfig := &container.Config{
-		Image:      s.config.Image,
-		Cmd:        cmd,
-		Env:        s.buildEnv(),
-		WorkingDir: s.config.WorkDir,
-	}
-	if s.config.User != "" {
-		containerConfig.User = s.config.User
-	}
-
-	hostConfig := s.buildHostConfig()
-
-	resp, err := s.client.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
+	args := append([]string{"create"}, s.dockerRunArgs()...)
+	args = append(args, s.config.Image)
+	args = append(args, cmd...)
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
 	if err != nil {
 		return nil, nil, fmt.Errorf("sandbox: failed to create container: %w", err)
 	}
-	containerID := resp.ID
+	containerID := strings.TrimSpace(string(out))
 
 	defer func() {
 		removeCtx, removeCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer removeCancel()
-		_ = s.client.ContainerRemove(removeCtx, containerID, container.RemoveOptions{Force: true})
+		_ = exec.CommandContext(removeCtx, "docker", "rm", "-f", containerID).Run()
 	}()
 
-	// Copy files into container before starting
 	for hostPath, containerPath := range copyIn {
 		if err := s.copyToContainer(ctx, containerID, hostPath, containerPath); err != nil {
 			return nil, nil, fmt.Errorf("sandbox: failed to copy %s to container: %w", hostPath, err)
 		}
 	}
 
-	if err := s.client.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
-		return nil, nil, fmt.Errorf("sandbox: failed to start container: %w", err)
-	}
-
-	statusCh, errCh := s.client.ContainerWait(ctx, containerID, container.WaitConditionNotRunning)
-	var exitCode int
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return nil, nil, fmt.Errorf("sandbox: error waiting for container: %w", err)
-		}
-	case status := <-statusCh:
-		exitCode = int(status.StatusCode)
-	case <-ctx.Done():
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-		_ = s.client.ContainerStop(stopCtx, containerID, container.StopOptions{})
-		return nil, nil, fmt.Errorf("sandbox: execution timed out after %s", s.config.Timeout)
-	}
-
-	stdout, stderr, err := s.getLogs(ctx, containerID)
+	result, err := runDockerResult(ctx, []string{"start", "-a", containerID})
 	if err != nil {
-		return nil, nil, fmt.Errorf("sandbox: failed to capture logs: %w", err)
+		return nil, nil, err
 	}
 
-	// Copy files out of container
 	outputs := make(map[string]io.ReadCloser)
 	for _, path := range copyOutPaths {
-		reader, _, err := s.client.CopyFromContainer(ctx, containerID, path)
+		reader, err := s.copyFromContainer(ctx, containerID, path)
 		if err != nil {
-			// Close any already-opened readers
 			for _, r := range outputs {
-				r.Close()
+				_ = r.Close()
 			}
 			return nil, nil, fmt.Errorf("sandbox: failed to copy %s from container: %w", path, err)
 		}
 		outputs[path] = reader
 	}
 
-	result := &ExecResult{
-		ExitCode: exitCode,
-		Stdout:   stdout,
-		Stderr:   stderr,
-	}
-
 	return result, outputs, nil
 }
 
-// Close cleans up the Docker client.
+// Close cleans up resources held by the sandbox.
 func (s *DockerSandbox) Close() error {
-	if s.client != nil {
-		return s.client.Close()
-	}
 	return nil
 }
 
 // ensureImage pulls the image if it is not available locally.
 func (s *DockerSandbox) ensureImage(ctx context.Context) error {
-	_, err := s.client.ImageInspect(ctx, s.config.Image)
-	if err == nil {
-		return nil // Image already present
+	if err := exec.CommandContext(ctx, "docker", "image", "inspect", s.config.Image).Run(); err == nil {
+		return nil
 	}
-
-	reader, err := s.client.ImagePull(ctx, s.config.Image, image.PullOptions{})
+	cmd := exec.CommandContext(ctx, "docker", "pull", s.config.Image)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %s", err, string(out))
 	}
-	defer reader.Close()
-
-	// Consume the pull output to completion
-	_, err = io.Copy(io.Discard, reader)
-	return err
+	return nil
 }
 
 // buildEnv converts the config env map into Docker's KEY=VALUE format.
@@ -373,16 +277,14 @@ func (s *DockerSandbox) buildEnv() []string {
 	return env
 }
 
-// buildHostConfig creates the Docker HostConfig from SandboxConfig.
-func (s *DockerSandbox) buildHostConfig() *container.HostConfig {
-	hc := &container.HostConfig{}
+// buildHostConfig creates an internal HostConfig from SandboxConfig.
+func (s *DockerSandbox) buildHostConfig() *hostConfig {
+	hc := &hostConfig{}
 
-	// Resource limits
 	if s.config.MemoryLimit > 0 {
 		hc.Memory = s.config.MemoryLimit
 	}
 	if s.config.CPULimit > 0 {
-		// Docker uses NanoCPUs (1 CPU = 1e9 NanoCPUs)
 		hc.NanoCPUs = int64(s.config.CPULimit * 1e9)
 	}
 	if s.config.PidsLimit > 0 {
@@ -390,26 +292,21 @@ func (s *DockerSandbox) buildHostConfig() *container.HostConfig {
 		hc.PidsLimit = &limit
 	}
 
-	// Mounts
 	if len(s.config.Mounts) > 0 {
-		mounts := make([]mount.Mount, len(s.config.Mounts))
+		hc.Mounts = make([]hostMount, len(s.config.Mounts))
 		for i, m := range s.config.Mounts {
-			mounts[i] = mount.Mount{
-				Type:     mount.TypeBind,
+			hc.Mounts[i] = hostMount{
 				Source:   m.Source,
 				Target:   m.Target,
 				ReadOnly: m.ReadOnly,
 			}
 		}
-		hc.Mounts = mounts
 	}
 
-	// Network mode
 	if s.config.NetworkMode != "" {
-		hc.NetworkMode = container.NetworkMode(s.config.NetworkMode)
+		hc.NetworkMode = s.config.NetworkMode
 	}
 
-	// Security options
 	secOpts := make([]string, len(s.config.SecurityOpts))
 	copy(secOpts, s.config.SecurityOpts)
 	if s.config.NoNewPrivileges {
@@ -419,7 +316,6 @@ func (s *DockerSandbox) buildHostConfig() *container.HostConfig {
 		hc.SecurityOpt = secOpts
 	}
 
-	// Capabilities
 	if len(s.config.CapAdd) > 0 {
 		hc.CapAdd = s.config.CapAdd
 	}
@@ -427,7 +323,6 @@ func (s *DockerSandbox) buildHostConfig() *container.HostConfig {
 		hc.CapDrop = s.config.CapDrop
 	}
 
-	// Filesystem hardening
 	hc.ReadonlyRootfs = s.config.ReadOnlyRootfs
 	if len(s.config.Tmpfs) > 0 {
 		hc.Tmpfs = s.config.Tmpfs
@@ -436,43 +331,94 @@ func (s *DockerSandbox) buildHostConfig() *container.HostConfig {
 	return hc
 }
 
-// getLogs captures stdout and stderr from a container.
-func (s *DockerSandbox) getLogs(ctx context.Context, containerID string) (string, string, error) {
-	logReader, err := s.client.ContainerLogs(ctx, containerID, container.LogsOptions{
-		ShowStdout: true,
-		ShowStderr: true,
-	})
-	if err != nil {
-		return "", "", err
+func (s *DockerSandbox) dockerRunArgs() []string {
+	hc := s.buildHostConfig()
+	args := make([]string, 0, 32)
+	if s.config.WorkDir != "" {
+		args = append(args, "-w", s.config.WorkDir)
 	}
-	defer logReader.Close()
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-	_, err = stdcopy.StdCopy(&stdoutBuf, &stderrBuf, logReader)
-	if err != nil {
-		return "", "", err
+	if s.config.User != "" {
+		args = append(args, "-u", s.config.User)
 	}
-
-	return strings.TrimSpace(stdoutBuf.String()), strings.TrimSpace(stderrBuf.String()), nil
+	for _, env := range s.buildEnv() {
+		args = append(args, "-e", env)
+	}
+	for _, mount := range hc.Mounts {
+		spec := "type=bind,src=" + mount.Source + ",dst=" + mount.Target
+		if mount.ReadOnly {
+			spec += ",readonly"
+		}
+		args = append(args, "--mount", spec)
+	}
+	if hc.Memory > 0 {
+		args = append(args, "--memory", strconv.FormatInt(hc.Memory, 10))
+	}
+	if hc.NanoCPUs > 0 {
+		args = append(args, "--cpus", strconv.FormatFloat(float64(hc.NanoCPUs)/1e9, 'f', -1, 64))
+	}
+	if hc.PidsLimit != nil {
+		args = append(args, "--pids-limit", strconv.FormatInt(*hc.PidsLimit, 10))
+	}
+	if hc.NetworkMode != "" {
+		args = append(args, "--network", hc.NetworkMode)
+	}
+	for _, opt := range hc.SecurityOpt {
+		args = append(args, "--security-opt", opt)
+	}
+	for _, cap := range hc.CapAdd {
+		args = append(args, "--cap-add", cap)
+	}
+	for _, cap := range hc.CapDrop {
+		args = append(args, "--cap-drop", cap)
+	}
+	if hc.ReadonlyRootfs {
+		args = append(args, "--read-only")
+	}
+	for path, spec := range hc.Tmpfs {
+		args = append(args, "--tmpfs", path+":"+spec)
+	}
+	return args
 }
 
-// copyToContainer copies a host file into the container at destPath.
-func (s *DockerSandbox) copyToContainer(ctx context.Context, containerID, hostPath, destPath string) error {
-	f, err := os.Open(hostPath)
-	if err != nil {
-		return fmt.Errorf("failed to open %s: %w", hostPath, err)
-	}
-	defer f.Close()
+func runDockerResult(ctx context.Context, args []string) (*ExecResult, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	stat, err := f.Stat()
+	err := cmd.Run()
+	exitCode := 0
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return nil, fmt.Errorf("sandbox: docker command failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+		}
+	}
+
+	return &ExecResult{
+		ExitCode: exitCode,
+		Stdout:   strings.TrimSpace(stdout.String()),
+		Stderr:   strings.TrimSpace(stderr.String()),
+	}, nil
+}
+
+func (s *DockerSandbox) copyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error) {
+	out, err := exec.CommandContext(ctx, "docker", "cp", containerID+":"+srcPath, "-").Output()
+	if err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(out)), nil
+}
+
+func (s *DockerSandbox) copyToContainer(ctx context.Context, containerID, hostPath, destPath string) error {
+	if _, err := os.Stat(hostPath); err != nil {
 		return fmt.Errorf("failed to stat %s: %w", hostPath, err)
 	}
-
-	tarReader, err := createTarFromFile(f, stat)
+	out, err := exec.CommandContext(ctx, "docker", "cp", hostPath, containerID+":"+destPath).CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %s", err, string(out))
 	}
-
-	return s.client.CopyToContainer(ctx, containerID, destPath, tarReader, container.CopyToContainerOptions{})
+	return nil
 }

--- a/sandbox/docker.go
+++ b/sandbox/docker.go
@@ -174,9 +174,9 @@ func (s *DockerSandbox) CreateContainer(ctx context.Context, cmd []string) error
 	args = append(args, s.config.Image)
 	args = append(args, cmd...)
 
-	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("sandbox: create container: %w", err)
+		return fmt.Errorf("sandbox: create container: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	s.containerID = strings.TrimSpace(string(out))
 	return nil
@@ -209,9 +209,9 @@ func (s *DockerSandbox) ExecInContainer(ctx context.Context, cmd []string, copyI
 	args := append([]string{"create"}, s.dockerRunArgs()...)
 	args = append(args, s.config.Image)
 	args = append(args, cmd...)
-	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
 	if err != nil {
-		return nil, nil, fmt.Errorf("sandbox: failed to create container: %w", err)
+		return nil, nil, fmt.Errorf("sandbox: failed to create container: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	containerID := strings.TrimSpace(string(out))
 
@@ -405,11 +405,42 @@ func runDockerResult(ctx context.Context, args []string) (*ExecResult, error) {
 }
 
 func (s *DockerSandbox) copyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error) {
-	out, err := exec.CommandContext(ctx, "docker", "cp", containerID+":"+srcPath, "-").Output()
+	cmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+srcPath, "-")
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
 	}
-	return io.NopCloser(bytes.NewReader(out)), nil
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		_, copyErr := io.Copy(pw, stdout)
+		waitErr := cmd.Wait()
+		switch {
+		case copyErr != nil:
+			_ = pw.CloseWithError(copyErr)
+		case waitErr != nil:
+			msg := strings.TrimSpace(stderr.String())
+			if msg != "" {
+				_ = pw.CloseWithError(fmt.Errorf("%w: %s", waitErr, msg))
+			} else {
+				_ = pw.CloseWithError(waitErr)
+			}
+		default:
+			_ = pw.Close()
+		}
+	}()
+
+	return pr, nil
 }
 
 func (s *DockerSandbox) copyToContainer(ctx context.Context, containerID, hostPath, destPath string) error {

--- a/sandbox/docker.go
+++ b/sandbox/docker.go
@@ -421,10 +421,20 @@ func (s *DockerSandbox) copyFromContainer(ctx context.Context, containerID, srcP
 	pr, pw := io.Pipe()
 	go func() {
 		_, copyErr := io.Copy(pw, stdout)
+		if copyErr != nil {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = cmd.Wait()
+			if errors.Is(copyErr, io.ErrClosedPipe) {
+				return
+			}
+			_ = pw.CloseWithError(copyErr)
+			return
+		}
+
 		waitErr := cmd.Wait()
 		switch {
-		case copyErr != nil:
-			_ = pw.CloseWithError(copyErr)
 		case waitErr != nil:
 			msg := strings.TrimSpace(stderr.String())
 			if msg != "" {

--- a/sandbox/docker.go
+++ b/sandbox/docker.go
@@ -174,7 +174,7 @@ func (s *DockerSandbox) CreateContainer(ctx context.Context, cmd []string) error
 	args = append(args, s.config.Image)
 	args = append(args, cmd...)
 
-	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput() // #nosec G204 - sandbox intentionally maps config into Docker CLI args.
 	if err != nil {
 		return fmt.Errorf("sandbox: create container: %w: %s", err, strings.TrimSpace(string(out)))
 	}
@@ -189,7 +189,7 @@ func (s *DockerSandbox) RemoveContainer(ctx context.Context) error {
 	}
 	id := s.containerID
 	s.containerID = ""
-	return exec.CommandContext(ctx, "docker", "rm", "-f", id).Run()
+	return exec.CommandContext(ctx, "docker", "rm", "-f", id).Run() // #nosec G204 - container ID comes from Docker create output.
 }
 
 // ExecInContainer creates a container, copies files in, runs the command, and allows file extraction.
@@ -209,7 +209,7 @@ func (s *DockerSandbox) ExecInContainer(ctx context.Context, cmd []string, copyI
 	args := append([]string{"create"}, s.dockerRunArgs()...)
 	args = append(args, s.config.Image)
 	args = append(args, cmd...)
-	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput() // #nosec G204 - sandbox intentionally maps config into Docker CLI args.
 	if err != nil {
 		return nil, nil, fmt.Errorf("sandbox: failed to create container: %w: %s", err, strings.TrimSpace(string(out)))
 	}
@@ -218,7 +218,7 @@ func (s *DockerSandbox) ExecInContainer(ctx context.Context, cmd []string, copyI
 	defer func() {
 		removeCtx, removeCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer removeCancel()
-		_ = exec.CommandContext(removeCtx, "docker", "rm", "-f", containerID).Run()
+		_ = exec.CommandContext(removeCtx, "docker", "rm", "-f", containerID).Run() // #nosec G204 - container ID comes from Docker create output.
 	}()
 
 	for hostPath, containerPath := range copyIn {
@@ -254,10 +254,10 @@ func (s *DockerSandbox) Close() error {
 
 // ensureImage pulls the image if it is not available locally.
 func (s *DockerSandbox) ensureImage(ctx context.Context) error {
-	if err := exec.CommandContext(ctx, "docker", "image", "inspect", s.config.Image).Run(); err == nil {
+	if err := exec.CommandContext(ctx, "docker", "image", "inspect", s.config.Image).Run(); err == nil { // #nosec G204 - sandbox image is an explicit execution input.
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, "docker", "pull", s.config.Image)
+	cmd := exec.CommandContext(ctx, "docker", "pull", s.config.Image) // #nosec G204 - sandbox image is an explicit execution input.
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, string(out))
@@ -295,11 +295,7 @@ func (s *DockerSandbox) buildHostConfig() *hostConfig {
 	if len(s.config.Mounts) > 0 {
 		hc.Mounts = make([]hostMount, len(s.config.Mounts))
 		for i, m := range s.config.Mounts {
-			hc.Mounts[i] = hostMount{
-				Source:   m.Source,
-				Target:   m.Target,
-				ReadOnly: m.ReadOnly,
-			}
+			hc.Mounts[i] = hostMount(m)
 		}
 	}
 
@@ -382,7 +378,7 @@ func (s *DockerSandbox) dockerRunArgs() []string {
 
 func runDockerResult(ctx context.Context, args []string) (*ExecResult, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd := exec.CommandContext(ctx, "docker", args...) // #nosec G204 - sandbox intentionally maps config into Docker CLI args.
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
@@ -405,7 +401,7 @@ func runDockerResult(ctx context.Context, args []string) (*ExecResult, error) {
 }
 
 func (s *DockerSandbox) copyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error) {
-	cmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+srcPath, "-")
+	cmd := exec.CommandContext(ctx, "docker", "cp", containerID+":"+srcPath, "-") // #nosec G204 - container ID comes from Docker create output; path is caller-selected copy target.
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -447,7 +443,7 @@ func (s *DockerSandbox) copyToContainer(ctx context.Context, containerID, hostPa
 	if _, err := os.Stat(hostPath); err != nil {
 		return fmt.Errorf("failed to stat %s: %w", hostPath, err)
 	}
-	out, err := exec.CommandContext(ctx, "docker", "cp", hostPath, containerID+":"+destPath).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", "cp", hostPath, containerID+":"+destPath).CombinedOutput() // #nosec G204 - caller-selected copy paths are the sandbox API contract.
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, string(out))
 	}

--- a/sandbox/docker.go
+++ b/sandbox/docker.go
@@ -410,6 +410,7 @@ func (s *DockerSandbox) copyFromContainer(ctx context.Context, containerID, srcP
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
+		_ = stdout.Close()
 		msg := strings.TrimSpace(stderr.String())
 		if msg != "" {
 			return nil, fmt.Errorf("%w: %s", err, msg)


### PR DESCRIPTION
## Summary

- replaces built-in docker build/push step execution with Docker CLI calls
- replaces the local Docker sandbox wrapper with Docker CLI lifecycle commands while preserving the existing SandboxConfig/DockerSandbox methods
- removes github.com/docker/docker from the root workflow module graph

## Root Cause

Downstream plugins such as workflow-plugin-hover import the workflow plugin SDK from the root workflow module. Even after the SDK package stopped importing host adapter code, the root module still directly required github.com/docker/docker for built-in Docker steps and sandbox support. Go module consumers inherit those root requirements, so Hover still surfaced Docker Dependabot alerts.

## Verification

- GOWORK=off go mod why -m github.com/docker/docker => main module does not need module github.com/docker/docker
- rg github.com/docker/docker go.mod go.sum module sandbox => only the SDK regression-test forbidden string remains outside testdata/example fixtures
- GOWORK=off go test ./sandbox ./module ./plugin/external/sdk
- GOWORK=off go test ./...
- git diff --check
