### PR TITLE
fix: run migration plugins through CLI mode

### DIFF
--- a/cmd/wfctl/migrations_plugin_runner.go
+++ b/cmd/wfctl/migrations_plugin_runner.go
@@ -93,7 +93,8 @@ func defaultMigrationPluginExecutor(ctx context.Context, pluginName string, args
 		pluginRoot = env["WFCTL_PLUGIN_DIR"]
 	}
 	binaryPath := filepath.Join(pluginRoot, pluginDirName, pluginDirName)
-	cmd := exec.CommandContext(ctx, binaryPath, args...) //nolint:gosec // binary path follows wfctl installed-plugin layout.
+	cmdArgs := append([]string{"--wfctl-cli"}, args...)
+	cmd := exec.CommandContext(ctx, binaryPath, cmdArgs...) //nolint:gosec // binary path follows wfctl installed-plugin layout.
 
 	cmd.Env = mapEnv(withMigrationPluginBaseEnv(env))
 

--- a/cmd/wfctl/migrations_plugin_runner_test.go
+++ b/cmd/wfctl/migrations_plugin_runner_test.go
@@ -114,8 +114,9 @@ func TestDefaultMigrationPluginExecutorDoesNotInheritProcessSecrets(t *testing.T
 		t.Fatal(err)
 	}
 	envPath := filepath.Join(root, "env.txt")
+	argsPath := filepath.Join(root, "args.txt")
 	binaryPath := filepath.Join(pluginDir, "migrations")
-	script := "#!/bin/sh\n/usr/bin/env > " + envPath + "\n"
+	script := "#!/bin/sh\n/usr/bin/env > " + envPath + "\nprintf '%s\\n' \"$@\" > " + argsPath + "\n"
 	if err := os.WriteFile(binaryPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -139,6 +140,14 @@ func TestDefaultMigrationPluginExecutorDoesNotInheritProcessSecrets(t *testing.T
 	}
 	if !strings.Contains(envDump, "DATABASE_URL=postgres://user:secret@example.com/app") || !strings.Contains(envDump, "PLUGIN_PUBLIC_VAR=ok") {
 		t.Fatalf("plugin did not receive explicit env:\n%s", envDump)
+	}
+	argsDump, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := "--wfctl-cli\nstatus\n--driver\ngolang-migrate\n--source-dir\nmigrations\n"
+	if string(argsDump) != wantArgs {
+		t.Fatalf("args = %q, want %q", argsDump, wantArgs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Invoke installed migration plugin binaries with `--wfctl-cli` before migration arguments.
- Extend the executor regression test to assert the CLI-mode argv while preserving the secret-env isolation check.

## Root Cause
`wfctl migrations up` was executing the installed plugin server binary directly as `data/plugins/migrations/migrations`. After registry install correctly selected the actual `workflow-plugin-migrations` plugin archive, that binary exited with the go-plugin server message instead of running migrations. The migration runner needed to follow the same dynamic CLI contract as other plugin CLI commands: `<binary> --wfctl-cli <args...>`.

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'MigrationPlugin|Migrations'`
- `GOWORK=off go test ./cmd/wfctl`