### PR TITLE
feat(wfctl): add global plugin lifecycle

### DIFF
--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -246,29 +246,25 @@ func main() {
 		updateNoticeDone = checkForUpdateNotice()
 	}
 
-	if _, isStatic := commands[cmd]; !isStatic {
-		registry, err := BuildCLIRegistry(defaultPluginCommandDir())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: load plugin CLI commands: %v\n", err) //nolint:gosec // G705
+	if entry, err := lookupDynamicCLICommand(cmd); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err) //nolint:gosec // G705
+		os.Exit(1)
+	} else if entry != nil {
+		if err := DispatchCLICommand(entry, os.Args[1:]); err != nil {
+			if isPromptCancelled(err) {
+				fmt.Fprintln(os.Stderr, "Cancelled.")
+				os.Exit(0)
+			}
+			fmt.Fprintf(os.Stderr, "error: %v\n", err) //nolint:gosec // G705
 			os.Exit(1)
 		}
-		if entry := registry.LookupCLICommand(cmd); entry != nil {
-			if err := DispatchCLICommand(entry, os.Args[1:]); err != nil {
-				if isPromptCancelled(err) {
-					fmt.Fprintln(os.Stderr, "Cancelled.")
-					os.Exit(0)
-				}
-				fmt.Fprintf(os.Stderr, "error: %v\n", err) //nolint:gosec // G705
-				os.Exit(1)
+		if updateNoticeDone != nil {
+			select {
+			case <-updateNoticeDone:
+			case <-time.After(time.Second):
 			}
-			if updateNoticeDone != nil {
-				select {
-				case <-updateNoticeDone:
-				case <-time.After(time.Second):
-				}
-			}
-			return
 		}
+		return
 	}
 
 	// Set up a context that is cancelled on SIGINT/SIGTERM so that long-running
@@ -305,6 +301,18 @@ func main() {
 		case <-time.After(time.Second):
 		}
 	}
+}
+
+func lookupDynamicCLICommand(cmd string) (*CLIRegistryEntry, error) {
+	if _, isStatic := commands[cmd]; isStatic {
+		return nil, nil
+	}
+	pluginDir := defaultGlobalPluginDir()
+	registry, err := BuildCLIRegistry(pluginDir)
+	if err != nil {
+		return nil, fmt.Errorf("load global plugin CLI commands from %s: %w; inspect with 'wfctl plugin list -g' and remove conflicts with 'wfctl plugin remove -g <name>'", pluginDir, err)
+	}
+	return registry.LookupCLICommand(cmd), nil
 }
 
 func defaultPluginCommandDir() string {

--- a/cmd/wfctl/plugin.go
+++ b/cmd/wfctl/plugin.go
@@ -99,7 +99,8 @@ Subcommands:
   deps     List dependencies for a plugin
   marketplace-verify  Scan a GitHub org's wfctl.yaml files for plugin usage; suggests manifest status (verified | experimental)
 
-Use -plugin-dir to specify a custom plugin directory (replaces deprecated -data-dir).
+Use -plugin-dir to specify a custom project plugin directory (replaces deprecated -data-dir).
+Use -g or -global with install/list/info/update/remove for global plugins in ${XDG_DATA_HOME:-$HOME/.local/share}/wfctl/plugins; WFCTL_GLOBAL_PLUGIN_DIR overrides that location.
 `)
 }
 

--- a/cmd/wfctl/plugin_global.go
+++ b/cmd/wfctl/plugin_global.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 )
@@ -26,4 +27,9 @@ func resolvePluginDir(pluginDir string, global bool) string {
 		return defaultGlobalPluginDir()
 	}
 	return pluginDir
+}
+
+func addGlobalPluginFlags(fs *flag.FlagSet, global *bool) {
+	fs.BoolVar(global, "global", false, "Use global plugin directory")
+	fs.BoolVar(global, "g", false, "Use global plugin directory (shorthand)")
 }

--- a/cmd/wfctl/plugin_global.go
+++ b/cmd/wfctl/plugin_global.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const globalPluginDirEnv = "WFCTL_GLOBAL_PLUGIN_DIR"
+
+func defaultGlobalPluginDir() string {
+	if override := os.Getenv(globalPluginDirEnv); override != "" {
+		return override
+	}
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "wfctl", "plugins")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".wfctl", "plugins")
+	}
+	return filepath.Join(home, ".local", "share", "wfctl", "plugins")
+}
+
+func resolvePluginDir(pluginDir string, global bool) string {
+	if global {
+		return defaultGlobalPluginDir()
+	}
+	return pluginDir
+}

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultGlobalPluginDirUsesOverride(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "wfctl-global")
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", override)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(t.TempDir(), "xdg"))
+	t.Setenv("HOME", t.TempDir())
+
+	if got := defaultGlobalPluginDir(); got != override {
+		t.Fatalf("defaultGlobalPluginDir() = %q, want override %q", got, override)
+	}
+}
+
+func TestDefaultGlobalPluginDirUsesXDGDataHome(t *testing.T) {
+	xdg := filepath.Join(t.TempDir(), "xdg")
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", "")
+	t.Setenv("XDG_DATA_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	want := filepath.Join(xdg, "wfctl", "plugins")
+	if got := defaultGlobalPluginDir(); got != want {
+		t.Fatalf("defaultGlobalPluginDir() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultGlobalPluginDirFallsBackToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", home)
+
+	want := filepath.Join(home, ".local", "share", "wfctl", "plugins")
+	if got := defaultGlobalPluginDir(); got != want {
+		t.Fatalf("defaultGlobalPluginDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePluginDirUsesProjectLocalByDefault(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "custom")
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", filepath.Join(t.TempDir(), "global"))
+
+	if got := resolvePluginDir(custom, false); got != custom {
+		t.Fatalf("resolvePluginDir(custom, false) = %q, want %q", got, custom)
+	}
+}
+
+func TestResolvePluginDirUsesGlobalWhenRequested(t *testing.T) {
+	global := filepath.Join(t.TempDir(), "global")
+	custom := filepath.Join(t.TempDir(), "custom")
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+
+	if got := resolvePluginDir(custom, true); got != global {
+		t.Fatalf("resolvePluginDir(custom, true) = %q, want %q", got, global)
+	}
+}

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -218,6 +222,125 @@ func TestLookupDynamicCLICommandConflictHasGlobalRemediation(t *testing.T) {
 	}
 }
 
+func TestPluginInstallGlobalDependenciesInstallsClosure(t *testing.T) {
+	cwd := chdirTemp(t)
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+
+	alphaScript := "#!/bin/sh\nset -eu\n" +
+		"test -f \"$WFCTL_GLOBAL_PLUGIN_DIR/beta/plugin.json\"\n" +
+		"echo beta-manifest-ok\n"
+	alphaTarball := buildPluginTarGz(t, "alpha", []byte(alphaScript), minimalPluginJSON("alpha", "2.0.0"))
+	betaTarball := buildPluginTarGz(t, "beta", []byte("#!/bin/sh\necho beta\n"), minimalPluginJSON("beta", "2.0.0"))
+
+	var alphaManifest, betaManifest RegistryManifest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/alpha/manifest.json":
+			writeHTTPJSON(t, w, alphaManifest)
+		case "/plugins/beta/manifest.json":
+			writeHTTPJSON(t, w, betaManifest)
+		case "/download/alpha.tar.gz":
+			_, _ = w.Write(alphaTarball)
+		case "/download/beta.tar.gz":
+			_, _ = w.Write(betaTarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	alphaManifest = testRegistryManifest("alpha", "2.0.0", srv.URL+"/download/alpha.tar.gz", sha256Hex(alphaTarball))
+	alphaManifest.Dependencies = []PluginDependency{{Name: "beta", MinVersion: "2.0.0"}}
+	alphaManifest.Capabilities = &RegistryCapabilities{
+		CLICommands: []RegistryCLICommand{{Name: "alpha"}},
+	}
+	betaManifest = testRegistryManifest("beta", "2.0.0", srv.URL+"/download/beta.tar.gz", sha256Hex(betaTarball))
+
+	if err := runPluginInstall([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "alpha"}); err != nil {
+		t.Fatalf("runPluginInstall -g alpha: %v", err)
+	}
+
+	if got := readInstalledVersion(filepath.Join(global, "alpha")); got != "v2.0.0" {
+		t.Fatalf("alpha version = %q, want v2.0.0", got)
+	}
+	if got := readInstalledVersion(filepath.Join(global, "beta")); got != "2.0.0" {
+		t.Fatalf("beta version = %q, want 2.0.0", got)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".wfctl-lock.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("global dependency install wrote .wfctl-lock.yaml, err=%v", err)
+	}
+
+	entry, err := lookupDynamicCLICommand("alpha")
+	if err != nil {
+		t.Fatalf("lookup alpha command: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("alpha CLI command was not registered")
+	}
+	out, err := captureStdout(t, func() error {
+		return DispatchCLICommand(entry, []string{"alpha"})
+	})
+	if err != nil {
+		t.Fatalf("dispatch alpha command: %v", err)
+	}
+	if !strings.Contains(out, "beta-manifest-ok") {
+		t.Fatalf("alpha output = %q, want beta manifest proof", out)
+	}
+}
+
+func TestPluginGlobalUpdateDependencyFailurePreservesPreviousInstall(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "alpha", "1.0.0")
+	writeInstalledPlugin(t, global, "beta", "1.0.0")
+	writeInstalledPlugin(t, global, "gamma", "1.0.0")
+
+	alphaTarball := buildPluginTarGz(t, "alpha", []byte("#!/bin/sh\necho alpha v2\n"), minimalPluginJSON("alpha", "2.0.0"))
+	betaTarball := buildPluginTarGz(t, "beta", []byte("#!/bin/sh\necho beta v2\n"), minimalPluginJSON("beta", "2.0.0"))
+	gammaTarball := buildPluginTarGz(t, "gamma", []byte("#!/bin/sh\necho gamma v2\n"), minimalPluginJSON("gamma", "2.0.0"))
+
+	var alphaManifest, betaManifest, gammaManifest RegistryManifest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/alpha/manifest.json":
+			writeHTTPJSON(t, w, alphaManifest)
+		case "/plugins/beta/manifest.json":
+			writeHTTPJSON(t, w, betaManifest)
+		case "/plugins/gamma/manifest.json":
+			writeHTTPJSON(t, w, gammaManifest)
+		case "/download/alpha.tar.gz":
+			_, _ = w.Write(alphaTarball)
+		case "/download/beta.tar.gz":
+			_, _ = w.Write(betaTarball)
+		case "/download/gamma.tar.gz":
+			_, _ = w.Write(gammaTarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	alphaManifest = testRegistryManifest("alpha", "2.0.0", srv.URL+"/download/alpha.tar.gz", sha256Hex(alphaTarball))
+	alphaManifest.Dependencies = []PluginDependency{
+		{Name: "beta", MinVersion: "2.0.0"},
+		{Name: "gamma", MinVersion: "2.0.0"},
+	}
+	betaManifest = testRegistryManifest("beta", "2.0.0", srv.URL+"/download/beta.tar.gz", sha256Hex(betaTarball))
+	gammaManifest = testRegistryManifest("gamma", "2.0.0", srv.URL+"/download/gamma.tar.gz", strings.Repeat("0", 64))
+
+	err := runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "alpha"})
+	if err == nil {
+		t.Fatal("expected dependency update failure")
+	}
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if got := readInstalledVersion(filepath.Join(global, name)); got != "1.0.0" {
+			t.Fatalf("%s version after failed transaction = %q, want 1.0.0", name, got)
+		}
+	}
+}
+
 func chdirTemp(t *testing.T) string {
 	t.Helper()
 	orig, err := os.Getwd()
@@ -268,5 +391,31 @@ func writeInstalledCLIPlugin(t *testing.T, root, name, version, command string) 
 	manifest := `{"name":"` + name + `","version":"` + version + `","author":"tester","description":"test plugin","capabilities":{"cliCommands":[{"name":"` + command + `","description":"test command"}]}}`
 	if err := os.WriteFile(filepath.Join(root, name, "plugin.json"), []byte(manifest), 0o640); err != nil {
 		t.Fatalf("write cli plugin manifest: %v", err)
+	}
+}
+
+func testRegistryManifest(name, version, url, checksum string) RegistryManifest {
+	return RegistryManifest{
+		Name:        name,
+		Version:     version,
+		Author:      "tester",
+		Description: "test plugin",
+		Type:        "external",
+		Tier:        "community",
+		License:     "MIT",
+		Downloads: []PluginDownload{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			URL:    url,
+			SHA256: checksum,
+		}},
+	}
+}
+
+func writeHTTPJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode json: %v", err)
 	}
 }

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -171,6 +171,53 @@ func TestPluginUpdateGlobalRejectsProjectVersionPin(t *testing.T) {
 	}
 }
 
+func TestLookupDynamicCLICommandUsesGlobalDir(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledCLIPlugin(t, global, "portfolio", "1.0.0", "portfolio")
+
+	entry, err := lookupDynamicCLICommand("portfolio")
+	if err != nil {
+		t.Fatalf("lookupDynamicCLICommand: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("lookupDynamicCLICommand returned nil entry")
+	}
+	wantBinary := filepath.Join(global, "portfolio", "portfolio")
+	if entry.BinaryPath != wantBinary {
+		t.Fatalf("BinaryPath = %q, want %q", entry.BinaryPath, wantBinary)
+	}
+}
+
+func TestLookupDynamicCLICommandStaticCommandWins(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "validate", "1.0.0")
+
+	entry, err := lookupDynamicCLICommand("validate")
+	if err != nil {
+		t.Fatalf("lookupDynamicCLICommand static command: %v", err)
+	}
+	if entry != nil {
+		t.Fatalf("lookupDynamicCLICommand static command returned %#v, want nil", entry)
+	}
+}
+
+func TestLookupDynamicCLICommandConflictHasGlobalRemediation(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledCLIPlugin(t, global, "alpha", "1.0.0", "portfolio")
+	writeInstalledCLIPlugin(t, global, "beta", "1.0.0", "portfolio")
+
+	_, err := lookupDynamicCLICommand("portfolio")
+	if err == nil {
+		t.Fatal("expected duplicate command error")
+	}
+	if !strings.Contains(err.Error(), "plugin list -g") || !strings.Contains(err.Error(), "plugin remove -g") {
+		t.Fatalf("error = %q, want global remediation hint", err)
+	}
+}
+
 func chdirTemp(t *testing.T) string {
 	t.Helper()
 	orig, err := os.Getwd()
@@ -212,5 +259,14 @@ func writeInstalledPlugin(t *testing.T, root, name, version string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\necho plugin\n"), 0o750); err != nil {
 		t.Fatalf("write installed plugin binary: %v", err)
+	}
+}
+
+func writeInstalledCLIPlugin(t *testing.T, root, name, version, command string) {
+	t.Helper()
+	writeInstalledPlugin(t, root, name, version)
+	manifest := `{"name":"` + name + `","version":"` + version + `","author":"tester","description":"test plugin","capabilities":{"cliCommands":[{"name":"` + command + `","description":"test command"}]}}`
+	if err := os.WriteFile(filepath.Join(root, name, "plugin.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatalf("write cli plugin manifest: %v", err)
 	}
 }

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -233,12 +233,19 @@ func TestPluginInstallGlobalDependenciesInstallsClosure(t *testing.T) {
 	alphaTarball := buildPluginTarGz(t, "alpha", []byte(alphaScript), minimalPluginJSON("alpha", "2.0.0"))
 	betaTarball := buildPluginTarGz(t, "beta", []byte("#!/bin/sh\necho beta\n"), minimalPluginJSON("beta", "2.0.0"))
 
-	var alphaManifest, betaManifest RegistryManifest
+	alphaChecksum := sha256Hex(alphaTarball)
+	betaChecksum := sha256Hex(betaTarball)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/plugins/alpha/manifest.json":
+			alphaManifest := testRegistryManifestForRequest(r, "alpha", "2.0.0", "/download/alpha.tar.gz", alphaChecksum)
+			alphaManifest.Dependencies = []PluginDependency{{Name: "beta", MinVersion: "2.0.0"}}
+			alphaManifest.Capabilities = &RegistryCapabilities{
+				CLICommands: []RegistryCLICommand{{Name: "alpha"}},
+			}
 			writeHTTPJSON(t, w, alphaManifest)
 		case "/plugins/beta/manifest.json":
+			betaManifest := testRegistryManifestForRequest(r, "beta", "2.0.0", "/download/beta.tar.gz", betaChecksum)
 			writeHTTPJSON(t, w, betaManifest)
 		case "/download/alpha.tar.gz":
 			_, _ = w.Write(alphaTarball)
@@ -249,13 +256,6 @@ func TestPluginInstallGlobalDependenciesInstallsClosure(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-
-	alphaManifest = testRegistryManifest("alpha", "2.0.0", srv.URL+"/download/alpha.tar.gz", sha256Hex(alphaTarball))
-	alphaManifest.Dependencies = []PluginDependency{{Name: "beta", MinVersion: "2.0.0"}}
-	alphaManifest.Capabilities = &RegistryCapabilities{
-		CLICommands: []RegistryCLICommand{{Name: "alpha"}},
-	}
-	betaManifest = testRegistryManifest("beta", "2.0.0", srv.URL+"/download/beta.tar.gz", sha256Hex(betaTarball))
 
 	if err := runPluginInstall([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "alpha"}); err != nil {
 		t.Fatalf("runPluginInstall -g alpha: %v", err)
@@ -300,14 +300,22 @@ func TestPluginUpdateGlobalDependencyFailurePreservesPreviousInstall(t *testing.
 	betaTarball := buildPluginTarGz(t, "beta", []byte("#!/bin/sh\necho beta v2\n"), minimalPluginJSON("beta", "2.0.0"))
 	gammaTarball := buildPluginTarGz(t, "gamma", []byte("#!/bin/sh\necho gamma v2\n"), minimalPluginJSON("gamma", "2.0.0"))
 
-	var alphaManifest, betaManifest, gammaManifest RegistryManifest
+	alphaChecksum := sha256Hex(alphaTarball)
+	betaChecksum := sha256Hex(betaTarball)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/plugins/alpha/manifest.json":
+			alphaManifest := testRegistryManifestForRequest(r, "alpha", "2.0.0", "/download/alpha.tar.gz", alphaChecksum)
+			alphaManifest.Dependencies = []PluginDependency{
+				{Name: "beta", MinVersion: "2.0.0"},
+				{Name: "gamma", MinVersion: "2.0.0"},
+			}
 			writeHTTPJSON(t, w, alphaManifest)
 		case "/plugins/beta/manifest.json":
+			betaManifest := testRegistryManifestForRequest(r, "beta", "2.0.0", "/download/beta.tar.gz", betaChecksum)
 			writeHTTPJSON(t, w, betaManifest)
 		case "/plugins/gamma/manifest.json":
+			gammaManifest := testRegistryManifestForRequest(r, "gamma", "2.0.0", "/download/gamma.tar.gz", strings.Repeat("0", 64))
 			writeHTTPJSON(t, w, gammaManifest)
 		case "/download/alpha.tar.gz":
 			_, _ = w.Write(alphaTarball)
@@ -320,14 +328,6 @@ func TestPluginUpdateGlobalDependencyFailurePreservesPreviousInstall(t *testing.
 		}
 	}))
 	defer srv.Close()
-
-	alphaManifest = testRegistryManifest("alpha", "2.0.0", srv.URL+"/download/alpha.tar.gz", sha256Hex(alphaTarball))
-	alphaManifest.Dependencies = []PluginDependency{
-		{Name: "beta", MinVersion: "2.0.0"},
-		{Name: "gamma", MinVersion: "2.0.0"},
-	}
-	betaManifest = testRegistryManifest("beta", "2.0.0", srv.URL+"/download/beta.tar.gz", sha256Hex(betaTarball))
-	gammaManifest = testRegistryManifest("gamma", "2.0.0", srv.URL+"/download/gamma.tar.gz", strings.Repeat("0", 64))
 
 	err := runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "alpha"})
 	if err == nil {
@@ -410,6 +410,10 @@ func testRegistryManifest(name, version, url, checksum string) RegistryManifest 
 			SHA256: checksum,
 		}},
 	}
+}
+
+func testRegistryManifestForRequest(r *http.Request, name, version, path, checksum string) RegistryManifest {
+	return testRegistryManifest(name, version, "http://"+r.Host+path, checksum)
 }
 
 func writeHTTPJSON(t *testing.T, w http.ResponseWriter, v any) {

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -56,5 +58,159 @@ func TestResolvePluginDirUsesGlobalWhenRequested(t *testing.T) {
 
 	if got := resolvePluginDir(custom, true); got != global {
 		t.Fatalf("resolvePluginDir(custom, true) = %q, want %q", got, global)
+	}
+}
+
+func TestPluginInstallGlobalLocalDoesNotWriteLockfile(t *testing.T) {
+	cwd := chdirTemp(t)
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+
+	src := writeLocalPluginSource(t, "global-local", "1.0.0")
+	if err := runPluginInstall([]string{"-g", "--local", src}); err != nil {
+		t.Fatalf("runPluginInstall -g --local: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(global, "global-local", "plugin.json")); err != nil {
+		t.Fatalf("global plugin not installed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".wfctl-lock.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("global install wrote .wfctl-lock.yaml, err=%v", err)
+	}
+}
+
+func TestPluginListGlobalReadsGlobalDir(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "global-list", "1.0.0")
+
+	out, err := captureStdout(t, func() error {
+		return runPluginList([]string{"--global"})
+	})
+	if err != nil {
+		t.Fatalf("runPluginList --global: %v", err)
+	}
+	if !strings.Contains(out, "global-list") {
+		t.Fatalf("runPluginList --global output = %q, want global-list", out)
+	}
+}
+
+func TestPluginInfoGlobalReadsGlobalDir(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "global-info", "2.3.4")
+
+	out, err := captureStdout(t, func() error {
+		return runPluginInfo([]string{"-g", "global-info"})
+	})
+	if err != nil {
+		t.Fatalf("runPluginInfo -g: %v", err)
+	}
+	if !strings.Contains(out, "Name:         global-info") || !strings.Contains(out, "Version:      2.3.4") {
+		t.Fatalf("runPluginInfo -g output = %q, want global plugin info", out)
+	}
+}
+
+func TestPluginRemoveGlobalDoesNotMutateProjectState(t *testing.T) {
+	cwd := chdirTemp(t)
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "global-remove", "1.0.0")
+
+	manifest := "version: 1\nplugins:\n  - name: global-remove\n    version: 0.9.0\n    source: github.com/example/global-remove\n"
+	lockfile := "version: 1\nplugins:\n  global-remove:\n    version: 0.9.0\n    source: github.com/example/global-remove\n"
+	if err := os.WriteFile(filepath.Join(cwd, "wfctl.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, ".wfctl-lock.yaml"), []byte(lockfile), 0o600); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+
+	if err := runPluginRemove([]string{"-g", "global-remove"}); err != nil {
+		t.Fatalf("runPluginRemove -g: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(global, "global-remove")); !os.IsNotExist(err) {
+		t.Fatalf("global plugin dir still exists or unexpected stat error: %v", err)
+	}
+	gotManifest, err := os.ReadFile(filepath.Join(cwd, "wfctl.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if string(gotManifest) != manifest {
+		t.Fatalf("manifest mutated:\n%s", gotManifest)
+	}
+	gotLockfile, err := os.ReadFile(filepath.Join(cwd, ".wfctl-lock.yaml"))
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	if string(gotLockfile) != lockfile {
+		t.Fatalf("lockfile mutated:\n%s", gotLockfile)
+	}
+}
+
+func TestPluginUpdateGlobalRejectsProjectVersionPin(t *testing.T) {
+	cwd := chdirTemp(t)
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+
+	manifest := "version: 1\nplugins:\n  - name: global-update\n    version: 0.9.0\n    source: github.com/example/global-update\n"
+	if err := os.WriteFile(filepath.Join(cwd, "wfctl.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	err := runPluginUpdate([]string{"-g", "-version", "1.0.0", "global-update"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with --global") {
+		t.Fatalf("runPluginUpdate -g -version error = %v, want cannot combine error", err)
+	}
+	gotManifest, err := os.ReadFile(filepath.Join(cwd, "wfctl.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if string(gotManifest) != manifest {
+		t.Fatalf("manifest mutated:\n%s", gotManifest)
+	}
+}
+
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	return dir
+}
+
+func writeLocalPluginSource(t *testing.T, name, version string) string {
+	t.Helper()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "plugin.json"), minimalPluginJSON(name, version), 0o640); err != nil {
+		t.Fatalf("write plugin.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, name), []byte("#!/bin/sh\necho plugin\n"), 0o750); err != nil {
+		t.Fatalf("write plugin binary: %v", err)
+	}
+	return src
+}
+
+func writeInstalledPlugin(t *testing.T, root, name, version string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir installed plugin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), minimalPluginJSON(name, version), 0o640); err != nil {
+		t.Fatalf("write installed plugin.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\necho plugin\n"), 0o750); err != nil {
+		t.Fatalf("write installed plugin binary: %v", err)
 	}
 }

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -289,7 +289,7 @@ func TestPluginInstallGlobalDependenciesInstallsClosure(t *testing.T) {
 	}
 }
 
-func TestPluginGlobalUpdateDependencyFailurePreservesPreviousInstall(t *testing.T) {
+func TestPluginUpdateGlobalDependencyFailurePreservesPreviousInstall(t *testing.T) {
 	global := t.TempDir()
 	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
 	writeInstalledPlugin(t, global, "alpha", "1.0.0")

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -96,8 +96,10 @@ func formatPluginSearchResults(plugins []PluginSearchResult) string {
 func runPluginInstall(args []string) error {
 	fs := flag.NewFlagSet("plugin install", flag.ContinueOnError)
 	var pluginDirVal string
+	var global bool
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
+	addGlobalPluginFlags(fs, &global)
 	cfgPath := fs.String("config", "", "Registry config file path")
 	registryName := fs.String("registry", "", "Use a specific registry by name")
 	directURL := fs.String("url", "", "Install from a direct download URL (tar.gz archive)")
@@ -123,6 +125,12 @@ func runPluginInstall(args []string) error {
 	if err := fs.Parse(parsedArgs); err != nil {
 		return err
 	}
+	pluginDirVal = resolvePluginDir(pluginDirVal, global)
+	if global {
+		prev := installSkipLockfileUpdate
+		installSkipLockfileUpdate = true
+		defer func() { installSkipLockfileUpdate = prev }()
+	}
 	restoreDownloadProgress := setDownloadProgressQuiet(*quiet)
 	defer restoreDownloadProgress()
 	// Validate flag combinations before doing anything else.
@@ -139,6 +147,12 @@ func runPluginInstall(args []string) error {
 	}
 	if *locked && (*fromConfig != "" || *directURL != "" || *localPath != "" || fs.NArg() > 0) {
 		return fmt.Errorf("--locked is only supported for lockfile installs; run without plugin arguments, --from-config, --url, or --local")
+	}
+	if global && *locked {
+		return fmt.Errorf("--global and --locked cannot be combined")
+	}
+	if global && *directURL == "" && *localPath == "" && *fromConfig == "" && fs.NArg() < 1 {
+		return fmt.Errorf("--global install requires <name>, --url, --local, or --from-config")
 	}
 
 	// --from-config: batch install from workflow requires.plugins[].
@@ -524,8 +538,10 @@ func installPluginFromManifest(dataDir, pluginName string, manifest *RegistryMan
 func runPluginList(args []string) error {
 	fs := flag.NewFlagSet("plugin list", flag.ContinueOnError)
 	var pluginDirVal string
+	var global bool
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
+	addGlobalPluginFlags(fs, &global)
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin list [options]\n\nList installed plugins.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -533,6 +549,7 @@ func runPluginList(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	pluginDirVal = resolvePluginDir(pluginDirVal, global)
 
 	entries, err := os.ReadDir(pluginDirVal)
 	if os.IsNotExist(err) {
@@ -579,8 +596,10 @@ func runPluginList(args []string) error {
 func runPluginUpdate(args []string) error {
 	fs := flag.NewFlagSet("plugin update", flag.ContinueOnError)
 	var pluginDirVal string
+	var global bool
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
+	addGlobalPluginFlags(fs, &global)
 	cfgPath := fs.String("config", "", "Registry config file path")
 	pinVersion := fs.String("version", "", "Pin to this specific version in wfctl.yaml (skips registry lookup)")
 	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
@@ -597,6 +616,12 @@ func runPluginUpdate(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	pluginDirVal = resolvePluginDir(pluginDirVal, global)
+	if global {
+		prev := installSkipLockfileUpdate
+		installSkipLockfileUpdate = true
+		defer func() { installSkipLockfileUpdate = prev }()
+	}
 	restoreDownloadProgress := setDownloadProgressQuiet(*quiet)
 	defer restoreDownloadProgress()
 	if fs.NArg() < 1 {
@@ -608,6 +633,9 @@ func runPluginUpdate(args []string) error {
 
 	// --version: pin a specific version in the manifest without hitting registry.
 	if *pinVersion != "" {
+		if global {
+			return fmt.Errorf("--version updates wfctl.yaml and cannot be combined with --global")
+		}
 		if err := updateManifestVersion(pluginName, *pinVersion, *manifestPath, *lockPath); err != nil {
 			return err
 		}
@@ -701,8 +729,10 @@ func runPluginUpdate(args []string) error {
 func runPluginRemove(args []string) error {
 	fs := flag.NewFlagSet("plugin remove", flag.ContinueOnError)
 	var pluginDirVal string
+	var global bool
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
+	addGlobalPluginFlags(fs, &global)
 	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
 	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile")
 	fs.Usage = func() {
@@ -712,6 +742,7 @@ func runPluginRemove(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	pluginDirVal = resolvePluginDir(pluginDirVal, global)
 	if fs.NArg() < 1 {
 		fs.Usage()
 		return fmt.Errorf("plugin name is required")
@@ -725,6 +756,16 @@ func runPluginRemove(args []string) error {
 	binaryInstalled := true
 	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
 		binaryInstalled = false
+	}
+	if global {
+		if !binaryInstalled {
+			return fmt.Errorf("plugin %q is not installed", pluginName)
+		}
+		if err := os.RemoveAll(pluginDir); err != nil {
+			return fmt.Errorf("remove plugin %q: %w", pluginName, err)
+		}
+		fmt.Printf("Removed plugin %q\n", pluginName)
+		return nil
 	}
 
 	// Check if the plugin is in the manifest.
@@ -763,8 +804,10 @@ func runPluginRemove(args []string) error {
 func runPluginInfo(args []string) error {
 	fs := flag.NewFlagSet("plugin info", flag.ContinueOnError)
 	var pluginDirVal string
+	var global bool
 	fs.StringVar(&pluginDirVal, "plugin-dir", defaultDataDir, "Plugin directory")
 	fs.StringVar(&pluginDirVal, "data-dir", defaultDataDir, "Plugin directory (deprecated, use -plugin-dir)")
+	addGlobalPluginFlags(fs, &global)
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: wfctl plugin info [options] <name>\n\nShow details about an installed plugin.\n\nOptions:\n")
 		fs.PrintDefaults()
@@ -772,6 +815,7 @@ func runPluginInfo(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	pluginDirVal = resolvePluginDir(pluginDirVal, global)
 	if fs.NArg() < 1 {
 		fs.Usage()
 		return fmt.Errorf("plugin name is required")

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -705,6 +705,7 @@ func runPluginUpdate(args []string) error {
 	addGlobalPluginFlags(fs, &global)
 	cfgPath := fs.String("config", "", "Registry config file path")
 	pinVersion := fs.String("version", "", "Pin to this specific version in wfctl.yaml (skips registry lookup)")
+	updateAll := fs.Bool("all", false, "Update all installed plugins in the active plugin directory")
 	manifestPath := fs.String("manifest", wfctlManifestPath, "Path to wfctl.yaml manifest")
 	lockPath := fs.String("lock-file", wfctlLockPath, "Path to lockfile")
 	compatMode := fs.String("compat-mode", "", "Compatibility mode for registry updates: enforce or warn")
@@ -727,6 +728,15 @@ func runPluginUpdate(args []string) error {
 	}
 	restoreDownloadProgress := setDownloadProgressQuiet(*quiet)
 	defer restoreDownloadProgress()
+	if *updateAll {
+		if fs.NArg() > 0 {
+			return fmt.Errorf("--all cannot be combined with an explicit plugin name")
+		}
+		if *pinVersion != "" {
+			return fmt.Errorf("--all cannot be combined with --version")
+		}
+		return updateAllInstalledPlugins(pluginDirVal, global, *cfgPath, *compatMode, *engineVersion, *forceCompat, *skipChecksum, *quiet)
+	}
 	if fs.NArg() < 1 {
 		fs.Usage()
 		return fmt.Errorf("plugin name is required")
@@ -833,6 +843,63 @@ func runPluginUpdate(args []string) error {
 	}
 
 	return registryErr
+}
+
+func updateAllInstalledPlugins(pluginDir string, global bool, cfgPath, compatMode, engineVersion string, forceCompat, skipChecksum, quiet bool) error {
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No plugins installed.")
+			return nil
+		}
+		return fmt.Errorf("read plugin dir %q: %w", pluginDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".installing") || strings.HasSuffix(name, ".uninstalling") {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		fmt.Println("No plugins installed.")
+		return nil
+	}
+
+	for _, name := range names {
+		args := []string{"-plugin-dir", pluginDir}
+		if global {
+			args = append(args, "-g")
+		}
+		if cfgPath != "" {
+			args = append(args, "-config", cfgPath)
+		}
+		if compatMode != "" {
+			args = append(args, "-compat-mode", compatMode)
+		}
+		if engineVersion != "" {
+			args = append(args, "-engine-version", engineVersion)
+		}
+		if forceCompat {
+			args = append(args, "-force")
+		}
+		if skipChecksum {
+			args = append(args, "-skip-checksum")
+		}
+		if quiet {
+			args = append(args, "-quiet")
+		}
+		args = append(args, name)
+		if err := runPluginUpdate(args); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func runPluginRemove(args []string) error {

--- a/cmd/wfctl/plugin_install.go
+++ b/cmd/wfctl/plugin_install.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -278,6 +279,17 @@ func runPluginInstall(args []string) error {
 		manifest = manifestForCompatibilityVersion(manifest, index, decision.Version)
 	}
 
+	if global {
+		if err := installGlobalPluginTransaction(pluginDirVal, pluginName, manifest, *cfgPath, *skipChecksum); err != nil {
+			if requestedVersion != "" && requestedVersion != registryVersion {
+				return fmt.Errorf("requested version %s not available for %q (registry manifest is at %s): %w",
+					requestedVersion, pluginName, registryVersion, err)
+			}
+			return err
+		}
+		return nil
+	}
+
 	// Resolve and install dependencies before installing the plugin itself.
 	if len(manifest.Dependencies) > 0 {
 		resolved := make(map[string]string)
@@ -535,6 +547,97 @@ func installPluginFromManifest(dataDir, pluginName string, manifest *RegistryMan
 	return nil
 }
 
+func installGlobalPluginTransaction(pluginDir, pluginName string, manifest *RegistryManifest, cfgPath string, skipChecksum bool) error {
+	parentDir := filepath.Dir(pluginDir)
+	if err := os.MkdirAll(parentDir, 0750); err != nil {
+		return fmt.Errorf("create global plugin parent dir: %w", err)
+	}
+	stagingRoot, err := os.MkdirTemp(parentDir, ".wfctl-global-install-*")
+	if err != nil {
+		return fmt.Errorf("create global plugin staging root: %w", err)
+	}
+	defer os.RemoveAll(stagingRoot) //nolint:errcheck
+
+	prev := installSkipLockfileUpdate
+	installSkipLockfileUpdate = true
+	defer func() { installSkipLockfileUpdate = prev }()
+
+	if len(manifest.Dependencies) > 0 {
+		resolved := make(map[string]string)
+		if err := resolveDependencies(pluginName, manifest, stagingRoot, cfgPath, []string{}, resolved); err != nil {
+			return fmt.Errorf("resolve dependencies for %q: %w", pluginName, err)
+		}
+	}
+	if err := installPluginFromManifest(stagingRoot, pluginName, manifest, nil, skipChecksum); err != nil {
+		return err
+	}
+
+	return commitGlobalPluginTransaction(stagingRoot, pluginDir)
+}
+
+func commitGlobalPluginTransaction(stagingRoot, pluginDir string) error {
+	entries, err := os.ReadDir(stagingRoot)
+	if err != nil {
+		return fmt.Errorf("read global plugin staging root: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	if err := os.MkdirAll(pluginDir, 0750); err != nil {
+		return fmt.Errorf("create global plugin dir: %w", err)
+	}
+	backupRoot, err := os.MkdirTemp(filepath.Dir(pluginDir), ".wfctl-global-backup-*")
+	if err != nil {
+		return fmt.Errorf("create global plugin backup root: %w", err)
+	}
+	defer os.RemoveAll(backupRoot) //nolint:errcheck
+
+	type movedPlugin struct {
+		name      string
+		hadBackup bool
+	}
+	var moved []movedPlugin
+	rollback := func() {
+		for i := len(moved) - 1; i >= 0; i-- {
+			name := moved[i].name
+			target := filepath.Join(pluginDir, name)
+			_ = os.RemoveAll(target) //nolint:errcheck
+			if moved[i].hadBackup {
+				_ = os.Rename(filepath.Join(backupRoot, name), target) //nolint:errcheck
+			}
+		}
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		source := filepath.Join(stagingRoot, name)
+		target := filepath.Join(pluginDir, name)
+		backup := filepath.Join(backupRoot, name)
+
+		hadBackup := false
+		if _, statErr := os.Stat(target); statErr == nil {
+			hadBackup = true
+			if err := os.Rename(target, backup); err != nil {
+				rollback()
+				return fmt.Errorf("preserve existing global plugin dir %s: %w", target, err)
+			}
+		} else if !os.IsNotExist(statErr) {
+			rollback()
+			return fmt.Errorf("stat global plugin dir %s: %w", target, statErr)
+		}
+
+		moved = append(moved, movedPlugin{name: name, hadBackup: hadBackup})
+		if err := os.Rename(source, target); err != nil {
+			rollback()
+			return fmt.Errorf("install global plugin dir %s: %w", target, err)
+		}
+	}
+
+	return nil
+}
+
 func runPluginList(args []string) error {
 	fs := flag.NewFlagSet("plugin list", flag.ContinueOnError)
 	var pluginDirVal string
@@ -699,6 +802,9 @@ func runPluginUpdate(args []string) error {
 			return nil
 		}
 		fmt.Fprintf(os.Stderr, "Updating from %s to %s...\n", installedVer, manifest.Version)
+		if global {
+			return installGlobalPluginTransaction(pluginDirVal, pluginName, manifest, *cfgPath, *skipChecksum)
+		}
 		return installPluginFromManifest(pluginDirVal, pluginName, manifest, nil, *skipChecksum)
 	}
 
@@ -720,6 +826,9 @@ func runPluginUpdate(args []string) error {
 			return nil
 		}
 		fmt.Fprintf(os.Stderr, "Updating from %s to %s...\n", installedVer, manifest.Version)
+		if global {
+			return installGlobalPluginTransaction(pluginDirVal, pluginName, manifest, *cfgPath, *skipChecksum)
+		}
 		return installPluginFromManifest(pluginDirVal, pluginName, manifest, nil, *skipChecksum)
 	}
 

--- a/cmd/wfctl/plugin_install_test.go
+++ b/cmd/wfctl/plugin_install_test.go
@@ -33,6 +33,21 @@ type captureTransport struct {
 	target string // host:port of the httptest.Server
 }
 
+func TestPluginUsageMentionsGlobalLifecycle(t *testing.T) {
+	var buf bytes.Buffer
+	prevOutput := flag.CommandLine.Output()
+	flag.CommandLine.SetOutput(&buf)
+	t.Cleanup(func() { flag.CommandLine.SetOutput(prevOutput) })
+
+	printPluginUsage()
+	out := buf.String()
+	for _, want := range []string{"-g", "-global", "WFCTL_GLOBAL_PLUGIN_DIR"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("plugin usage missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func (ct *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ct.mu.Lock()
 	ct.header = req.Header.Get("Authorization")

--- a/cmd/wfctl/plugin_update_test.go
+++ b/cmd/wfctl/plugin_update_test.go
@@ -110,11 +110,11 @@ func TestPluginUpdateGlobalNamedUsesGlobalDir(t *testing.T) {
 	writeInstalledPlugin(t, filepath.Join(cwd, "data", "plugins"), "portfolio", "1.0.0")
 
 	tarball := buildPluginTarGz(t, "portfolio", []byte("#!/bin/sh\necho portfolio v2\n"), minimalPluginJSON("portfolio", "v2.0.0"))
-	var manifest RegistryManifest
+	checksum := sha256Hex(tarball)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/plugins/portfolio/manifest.json":
-			writeHTTPJSON(t, w, manifest)
+			writeHTTPJSON(t, w, testRegistryManifestForRequest(r, "portfolio", "v2.0.0", "/download/portfolio.tar.gz", checksum))
 		case "/download/portfolio.tar.gz":
 			_, _ = w.Write(tarball)
 		default:
@@ -122,7 +122,6 @@ func TestPluginUpdateGlobalNamedUsesGlobalDir(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	manifest = testRegistryManifest("portfolio", "v2.0.0", srv.URL+"/download/portfolio.tar.gz", sha256Hex(tarball))
 
 	if err := runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "portfolio"}); err != nil {
 		t.Fatalf("runPluginUpdate -g portfolio: %v", err)
@@ -143,13 +142,14 @@ func TestPluginUpdateGlobalAllUpdatesInstalledPlugins(t *testing.T) {
 
 	portfolioTarball := buildPluginTarGz(t, "portfolio", []byte("#!/bin/sh\necho portfolio v2\n"), minimalPluginJSON("portfolio", "v2.0.0"))
 	moderationTarball := buildPluginTarGz(t, "moderation", []byte("#!/bin/sh\necho moderation v2\n"), minimalPluginJSON("moderation", "v2.0.0"))
-	var portfolioManifest, moderationManifest RegistryManifest
+	portfolioChecksum := sha256Hex(portfolioTarball)
+	moderationChecksum := sha256Hex(moderationTarball)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/plugins/portfolio/manifest.json":
-			writeHTTPJSON(t, w, portfolioManifest)
+			writeHTTPJSON(t, w, testRegistryManifestForRequest(r, "portfolio", "v2.0.0", "/download/portfolio.tar.gz", portfolioChecksum))
 		case "/plugins/moderation/manifest.json":
-			writeHTTPJSON(t, w, moderationManifest)
+			writeHTTPJSON(t, w, testRegistryManifestForRequest(r, "moderation", "v2.0.0", "/download/moderation.tar.gz", moderationChecksum))
 		case "/download/portfolio.tar.gz":
 			_, _ = w.Write(portfolioTarball)
 		case "/download/moderation.tar.gz":
@@ -159,8 +159,6 @@ func TestPluginUpdateGlobalAllUpdatesInstalledPlugins(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	portfolioManifest = testRegistryManifest("portfolio", "v2.0.0", srv.URL+"/download/portfolio.tar.gz", sha256Hex(portfolioTarball))
-	moderationManifest = testRegistryManifest("moderation", "v2.0.0", srv.URL+"/download/moderation.tar.gz", sha256Hex(moderationTarball))
 
 	if err := runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "--all"}); err != nil {
 		t.Fatalf("runPluginUpdate -g --all: %v", err)

--- a/cmd/wfctl/plugin_update_test.go
+++ b/cmd/wfctl/plugin_update_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/config"
@@ -96,5 +99,102 @@ plugins:
 	err := updateManifestVersion("workflow-plugin-nonexistent", "v1.5.0", manifestPath, lockPath)
 	if err == nil {
 		t.Fatal("expected error when plugin not in manifest")
+	}
+}
+
+func TestPluginUpdateGlobalNamedUsesGlobalDir(t *testing.T) {
+	cwd := chdirTemp(t)
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "portfolio", "1.0.0")
+	writeInstalledPlugin(t, filepath.Join(cwd, "data", "plugins"), "portfolio", "1.0.0")
+
+	tarball := buildPluginTarGz(t, "portfolio", []byte("#!/bin/sh\necho portfolio v2\n"), minimalPluginJSON("portfolio", "v2.0.0"))
+	var manifest RegistryManifest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/portfolio/manifest.json":
+			writeHTTPJSON(t, w, manifest)
+		case "/download/portfolio.tar.gz":
+			_, _ = w.Write(tarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	manifest = testRegistryManifest("portfolio", "v2.0.0", srv.URL+"/download/portfolio.tar.gz", sha256Hex(tarball))
+
+	if err := runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "portfolio"}); err != nil {
+		t.Fatalf("runPluginUpdate -g portfolio: %v", err)
+	}
+	if got := readInstalledVersion(filepath.Join(global, "portfolio")); got != "v2.0.0" {
+		t.Fatalf("global portfolio version = %q, want v2.0.0", got)
+	}
+	if got := readInstalledVersion(filepath.Join(cwd, "data", "plugins", "portfolio")); got != "1.0.0" {
+		t.Fatalf("project portfolio version = %q, want unchanged 1.0.0", got)
+	}
+}
+
+func TestPluginUpdateGlobalAllUpdatesInstalledPlugins(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "portfolio", "1.0.0")
+	writeInstalledPlugin(t, global, "moderation", "1.0.0")
+
+	portfolioTarball := buildPluginTarGz(t, "portfolio", []byte("#!/bin/sh\necho portfolio v2\n"), minimalPluginJSON("portfolio", "v2.0.0"))
+	moderationTarball := buildPluginTarGz(t, "moderation", []byte("#!/bin/sh\necho moderation v2\n"), minimalPluginJSON("moderation", "v2.0.0"))
+	var portfolioManifest, moderationManifest RegistryManifest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/plugins/portfolio/manifest.json":
+			writeHTTPJSON(t, w, portfolioManifest)
+		case "/plugins/moderation/manifest.json":
+			writeHTTPJSON(t, w, moderationManifest)
+		case "/download/portfolio.tar.gz":
+			_, _ = w.Write(portfolioTarball)
+		case "/download/moderation.tar.gz":
+			_, _ = w.Write(moderationTarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	portfolioManifest = testRegistryManifest("portfolio", "v2.0.0", srv.URL+"/download/portfolio.tar.gz", sha256Hex(portfolioTarball))
+	moderationManifest = testRegistryManifest("moderation", "v2.0.0", srv.URL+"/download/moderation.tar.gz", sha256Hex(moderationTarball))
+
+	if err := runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "--all"}); err != nil {
+		t.Fatalf("runPluginUpdate -g --all: %v", err)
+	}
+	for _, name := range []string{"portfolio", "moderation"} {
+		if got := readInstalledVersion(filepath.Join(global, name)); got != "v2.0.0" {
+			t.Fatalf("%s version = %q, want v2.0.0", name, got)
+		}
+	}
+}
+
+func TestPluginUpdateGlobalAlreadyLatestPrintsVersion(t *testing.T) {
+	global := t.TempDir()
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledPlugin(t, global, "portfolio", "v2.0.0")
+
+	tarball := buildPluginTarGz(t, "portfolio", []byte("#!/bin/sh\necho portfolio v2\n"), minimalPluginJSON("portfolio", "v2.0.0"))
+	manifest := testRegistryManifest("portfolio", "v2.0.0", "unused", sha256Hex(tarball))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/plugins/portfolio/manifest.json" {
+			writeHTTPJSON(t, w, manifest)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	out, err := captureStdout(t, func() error {
+		return runPluginUpdate([]string{"-g", "-config", writeTestRegistryConfig(t, srv.URL), "portfolio"})
+	})
+	if err != nil {
+		t.Fatalf("runPluginUpdate already latest: %v", err)
+	}
+	if !strings.Contains(out, "already at latest version (v2.0.0)") {
+		t.Fatalf("output = %q, want already latest version", out)
 	}
 }

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -858,6 +858,7 @@ wfctl plugin install [options] [<name>[@<version>]]
 |------|---------|-------------|
 | `--plugin-dir` | `data/plugins` | Plugin directory |
 | `--data-dir` | `data/plugins` | Deprecated alias for `--plugin-dir` |
+| `--global`, `-g` | `false` | Install into the global plugin directory |
 | `--config` | _(default registry)_ | Registry config file path |
 | `-registry` | _(all registries)_ | Use a specific registry by name |
 | `--manifest` | `wfctl.yaml` | wfctl project manifest path for lockfile installs |
@@ -872,6 +873,7 @@ wfctl plugin install [options] [<name>[@<version>]]
 ```bash
 wfctl plugin install my-plugin
 wfctl plugin install my-plugin@1.2.0
+wfctl plugin install -g portfolio
 wfctl plugin install --data-dir /opt/plugins my-plugin
 wfctl plugin install
 wfctl plugin install --locked
@@ -895,6 +897,15 @@ installs cannot silently skip lockfile freshness checks.
 Registry installs resolve compatibility before selecting a version. Direct URL
 installs, local installs, GitHub repository fallback, and lockfile installs do
 not use registry evidence unless they are backed by registry metadata.
+
+Global installs use `${XDG_DATA_HOME:-$HOME/.local/share}/wfctl/plugins` by
+default. Set `WFCTL_GLOBAL_PLUGIN_DIR` to override the location. Global
+lifecycle commands install binaries and manifests only; they do not create or
+modify project `wfctl.yaml` or `.wfctl-lock.yaml`. Registry dependency closure
+is installed globally with the parent plugin, and existing global plugin dirs
+are swapped only after the staged parent and dependency set validates.
+Top-level wfctl commands are resolved before global plugin CLI commands, so a
+plugin cannot shadow built-in commands such as `validate` or `plugin`.
 
 #### `plugin ci`
 
@@ -987,20 +998,24 @@ wfctl plugin list [options]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-data-dir` | `data/plugins` | Plugin data directory |
+| `--plugin-dir` | `data/plugins` | Plugin directory |
+| `--data-dir` | `data/plugins` | Deprecated alias for `--plugin-dir` |
+| `--global`, `-g` | `false` | List plugins from the global plugin directory |
 
 #### `plugin update`
 
 Update an installed plugin to its latest version.
 
 ```
-wfctl plugin update [options] <name>
+wfctl plugin update [options] <name|--all>
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--plugin-dir` | `data/plugins` | Plugin directory |
 | `--data-dir` | `data/plugins` | Deprecated alias for `--plugin-dir` |
+| `--global`, `-g` | `false` | Update plugins in the global plugin directory |
+| `--all` | `false` | Update every installed plugin in the active plugin directory |
 | `--config` | _(default registry)_ | Registry config file path |
 | `--manifest` | `wfctl.yaml` | wfctl project manifest path |
 | `--lock-file` | `.wfctl-lock.yaml` | Lockfile path |
@@ -1010,6 +1025,15 @@ wfctl plugin update [options] <name>
 | `--force` | `false` | Permit known-failing or missing required compatibility evidence while still enforcing archive checksums |
 | `--quiet` | `false` | Suppress per-download progress output |
 | `--skip-checksum` | `false` | Skip archive integrity verification. Use only for trusted internal URLs |
+
+```bash
+wfctl plugin update -g portfolio
+wfctl plugin update -g --all
+```
+
+Global updates reuse the global dependency transaction path. If any dependency
+download, checksum, or validation fails, existing global plugin directories
+remain in place and later plugins in `--all` are not updated.
 
 #### `plugin remove`
 
@@ -1021,7 +1045,9 @@ wfctl plugin remove [options] <name>
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-data-dir` | `data/plugins` | Plugin data directory |
+| `--plugin-dir` | `data/plugins` | Plugin directory |
+| `--data-dir` | `data/plugins` | Deprecated alias for `--plugin-dir` |
+| `--global`, `-g` | `false` | Remove from the global plugin directory |
 
 #### `plugin validate`
 
@@ -1051,7 +1077,9 @@ wfctl plugin info [options] <name>
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-data-dir` | `data/plugins` | Plugin data directory |
+| `--plugin-dir` | `data/plugins` | Plugin directory |
+| `--data-dir` | `data/plugins` | Deprecated alias for `--plugin-dir` |
+| `--global`, `-g` | `false` | Read from the global plugin directory |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add global wfctl plugin directory resolution and lifecycle flags (`--global`/`-g`) for install/list/info/update/remove.
- Dispatch unknown top-level commands from globally installed CLI plugins after static wfctl commands win.
- Stage global install/update dependency closures transactionally before swapping plugin dirs into the global directory.
- Add `wfctl plugin update -g --all` and document global plugin behavior.

## Verification
- `GOWORK=off go test ./cmd/wfctl -run 'TestPluginUpdateGlobal' -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestPlugin.*Global|TestGlobalCLI|TestResolveDependencies|TestPluginUpdateGlobal' -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `GOWORK=off go build -o /tmp/wfctl-global-final ./cmd/wfctl`
- `WFCTL_GLOBAL_PLUGIN_DIR="$(mktemp -d)" /tmp/wfctl-global-final plugin list -g` -> `No plugins installed.`
- `rg -n 'WFCTL_GLOBAL_PLUGIN_DIR|plugin install -g|plugin update -g --all' docs/WFCTL.md`

## TDD proof
- Disabling the global update transaction made the dependency preservation regression fail because update ignored dependency closure.
- Disabling the `--all` flag registration made `TestPluginUpdateGlobalAllUpdatesInstalledPlugins` fail with `flag provided but not defined: -all`.

Part of `/Users/jon/workspace/docs/plans/2026-06-23-wfctl-global-plugins-and-registry-refresh.md` PR group 1.