### PR TITLE
feat(capability): add `wfctl capability recommend`

### DIFF
--- a/capability/recommend/recommend.go
+++ b/capability/recommend/recommend.go
@@ -53,7 +53,12 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 	req := normalize(opts.Capabilities)
 	cats := normalize(opts.Categories)
 	r.Requested = append([]string(nil), keysSorted(req)...)
-	matched := make(map[string]bool)
+
+	// matchedTerms records which REQUESTED terms found at least one capability.
+	// A requested term may match by id, name, tag, or description substring, so
+	// we cannot infer "matched" from capability ids/names alone — tracking the
+	// terms themselves avoids false "unmatched" reports for tag/description hits.
+	matchedTerms := make(map[string]bool)
 	for i := range inv.Capabilities {
 		cap := &inv.Capabilities[i]
 		if !opts.IncludeUncategorized && isUncategorized(*cap) {
@@ -62,14 +67,19 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 		if len(cats) > 0 && !cats[strings.ToLower(cap.Category)] {
 			continue
 		}
-		if len(req) > 0 && !matchesRequested(*cap, req) {
-			continue
+		if len(req) > 0 {
+			any := false
+			for term := range req {
+				if termMatches(cap, term) {
+					matchedTerms[term] = true
+					any = true
+				}
+			}
+			if !any {
+				continue
+			}
 		}
 		r.Capabilities = append(r.Capabilities, buildHit(cap))
-		if len(req) > 0 {
-			matched[strings.ToLower(cap.ID)] = true
-			matched[strings.ToLower(cap.Name)] = true
-		}
 	}
 	sort.Slice(r.Capabilities, func(i, j int) bool {
 		if r.Capabilities[i].Category != r.Capabilities[j].Category {
@@ -78,7 +88,7 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 		return r.Capabilities[i].ID < r.Capabilities[j].ID
 	})
 	for _, want := range keysSorted(req) {
-		if !matched[want] {
+		if !matchedTerms[want] {
 			r.Unmatched = append(r.Unmatched, want)
 		}
 	}
@@ -90,10 +100,14 @@ func buildHit(cap *inventory.Capability) CapabilityHit {
 	seen := map[string]bool{}
 	for i := range cap.Providers {
 		p := &cap.Providers[i]
-		if seen[p.Name] {
+		// De-dupe by (name, kind, releaseStatus): the inventory may carry the
+		// same provider name with different release status (registry vs local),
+		// and both variants are meaningful to surface.
+		key := strings.Join([]string{p.Name, p.Kind, p.ReleaseStatus}, "\x00")
+		if seen[key] {
 			continue
 		}
-		seen[p.Name] = true
+		seen[key] = true
 		h.Providers = append(h.Providers, ProviderSummary{
 			Name:          p.Name,
 			Kind:          p.Kind,
@@ -105,20 +119,19 @@ func buildHit(cap *inventory.Capability) CapabilityHit {
 	return h
 }
 
-func matchesRequested(cap inventory.Capability, req map[string]bool) bool {
-	lname, ldesc := strings.ToLower(cap.Name), strings.ToLower(cap.Description)
-	if req[strings.ToLower(cap.ID)] || req[lname] {
+// termMatches reports whether a single requested term matches cap by id, name,
+// tag, or description substring (all case-insensitive; term is pre-lowercased).
+func termMatches(cap *inventory.Capability, term string) bool {
+	if strings.EqualFold(term, cap.ID) || strings.EqualFold(term, cap.Name) {
 		return true
 	}
 	for _, t := range cap.Tags {
-		if req[strings.ToLower(t)] {
+		if strings.EqualFold(term, t) {
 			return true
 		}
 	}
-	for r := range req {
-		if ldesc != "" && strings.Contains(ldesc, r) {
-			return true
-		}
+	if desc := strings.ToLower(cap.Description); desc != "" && strings.Contains(desc, term) {
+		return true
 	}
 	return false
 }

--- a/capability/recommend/recommend.go
+++ b/capability/recommend/recommend.go
@@ -1,0 +1,149 @@
+// Package recommend produces a filtered, grouped view of which plugins provide
+// a set of requested capabilities. Pure + deterministic (design V2): no ranking
+// (inventory carries no quality/popularity signal — design review D13).
+//
+// NOTE: the inventory is manifest-derived (registry manifests + sibling plugin.json
+// checkouts); it does NOT carry runtime-factory-verified signal. Providers carry
+// real Kind ("registry"|"external"|"local-plugin") + ReleaseStatus ("released"|
+// "local-only") fields, surfaced as-is for the consumer to interpret.
+package recommend
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+)
+
+// Options selects capabilities to recommend for.
+type Options struct {
+	Capabilities         []string
+	Categories           []string
+	IncludeUncategorized bool
+}
+
+// Recommendation is the filtered + grouped result.
+type Recommendation struct {
+	Requested    []string        `json:"requested"`
+	Capabilities []CapabilityHit `json:"capabilities"`
+	Unmatched    []string        `json:"unmatched,omitempty"`
+}
+
+// CapabilityHit groups providers of one capability.
+type CapabilityHit struct {
+	ID        string            `json:"id"`
+	Category  string            `json:"category"`
+	Name      string            `json:"name"`
+	Providers []ProviderSummary `json:"providers"`
+}
+
+// ProviderSummary is a compact provider descriptor (real inventory fields).
+type ProviderSummary struct {
+	Name          string `json:"name"`
+	Kind          string `json:"kind"`
+	ReleaseStatus string `json:"releaseStatus,omitempty"`
+	Source        string `json:"source,omitempty"`
+}
+
+// Recommend filters inv to requested capabilities and groups their providers.
+// It is pure: it performs no ranking (the inventory carries no quality or
+// popularity signal) and produces a deterministic ordering.
+func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
+	r := &Recommendation{}
+	req := normalize(opts.Capabilities)
+	cats := normalize(opts.Categories)
+	r.Requested = append([]string(nil), keysSorted(req)...)
+	matched := make(map[string]bool)
+	for i := range inv.Capabilities {
+		cap := &inv.Capabilities[i]
+		if !opts.IncludeUncategorized && isUncategorized(*cap) {
+			continue
+		}
+		if len(cats) > 0 && !cats[strings.ToLower(cap.Category)] {
+			continue
+		}
+		if len(req) > 0 && !matchesRequested(*cap, req) {
+			continue
+		}
+		r.Capabilities = append(r.Capabilities, buildHit(cap))
+		if len(req) > 0 {
+			matched[strings.ToLower(cap.ID)] = true
+			matched[strings.ToLower(cap.Name)] = true
+		}
+	}
+	sort.Slice(r.Capabilities, func(i, j int) bool {
+		if r.Capabilities[i].Category != r.Capabilities[j].Category {
+			return r.Capabilities[i].Category < r.Capabilities[j].Category
+		}
+		return r.Capabilities[i].ID < r.Capabilities[j].ID
+	})
+	for _, want := range keysSorted(req) {
+		if !matched[want] {
+			r.Unmatched = append(r.Unmatched, want)
+		}
+	}
+	return r
+}
+
+func buildHit(cap *inventory.Capability) CapabilityHit {
+	h := CapabilityHit{ID: cap.ID, Category: cap.Category, Name: cap.Name}
+	seen := map[string]bool{}
+	for i := range cap.Providers {
+		p := &cap.Providers[i]
+		if seen[p.Name] {
+			continue
+		}
+		seen[p.Name] = true
+		h.Providers = append(h.Providers, ProviderSummary{
+			Name:          p.Name,
+			Kind:          p.Kind,
+			ReleaseStatus: p.ReleaseStatus,
+			Source:        p.Source,
+		})
+	}
+	sort.Slice(h.Providers, func(i, j int) bool { return h.Providers[i].Name < h.Providers[j].Name })
+	return h
+}
+
+func matchesRequested(cap inventory.Capability, req map[string]bool) bool {
+	lname, ldesc := strings.ToLower(cap.Name), strings.ToLower(cap.Description)
+	if req[strings.ToLower(cap.ID)] || req[lname] {
+		return true
+	}
+	for _, t := range cap.Tags {
+		if req[strings.ToLower(t)] {
+			return true
+		}
+	}
+	for r := range req {
+		if ldesc != "" && strings.Contains(ldesc, r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isUncategorized(c inventory.Capability) bool {
+	return c.Category == "uncategorized" || strings.HasPrefix(c.ID, "uncategorized:")
+}
+
+// normalize lower-cases, trims, and drops empty entries from ss.
+func normalize(ss []string) map[string]bool {
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		if s = strings.ToLower(strings.TrimSpace(s)); s != "" {
+			m[s] = true
+		}
+	}
+	return m
+}
+
+// keysSorted returns the keys of m sorted ascending for deterministic output.
+func keysSorted(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/capability/recommend/recommend_test.go
+++ b/capability/recommend/recommend_test.go
@@ -66,6 +66,54 @@ func TestRecommend_ExcludesUncategorizedByDefault(t *testing.T) {
 	}
 }
 
+func TestRecommend_ByTagNotUnmatched(t *testing.T) {
+	// Requesting by a TAG (not id/name) must still match and NOT report Unmatched.
+	inv := smallInventory(t) // auth.authz carries tag "cross-cutting"
+	rec := recommend.Recommend(inv, recommend.Options{Capabilities: []string{"cross-cutting"}})
+	if len(rec.Unmatched) != 0 {
+		t.Fatalf("tag request falsely unmatched: %#v", rec.Unmatched)
+	}
+	if len(rec.Capabilities) != 1 || rec.Capabilities[0].ID != "auth.authz" {
+		t.Fatalf("tag request should match auth.authz: %#v", rec.Capabilities)
+	}
+}
+
+func TestRecommend_ByDescriptionNotUnmatched(t *testing.T) {
+	// Requesting by a description substring must match and NOT report Unmatched.
+	inv := smallInventory(t) // auth.authz description "Enforces permissions and roles"
+	rec := recommend.Recommend(inv, recommend.Options{Capabilities: []string{"permissions"}})
+	if len(rec.Unmatched) != 0 {
+		t.Fatalf("description request falsely unmatched: %#v", rec.Unmatched)
+	}
+	if len(rec.Capabilities) != 1 {
+		t.Fatalf("description request should match auth.authz: %#v", rec.Capabilities)
+	}
+}
+
+func TestRecommend_PreservesSameNameDiffStatus(t *testing.T) {
+	// A capability provided by the same plugin name under different release
+	// statuses (registry vs local) must surface BOTH provider rows, not dedupe
+	// them away by name.
+	inv := &inventory.Inventory{
+		Capabilities: []inventory.Capability{
+			{
+				ID:       "auth.authz",
+				Category: "auth",
+				Name:     "Authorization",
+				Providers: []inventory.Provider{
+					{Name: "auth", Kind: "external", ReleaseStatus: "released"},
+					{Name: "auth", Kind: "local-plugin", ReleaseStatus: "local-only"},
+				},
+			},
+		},
+	}
+	rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"auth"}})
+	hit := findHit(t, rec, "auth.authz")
+	if len(hit.Providers) != 2 {
+		t.Fatalf("expected 2 providers (registry+local), got %#v", hit.Providers)
+	}
+}
+
 // findHit returns the CapabilityHit with the given ID, failing the test if absent.
 func findHit(t *testing.T, rec *recommend.Recommendation, id string) recommend.CapabilityHit {
 	t.Helper()

--- a/capability/recommend/recommend_test.go
+++ b/capability/recommend/recommend_test.go
@@ -1,0 +1,132 @@
+package recommend_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/capability/recommend"
+)
+
+func TestRecommend_GroupsProvidersPerCapability(t *testing.T) {
+	inv, err := inventory.CollectEcosystem(inventory.EcosystemOptions{
+		RegistryDir:  "../inventory/testdata/ecosystem/registry",
+		RepoRoot:     "../inventory/testdata/ecosystem/repos",
+		TaxonomyPath: "../inventory/testdata/taxonomy.yaml",
+		GeneratedAt:  time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CollectEcosystem: %v", err)
+	}
+	rec := recommend.Recommend(inv, recommend.Options{Capabilities: []string{"auth.authz"}})
+	if len(rec.Requested) != 1 || rec.Requested[0] != "auth.authz" {
+		t.Fatalf("Requested = %#v, want [auth.authz]", rec.Requested)
+	}
+	hit := findHit(t, rec, "auth.authz")
+	if len(hit.Providers) < 1 {
+		t.Fatalf("auth.authz has no providers: %#v", hit)
+	}
+	if !hasProvider(hit, "auth") {
+		t.Fatalf("auth.authz missing provider %q: %#v", "auth", hit.Providers)
+	}
+	if len(rec.Unmatched) != 0 {
+		t.Fatalf("Unmatched = %#v, want empty", rec.Unmatched)
+	}
+}
+
+func TestRecommend_UnmatchedRequestedCapability(t *testing.T) {
+	inv := smallInventory(t)
+	rec := recommend.Recommend(inv, recommend.Options{Capabilities: []string{"does.not.exist"}})
+	if len(rec.Unmatched) != 1 || rec.Unmatched[0] != "does.not.exist" {
+		t.Fatalf("Unmatched = %#v, want [does.not.exist]", rec.Unmatched)
+	}
+	if len(rec.Capabilities) != 0 {
+		t.Fatalf("expected zero hits, got %#v", rec.Capabilities)
+	}
+}
+
+func TestRecommend_Deterministic(t *testing.T) {
+	inv := smallInventory(t)
+	opts := recommend.Options{Categories: []string{"auth"}}
+	a := recommend.Recommend(inv, opts)
+	b := recommend.Recommend(inv, opts)
+	if !equalRec(a, b) {
+		t.Fatalf("non-deterministic: %#v != %#v", a, b)
+	}
+}
+
+func TestRecommend_ExcludesUncategorizedByDefault(t *testing.T) {
+	inv := uncategorizedInventory(t)
+	if rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"uncategorized"}}); len(rec.Capabilities) != 0 {
+		t.Fatalf("uncategorized leaked: %#v", rec.Capabilities)
+	}
+	if rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"uncategorized"}, IncludeUncategorized: true}); len(rec.Capabilities) != 1 {
+		t.Fatalf("IncludeUncategorized dropped row: %#v", rec.Capabilities)
+	}
+}
+
+// findHit returns the CapabilityHit with the given ID, failing the test if absent.
+func findHit(t *testing.T, rec *recommend.Recommendation, id string) recommend.CapabilityHit {
+	t.Helper()
+	for _, h := range rec.Capabilities {
+		if h.ID == id {
+			return h
+		}
+	}
+	t.Fatalf("no CapabilityHit with id %q in recommendation: %#v", id, rec)
+	return recommend.CapabilityHit{}
+}
+
+// hasProvider reports whether hit has a provider with the given name.
+func hasProvider(hit recommend.CapabilityHit, name string) bool {
+	for _, p := range hit.Providers {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// smallInventory builds a minimal in-memory inventory with one capability
+// (id auth.authz, category auth) provided by one local plugin.
+func smallInventory(t *testing.T) *inventory.Inventory {
+	t.Helper()
+	return &inventory.Inventory{
+		Capabilities: []inventory.Capability{
+			{
+				ID:          "auth.authz",
+				Category:    "auth",
+				Name:        "Authorization",
+				Description: "Enforces permissions and roles",
+				Tags:        []string{"cross-cutting", "authz-sensitive"},
+				Providers: []inventory.Provider{
+					{Name: "auth", Kind: "local-plugin", ReleaseStatus: "local-only"},
+				},
+			},
+		},
+	}
+}
+
+// uncategorizedInventory builds a minimal inventory with one uncategorized capability.
+func uncategorizedInventory(t *testing.T) *inventory.Inventory {
+	t.Helper()
+	return &inventory.Inventory{
+		Capabilities: []inventory.Capability{
+			{
+				ID:          "uncategorized:module:custom.thing",
+				Category:    "uncategorized",
+				Name:        "custom.thing",
+				Description: "Raw capability declaration with no taxonomy mapping",
+				Providers: []inventory.Provider{
+					{Name: "custom", Kind: "local-plugin", ReleaseStatus: "local-only"},
+				},
+			},
+		},
+	}
+}
+
+// equalRec reports deep equality between two Recommendations.
+func equalRec(a, b *recommend.Recommendation) bool {
+	return reflect.DeepEqual(a, b)
+}

--- a/cmd/wfctl/capability.go
+++ b/cmd/wfctl/capability.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/capability/recommend"
 )
 
 func runCapability(args []string) error {
@@ -36,6 +37,8 @@ func runCapabilityWithOutput(args []string, out io.Writer) error {
 		return runCapabilityApp(args[1:], out)
 	case "check":
 		return runCapabilityCheck(args[1:], out)
+	case "recommend":
+		return runCapabilityRecommend(args[1:], out)
 	case "-h", "--help", "help":
 		printCapabilityUsage(out)
 		return nil
@@ -54,6 +57,7 @@ Subcommands:
   crossrefs  Generate plugin/provider capability cross-reference index
   app        Generate capability profile for an application
   check      Print detected capabilities and findings for an application
+  recommend  Recommend plugins that provide requested capabilities
 
 Use "wfctl capability <subcommand> -h" for subcommand options.`)
 }
@@ -203,6 +207,109 @@ func runCapabilityCheck(args []string, out io.Writer) error {
 		return fmt.Errorf("unsupported check format %q", format)
 	}
 	return writeCapabilityOutput(out, outputPath, buf.Bytes())
+}
+
+func runCapabilityRecommend(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("capability recommend", flag.ContinueOnError)
+	fs.SetOutput(out)
+	var registryDir, repoRoot, taxonomyPath, format, outputPath string
+	var includeUncat bool
+	var capabilities, categories stringSliceValue
+	fs.StringVar(&registryDir, "registry", defaultCapabilityRegistryPath(), "registry directory")
+	fs.StringVar(&repoRoot, "repo-root", "..", "workspace root containing workflow-plugin-* repos")
+	fs.StringVar(&taxonomyPath, "taxonomy", defaultCapabilityTaxonomyPath(), "capability taxonomy YAML")
+	fs.StringVar(&format, "format", "json", "output format: json or md")
+	fs.StringVar(&outputPath, "output", "", "write output to path instead of stdout")
+	fs.BoolVar(&includeUncat, "include-uncategorized", false, "include uncategorized capabilities")
+	fs.Var(&capabilities, "capability", "requested capability id/name/tag; repeat for multiple")
+	fs.Var(&categories, "category", "requested category; repeat for multiple")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	inv, err := inventory.CollectEcosystem(inventory.EcosystemOptions{
+		RegistryDir:     registryDir,
+		RepoRoot:        repoRoot,
+		TaxonomyPath:    taxonomyPath,
+		GeneratedAt:     time.Now().UTC(),
+		WorkflowVersion: version,
+	})
+	if err != nil {
+		return err
+	}
+	rec := recommend.Recommend(inv, recommend.Options{
+		Capabilities:         capabilities,
+		Categories:           categories,
+		IncludeUncategorized: includeUncat,
+	})
+	var buf bytes.Buffer
+	switch format {
+	case "json":
+		if err := writeCapabilityJSON(&buf, rec); err != nil {
+			return err
+		}
+	case "md", "markdown":
+		renderRecommendMarkdown(&buf, rec)
+	default:
+		return fmt.Errorf("unsupported recommend format %q", format)
+	}
+	if len(rec.Unmatched) > 0 {
+		fmt.Fprintf(out, "# warning: %d requested capability(ies) unmatched: %s\n", len(rec.Unmatched), strings.Join(rec.Unmatched, ", "))
+	}
+	return writeCapabilityOutput(out, outputPath, buf.Bytes())
+}
+
+// stringSliceValue is a repeatable string flag used by `capability recommend`.
+// Unlike capabilityFilterFlags, recommend only consumes capability/category
+// dimensions, so it registers just what it needs.
+type stringSliceValue []string
+
+func (s *stringSliceValue) String() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(*s, ",")
+}
+
+func (s *stringSliceValue) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+func renderRecommendMarkdown(out io.Writer, rec *recommend.Recommendation) {
+	fmt.Fprintln(out, "# Workflow Capability Recommendations")
+	fmt.Fprintln(out)
+	if len(rec.Requested) > 0 {
+		fmt.Fprintf(out, "- Requested: %s\n", strings.Join(rec.Requested, ", "))
+	}
+	fmt.Fprintf(out, "- Matched capabilities: %d\n", len(rec.Capabilities))
+	fmt.Fprintln(out)
+	for i := range rec.Capabilities {
+		hit := &rec.Capabilities[i]
+		header := hit.Name + " (" + hit.ID + ")"
+		if hit.Category != "" {
+			header += " [" + hit.Category + "]"
+		}
+		fmt.Fprintf(out, "## %s\n", header)
+		for j := range hit.Providers {
+			p := &hit.Providers[j]
+			line := "- " + p.Name + " (kind=" + p.Kind
+			if p.ReleaseStatus != "" {
+				line += " status=" + p.ReleaseStatus
+			}
+			if p.Source != "" {
+				line += " source=" + p.Source
+			}
+			line += ")"
+			fmt.Fprintln(out, line)
+		}
+		fmt.Fprintln(out)
+	}
+	if len(rec.Unmatched) > 0 {
+		fmt.Fprintln(out, "## Unmatched")
+		for _, name := range rec.Unmatched {
+			fmt.Fprintf(out, "- %s\n", name)
+		}
+	}
 }
 
 func parseCapabilityCheckFlags(args []string, out io.Writer) (inventory.AppOptions, string, string, bool, capabilityFilterFlags, error) {

--- a/cmd/wfctl/capability.go
+++ b/cmd/wfctl/capability.go
@@ -253,7 +253,8 @@ func runCapabilityRecommend(args []string, out io.Writer) error {
 		return fmt.Errorf("unsupported recommend format %q", format)
 	}
 	if len(rec.Unmatched) > 0 {
-		fmt.Fprintf(out, "# warning: %d requested capability(ies) unmatched: %s\n", len(rec.Unmatched), strings.Join(rec.Unmatched, ", "))
+		// Warnings go to stderr so they never corrupt the JSON/MD artifact on stdout.
+		fmt.Fprintf(os.Stderr, "# warning: %d requested capability(ies) unmatched: %s\n", len(rec.Unmatched), strings.Join(rec.Unmatched, ", "))
 	}
 	return writeCapabilityOutput(out, outputPath, buf.Bytes())
 }

--- a/cmd/wfctl/capability_recommend_test.go
+++ b/cmd/wfctl/capability_recommend_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCapabilityRecommend_JSON(t *testing.T) {
+	var out bytes.Buffer
+	args := []string{"recommend", "-capability", "auth.authz",
+		"-registry", "testdata/capability/registry",
+		"-repo-root", "testdata/capability/repos",
+		"-taxonomy", "../../capability/inventory/testdata/taxonomy.yaml"}
+	if err := runCapabilityWithOutput(args, &out); err != nil {
+		t.Fatalf("runCapability recommend: %v", err)
+	}
+	if !strings.Contains(out.String(), `"capabilities"`) {
+		t.Fatalf("expected JSON capabilities, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "auth") {
+		t.Fatalf("expected auth provider in output: %s", out.String())
+	}
+}
+
+func TestCapabilityRecommend_Help(t *testing.T) {
+	var out bytes.Buffer
+	if err := runCapabilityWithOutput([]string{"recommend", "-h"}, &out); err == nil {
+		t.Fatal("expected non-nil error from -h")
+	}
+	if !strings.Contains(out.String(), "recommend") {
+		t.Fatalf("help missing recommend: %s", out.String())
+	}
+}

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -249,7 +249,7 @@ wfctl capability recommend --category auth --category database --format json
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--capability` | (none) | Requested capability id/name/tag; repeat for multiple |
+| `--capability` | (none) | Requested capability id/name/tag/description; repeat for multiple |
 | `--category` | (none) | Requested category; repeat for multiple |
 | `--include-uncategorized` | false | Include capabilities whose id begins `uncategorized:` |
 | `--registry` | `data/registry` | Registry root containing `plugins/*/manifest.json` |

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -217,6 +217,7 @@ wfctl capability catalog --capability secrets --tag cross-cutting
 wfctl capability crossrefs --plugin workflow-plugin-github
 wfctl capability app --repo workflow.yaml --capability tenancy
 wfctl capability check --finding tenant-evidence-missing --findings-only
+wfctl capability recommend --capability auth.authz --format md
 ```
 
 | Filter | Applies to | Description |
@@ -230,6 +231,32 @@ wfctl capability check --finding tenant-evidence-missing --findings-only
 | `--finding` | all | Match finding code, level, or message |
 | `--tag` | ecosystem, catalog | Match taxonomy tags |
 | `--exact` | all | Use exact matching instead of substring matching |
+
+#### `wfctl capability recommend`
+
+Recommends plugins that provide a set of requested capabilities. Unlike the
+other capability subcommands, `recommend` does not apply the full filter set —
+it accepts only `--capability` / `--category` (repeatable) plus
+`--include-uncategorized`, groups providers per matched capability, and surfaces
+any requested capabilities that matched no provider under `unmatched`. Output is
+deterministic (sorted); the inventory carries no quality or popularity signal,
+so providers are listed, not ranked.
+
+```
+wfctl capability recommend --capability auth.authz --format md
+wfctl capability recommend --category auth --category database --format json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--capability` | (none) | Requested capability id/name/tag; repeat for multiple |
+| `--category` | (none) | Requested category; repeat for multiple |
+| `--include-uncategorized` | false | Include capabilities whose id begins `uncategorized:` |
+| `--registry` | `data/registry` | Registry root containing `plugins/*/manifest.json` |
+| `--repo-root` | `..` | Workspace root to scan for local `workflow-plugin-*` repos |
+| `--taxonomy` | `data/capabilities/taxonomy.yaml` | Capability taxonomy YAML |
+| `--format` | `json` | `json` or `md` |
+| `--output` | stdout | Write the artifact to a file |
 
 #### `wfctl capability ecosystem`
 


### PR DESCRIPTION
## What

Adds `wfctl capability recommend` — an engine builtin that recommends plugins providing a set of requested capabilities. Given a goal (one or more capabilities), it filters the ecosystem inventory and groups the providers per capability, surfacing alternatives and any unmatched requests.

```
$ wfctl capability recommend --capability auth.authz --format md
## Authorization (auth.authz) [auth]
- auth (kind=external status=released …)
- workflow-plugin-authz (kind=local-plugin status=local-only …)
```

## Design

- **Engine builtin** (joins the existing `wfctl capability {ecosystem,catalog,crossrefs,app,check}` group), not a plugin — reuses `capability/inventory.CollectEcosystem` + the checked-in capability taxonomy **in-process**; no new index or taxonomy.
- **Filter + group, no ranking.** The inventory is manifest-derived and carries no quality/popularity signal, so providers are listed (sorted deterministically by category/id/name), not ranked. Each provider's real `Kind` (`registry`/`external`/`local-plugin`) and `ReleaseStatus` are surfaced as-is for the consumer to interpret.
- **Narrow flag surface.** `recommend` accepts only `--capability` / `--category` (repeatable) + `--include-uncategorized` (plus the standard registry/repo-root/taxonomy/format/output flags). It deliberately does *not* reuse the full capability filter-flag set — it does its own grouping so it can detect and report `unmatched` requested capabilities.
- **No LLM.** Recommendation is a pure deterministic function of `(inventory, options)`. Natural-language intent is the caller's job (an agent driving wfctl shapes the capability query); the matcher never calls a model.

## Changes

- `capability/recommend/` — new pure package: `Recommend(inv, opts) *Recommendation` (filter + group + `unmatched` + uncategorized handling). Pure + deterministic.
- `cmd/wfctl/capability.go` — `case "recommend"` dispatch + `runCapabilityRecommend` handler + `stringSliceValue` flag + `renderRecommendMarkdown` + usage line.
- `docs/WFCTL.md` — `#### wfctl capability recommend` section.

## Scope

This is **PR 1 of 2**. A follow-up adds `wfctl capability build` (interactive Bubbletea wizard, agent-less path) and an assemble-feasibility spike. Scaffold assembly (`wfctl capability assemble`) and MCP-tool twins are intentionally out of scope for this first pass.

## Verification

- `go test ./capability/recommend/... ./cmd/wfctl/` → ok
- `golangci-lint run --new-from-rev=origin/main ./capability/recommend/... ./cmd/wfctl/...` → 0 issues
- CLI smoke: `recommend -capability auth.authz -format md` → grouped output with both providers (shown above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)