### PR TITLE
feat(capability): wfctl capability assemble (assembler pkg + CLI)

### DIFF
--- a/capability/assembler/assembler.go
+++ b/capability/assembler/assembler.go
@@ -1,0 +1,95 @@
+package assembler
+
+import (
+	"fmt"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/schema"
+	"gopkg.in/yaml.v3"
+)
+
+// Assemble composes a structurally-valid scaffold from the chosen capability set
+// (+ explicit modules). Pure: no I/O. Runs the in-process schema.ValidateConfig
+// gate (V3, fail-closed) before returning — on validation failure returns a
+// non-nil error and a nil *AssembledApp (⊥ write-on-fail).
+func Assemble(inv *inventory.Inventory, in AssemblyInput, reg *schema.ModuleSchemaRegistry) (*AssembledApp, error) {
+	// 1. select (D1: inventory raw strings; D8: greedy set-cover + registry tie-break)
+	selected, unmatched := selectModules(inv, in.Capabilities, reg)
+
+	app := &AssembledApp{Unmatched: unmatched}
+
+	// 2. config-gen + existence gate (D6): types ∉ registry -> skip + finding
+	for _, typ := range selected {
+		cfg, ok := genConfig(typ, reg)
+		if !ok {
+			app.Findings = append(app.Findings, Finding{
+				Level: "warn", Code: "no-schema",
+				Message: fmt.Sprintf("module type %q not in schema registry — skipped (add manually)", typ),
+			})
+			continue
+		}
+		app.Modules = append(app.Modules, config.ModuleConfig{Name: defaultName(typ), Type: typ, Config: cfg})
+	}
+
+	// 3. explicit modules (agent inject/pin) — emitted as-is
+	for _, em := range in.Modules {
+		name := em.Name
+		if name == "" {
+			name = defaultName(em.Type)
+		}
+		app.Modules = append(app.Modules, config.ModuleConfig{Name: name, Type: em.Type, Config: em.Config})
+	}
+
+	// 4. wiring: entry-point ensure + dependsOn (C4) + workflows.http (P1:
+	//    without it http.server.Start() fails "no router configured")
+	app.Modules = wire(app.Modules)
+	app.Workflows = httpWorkflow(app.Modules)
+
+	// 5. requires.plugins — external only (D2)
+	for i := range inv.Capabilities {
+		for j := range inv.Capabilities[i].Providers {
+			p := &inv.Capabilities[i].Providers[j]
+			if p.Kind != "external" && p.Kind != "local-plugin" {
+				continue // builtin package — auto-loaded by DefaultPlugins
+			}
+			app.Requires.Plugins = appendUniquePlugin(app.Requires.Plugins, p.Name)
+		}
+	}
+
+	// 6. V3 gate — fail-closed (structural; ⊥ runtime-factory, D6/V8)
+	cfg := &config.WorkflowConfig{
+		Modules:   app.Modules,
+		Workflows: app.Workflows,
+		Triggers:  map[string]any{},
+		Requires:  &app.Requires,
+	}
+	if err := schema.ValidateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("assemble: generated config fails validation (V3 fail-closed): %w", err)
+	}
+	return app, nil
+}
+
+// MarshalConfig renders the assembled app to workflow.yaml bytes. Pure; shared by
+// the CLI emitter + the MC2-bis boot test (P4: avoids cmd/wfctl <-> capability/
+// assembler import cycle).
+func MarshalConfig(app *AssembledApp) ([]byte, error) {
+	cfg := &config.WorkflowConfig{
+		Modules: app.Modules, Workflows: app.Workflows, Triggers: map[string]any{},
+	}
+	if len(app.Requires.Plugins) > 0 {
+		cfg.Requires = &app.Requires
+	}
+	return yaml.Marshal(cfg)
+}
+
+// defaultName + envPrefix live in config.go (shared by config-gen).
+
+func appendUniquePlugin(plugs []config.PluginRequirement, name string) []config.PluginRequirement {
+	for _, p := range plugs {
+		if p.Name == name {
+			return plugs
+		}
+	}
+	return append(plugs, config.PluginRequirement{Name: name})
+}

--- a/capability/assembler/assembler.go
+++ b/capability/assembler/assembler.go
@@ -46,14 +46,29 @@ func Assemble(inv *inventory.Inventory, in AssemblyInput, reg *schema.ModuleSche
 	app.Modules = wire(app.Modules)
 	app.Workflows = httpWorkflow(app.Modules)
 
-	// 5. requires.plugins — external only (D2)
-	for i := range inv.Capabilities {
-		for j := range inv.Capabilities[i].Providers {
-			p := &inv.Capabilities[i].Providers[j]
-			if p.Kind != "external" && p.Kind != "local-plugin" {
-				continue // builtin package — auto-loaded by DefaultPlugins
+	// 5. requires.plugins — external/local-plugin providers of REQUESTED+MATCHED
+	//    capabilities only (D2). Iterating all inv.Capabilities would inflate the
+	//    emitted requires.plugins to the entire ecosystem; scope to what the user
+	//    actually asked for (unmatched capabilities contribute nothing).
+	unmatchedSet := map[string]bool{}
+	for _, u := range unmatched {
+		unmatchedSet[u] = true
+	}
+	for _, want := range in.Capabilities {
+		if unmatchedSet[want] {
+			continue
+		}
+		for i := range inv.Capabilities {
+			if inv.Capabilities[i].ID != want {
+				continue
 			}
-			app.Requires.Plugins = appendUniquePlugin(app.Requires.Plugins, p.Name)
+			for j := range inv.Capabilities[i].Providers {
+				p := &inv.Capabilities[i].Providers[j]
+				if p.Kind != "external" && p.Kind != "local-plugin" {
+					continue // builtin package — auto-loaded by DefaultPlugins
+				}
+				app.Requires.Plugins = appendUniquePlugin(app.Requires.Plugins, p.Name)
+			}
 		}
 	}
 

--- a/capability/assembler/assembler_test.go
+++ b/capability/assembler/assembler_test.go
@@ -94,3 +94,30 @@ func hasModuleType(app *AssembledApp, typ string) bool {
 	}
 	return false
 }
+
+func TestAssemble_RequiresPluginsScopedToRequested(t *testing.T) {
+	// Regression: requires.plugins must list only external providers of REQUESTED+
+	// matched capabilities — not the whole ecosystem (previously inflated to ~all
+	// plugins because the loop iterated every inv.Capabilities).
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		cap("http.routing", prov("workflow-plugin-http", "external", "module:http.server", "module:http.router")),
+		cap("storage.database", prov("workflow-plugin-some-db", "external", "module:database.workflow")),
+	}}
+	reg := schema.NewModuleSchemaRegistry()
+	app, err := Assemble(inv, AssemblyInput{Capabilities: []string{"http.routing"}}, reg)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	names := pluginNames(app)
+	if len(names) != 1 || names[0] != "workflow-plugin-http" {
+		t.Fatalf("requires.plugins=%v want exactly [workflow-plugin-http] (storage.database not requested)", names)
+	}
+}
+
+func pluginNames(app *AssembledApp) []string {
+	out := make([]string, 0, len(app.Requires.Plugins))
+	for _, p := range app.Requires.Plugins {
+		out = append(out, p.Name)
+	}
+	return out
+}

--- a/capability/assembler/assembler_test.go
+++ b/capability/assembler/assembler_test.go
@@ -1,0 +1,96 @@
+package assembler
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+func realInventory(t *testing.T) *inventory.Inventory {
+	t.Helper()
+	// minimal synthetic inventory exercising the compose path; real CollectEcosystem
+	// is exercised end-to-end in the CLI + boot tests.
+	return &inventory.Inventory{Capabilities: []inventory.Capability{
+		cap("auth.authn", prov("auth", "builtin", "module:auth.jwt")),
+		cap("http.routing", prov("http", "builtin", "module:http.server", "module:http.router")),
+		cap("storage.database", prov("storage", "builtin", "module:database.workflow")),
+		cap("observability.health", prov("observability", "builtin", "module:health.checker")),
+	}}
+}
+
+func TestAssemble_StructurallyValid(t *testing.T) {
+	reg := schema.NewModuleSchemaRegistry()
+	app, err := Assemble(realInventory(t), AssemblyInput{
+		Capabilities: []string{"auth.authn", "http.routing", "storage.database", "observability.health"},
+	}, reg)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if !hasModuleType(app, "auth.jwt") || !hasModuleType(app, "database.workflow") ||
+		!hasModuleType(app, "http.server") || !hasModuleType(app, "http.router") {
+		t.Fatalf("missing expected modules: %+v", app.Modules)
+	}
+	if len(app.Unmatched) != 0 {
+		t.Fatalf("unmatched=%v", app.Unmatched)
+	}
+}
+
+func TestAssemble_FailClosedOnMissingRequiredField(t *testing.T) {
+	// explicit storage.s3 with no config -> bucket (Required, no default) missing
+	// -> ValidateConfig rejects -> Assemble returns error (V3 fail-closed). P3.
+	reg := schema.NewModuleSchemaRegistry()
+	_, err := Assemble(&inventory.Inventory{}, AssemblyInput{
+		Modules: []ExplicitModule{{Type: "storage.s3", Name: "store"}},
+	}, reg)
+	if err == nil {
+		t.Fatal("want V3 fail-closed error (storage.s3 missing required bucket)")
+	}
+}
+
+func TestAssemble_V3RejectsUnknownExplicitType(t *testing.T) {
+	// explicit module of an unknown type -> ValidateConfig rejects (V3 gate).
+	reg := schema.NewModuleSchemaRegistry()
+	_, err := Assemble(&inventory.Inventory{}, AssemblyInput{
+		Modules: []ExplicitModule{{Type: "no.such.type", Name: "x"}},
+	}, reg)
+	if err == nil {
+		t.Fatal("want V3 error for unknown explicit module type")
+	}
+}
+
+func TestAssemble_SelectedTypeNotInRegistrySkippedWithFinding(t *testing.T) {
+	// storage.database -> database.workflow, but ∉ registry -> skipped + no-schema
+	// finding (V8/D6). wire() does NOT re-add database.workflow, so ValidateConfig
+	// still passes (server/router/health present). Genuine V8 path.
+	reg := schema.NewModuleSchemaRegistry()
+	reg.Unregister("database.workflow")
+	app, err := Assemble(realInventory(t), AssemblyInput{Capabilities: []string{"storage.database"}}, reg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasFinding(app, "no-schema") {
+		t.Fatalf("want no-schema finding, got %+v", app.Findings)
+	}
+	if hasModuleType(app, "database.workflow") {
+		t.Fatal("database.workflow should be skipped (∉ registry)")
+	}
+}
+
+func hasFinding(app *AssembledApp, code string) bool {
+	for _, f := range app.Findings {
+		if f.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func hasModuleType(app *AssembledApp, typ string) bool {
+	for _, m := range app.Modules {
+		if m.Type == typ {
+			return true
+		}
+	}
+	return false
+}

--- a/capability/assembler/config.go
+++ b/capability/assembler/config.go
@@ -1,6 +1,7 @@
 package assembler
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/schema"
@@ -33,18 +34,17 @@ func genConfig(moduleType string, reg *schema.ModuleSchemaRegistry) (map[string]
 	if s == nil {
 		return nil, false
 	}
-	cfg := map[string]any{}
-	for k, v := range s.DefaultConfig {
-		cfg[k] = v
-	}
-	for _, f := range s.ConfigFields {
+	cfg := make(map[string]any, len(s.DefaultConfig))
+	maps.Copy(cfg, s.DefaultConfig)
+	for i := range s.ConfigFields {
+		f := &s.ConfigFields[i] // pointer: avoid 200B per-iter copy (gocritic rangeValCopy)
 		if _, set := cfg[f.Key]; set {
 			continue
 		}
 		if !f.Required {
 			continue // optional + no default -> omit (clean scaffold)
 		}
-		cfg[f.Key] = placeholderFor(moduleType, f)
+		cfg[f.Key] = placeholderFor(moduleType, *f)
 	}
 	return cfg, true
 }

--- a/capability/assembler/config.go
+++ b/capability/assembler/config.go
@@ -1,0 +1,98 @@
+package assembler
+
+import (
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+// defaultName derives a module instance name from its type (last segment):
+// http.server -> "server" ; auth.jwt -> "jwt" ; database.workflow -> "workflow".
+func defaultName(typ string) string {
+	for i := len(typ) - 1; i >= 0; i-- {
+		if typ[i] == '.' || typ[i] == ':' {
+			return typ[i+1:]
+		}
+	}
+	return typ
+}
+
+// envPrefix derives the module-type segment for env-var namespacing (P2b):
+// auth.jwt -> JWT ; database.workflow -> WORKFLOW ; disambiguates multi-module scaffolds.
+func envPrefix(moduleType string) string {
+	return strings.ToUpper(snakeCase(defaultName(moduleType)))
+}
+
+// genConfig produces a starter config for moduleType from the registry:
+// DefaultConfig as base; for every Required field lacking a default, emit a
+// placeholder — namespaced ${<TYPESEG>_<FIELD>} when Sensitive (V4, P2b), else
+// the schema Placeholder or a type-sensible default. ok=false if type ∉ registry
+// (existence gate, D6).
+func genConfig(moduleType string, reg *schema.ModuleSchemaRegistry) (map[string]any, bool) {
+	s := reg.Get(moduleType)
+	if s == nil {
+		return nil, false
+	}
+	cfg := map[string]any{}
+	for k, v := range s.DefaultConfig {
+		cfg[k] = v
+	}
+	for _, f := range s.ConfigFields {
+		if _, set := cfg[f.Key]; set {
+			continue
+		}
+		if !f.Required {
+			continue // optional + no default -> omit (clean scaffold)
+		}
+		cfg[f.Key] = placeholderFor(moduleType, f)
+	}
+	return cfg, true
+}
+
+// placeholderFor returns the starter value for a required field without a default.
+// Sensitive -> namespaced env ref ${<TYPESEG>_<FIELD>} (P2b, e.g. auth.jwt/secret
+// -> ${JWT_SECRET}); else Placeholder or a type-sensible default (select -> first
+// Option, P2: database.workflow.driver).
+func placeholderFor(moduleType string, f schema.ConfigFieldDef) any {
+	if f.Sensitive {
+		return "${" + envPrefix(moduleType) + "_" + strings.ToUpper(snakeCase(f.Key)) + "}"
+	}
+	if f.Placeholder != "" {
+		return f.Placeholder
+	}
+	return zeroFor(f)
+}
+
+func zeroFor(f schema.ConfigFieldDef) any {
+	switch f.Type {
+	case schema.FieldTypeSelect:
+		if len(f.Options) > 0 {
+			return f.Options[0] // valid select default (P2)
+		}
+		return ""
+	case schema.FieldTypeString, schema.FieldTypeDuration, schema.FieldTypeSQL, schema.FieldTypeFilePath:
+		return ""
+	case schema.FieldTypeNumber:
+		return 0
+	case schema.FieldTypeBool:
+		return false
+	default:
+		return ""
+	}
+}
+
+// snakeCase converts camelCase/json keys to UPPER_SNAKE for env-var refs.
+// (e.g. tokenExpiry -> TOKEN_EXPIRY; dsn -> DSN; accessKeyId -> ACCESS_KEY_ID).
+func snakeCase(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			b.WriteByte('_')
+		}
+		if r >= 'a' && r <= 'z' {
+			r -= 'a' - 'A'
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/capability/assembler/config_test.go
+++ b/capability/assembler/config_test.go
@@ -1,0 +1,57 @@
+package assembler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+func TestGenConfig_DefaultsPlusSensitiveEnv(t *testing.T) {
+	// auth.jwt: secret (Required+Sensitive) -> ${JWT_SECRET}; tokenExpiry/issuer defaults present
+	reg := schema.NewModuleSchemaRegistry() // has real auth.jwt registered
+	cfg, ok := genConfig("auth.jwt", reg)
+	if !ok {
+		t.Fatal("expected auth.jwt in registry")
+	}
+	if cfg["secret"] != "${JWT_SECRET}" {
+		t.Fatalf("secret=%v want ${JWT_SECRET}", cfg["secret"])
+	}
+	if cfg["tokenExpiry"] != "24h" {
+		t.Fatalf("tokenExpiry=%v want 24h", cfg["tokenExpiry"])
+	}
+	if cfg["issuer"] != "workflow" {
+		t.Fatalf("issuer=%v want workflow", cfg["issuer"])
+	}
+}
+
+func TestGenConfig_UnknownTypeReturnsFalse(t *testing.T) {
+	reg := schema.NewModuleSchemaRegistry()
+	if _, ok := genConfig("no.such.type", reg); ok {
+		t.Fatal("want ok=false for unknown type (existence gate, D6)")
+	}
+}
+
+func TestGenConfig_DSNAsEnv(t *testing.T) {
+	reg := schema.NewModuleSchemaRegistry() // database.workflow.dsn Required+Sensitive
+	cfg, ok := genConfig("database.workflow", reg)
+	if !ok {
+		t.Fatal("expected database.workflow in registry")
+	}
+	if cfg["dsn"] != "${WORKFLOW_DSN}" {
+		t.Fatalf("dsn=%v want ${WORKFLOW_DSN}", cfg["dsn"])
+	} // namespaced (P2b)
+	_ = reflect.DeepEqual // keep import if unused by other asserts
+}
+
+func TestGenConfig_SelectRequiredGetsFirstOption(t *testing.T) {
+	// database.workflow.driver: FieldTypeSelect, Required, no default -> first Option (P2)
+	reg := schema.NewModuleSchemaRegistry()
+	cfg, ok := genConfig("database.workflow", reg)
+	if !ok {
+		t.Fatal("expected database.workflow in registry")
+	}
+	if cfg["driver"] == "" {
+		t.Fatalf("driver empty — want first select option (P2), cfg=%+v", cfg)
+	}
+}

--- a/capability/assembler/config_test.go
+++ b/capability/assembler/config_test.go
@@ -1,7 +1,6 @@
 package assembler
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/schema"
@@ -41,7 +40,6 @@ func TestGenConfig_DSNAsEnv(t *testing.T) {
 	if cfg["dsn"] != "${WORKFLOW_DSN}" {
 		t.Fatalf("dsn=%v want ${WORKFLOW_DSN}", cfg["dsn"])
 	} // namespaced (P2b)
-	_ = reflect.DeepEqual // keep import if unused by other asserts
 }
 
 func TestGenConfig_SelectRequiredGetsFirstOption(t *testing.T) {

--- a/capability/assembler/select.go
+++ b/capability/assembler/select.go
@@ -1,0 +1,100 @@
+package assembler
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+// selectModules runs greedy module-level set-cover over requested capability IDs.
+// Candidates = raw "module:<type>" strings on inventory.Provider.Capabilities[]
+// (⊥ NOT recommend.ProviderSummary — drops them, design D1). Tie-break:
+// (coverage desc, in-registry first, type-name asc) — deterministic (V2, D8).
+func selectModules(inv *inventory.Inventory, requested []string, reg *schema.ModuleSchemaRegistry) (selected []string, unmatched []string) {
+	want := map[string]bool{}
+	for _, c := range requested {
+		want[c] = true
+	}
+	// coverage: type -> set of requested caps it covers
+	cov := map[string]map[string]bool{}
+	for i := range inv.Capabilities {
+		cap := &inv.Capabilities[i]
+		if !want[cap.ID] {
+			continue
+		}
+		for j := range cap.Providers {
+			for _, raw := range cap.Providers[j].Capabilities {
+				typeName, ok := moduleTypeOf(raw)
+				if !ok {
+					continue
+				}
+				if cov[typeName] == nil {
+					cov[typeName] = map[string]bool{}
+				}
+				cov[typeName][cap.ID] = true
+			}
+		}
+	}
+	covered := map[string]bool{}
+	for len(covered) < len(want) {
+		best, bestUncovered := "", 0
+		for typ := range cov {
+			uncovered := 0
+			for c := range cov[typ] {
+				if !covered[c] {
+					uncovered++
+				}
+			}
+			if uncovered == 0 {
+				continue
+			}
+			if betterCandidate(typ, uncovered, reg, best, bestUncovered) {
+				best, bestUncovered = typ, uncovered
+			}
+		}
+		if best == "" {
+			break
+		}
+		selected = append(selected, best)
+		for c := range cov[best] {
+			covered[c] = true
+		}
+		delete(cov, best)
+	}
+	sort.Strings(selected)
+	// unmatched: requested caps never covered, in input order
+	seen := map[string]bool{}
+	for _, c := range requested {
+		if !covered[c] && !seen[c] {
+			unmatched = append(unmatched, c)
+			seen[c] = true
+		}
+	}
+	return selected, unmatched
+}
+
+// betterCandidate implements the deterministic tie-break (D8).
+func betterCandidate(typ string, uncovered int, reg *schema.ModuleSchemaRegistry, best string, bestUncovered int) bool {
+	if best == "" {
+		return true
+	}
+	if uncovered != bestUncovered {
+		return uncovered > bestUncovered
+	}
+	typInReg, bestInReg := reg.Get(typ) != nil, reg.Get(best) != nil
+	if typInReg != bestInReg {
+		return typInReg // prefer config-generatable (builtin-core)
+	}
+	return typ < best // name ascending
+}
+
+// moduleTypeOf strips the "module:" prefix from a raw inventory capability string.
+func moduleTypeOf(raw string) (string, bool) {
+	const prefix = "module:"
+	if !strings.HasPrefix(raw, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(raw, prefix), true
+}

--- a/capability/assembler/select_test.go
+++ b/capability/assembler/select_test.go
@@ -1,0 +1,97 @@
+package assembler
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+func regWith(types ...string) *schema.ModuleSchemaRegistry {
+	r := schema.NewModuleSchemaRegistry()
+	for _, t := range types {
+		if r.Get(t) == nil {
+			r.Register(&schema.ModuleSchema{Type: t, ConfigFields: nil})
+		}
+	}
+	return r
+}
+
+func cap(id string, providers ...inventory.Provider) inventory.Capability {
+	return inventory.Capability{ID: id, Providers: providers}
+}
+func prov(name, kind string, rawCaps ...string) inventory.Provider {
+	return inventory.Provider{Name: name, Kind: kind, Capabilities: rawCaps}
+}
+
+func TestSelect_GreedyCoversAllRequestedCaps(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		cap("http.routing", prov("http", "builtin", "module:http.server", "module:http.router")),
+		cap("observability.health", prov("observability", "builtin", "module:health.checker")),
+	}}
+	reg := regWith("http.server", "http.router", "health.checker")
+	got, unmatched := selectModules(inv, []string{"http.routing", "observability.health"}, reg)
+	// one type covers http.routing (set-cover picks http.server OR http.router; both cover only http.routing → 1 pick)
+	if len(unmatched) != 0 {
+		t.Fatalf("unmatched=%v want none", unmatched)
+	}
+	if !contains(got, "health.checker") {
+		t.Fatalf("got=%v want health.checker", got)
+	}
+}
+
+func TestSelect_RegistryPreferredTieBreak(t *testing.T) {
+	// auth.authn offered by a builtin (auth.jwt, in registry) + a plugin (auth.credential, NOT in registry)
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		cap("auth.authn",
+			prov("auth", "builtin", "module:auth.jwt", "module:auth.credential")),
+	}}
+	reg := regWith("auth.jwt") // auth.credential deliberately absent from registry
+	got, unmatched := selectModules(inv, []string{"auth.authn"}, reg)
+	if len(unmatched) != 0 || len(got) != 1 || got[0] != "auth.jwt" {
+		t.Fatalf("got=%v unmatched=%v want [auth.jwt]", got, unmatched)
+	}
+}
+
+func TestSelect_UnmatchedWhenNoModuleCandidate(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		cap("auth.sso", prov("sso", "external", "wiringHook:sso")), // no module:* → D17
+	}}
+	reg := regWith()
+	got, unmatched := selectModules(inv, []string{"auth.sso"}, reg)
+	if len(got) != 0 || len(unmatched) != 1 || unmatched[0] != "auth.sso" {
+		t.Fatalf("got=%v unmatched=%v want unmatched=[auth.sso]", got, unmatched)
+	}
+}
+
+func TestSelect_DeterministicAcrossMapOrder(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		cap("http.routing", prov("http", "builtin", "module:http.server", "module:http.router")),
+	}}
+	reg := regWith("http.server", "http.router")
+	a, _ := selectModules(inv, []string{"http.routing"}, reg)
+	b, _ := selectModules(inv, []string{"http.routing"}, reg)
+	if !equalStrings(a, b) {
+		t.Fatalf("non-deterministic: %v vs %v", a, b)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/capability/assembler/types.go
+++ b/capability/assembler/types.go
@@ -1,0 +1,37 @@
+// Package assembler composes a structurally-valid workflow scaffold from a
+// chosen capability set (+ optional explicit modules). Pure + deterministic.
+package assembler
+
+import "github.com/GoCodeAlone/workflow/config"
+
+// AssembledApp is the assembler output: module instances + a workflows.http
+// section (so http.server gets AddRouter at boot via ConfigureWorkflow — P1),
+// required external plugins, findings (NEXT_STEPS), + unmatched requested caps.
+type AssembledApp struct {
+	Modules   []config.ModuleConfig
+	Workflows map[string]any // {http: {server: <name>, router: <name>}} — P1
+	Requires  config.RequiresConfig
+	Findings  []Finding
+	Unmatched []string
+}
+
+// Finding is a NEXT_STEPS item (V8 honest wiring).
+type Finding struct {
+	Level   string // "info" | "warn"
+	Code    string
+	Message string
+}
+
+// AssemblyInput is the parsed --set payload.
+type AssemblyInput struct {
+	Capabilities []string         `json:"capabilities"`
+	Modules      []ExplicitModule `json:"modules"`
+	Goal         string           `json:"goal"`
+}
+
+// ExplicitModule is an agent-pinned/injected module instance.
+type ExplicitModule struct {
+	Type   string         `json:"type"`
+	Name   string         `json:"name,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
+}

--- a/capability/assembler/wiring.go
+++ b/capability/assembler/wiring.go
@@ -1,0 +1,83 @@
+package assembler
+
+import "github.com/GoCodeAlone/workflow/config"
+
+// wire applies the thin in-code wiring-rules table (D4: NOT recipes, NOT a data dir):
+//  1. ensure an entry-point module exists (http.server) — required by checkEntryPoints (V3)
+//  2. http.router depends on http.server
+//  3. middleware chain depends on the router
+//  4. auth.* depends on the rate-limit/middleware predecessor (best-effort)
+//  5. health.checker is present alongside http.router so the observability
+//     health-endpoints wiring hook can bind /healthz at boot (D15)
+//
+// It mutates mods in place and returns the (possibly appended) slice.
+func wire(mods []config.ModuleConfig) []config.ModuleConfig {
+	server := findType(mods, "http.server")
+	if server == nil {
+		mods = append(mods, config.ModuleConfig{Name: "server", Type: "http.server",
+			Config: map[string]any{"address": ":8080"}})
+		server = &mods[len(mods)-1]
+	}
+	router := findType(mods, "http.router")
+	if router == nil {
+		mods = append(mods, config.ModuleConfig{Name: "router", Type: "http.router",
+			DependsOn: []string{server.Name}})
+		router = &mods[len(mods)-1]
+	} else if !dependsOn(router, server.Name) {
+		router.DependsOn = append(router.DependsOn, server.Name)
+	}
+	// middleware -> router
+	for i := range mods {
+		if isMiddleware(mods[i].Type) && !dependsOn(&mods[i], router.Name) {
+			mods[i].DependsOn = append(mods[i].DependsOn, router.Name)
+		}
+	}
+	// health.checker presence for /healthz auto-binding (D15)
+	if findType(mods, "health.checker") == nil {
+		mods = append(mods, config.ModuleConfig{Name: "health", Type: "health.checker"})
+	}
+	return mods
+}
+
+// findType returns a pointer to the first module of the given type, or nil.
+func findType(mods []config.ModuleConfig, typ string) *config.ModuleConfig {
+	for i := range mods {
+		if mods[i].Type == typ {
+			return &mods[i]
+		}
+	}
+	return nil
+}
+
+// dependsOn reports whether m declares name in its DependsOn list.
+func dependsOn(m *config.ModuleConfig, name string) bool {
+	for _, d := range m.DependsOn {
+		if d == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isMiddleware(t string) bool {
+	const p = "http.middleware."
+	return len(t) > len(p) && t[:len(p)] == p
+}
+
+// httpWorkflow returns the workflows.http section that attaches the router to the
+// server at boot. The engine runs ConfigureWorkflow only for workflowType=="http"
+// (engine.go:676), which calls server.AddRouter(router); WITHOUT this section
+// http.server.Start() fails "no router configured for HTTP server" (P1).
+func httpWorkflow(mods []config.ModuleConfig) map[string]any {
+	server := findType(mods, "http.server")
+	router := findType(mods, "http.router")
+	if server == nil || router == nil {
+		return map[string]any{} // wire() ensured both; defensive
+	}
+	return map[string]any{
+		"http": map[string]any{
+			"server": server.Name,
+			"router": router.Name,
+		},
+	}
+}

--- a/capability/assembler/wiring_test.go
+++ b/capability/assembler/wiring_test.go
@@ -1,0 +1,63 @@
+package assembler
+
+import (
+	"github.com/GoCodeAlone/workflow/config"
+	"testing"
+)
+
+func TestWire_EnsuresEntryPointAndRouterChain(t *testing.T) {
+	mods := []config.ModuleConfig{
+		{Name: "db", Type: "database.workflow"},
+		{Name: "auth", Type: "auth.jwt"},
+	}
+	// wire appends (may reallocate); reassign from return (retro lesson #1).
+	mods = wire(mods)
+	// http.server auto-added as entry point (none present) ; http.router added + depends on server
+	if findType(mods, "http.server") == nil {
+		t.Fatal("want http.server entry point auto-added")
+	}
+	if r := findType(mods, "http.router"); r == nil || !dependsOn(r, serverName(mods)) {
+		t.Fatal("want http.router depending on the http.server")
+	}
+}
+
+func TestWire_NoDuplicateServerWhenPresent(t *testing.T) {
+	mods := []config.ModuleConfig{{Name: "srv", Type: "http.server"}}
+	mods = wire(mods)
+	count := 0
+	for _, m := range mods {
+		if m.Type == "http.server" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want exactly 1 http.server, got %d", count)
+	}
+}
+
+func serverName(mods []config.ModuleConfig) string {
+	for i := range mods {
+		if mods[i].Type == "http.server" {
+			return mods[i].Name
+		}
+	}
+	return ""
+}
+
+func TestWire_HttpWorkflowSection(t *testing.T) {
+	mods := wire([]config.ModuleConfig{{Name: "db", Type: "database.workflow"}})
+	wf := httpWorkflow(mods)
+	http, ok := wf["http"].(map[string]any)
+	if !ok || http["server"] == nil || http["router"] == nil {
+		t.Fatalf("want workflows.http{server,router}, got %+v", wf) // P1
+	}
+}
+
+func TestWire_RouterDependsOnExplicitServerName(t *testing.T) {
+	// explicit http.server named "api" -> auto-added router depends on "api" (P6)
+	mods := wire([]config.ModuleConfig{{Name: "api", Type: "http.server"}})
+	r := findType(mods, "http.router")
+	if r == nil || !dependsOn(r, "api") {
+		t.Fatalf("want router depending on explicit 'api' server, got %+v", r) // P6
+	}
+}

--- a/cmd/wfctl/capability.go
+++ b/cmd/wfctl/capability.go
@@ -41,6 +41,8 @@ func runCapabilityWithOutput(args []string, out io.Writer) error {
 		return runCapabilityRecommend(args[1:], out)
 	case "build":
 		return runCapabilityBuild(args[1:], out)
+	case "assemble":
+		return runCapabilityAssemble(args[1:], out)
 	case "-h", "--help", "help":
 		printCapabilityUsage(out)
 		return nil
@@ -61,6 +63,7 @@ Subcommands:
   check      Print detected capabilities and findings for an application
   recommend  Recommend plugins that provide requested capabilities
   build      Interactively select capabilities and emit a recommendation
+  assemble   Assemble a minimal workflow config from selected capabilities
 
 Use "wfctl capability <subcommand> -h" for subcommand options.`)
 }

--- a/cmd/wfctl/capability_assemble.go
+++ b/cmd/wfctl/capability_assemble.go
@@ -164,7 +164,9 @@ func resolveOutDir(outDir string, force bool) (string, error) {
 		resolved = abs // target doesn't exist yet
 	}
 	cwd, _ := os.Getwd()
-	if !strings.HasPrefix(resolved, cwd) && !force {
+	// Containment uses cwd + separator so "/tmp/app2" is NOT accepted as inside
+	// cwd "/tmp/app" (Copilot: bare HasPrefix(resolved, cwd) was bypassable).
+	if resolved != cwd && !strings.HasPrefix(resolved, cwd+string(filepath.Separator)) && !force {
 		return "", fmt.Errorf("--out %q resolves outside cwd (%s); use --force to allow", resolved, cwd)
 	}
 	return resolved, nil
@@ -186,10 +188,13 @@ func emit(outDir string, app *assembler.AssembledApp, in assembler.AssemblyInput
 	if err := os.WriteFile(filepath.Join(outDir, "workflow.yaml"), wfYAML, 0o600); err != nil {
 		return err
 	}
-	appYAML, _ := yaml.Marshal(map[string]any{
+	appYAML, err := yaml.Marshal(map[string]any{
 		"application": map[string]any{"name": "assembled-app", "version": "0.1.0"},
 		"requires":    app.Requires,
 	})
+	if err != nil {
+		return fmt.Errorf("marshal app.yaml: %w", err)
+	}
 	if err := os.WriteFile(filepath.Join(outDir, "app.yaml"), appYAML, 0o600); err != nil {
 		return err
 	}
@@ -258,8 +263,8 @@ func renderNextSteps(app *assembler.AssembledApp, in assembler.AssemblyInput) st
 		fmt.Fprintln(&b)
 	}
 
-	if goalHash := hashGoal(in.Goal); goalHash != "sha256:" {
-		fmt.Fprintf(&b, "_goal hash: %s_\n", goalHash)
+	if in.Goal != "" { // print only when a goal was provided (Copilot: hashGoal never returns bare "sha256:")
+		fmt.Fprintf(&b, "_goal hash: %s_\n", hashGoal(in.Goal))
 	}
 	return b.String()
 }
@@ -294,8 +299,10 @@ func writeAssembleAudit(app *assembler.AssembledApp, in assembler.AssemblyInput)
 	if err != nil {
 		return fmt.Errorf("audit: open %s: %w", path, err)
 	}
-	defer f.Close() //nolint:errcheck
 	_, err = fmt.Fprintf(f, "%s\n", line)
+	if cerr := f.Close(); cerr != nil && err == nil { // check Close (code-quality: was unhandled defer)
+		err = cerr
+	}
 	return err
 }
 

--- a/cmd/wfctl/capability_assemble.go
+++ b/cmd/wfctl/capability_assemble.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/capability/assembler"
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/schema"
+	"gopkg.in/yaml.v3"
+)
+
+// runCapabilityAssemble implements `wfctl capability assemble --set <f|@f|-> --out <dir> [--force]`.
+// It parses a capability set, validates canonical taxonomy IDs (D3), resolves a
+// path-safe output dir (D14), runs inventory.CollectEcosystem + assembler.Assemble
+// (V3 fail-closed), emits workflow.yaml + app.yaml + NEXT_STEPS.md, and appends an
+// audit record (V9). Unmatched capabilities are surfaced as a warning, not an error.
+func runCapabilityAssemble(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("capability assemble", flag.ContinueOnError)
+	fs.SetOutput(out)
+	var setSpec, outDir string
+	var registryDir, repoRoot, taxonomyPath string
+	var force bool
+	fs.StringVar(&setSpec, "set", "", "capability set JSON: file path, @file, - (stdin), or inline JSON")
+	fs.StringVar(&outDir, "out", "", "output directory (must be within cwd unless --force)")
+	fs.StringVar(&registryDir, "registry", defaultCapabilityRegistryPath(), "registry directory")
+	fs.StringVar(&repoRoot, "repo-root", "..", "workspace root containing workflow-plugin-* repos")
+	fs.StringVar(&taxonomyPath, "taxonomy", defaultCapabilityTaxonomyPath(), "capability taxonomy YAML")
+	fs.BoolVar(&force, "force", false, "overwrite existing --out + allow absolute/out-of-cwd paths")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if setSpec == "" || outDir == "" {
+		return errors.New("capability assemble: --set and --out are required")
+	}
+
+	in, err := parseAssemblySet(setSpec, fs) // file / @file / - / inline
+	if err != nil {
+		return err
+	}
+
+	tax, err := inventory.LoadTaxonomy(taxonomyPath)
+	if err != nil {
+		return fmt.Errorf("load taxonomy: %w", err)
+	}
+	if err := validateCanonicalIDs(in.Capabilities, tax); err != nil {
+		return err // includes did-you-mean (D3)
+	}
+
+	// --out path-safety (D14): resolve + reject out-of-cwd/system unless --force
+	resolved, err := resolveOutDir(outDir, force)
+	if err != nil {
+		return err
+	}
+
+	inv, err := inventory.CollectEcosystem(inventory.EcosystemOptions{
+		RegistryDir:     registryDir,
+		RepoRoot:        repoRoot,
+		TaxonomyPath:    taxonomyPath,
+		GeneratedAt:     nowUTC(),
+		WorkflowVersion: version,
+	})
+	if err != nil {
+		return err
+	}
+
+	app, err := assembler.Assemble(inv, in, schema.NewModuleSchemaRegistry())
+	if err != nil {
+		return err // V3 fail-closed already fired inside Assemble
+	}
+	if !force {
+		if _, err := os.Stat(resolved); err == nil {
+			return fmt.Errorf("capability assemble: %s exists (use --force to overwrite)", resolved)
+		}
+	}
+	if err := emit(resolved, app, in); err != nil {
+		return err
+	}
+	if err := writeAssembleAudit(app, in); err != nil {
+		return err // V9
+	}
+	if len(app.Unmatched) > 0 {
+		fmt.Fprintf(out, "WARN unmatched capabilities (see NEXT_STEPS.md): %s\n", strings.Join(app.Unmatched, ", "))
+	}
+	fmt.Fprintf(out, "assembled %d module(s) into %s\n", len(app.Modules), resolved)
+	return nil
+}
+
+// parseAssemblySet resolves the --set argument to an AssemblyInput. Supported
+// shapes: file path, "@file", "-" (stdin), or an inline JSON literal beginning
+// with '{'. Rejects an empty capabilities∪modules set (D7).
+func parseAssemblySet(spec string, fs *flag.FlagSet) (assembler.AssemblyInput, error) {
+	var data []byte
+	var err error
+	switch {
+	case spec == "-":
+		data, err = io.ReadAll(os.Stdin)
+	case strings.HasPrefix(spec, "@"):
+		data, err = os.ReadFile(strings.TrimPrefix(spec, "@"))
+	case strings.HasPrefix(spec, "{"):
+		data = []byte(spec) // inline JSON literal
+	default:
+		data, err = os.ReadFile(spec) // file path
+	}
+	if err != nil {
+		return assembler.AssemblyInput{}, fmt.Errorf("read --set: %w", err)
+	}
+	var in assembler.AssemblyInput
+	if err := json.Unmarshal(data, &in); err != nil {
+		return assembler.AssemblyInput{}, fmt.Errorf("parse --set JSON: %w", err)
+	}
+	if len(in.Capabilities) == 0 && len(in.Modules) == 0 {
+		return assembler.AssemblyInput{}, errors.New("--set: at least one capability or module is required (D7)")
+	}
+	return in, nil
+}
+
+// validateCanonicalIDs requires every requested ID to be a canonical taxonomy id
+// (taxonomy.ByID, D3). On the first unknown id it returns an error with up to 3
+// nearest canonical candidates (did-you-mean). Bare aliases / keywords are rejected
+// so the assembler never silently no-ops on a mis-spelled capability.
+func validateCanonicalIDs(ids []string, tax *inventory.Taxonomy) error {
+	var known []string
+	for _, id := range ids {
+		if _, ok := tax.ByID(id); ok {
+			continue
+		}
+		if known == nil {
+			for i := range tax.Capabilities { // index → avoid 488B per-iter copy (gocritic)
+				known = append(known, tax.Capabilities[i].ID)
+			}
+			sort.Strings(known)
+		}
+		return fmt.Errorf("capability %q is not a canonical taxonomy id; nearest: %s", id, strings.Join(nearest(id, known, 3), ", "))
+	}
+	return nil
+}
+
+// resolveOutDir hardens --out against symlink/path traversal (D14). It resolves
+// to an absolute path, evaluates symlinks (falling back to abs when the target
+// does not yet exist), and rejects paths outside cwd unless --force is set.
+func resolveOutDir(outDir string, force bool) (string, error) {
+	abs, err := filepath.Abs(outDir)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if resolved == "" {
+		resolved = abs // target doesn't exist yet
+	}
+	cwd, _ := os.Getwd()
+	if !strings.HasPrefix(resolved, cwd) && !force {
+		return "", fmt.Errorf("--out %q resolves outside cwd (%s); use --force to allow", resolved, cwd)
+	}
+	return resolved, nil
+}
+
+// emit writes workflow.yaml + app.yaml + NEXT_STEPS.md into outDir. workflow.yaml
+// is rendered via assembler.MarshalConfig (P4: shared pure fn — also used by the
+// MC2-bis boot test, avoiding a cmd/wfctl <-> capability/assembler import cycle).
+// Permissions: dir 0750, files 0600 (repo convention; stricter than the plan's
+// 0640, which gosec G306 rejects — scaffold files may contain ${SECRET} env refs).
+func emit(outDir string, app *assembler.AssembledApp, in assembler.AssemblyInput) error {
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
+		return err
+	}
+	wfYAML, err := assembler.MarshalConfig(app)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "workflow.yaml"), wfYAML, 0o600); err != nil {
+		return err
+	}
+	appYAML, _ := yaml.Marshal(map[string]any{
+		"application": map[string]any{"name": "assembled-app", "version": "0.1.0"},
+		"requires":    app.Requires,
+	})
+	if err := os.WriteFile(filepath.Join(outDir, "app.yaml"), appYAML, 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, "NEXT_STEPS.md"), []byte(renderNextSteps(app, in)), 0o600)
+}
+
+// renderNextSteps emits the markdown manual-wiring guide (V8): external-plugin
+// install cmds, ${SECRET} env exports, manual-wiring findings, and a DB note
+// when a database module is present. Pure; deterministic.
+func renderNextSteps(app *assembler.AssembledApp, in assembler.AssemblyInput) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "# NEXT STEPS")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Assembled scaffold generated by `wfctl capability assemble`. Complete the wiring before boot:")
+	fmt.Fprintln(&b)
+
+	if len(app.Requires.Plugins) > 0 {
+		fmt.Fprintln(&b, "## Install external plugins")
+		for _, p := range app.Requires.Plugins {
+			fmt.Fprintf(&b, "- `wfctl plugin install %s", p.Name)
+			if p.Version != "" {
+				fmt.Fprintf(&b, "@%s", p.Version)
+			}
+			fmt.Fprintln(&b, "`")
+		}
+		fmt.Fprintln(&b)
+	}
+
+	if refs := secretRefs(app); len(refs) > 0 {
+		fmt.Fprintln(&b, "## Provide secrets")
+		for _, name := range refs {
+			fmt.Fprintf(&b, "- `export %s=...`\n", name)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	var manualWiring []assembler.Finding
+	for _, f := range app.Findings {
+		if f.Code == "no-schema" {
+			manualWiring = append(manualWiring, f)
+		}
+	}
+	if len(manualWiring) > 0 {
+		fmt.Fprintln(&b, "## Manual wiring required")
+		for _, f := range manualWiring {
+			fmt.Fprintf(&b, "- [%s] %s\n", f.Level, f.Message)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	for _, m := range app.Modules {
+		if m.Type == "database.workflow" || strings.HasPrefix(m.Type, "database.") {
+			fmt.Fprintln(&b, "## Database setup")
+			fmt.Fprintln(&b, "- The scaffold includes a database module. Create the DB file / DSN before boot.")
+			fmt.Fprintln(&b, "  For local sqlite: `touch ./app.db` and set the `dsn` field accordingly.")
+			fmt.Fprintln(&b)
+			break
+		}
+	}
+
+	if len(app.Unmatched) > 0 {
+		fmt.Fprintln(&b, "## Unmatched requested capabilities")
+		for _, id := range app.Unmatched {
+			fmt.Fprintf(&b, "- %s (no module candidate in inventory; add a provider plugin or an explicit `modules` entry in --set)\n", id)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	if goalHash := hashGoal(in.Goal); goalHash != "sha256:" {
+		fmt.Fprintf(&b, "_goal hash: %s_\n", goalHash)
+	}
+	return b.String()
+}
+
+// writeAssembleAudit appends one JSONL record to the assemble audit log (V9).
+// Path + perms mirror secrets_audit.go (D4). The record stores the goal HASH
+// (⊥ raw goal, D11) — never the raw goal text, which may be sensitive.
+func writeAssembleAudit(app *assembler.AssembledApp, in assembler.AssemblyInput) error {
+	path, err := assembleAuditPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("audit: create dir: %w", err)
+	}
+	moduleTypes := make([]string, 0, len(app.Modules))
+	for _, m := range app.Modules {
+		moduleTypes = append(moduleTypes, m.Type)
+	}
+	sort.Strings(moduleTypes)
+	rec := map[string]any{
+		"ts":           nowUTC().Format(time.RFC3339),
+		"capabilities": in.Capabilities,
+		"moduleTypes":  moduleTypes,
+		"goalHash":     hashGoal(in.Goal),
+	}
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("audit: marshal: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("audit: open %s: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck
+	_, err = fmt.Fprintf(f, "%s\n", line)
+	return err
+}
+
+// assembleAuditPath returns the audit JSONL path, honouring $XDG_STATE_HOME with
+// a $HOME/.local/state fallback (mirrors secrets_audit.go).
+func assembleAuditPath() (string, error) {
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		u, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		base = filepath.Join(u.HomeDir, ".local", "state")
+	}
+	return filepath.Join(base, "wfctl", "plugins", "wfctl", "assemble-audit.jsonl"), nil
+}
+
+// nearest returns up to n candidates closest to s by Levenshtein distance
+// (did-you-mean, D3). Ties broken by candidate name for determinism.
+func nearest(s string, cands []string, n int) []string {
+	if len(cands) == 0 {
+		return nil
+	}
+	type sc struct {
+		c string
+		d int
+	}
+	ss := make([]sc, 0, len(cands))
+	for _, c := range cands {
+		ss = append(ss, sc{c, levenshtein(strings.ToLower(s), strings.ToLower(c))})
+	}
+	sort.Slice(ss, func(i, j int) bool {
+		if ss[i].d != ss[j].d {
+			return ss[i].d < ss[j].d
+		}
+		return ss[i].c < ss[j].c
+	})
+	out := make([]string, 0, n)
+	for i := 0; i < n && i < len(ss); i++ {
+		out = append(out, ss[i].c)
+	}
+	return out
+}
+
+// levenshtein is the standard O(m*n) DP edit distance (stdlib-only).
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = minInt(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}
+
+// minInt returns the smallest of its args. Caller MUST pass ≥1 arg.
+func minInt(a ...int) int {
+	m := a[0]
+	for _, x := range a[1:] {
+		if x < m {
+			m = x
+		}
+	}
+	return m
+}
+
+// secretRefs lists "${NAME}" env-var refs across module configs (V4: NEXT_STEPS
+// export list). Top-level-only scan (P15: complete for flat genConfig output;
+// agent-injected nested configs are out of scope).
+var secretRefRe = regexp.MustCompile(`^\$\{([A-Z0-9_]+)\}$`)
+
+func secretRefs(app *assembler.AssembledApp) []string {
+	seen := map[string]bool{}
+	for i := range app.Modules {
+		for _, v := range app.Modules[i].Config {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			if m := secretRefRe.FindStringSubmatch(s); m != nil {
+				seen[m[1]] = true
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// hashGoal returns "sha256:<hex>" of the goal (⊥ raw goal in audit, D11).
+// Returns "sha256:" for an empty goal so callers can elide the line.
+func hashGoal(goal string) string {
+	sum := sha256.Sum256([]byte(goal))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// nowUTC returns the current UTC time. Wrapped for testability + single seam.
+func nowUTC() time.Time {
+	return time.Now().UTC()
+}

--- a/cmd/wfctl/capability_assemble_test.go
+++ b/cmd/wfctl/capability_assemble_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+)
+
+func TestParseAssemblySet_FileAtFileInline(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "set.json")
+	if err := os.WriteFile(p, []byte(`{"capabilities":["auth.authn"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, spec := range []string{p, "@" + p} {
+		in, err := parseAssemblySet(spec, nil)
+		if err != nil || len(in.Capabilities) != 1 || in.Capabilities[0] != "auth.authn" {
+			t.Fatalf("spec=%q in=%+v err=%v", spec, in, err)
+		}
+	}
+	// inline literal
+	in, err := parseAssemblySet(`{"capabilities":["http.routing"]}`, nil)
+	if err != nil || in.Capabilities[0] != "http.routing" {
+		t.Fatalf("inline: %+v %v", in, err)
+	}
+}
+
+func TestCanonicalIDs_RejectNonCanonicalWithDidYouMean(t *testing.T) {
+	// "auth" (bare) is NOT a canonical id -> error mentioning candidate(s)
+	err := validateCanonicalIDs([]string{"auth"}, taxonomyForTest(t))
+	if err == nil || !strings.Contains(err.Error(), "auth.authn") {
+		t.Fatalf("want did-you-mean mentioning auth.authn, got %v", err)
+	}
+}
+
+func TestAssembleCLI_DeterministicEmission(t *testing.T) {
+	// D14 path-safety rejects --out outside cwd unless --force is set; t.TempDir()
+	// lives under the system temp root, so the test passes --force (the D14 escape
+	// hatch) to scaffold into an absolute temp dir. The determinism assertion
+	// (byte-identical workflow.yaml across two runs) is unchanged.
+	out1 := t.TempDir()
+	out2 := t.TempDir()
+	set := filepath.Join(t.TempDir(), "set.json")
+	os.WriteFile(set, []byte(`{"capabilities":["observability.health","http.routing"]}`), 0o600)
+	var b bytes.Buffer
+	for _, out := range []string{out1, out2} {
+		if err := runCapabilityAssemble([]string{"--set", set, "--out", out, "--force"}, &b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w1, _ := os.ReadFile(filepath.Join(out1, "workflow.yaml"))
+	w2, _ := os.ReadFile(filepath.Join(out2, "workflow.yaml"))
+	if !bytes.Equal(w1, w2) {
+		t.Fatalf("MC5 determinism: outputs differ\n%s\n%s", w1, w2)
+	}
+}
+
+func TestAssembleCLI_OutPathRejectsSystemPathWithoutForce(t *testing.T) {
+	var b bytes.Buffer
+	set := filepath.Join(t.TempDir(), "set.json")
+	os.WriteFile(set, []byte(`{"capabilities":["observability.health"]}`), 0o600)
+	err := runCapabilityAssemble([]string{"--set", set, "--out", "/etc/cap-asm-test"}, &b)
+	if err == nil {
+		t.Fatal("want rejection of system/out-of-cwd --out without --force (D14)")
+	}
+}
+
+// taxonomyForTest loads the real checked-in taxonomy (same default path the CLI uses).
+func taxonomyForTest(t *testing.T) *inventory.Taxonomy {
+	t.Helper()
+	tax, err := inventory.LoadTaxonomy(defaultCapabilityTaxonomyPath())
+	if err != nil {
+		t.Fatalf("load taxonomy: %v", err)
+	}
+	return tax
+}


### PR DESCRIPTION
Implements the deferred **assemble** half of the capability-builder (recommend+build shipped in v0.81.0). Composes a structurally-valid + bootable workflow scaffold from a chosen capability set (+ optional explicit modules).

## What
- New pure package `capability/assembler/` (mirrors shipped `capability/recommend/`):
  - `select.go` — greedy **module-level set-cover** over `inventory.Provider.Capabilities[]` raw `module:*` strings (⊥ NOT `recommend.ProviderSummary`, which drops them). Deterministic tie-break (coverage → in-registry → name). **Not** quality ranking (D13 — inventory has no signal).
  - `config.go` — registry-driven config-gen from `schema.ModuleSchemaRegistry`: `DefaultConfig` + required fields (`Sensitive` → namespaced `${ENV}` like `${JWT_SECRET}`; `FieldTypeSelect` → first option).
  - `wiring.go` — thin in-code wiring rules: entry-point ensure, `http.router`→`http.server`, `health.checker` present, + **`httpWorkflow()` emits `workflows.http:{server,router}`** so `http.server` gets `AddRouter` at boot.
  - `assembler.go` — `Assemble()` orchestrator with the **real `schema.ValidateConfig` gate (fail-closed, V3)** + `MarshalConfig()`.
- `cmd/wfctl/capability_assemble.go` — `wfctl capability assemble --set <file|@file|-> --out ./myapp [--force]`: canonical-taxonomy-ID validation (did-you-mean), path-safe `--out` (EvalSymlinks + cwd-scope, agent-invocation trust boundary), audit JSONL (follows `secrets_audit.go` precedent; `sha256:` goal hash), two-tier `requires.plugins` (external only; builtins auto-loaded).
- Dispatch wired into the existing `wfctl capability` group.

## Design / plan
- Design: `GoCodeAlone/workspace` `docs/plans/2026-06-22-capability-assemble-design.md` (adversarial Cycle 2 PASS, D1–D20).
- Plan: `docs/plans/2026-06-22-capability-assemble.md` (plan adversarial Cycle 2 PASS, P1–P15).
- ADRs 0047 (⊥ no embedded LLM) + 0048 (engine builtins MVP).

## Verification
- `go test ./capability/assembler/ ./cmd/wfctl/` green (16 assembler + CLI tests incl. MC2 structural = real `schema.ValidateConfig` PASS, MC5 determinism = byte-identical, MC6 honest-wiring skip+Finding, requires.plugins scoping regression).
- `golangci-lint run --new-from-rev=origin/main` → 0 issues.
- Real `wfctl capability assemble --set {http.routing,...} --out /tmp/x --force` → workflow.yaml + app.yaml + NEXT_STEPS.md, exit 0; builtin-only request emits zero `requires.plugins`.

## Scope / follow-ups
- Compositional-only (recipes deferred — D14). MCP twin / external plugin / HTTP-SPA deferred (ADR 0048).
- **PR2** (separate, `feat/capability-assemble-boot`): MC2-bis in-process boot proofs (`boot_test.go` — minimal + representative) — the runtime-boot gate, NOT deferred.
- Known limitation: capabilities whose only providers lack registry manifests (e.g. `observability.health` via `health.checker`) report `unmatched` via the real `CollectEcosystem` path (resilient per V8/G5); the MC2-bis proofs use a synthetic inventory that includes them.

GOWORK=off for all go commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)