### PR TITLE
Preserve DNS proxy metadata in portfolio exports

### DIFF
--- a/dns/record/canonicalize.go
+++ b/dns/record/canonicalize.go
@@ -159,6 +159,12 @@ func recordLess(a, b Record) bool {
 	if !strings.EqualFold(a.Tag, b.Tag) {
 		return strings.ToLower(a.Tag) < strings.ToLower(b.Tag)
 	}
+	if less, ok := optionalBoolLess(a.Proxied, b.Proxied); ok {
+		return less
+	}
+	if less, ok := optionalBoolLess(a.Proxiable, b.Proxiable); ok {
+		return less
+	}
 	return a.Tag < b.Tag
 }
 
@@ -172,6 +178,21 @@ func optionalIntLess(a, b *int) (bool, bool) {
 		return false, true
 	case *a != *b:
 		return *a < *b, true
+	default:
+		return false, false
+	}
+}
+
+func optionalBoolLess(a, b *bool) (bool, bool) {
+	switch {
+	case a == nil && b == nil:
+		return false, false
+	case a == nil:
+		return true, true
+	case b == nil:
+		return false, true
+	case *a != *b:
+		return !*a && *b, true
 	default:
 		return false, false
 	}
@@ -329,6 +350,14 @@ func recordFromMap(m map[string]any) Record {
 		n := toInt(v)
 		r.Flags = &n
 	}
+	if v, ok := m["proxied"]; ok {
+		b := toBool(v)
+		r.Proxied = &b
+	}
+	if v, ok := m["proxiable"]; ok {
+		b := toBool(v)
+		r.Proxiable = &b
+	}
 	return r
 }
 
@@ -368,4 +397,9 @@ func toInt(v any) int {
 		return int(n)
 	}
 	return 0
+}
+
+func toBool(v any) bool {
+	b, _ := v.(bool)
+	return b
 }

--- a/dns/record/canonicalize_test.go
+++ b/dns/record/canonicalize_test.go
@@ -369,6 +369,29 @@ func TestFromResourceStatesOmitsAbsentOptionalFields(t *testing.T) {
 	}
 }
 
+func TestFromResourceStatesPreservesCloudflareProxyMetadata(t *testing.T) {
+	states := []interfaces.ResourceState{
+		{
+			Type:       "infra.dns",
+			Provider:   "cloudflare",
+			ProviderID: "example.com",
+			Outputs: map[string]any{
+				"records": []any{
+					map[string]any{"type": "A", "name": "@", "data": "192.0.2.10", "ttl": 300, "proxied": false, "proxiable": true},
+				},
+			},
+		},
+	}
+	p := record.FromResourceStates(states)
+	r := p.Snapshots[0].Records[0]
+	if r.Proxied == nil || *r.Proxied {
+		t.Fatalf("proxied = %v, want explicit false", r.Proxied)
+	}
+	if r.Proxiable == nil || !*r.Proxiable {
+		t.Fatalf("proxiable = %v, want explicit true", r.Proxiable)
+	}
+}
+
 func TestFromResourceStatesCanonicalizesRecordAndAuthorityOrder(t *testing.T) {
 	states := []interfaces.ResourceState{
 		{

--- a/dns/record/record.go
+++ b/dns/record/record.go
@@ -10,15 +10,17 @@ import "fmt"
 // provider returns, so unknown/newer types (PTR, HTTPS, SVCB, TLSA, DNAME, …)
 // MUST be preserved, never rejected. KnownType drives an optional warning only.
 type Record struct {
-	Type     string `json:"type"`
-	Name     string `json:"name"`
-	Value    string `json:"value"`
-	TTL      int    `json:"ttl"`
-	Priority *int   `json:"priority,omitempty"`
-	Port     *int   `json:"port,omitempty"`
-	Weight   *int   `json:"weight,omitempty"`
-	Flags    *int   `json:"flags,omitempty"`
-	Tag      string `json:"tag,omitempty"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+	TTL       int    `json:"ttl"`
+	Priority  *int   `json:"priority,omitempty"`
+	Port      *int   `json:"port,omitempty"`
+	Weight    *int   `json:"weight,omitempty"`
+	Flags     *int   `json:"flags,omitempty"`
+	Tag       string `json:"tag,omitempty"`
+	Proxied   *bool  `json:"proxied,omitempty"`
+	Proxiable *bool  `json:"proxiable,omitempty"`
 }
 
 // Snapshot is a flat representation of one DNS zone at a point in time.


### PR DESCRIPTION
## Summary
- add optional `proxied` and `proxiable` fields to canonical DNS portfolio records
- preserve explicit Cloudflare proxy metadata from imported `infra.dns` outputs
- keep absent proxy metadata omitted for providers that do not emit it

Fixes #958

## Verification
- `GOWORK=off go test ./dns/record -run TestFromResourceStatesPreservesCloudflareProxyMetadata -count=1`
- `GOWORK=off go test ./dns/record ./cmd/wfctl -count=1`