### PR TITLE
fix: fetch private release checksums via API

### DIFF
--- a/cmd/wfctl/plugin_checksum.go
+++ b/cmd/wfctl/plugin_checksum.go
@@ -83,7 +83,7 @@ func lookupChecksumForURL(downloadURL string) (string, error) {
 	var body []byte
 	if owner, repo, tag, filename, ok := parseGitHubReleaseDownloadURL(checksumsURL); ok {
 		if tok := gitHubToken(); tok != "" {
-			body, err = downloadGitHubReleaseAsset(owner, repo, tag, filename, tok)
+			body, err = downloadGitHubReleaseAssetWithTimeout(owner, repo, tag, filename, tok, 30*time.Second)
 		} else {
 			body, err = downloadWithTimeout(checksumsURL, 30*time.Second)
 		}

--- a/cmd/wfctl/plugin_checksum.go
+++ b/cmd/wfctl/plugin_checksum.go
@@ -80,7 +80,16 @@ func lookupChecksumForURL(downloadURL string) (string, error) {
 	u.Fragment = ""
 	checksumsURL := u.String()
 
-	body, err := downloadWithTimeout(checksumsURL, 30*time.Second)
+	var body []byte
+	if owner, repo, tag, filename, ok := parseGitHubReleaseDownloadURL(checksumsURL); ok {
+		if tok := gitHubToken(); tok != "" {
+			body, err = downloadGitHubReleaseAsset(owner, repo, tag, filename, tok)
+		} else {
+			body, err = downloadWithTimeout(checksumsURL, 30*time.Second)
+		}
+	} else {
+		body, err = downloadWithTimeout(checksumsURL, 30*time.Second)
+	}
 	if err != nil {
 		return "", fmt.Errorf("fetch checksums.txt from %s: %w", checksumsURL, err)
 	}

--- a/cmd/wfctl/plugin_checksum_test.go
+++ b/cmd/wfctl/plugin_checksum_test.go
@@ -220,7 +220,9 @@ func TestLookupChecksumForURL_URLEncodedAssetName(t *testing.T) {
 
 func TestLookupChecksumForURL_UsesGitHubAPIForPrivateReleaseChecksums(t *testing.T) {
 	const expectedSHA = "abc123def456"
+	t.Setenv("RELEASES_TOKEN", "")
 	t.Setenv("GH_TOKEN", "test-token")
+	t.Setenv("GITHUB_TOKEN", "")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/GoCodeAlone/repo/releases/tags/v1.0.0", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/wfctl/plugin_checksum_test.go
+++ b/cmd/wfctl/plugin_checksum_test.go
@@ -217,3 +217,41 @@ func TestLookupChecksumForURL_URLEncodedAssetName(t *testing.T) {
 		t.Errorf("expected %s, got %s", expectedSHA, got)
 	}
 }
+
+func TestLookupChecksumForURL_UsesGitHubAPIForPrivateReleaseChecksums(t *testing.T) {
+	const expectedSHA = "abc123def456"
+	t.Setenv("GH_TOKEN", "test-token")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/GoCodeAlone/repo/releases/tags/v1.0.0", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("release metadata Authorization = %q, want bearer token", got)
+		}
+		_, _ = w.Write([]byte(`{"assets":[{"id":123,"name":"checksums.txt"}]}`))
+	})
+	mux.HandleFunc("/repos/GoCodeAlone/repo/releases/assets/123", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+			t.Fatalf("asset Accept = %q, want application/octet-stream", got)
+		}
+		fmt.Fprintf(w, "%s  plugin-darwin-arm64.tar.gz\n", expectedSHA)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	origBaseURL := gitHubAPIBaseURL
+	origClient := gitHubAPIClient
+	gitHubAPIBaseURL = srv.URL
+	gitHubAPIClient = srv.Client()
+	t.Cleanup(func() {
+		gitHubAPIBaseURL = origBaseURL
+		gitHubAPIClient = origClient
+	})
+
+	got, err := lookupChecksumForURL("https://github.com/GoCodeAlone/repo/releases/download/v1.0.0/plugin-darwin-arm64.tar.gz")
+	if err != nil {
+		t.Fatalf("lookupChecksumForURL: %v", err)
+	}
+	if got != expectedSHA {
+		t.Fatalf("checksum = %q, want %q", got, expectedSHA)
+	}
+}

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -1196,6 +1196,10 @@ func parseGitHubReleaseDownloadURL(rawURL string) (owner, repo, tag, filename st
 // (github.com/.../releases/download/.../file) redirects to a signed S3 URL and
 // does not propagate the Authorization header correctly.
 func downloadGitHubReleaseAsset(owner, repo, tag, filename, token string) ([]byte, error) {
+	return downloadGitHubReleaseAssetWithTimeout(owner, repo, tag, filename, token, downloadTimeout)
+}
+
+func downloadGitHubReleaseAssetWithTimeout(owner, repo, tag, filename, token string, assetTimeout time.Duration) ([]byte, error) {
 	// Step 1: resolve the asset ID from the release metadata.
 	releaseURL := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", //nolint:gosec // G107
 		gitHubAPIBaseURL,
@@ -1256,7 +1260,7 @@ func downloadGitHubReleaseAsset(owner, repo, tag, filename, token string) ([]byt
 		neturl.PathEscape(repo),
 		assetID,
 	)
-	assetCtx, assetCancel := context.WithTimeout(context.Background(), downloadTimeout)
+	assetCtx, assetCancel := context.WithTimeout(context.Background(), assetTimeout)
 	defer assetCancel()
 	req2, err := http.NewRequestWithContext(assetCtx, http.MethodGet, assetURL, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- uses the GitHub releases API for checksums.txt when a token is present
- keeps direct checksum fetch behavior for public/non-GitHub URLs
- covers private-release checksum lookup with a regression test

## Verification
- GOWORK=off go test ./cmd/wfctl -run 'TestLookupChecksumForURL|TestDownloadURL_UsesGitHubAPIForPrivateReleaseAsset|TestDownloadURL_GitHubToken' -count=1
- GOWORK=off go test ./cmd/wfctl -count=1