### PR TITLE
feat(schema): Assembly Grammar model + loader (ModuleSchema ext + PluginManifest.Grammar + merge/SCC + MCP visibility)

### DIFF
--- a/capability/inventory/ecosystem.go
+++ b/capability/inventory/ecosystem.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	workflowplugin "github.com/GoCodeAlone/workflow/plugin"
+	"github.com/GoCodeAlone/workflow/schema"
 )
 
 // EcosystemOptions controls ecosystem capability inventory generation.
@@ -173,6 +174,7 @@ func collectLocalProviders(builder *inventoryBuilder, repoRoot string) (int, err
 			Dependencies:  dependencyNames(manifest.Dependencies),
 			Path:          manifestPath,
 			Raw:           manifestRawCapabilities(manifest),
+			Grammar:       manifest.Grammar,
 		})
 		count++
 	}
@@ -261,6 +263,7 @@ type providerInput struct {
 	Dependencies  []string
 	Path          string
 	Raw           []rawCapability
+	Grammar       map[string]schema.GrammarDecl
 }
 
 type inventoryBuilder struct {
@@ -379,6 +382,9 @@ func mergeProvider(cap *Capability, input providerInput, raw rawCapability) {
 		Source:        input.Source,
 		Capabilities:  []string{rawName},
 		Dependencies:  append([]string(nil), input.Dependencies...),
+		// P5/D26 single-source: grammar is carried from the first declaring
+		// provider only; the existing-provider branch above leaves it untouched.
+		Grammar: input.Grammar,
 	})
 }
 

--- a/capability/inventory/grammar_retention_test.go
+++ b/capability/inventory/grammar_retention_test.go
@@ -1,0 +1,122 @@
+package inventory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLocalPluginGrammarRetained asserts a local plugin.json's sibling Grammar
+// field reaches Provider.Grammar via the sibling-checkout path (design D1/D26 —
+// grammar is a NEW sibling top-level PluginManifest field, ⊥ nesting under
+// moduleTypes which is []string).
+func TestLocalPluginGrammarRetained(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "workflow-plugin-x")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pj := []byte(`{
+		"name": "x",
+		"version": "0.1.0",
+		"author": "test",
+		"description": "test plugin",
+		"moduleTypes": ["x.foo"],
+		"grammar": {
+			"x.foo": {
+				"provides": ["x.Foo"],
+				"requires": ["http.router"]
+			}
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), pj, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := CollectEcosystem(EcosystemOptions{
+		RepoRoot:     root,
+		TaxonomyPath: "testdata/taxonomy.yaml",
+		GeneratedAt:  fixedTime,
+	})
+	if err != nil {
+		t.Fatalf("CollectEcosystem: %v", err)
+	}
+
+	// The grammar must be carried onto the declaring provider. Selection-filter
+	// (only-for-selected-set) is the assembler's job (Task 3); retention plumbing
+	// serves all providers here (D26).
+	var found bool
+	for i := range inv.Capabilities {
+		for j := range inv.Capabilities[i].Providers {
+			p := &inv.Capabilities[i].Providers[j]
+			if p.Name != "x" || p.Grammar == nil {
+				continue
+			}
+			g, ok := p.Grammar["x.foo"]
+			if !ok {
+				continue
+			}
+			if len(g.Requires) == 1 && g.Requires[0] == "http.router" && len(g.Provides) == 1 && g.Provides[0] == "x.Foo" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("plugin Grammar not retained on Provider (D1): %+v", inv.Capabilities)
+	}
+}
+
+// TestLocalPluginGrammarSingleSource asserts P5/D26 single-source semantics:
+// Grammar is set on first provider insert and not overwritten by a later
+// mergeProvider for the same (Name, ReleaseStatus). (A single manifest's grammar
+// is constant across its raw capabilities, so the first-insert wins and is stable.)
+func TestLocalPluginGrammarSingleSource(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "workflow-plugin-multi")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Two module types, one shared grammar map → provider carries grammar once.
+	pj := []byte(`{
+		"name": "multi",
+		"version": "0.1.0",
+		"author": "test",
+		"description": "test plugin",
+		"moduleTypes": ["multi.a", "multi.b"],
+		"grammar": {
+			"multi.a": {"provides": ["multi.A"]},
+			"multi.b": {"requires": ["multi.a"]}
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), pj, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := CollectEcosystem(EcosystemOptions{
+		RepoRoot:     root,
+		TaxonomyPath: "testdata/taxonomy.yaml",
+		GeneratedAt:  fixedTime,
+	})
+	if err != nil {
+		t.Fatalf("CollectEcosystem: %v", err)
+	}
+
+	// Every provider row named "multi" must carry the SAME grammar map (both keys).
+	for i := range inv.Capabilities {
+		for j := range inv.Capabilities[i].Providers {
+			p := &inv.Capabilities[i].Providers[j]
+			if p.Name != "multi" {
+				continue
+			}
+			if p.Grammar == nil {
+				t.Fatalf("provider %q missing Grammar (P5 single-source): %+v", p.Name, p)
+			}
+			if _, ok := p.Grammar["multi.a"]; !ok {
+				t.Fatalf("provider %q Grammar missing multi.a: %+v", p.Name, p.Grammar)
+			}
+			if _, ok := p.Grammar["multi.b"]; !ok {
+				t.Fatalf("provider %q Grammar missing multi.b: %+v", p.Name, p.Grammar)
+			}
+		}
+	}
+}

--- a/capability/inventory/types.go
+++ b/capability/inventory/types.go
@@ -2,6 +2,8 @@
 // plugins, registries, and applications.
 package inventory
 
+import "github.com/GoCodeAlone/workflow/schema"
+
 // Inventory is the top-level ecosystem capability report.
 type Inventory struct {
 	Metadata     Metadata     `json:"metadata"`
@@ -43,6 +45,12 @@ type Provider struct {
 	Source        string   `json:"source,omitempty"`
 	Capabilities  []string `json:"capabilities,omitempty"`
 	Dependencies  []string `json:"dependencies,omitempty"`
+
+	// Grammar carries this provider's Assembly Grammar (design D1/D26), retained
+	// from the sibling PluginManifest.Grammar field. Populated for local-plugin
+	// providers; nil for registry providers (registry-manifest grammar is M2).
+	// Single-source: set on first provider insert (P5).
+	Grammar map[string]schema.GrammarDecl `json:"grammar,omitempty"`
 }
 
 // Catalog is the docs-facing capability report derived from Inventory.

--- a/capability/scaffold/grammar.go
+++ b/capability/scaffold/grammar.go
@@ -29,14 +29,18 @@ func MergeGrammar(reg *schema.ModuleSchemaRegistry, inv *inventory.Inventory) (M
 
 	// 1. Engine builtins (D25: engine wins — seeded first; a plugin re-declaring
 	//    grammar for an engine-registered type is ignored, NOT a conflict).
+	//    Engine ownership applies to EVERY registered engine type, not only those
+	//    that currently declare grammar — otherwise a plugin could shadow an
+	//    engine type whose grammar hasn't been authored yet (Task 6 sweep), then
+	//    have its grammar silently dropped once the engine adds one.
 	engineTypes := map[string]bool{}
 	for _, t := range reg.Types() { // reg.Types() is []string (retro #1: range two-value)
+		engineTypes[t] = true
 		s := reg.Get(t)
 		if s == nil || !hasGrammar(s) {
 			continue
 		}
 		merged[t] = fromSchema(s)
-		engineTypes[t] = true
 	}
 
 	// 2. Plugin grammar, sorted by (provider-name, module-type) for V10 determinism.

--- a/capability/scaffold/grammar.go
+++ b/capability/scaffold/grammar.go
@@ -1,0 +1,295 @@
+// Package scaffold composes functional workflow scaffolds via Assembly Grammar.
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+// MergedGrammar is the per-module-type resolved grammar (engine ∪ plugins).
+type MergedGrammar map[string]schema.GrammarDecl
+
+// MergeGrammar merges engine ModuleSchemaRegistry grammar ∪ plugin Provider.Grammar.
+// Order: engine-first, then plugins by (provider-name, module-type). Conflict
+// policy (D2/D16/D17/D22/D23):
+//   - scalar-field conflict = error (per-field across structs); list-field = union;
+//   - engine wins for engine-registered types (D25);
+//   - phantom Attaches/Requires target = load-error (D23);
+//   - circular Requires = error (D17, via Tarjan SCC).
+//
+// Returns the merged grammar + the sorted, de-duplicated union of Category-B
+// RuntimeHooks (for NEXT_STEPS documentation, D3).
+func MergeGrammar(reg *schema.ModuleSchemaRegistry, inv *inventory.Inventory) (MergedGrammar, []string, error) {
+	merged := MergedGrammar{}
+
+	// 1. Engine builtins (D25: engine wins — seeded first; a plugin re-declaring
+	//    grammar for an engine-registered type is ignored, NOT a conflict).
+	engineTypes := map[string]bool{}
+	for _, t := range reg.Types() { // reg.Types() is []string (retro #1: range two-value)
+		s := reg.Get(t)
+		if s == nil || !hasGrammar(s) {
+			continue
+		}
+		merged[t] = fromSchema(s)
+		engineTypes[t] = true
+	}
+
+	// 2. Plugin grammar, sorted by (provider-name, module-type) for V10 determinism.
+	type pluginEntry struct {
+		provider string
+		typ      string
+		decl     schema.GrammarDecl
+	}
+	var entries []pluginEntry
+	for i := range inv.Capabilities {
+		for j := range inv.Capabilities[i].Providers {
+			p := &inv.Capabilities[i].Providers[j]
+			if p.Grammar == nil {
+				continue
+			}
+			for typ, decl := range p.Grammar {
+				entries = append(entries, pluginEntry{p.Name, typ, decl})
+			}
+		}
+	}
+	sort.Slice(entries, func(a, b int) bool {
+		if entries[a].provider != entries[b].provider {
+			return entries[a].provider < entries[b].provider
+		}
+		return entries[a].typ < entries[b].typ
+	})
+	for i := range entries {
+		e := &entries[i]
+		if engineTypes[e.typ] {
+			// P9/P15: surface the drop (⊥ silent field-loss) so plugin authors see it.
+			fmt.Fprintf(os.Stderr, "scaffold: plugin %q grammar for engine type %q ignored (engine wins, D25)\n", e.provider, e.typ)
+			continue
+		}
+		existing, ok := merged[e.typ]
+		if !ok {
+			merged[e.typ] = e.decl
+			continue
+		}
+		// merge field-by-field; scalar conflict = error (D22)
+		merged2, err := mergeDecl(existing, e.decl, e.typ)
+		if err != nil {
+			return nil, nil, err
+		}
+		merged[e.typ] = merged2
+	}
+
+	// 3. Validate references (D23: phantom target = load-error) + collect RuntimeHooks.
+	allTypes := map[string]bool{}
+	for t := range merged {
+		allTypes[t] = true
+	}
+	for _, t := range reg.Types() { // a grammar target may be a non-grammar type
+		allTypes[t] = true
+	}
+	seenHooks := map[string]bool{}
+	var hooks []string
+	for typ, decl := range merged {
+		for _, tgt := range refTargets(decl) {
+			if !allTypes[tgt] {
+				return nil, nil, fmt.Errorf("grammar: %q references unknown type %q (D23 phantom target)", typ, tgt)
+			}
+		}
+		for _, h := range decl.RuntimeHooks {
+			if !seenHooks[h] {
+				seenHooks[h] = true
+				hooks = append(hooks, h)
+			}
+		}
+	}
+	sort.Strings(hooks)
+
+	// 4. Cycle detection (D17): Tarjan SCC over Requires-edges at merge time
+	//    (selection-independent). Recursion bounded by the visited indices set.
+	if err := detectCycles(merged); err != nil {
+		return nil, nil, err
+	}
+	return merged, hooks, nil
+}
+
+// mergeDecl merges two GrammarDecls for the same type (D22): list-fields union;
+// scalar/struct fields conflict-if-differ (per-field); identical re-decl = no-op.
+func mergeDecl(a, b schema.GrammarDecl, typ string) (schema.GrammarDecl, error) {
+	out := a
+	out.Provides = union(out.Provides, b.Provides)
+	out.Requires = union(out.Requires, b.Requires)
+	out.RouteMiddlewares = union(out.RouteMiddlewares, b.RouteMiddlewares)
+	out.RuntimeHooks = union(out.RuntimeHooks, b.RuntimeHooks)
+	// Attaches (struct): conflict if both set and differ.
+	if b.Attaches != nil {
+		if out.Attaches == nil {
+			out.Attaches = b.Attaches
+		} else if *out.Attaches != *b.Attaches {
+			return out, fmt.Errorf("grammar: conflicting Attaches for %q (D22)", typ)
+		}
+	}
+	// Fragment (struct): conflict if both set and differ. FragmentSpec contains
+	// a []string (Fields), so it is not comparable with != — compare by value.
+	if b.Fragment != nil {
+		if out.Fragment == nil {
+			out.Fragment = b.Fragment
+		} else if !fragmentEqual(out.Fragment, b.Fragment) {
+			return out, fmt.Errorf("grammar: conflicting Fragment for %q (D22)", typ)
+		}
+	}
+	return out, nil
+}
+
+// fragmentEqual compares two FragmentSpecs by value (Kind + Fields). nil-safe.
+func fragmentEqual(a, b *schema.FragmentSpec) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	return stringSliceEqual(a.Fields, b.Fields)
+}
+
+// stringSliceEqual is an order-sensitive []string comparison.
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// refTargets returns all type-references in a decl (Requires + Attaches.To) for
+// the phantom-check (D23).
+func refTargets(d schema.GrammarDecl) []string {
+	out := append([]string{}, d.Requires...)
+	if d.Attaches != nil {
+		out = append(out, d.Attaches.To)
+	}
+	return out
+}
+
+// detectCycles runs Tarjan SCC over Requires-edges; any SCC of size>1 (or a
+// self-loop) is a cycle → named-offender error (D17).
+func detectCycles(g MergedGrammar) error {
+	index := 0
+	stack := []string{}
+	onStack := map[string]bool{}
+	indices := map[string]int{}
+	low := map[string]int{}
+	var cycle []string
+
+	var sc func(v string)
+	sc = func(v string) {
+		indices[v], low[v] = index, index
+		index++
+		stack = append(stack, v)
+		onStack[v] = true
+		for _, w := range g[v].Requires {
+			if w == v {
+				// self-loop = a cycle (P11: set + continue, ⊥ return which would
+				// skip SCC finalization; safe because the outer loop breaks on cycle).
+				if !slices.Contains(cycle, v) {
+					cycle = append(cycle, v)
+				}
+				continue
+			}
+			if _, seen := indices[w]; !seen {
+				if _, ok := g[w]; ok { // only recurse into grammar-bearing nodes
+					sc(w)
+					low[v] = minI(low[v], low[w])
+				}
+			} else if onStack[w] {
+				low[v] = minI(low[v], indices[w])
+			}
+		}
+		if low[v] == indices[v] {
+			var comp []string
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				comp = append(comp, w)
+				if w == v {
+					break
+				}
+			}
+			if len(comp) > 1 { // SCC >1 node = cycle
+				for _, n := range comp {
+					if !slices.Contains(cycle, n) {
+						cycle = append(cycle, n)
+					}
+				}
+			}
+		}
+	}
+
+	// iterate types in sorted order for deterministic offender-naming
+	types := make([]string, 0, len(g))
+	for t := range g {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	for _, t := range types {
+		if _, seen := indices[t]; !seen {
+			sc(t)
+		}
+		if len(cycle) > 0 {
+			break
+		}
+	}
+	if len(cycle) > 0 {
+		sort.Strings(cycle)
+		return fmt.Errorf("grammar: circular Requires detected among %v (D17)", cycle)
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func hasGrammar(s *schema.ModuleSchema) bool {
+	d := fromSchema(s)
+	return len(d.Provides) > 0 || len(d.Requires) > 0 || d.Attaches != nil ||
+		d.Fragment != nil || len(d.RouteMiddlewares) > 0 || len(d.RuntimeHooks) > 0
+}
+
+func fromSchema(s *schema.ModuleSchema) schema.GrammarDecl {
+	return schema.GrammarDecl{
+		Provides:         s.Provides,
+		Requires:         s.Requires,
+		Attaches:         s.Attaches,
+		RouteMiddlewares: s.RouteMiddlewares,
+		Fragment:         s.Fragment,
+		RuntimeHooks:     s.RuntimeHooks,
+	}
+}
+
+func union(a, b []string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, x := range append(a, b...) {
+		if x == "" || seen[x] {
+			continue
+		}
+		seen[x] = true
+		out = append(out, x)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func minI(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/capability/scaffold/grammar_test.go
+++ b/capability/scaffold/grammar_test.go
@@ -1,0 +1,194 @@
+package scaffold
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+// TestMerge_DeterministicAcrossMapOrder asserts V10: the same {set, grammar
+// sources} produce byte-identical merged-grammar JSON across runs regardless of
+// Go map iteration order. Engine-first seeding + (provider, type) sort = stable.
+func TestMerge_DeterministicAcrossMapOrder(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "http.router", Requires: []string{"http.server"}})
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p1", Grammar: map[string]schema.GrammarDecl{"a": {Provides: []string{"a.Svc"}}}},
+			{Name: "p2", Grammar: map[string]schema.GrammarDecl{"b": {Provides: []string{"b.Svc"}}}},
+		}},
+	}}
+	g1, _, err := MergeGrammar(r, inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g2, _, err := MergeGrammar(r, inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalMerged(t, g1, g2) {
+		t.Fatal("non-deterministic merge (V10)")
+	}
+}
+
+// TestMerge_CycleDetected asserts D17: A.requires B, B.requires A → Tarjan SCC
+// cycle → named-offender error.
+func TestMerge_CycleDetected(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "A", Requires: []string{"B"}})
+	r.Register(&schema.ModuleSchema{Type: "B", Requires: []string{"A"}})
+	_, _, err := MergeGrammar(r, &inventory.Inventory{})
+	if err == nil {
+		t.Fatal("want cycle error (D17)")
+	}
+}
+
+// TestMerge_ConflictingAttachesIsError asserts D22: two plugins declare grammar
+// for the same type with different Attaches.To → scalar per-field conflict error.
+func TestMerge_ConflictingAttachesIsError(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p1", Grammar: map[string]schema.GrammarDecl{"m": {Attaches: &schema.AttachSpec{To: "a"}}}},
+			{Name: "p2", Grammar: map[string]schema.GrammarDecl{"m": {Attaches: &schema.AttachSpec{To: "b"}}}},
+		}},
+	}}
+	_, _, err := MergeGrammar(r, inv)
+	if err == nil {
+		t.Fatal("want scalar conflict error (D22)")
+	}
+}
+
+// TestMerge_IdenticalReDeclarationIsNoOp asserts D22's no-op half: two plugins
+// declare IDENTICAL grammar for the same type → union/merge, no conflict.
+func TestMerge_IdenticalReDeclarationIsNoOp(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "a"}) // Attaches.To target must resolve (D23)
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p1", Grammar: map[string]schema.GrammarDecl{"m": {Attaches: &schema.AttachSpec{To: "a"}, Provides: []string{"m.Svc"}}}},
+			{Name: "p2", Grammar: map[string]schema.GrammarDecl{"m": {Attaches: &schema.AttachSpec{To: "a"}, Provides: []string{"m.Other"}}}},
+		}},
+	}}
+	merged, _, err := MergeGrammar(r, inv)
+	if err != nil {
+		t.Fatalf("identical re-declaration must be a no-op (D22): %v", err)
+	}
+	g := merged["m"]
+	if g.Attaches == nil || g.Attaches.To != "a" {
+		t.Fatalf("Attaches not preserved on identical re-decl: %+v", g)
+	}
+	// Provides list-union (sorted): both contributes merged.
+	if len(g.Provides) != 2 {
+		t.Fatalf("Provides not union-merged: %+v", g.Provides)
+	}
+}
+
+// TestMerge_PhantomAttachesIsLoadError asserts D23: Attaches.To references a type
+// not present in the merged grammar (or engine registry) → grammar-load error.
+func TestMerge_PhantomAttachesIsLoadError(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p", Grammar: map[string]schema.GrammarDecl{"m": {Attaches: &schema.AttachSpec{To: "ghost"}}}},
+		}},
+	}}
+	_, _, err := MergeGrammar(r, inv)
+	if err == nil {
+		t.Fatal("want phantom-target load error (D23)")
+	}
+}
+
+// TestMerge_PhantomRequiresIsLoadError asserts D23 for Requires edges too.
+func TestMerge_PhantomRequiresIsLoadError(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p", Grammar: map[string]schema.GrammarDecl{"m": {Requires: []string{"nope"}}}},
+		}},
+	}}
+	_, _, err := MergeGrammar(r, inv)
+	if err == nil {
+		t.Fatal("want phantom-target load error for Requires (D23)")
+	}
+}
+
+// TestMerge_EmptyGrammarNoOp asserts D8: types/providers with no grammar
+// contribute nothing and produce no error. A bare (no-grammar) builtin is
+// excluded from merged; a no-grammar plugin adds nothing. merged is empty.
+// (GrammarWire receives the registry separately for type lookups, so merged
+// carries only grammar-bearing types.)
+func TestMerge_EmptyGrammarNoOp(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "http.server"}) // bare: no grammar
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{{Name: "p"}}}, // no Grammar
+	}}
+	merged, hooks, err := MergeGrammar(r, inv)
+	if err != nil || len(merged) != 0 || len(hooks) != 0 {
+		t.Fatalf("empty-grammar no-op failed: merged=%+v hooks=%v err=%v", merged, hooks, err)
+	}
+}
+
+// TestMerge_EngineWinsDropsPluginGrammar asserts D25: a plugin's grammar for an
+// engine-registered type is ignored (engine wins), NOT a conflict. The engine's
+// grammar for that type is what survives.
+func TestMerge_EngineWinsDropsPluginGrammar(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "engine.type", Provides: []string{"engine.Svc"}})
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p", Grammar: map[string]schema.GrammarDecl{"engine.type": {Provides: []string{"plugin.Svc"}}}},
+		}},
+	}}
+	merged, _, err := MergeGrammar(r, inv)
+	if err != nil {
+		t.Fatalf("engine-wins must not error (D25): %v", err)
+	}
+	g, ok := merged["engine.type"]
+	if !ok {
+		t.Fatal("engine grammar for engine.type must survive (D25)")
+	}
+	// Engine Provides wins; plugin Provides ignored (not unioned).
+	if len(g.Provides) != 1 || g.Provides[0] != "engine.Svc" {
+		t.Fatalf("engine-wins failed: %+v want [engine.Svc]", g.Provides)
+	}
+}
+
+// TestMerge_CollectsRuntimeHooks asserts Category B RuntimeHooks are collected
+// (sorted, de-duplicated) for NEXT_STEPS documentation (D3).
+func TestMerge_CollectsRuntimeHooks(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "auth.jwt", RuntimeHooks: []string{"auth-provider-registration"}})
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p", Grammar: map[string]schema.GrammarDecl{"health.checker": {RuntimeHooks: []string{"health-endpoints"}}}},
+		}},
+	}}
+	_, hooks, err := MergeGrammar(r, inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"auth-provider-registration": true, "health-endpoints": true}
+	if len(hooks) != 2 || !want[hooks[0]] || !want[hooks[1]] {
+		t.Fatalf("RuntimeHooks not collected/sorted: %+v", hooks)
+	}
+}
+
+// equalMerged proves determinism: marshal both merged grammars to JSON (map keys
+// sorted deterministically by encoding/json) and byte-compare.
+func equalMerged(t *testing.T, a, b MergedGrammar) bool {
+	t.Helper()
+	aj, err := json.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bj, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.Equal(aj, bj)
+}

--- a/capability/scaffold/grammar_test.go
+++ b/capability/scaffold/grammar_test.go
@@ -158,6 +158,28 @@ func TestMerge_EngineWinsDropsPluginGrammar(t *testing.T) {
 	}
 }
 
+// TestMerge_EngineWinsEvenWithoutGrammar locks in Copilot's D25 finding: an
+// engine-registered type with NO grammar today still owns its type namespace —
+// a plugin's grammar for it is ignored (engine wins), rather than adopted and
+// later silently dropped when the engine eventually authors grammar.
+func TestMerge_EngineWinsEvenWithoutGrammar(t *testing.T) {
+	r := schema.NewModuleSchemaRegistry()
+	r.Register(&schema.ModuleSchema{Type: "engine.bare"}) // registered, no grammar yet
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x", Providers: []inventory.Provider{
+			{Name: "p", Grammar: map[string]schema.GrammarDecl{"engine.bare": {Provides: []string{"plugin.Svc"}}}},
+		}},
+	}}
+	merged, _, err := MergeGrammar(r, inv)
+	if err != nil {
+		t.Fatalf("engine-wins must not error (D25): %v", err)
+	}
+	// engine.bare is engine-registered → plugin grammar ignored → NOT in merged.
+	if g, ok := merged["engine.bare"]; ok {
+		t.Fatalf("plugin grammar for engine-registered (grammar-less) type must be ignored (D25): %+v", g)
+	}
+}
+
 // TestMerge_CollectsRuntimeHooks asserts Category B RuntimeHooks are collected
 // (sorted, de-duplicated) for NEXT_STEPS documentation (D3).
 func TestMerge_CollectsRuntimeHooks(t *testing.T) {
@@ -165,7 +187,7 @@ func TestMerge_CollectsRuntimeHooks(t *testing.T) {
 	r.Register(&schema.ModuleSchema{Type: "auth.jwt", RuntimeHooks: []string{"auth-provider-registration"}})
 	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
 		{ID: "x", Providers: []inventory.Provider{
-			{Name: "p", Grammar: map[string]schema.GrammarDecl{"health.checker": {RuntimeHooks: []string{"health-endpoints"}}}},
+			{Name: "p", Grammar: map[string]schema.GrammarDecl{"plugin.thing": {RuntimeHooks: []string{"health-endpoints"}}}},
 		}},
 	}}
 	_, hooks, err := MergeGrammar(r, inv)

--- a/mcp/module_schema_mcp_test.go
+++ b/mcp/module_schema_mcp_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+// TestModuleSchemaToMapIncludesAllFields asserts D24: get_module_schema's
+// hand-map serializes EVERY ModuleSchema field, including the additive fields
+// the prior literal dropped — MaxIncoming/MaxOutgoing and the Assembly Grammar
+// fields (Provides/Requires/Attaches/RouteMiddlewares/Fragment/RuntimeHooks).
+func TestModuleSchemaToMapIncludesAllFields(t *testing.T) {
+	mi := 0
+	mo := 8
+	ms := &schema.ModuleSchema{
+		Type:             "x.test",
+		Label:            "Test",
+		Category:         "http",
+		Description:      "desc",
+		Provides:         []string{"x.Svc"},
+		Requires:         []string{"x.dep"},
+		Attaches:         &schema.AttachSpec{To: "x.dep", Emit: "workflows.http"},
+		RouteMiddlewares: []string{"auth-mw"},
+		Fragment:         &schema.FragmentSpec{Kind: "crud-route", Fields: []string{"resourceName"}},
+		RuntimeHooks:     []string{"auth-provider-registration"},
+		MaxIncoming:      &mi,
+		MaxOutgoing:      &mo,
+	}
+
+	out := moduleSchemaToMap(ms)
+
+	// Every field must be PRESENT in the output map (D24 — ⊥ the old hand-map
+	// which silently dropped additive fields). Check key existence explicitly.
+	wantKeys := []string{
+		"type", "label", "category", "description",
+		"inputs", "outputs", "configFields", "defaultConfig",
+		"maxIncoming", "maxOutgoing",
+		"provides", "requires", "attaches", "routeMiddlewares", "fragment", "runtimeHooks",
+	}
+	for _, k := range wantKeys {
+		if _, ok := out[k]; !ok {
+			t.Errorf("D24: field %q missing from moduleSchemaToMap output", k)
+		}
+	}
+
+	// Spot-check grammar CONTENT round-trips (not just presence).
+	if r, ok := out["requires"].([]string); !ok || len(r) != 1 || r[0] != "x.dep" {
+		t.Errorf("requires not round-tripped: %+v", out["requires"])
+	}
+	if a, ok := out["attaches"].(*schema.AttachSpec); !ok || a.To != "x.dep" || a.Emit != "workflows.http" {
+		t.Errorf("attaches not round-tripped: %+v", out["attaches"])
+	}
+	if f, ok := out["fragment"].(*schema.FragmentSpec); !ok || f.Kind != "crud-route" || len(f.Fields) != 1 {
+		t.Errorf("fragment not round-tripped: %+v", out["fragment"])
+	}
+	if mi2, ok := out["maxIncoming"].(*int); !ok || mi2 == nil || *mi2 != 0 {
+		t.Errorf("maxIncoming not round-tripped: %+v", out["maxIncoming"])
+	}
+}
+
+// TestModuleSchemaToMapNilOptionalFields asserts a bare schema (no grammar, no
+// limits) still maps cleanly — optional fields carry their zero value, not panic.
+func TestModuleSchemaToMapNilOptionalFields(t *testing.T) {
+	ms := &schema.ModuleSchema{Type: "bare"}
+	out := moduleSchemaToMap(ms)
+	if out["type"] != "bare" {
+		t.Fatalf("type not set: %+v", out)
+	}
+	// Grammar fields present as nil (⊥ absent). Existence is what matters for
+	// agent consumers expecting a stable shape.
+	for _, k := range []string{"provides", "requires", "attaches", "fragment", "runtimeHooks", "maxIncoming"} {
+		if _, ok := out[k]; !ok {
+			t.Errorf("D24: optional field %q must still be present (nil) for shape stability", k)
+		}
+	}
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -127,18 +127,36 @@ func (s *Server) handleGetModuleSchema(_ context.Context, req mcp.CallToolReques
 
 	example := generateModuleExample(ms)
 
-	result := map[string]any{
-		"type":          ms.Type,
-		"label":         ms.Label,
-		"category":      ms.Category,
-		"description":   ms.Description,
-		"inputs":        ms.Inputs,
-		"outputs":       ms.Outputs,
-		"configFields":  ms.ConfigFields,
-		"defaultConfig": ms.DefaultConfig,
-		"example":       example,
-	}
+	result := moduleSchemaToMap(ms)
+	result["example"] = example
 	return marshalToolResult(result)
+}
+
+// moduleSchemaToMap serializes a ModuleSchema into the get_module_schema tool's
+// output shape, including ALL fields. D24: the prior hand-map literal silently
+// dropped additive fields — MaxIncoming/MaxOutgoing and the Assembly Grammar
+// fields (Provides/Requires/Attaches/RouteMiddlewares/Fragment/RuntimeHooks) —
+// so agents consuming get_module_schema never saw them. Kept pure (no server
+// state) so the serialization is unit-testable directly.
+func moduleSchemaToMap(ms *schema.ModuleSchema) map[string]any {
+	return map[string]any{
+		"type":             ms.Type,
+		"label":            ms.Label,
+		"category":         ms.Category,
+		"description":      ms.Description,
+		"inputs":           ms.Inputs,
+		"outputs":          ms.Outputs,
+		"configFields":     ms.ConfigFields,
+		"defaultConfig":    ms.DefaultConfig,
+		"maxIncoming":      ms.MaxIncoming,
+		"maxOutgoing":      ms.MaxOutgoing,
+		"provides":         ms.Provides,
+		"requires":         ms.Requires,
+		"attaches":         ms.Attaches,
+		"routeMiddlewares": ms.RouteMiddlewares,
+		"fragment":         ms.Fragment,
+		"runtimeHooks":     ms.RuntimeHooks,
+	}
 }
 
 func (s *Server) handleGetStepSchema(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/plugin/manifest.go
+++ b/plugin/manifest.go
@@ -46,6 +46,12 @@ type PluginManifest struct {
 	WorkflowTypes []string         `json:"workflowTypes,omitempty" yaml:"workflowTypes,omitempty"`
 	WiringHooks   []string         `json:"wiringHooks,omitempty" yaml:"wiringHooks,omitempty"`
 
+	// Grammar is a NEW sibling top-level field (⊥ nesting under moduleTypes,
+	// which is []string) declaring Assembly Grammar keyed by module-type name
+	// (ADR 0049 / design D1). Local/sibling plugin.json parses permissively;
+	// registry-manifest grammar is deferred to M2 (strict registry-schema.json).
+	Grammar map[string]schema.GrammarDecl `json:"grammar,omitempty" yaml:"grammar,omitempty"`
+
 	// IaCStateBackends lists the iac.state backend names this plugin serves
 	// (e.g. "azure_blob"). Authored in plugin.json either as a top-level
 	// "iacStateBackends" key or nested under the legacy capabilities object

--- a/schema/grammar_test.go
+++ b/schema/grammar_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -31,9 +32,18 @@ func TestModuleSchemaGrammarFieldsRoundTrip(t *testing.T) {
 	if len(got.RouteMiddlewares) != 1 || got.RouteMiddlewares[0] != "auth-mw" {
 		t.Fatalf("RouteMiddlewares lost")
 	}
-	// omitzero: a schema w/o grammar marshals cleanly (no null fields)
+	// omitempty: a schema with no grammar marshals cleanly, OMITTING the grammar
+	// keys entirely (⊥ serializing them as explicit nulls). Assert each grammar
+	// key is absent from the marshaled output.
 	bare := &ModuleSchema{Type: "x"}
-	if out, _ := json.Marshal(bare); string(out) == "" {
-		t.Fatal("bare marshal empty")
+	out, err := json.Marshal(bare)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2 := string(out)
+	for _, field := range []string{"provides", "requires", "attaches", "routeMiddlewares", "fragment", "runtimeHooks"} {
+		if strings.Contains(got2, `"`+field+`"`) {
+			t.Fatalf("bare schema must omit empty grammar field %q via omitempty, got %s", field, got2)
+		}
 	}
 }

--- a/schema/grammar_test.go
+++ b/schema/grammar_test.go
@@ -1,0 +1,39 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestModuleSchemaGrammarFieldsRoundTrip(t *testing.T) {
+	s := &ModuleSchema{Type: "http.router",
+		Requires:         []string{"http.server"},
+		Attaches:         &AttachSpec{To: "http.server", Emit: "workflows.http"},
+		Fragment:         &FragmentSpec{Kind: "crud-route", Fields: []string{"resourceName"}},
+		RouteMiddlewares: []string{"auth-mw"},
+		RuntimeHooks:     []string{"auth-provider-registration"},
+		Provides:         []string{"routed"},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ModuleSchema
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Attaches == nil || got.Attaches.To != "http.server" {
+		t.Fatalf("Attaches lost: %+v", got)
+	}
+	if got.Fragment == nil || got.Fragment.Kind != "crud-route" {
+		t.Fatalf("Fragment lost")
+	}
+	if len(got.RouteMiddlewares) != 1 || got.RouteMiddlewares[0] != "auth-mw" {
+		t.Fatalf("RouteMiddlewares lost")
+	}
+	// omitzero: a schema w/o grammar marshals cleanly (no null fields)
+	bare := &ModuleSchema{Type: "x"}
+	if out, _ := json.Marshal(bare); string(out) == "" {
+		t.Fatal("bare marshal empty")
+	}
+}

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -42,18 +42,56 @@ type ServiceIODef struct {
 	Description string `json:"description,omitempty"`
 }
 
+// AttachSpec declares how a module attaches to another (Category A): To = target
+// module type; Emit = the entry-point section key to emit (e.g. "workflows.http").
+type AttachSpec struct {
+	To   string `json:"to,omitempty" yaml:"to,omitempty"`
+	Emit string `json:"emit,omitempty" yaml:"emit,omitempty"`
+}
+
+// FragmentSpec declares a YAML fragment this module emits (Category A): Kind names a
+// closed-set template; Fields are required substitution placeholders (validated present
+// at grammar-load, D20).
+type FragmentSpec struct {
+	Kind   string   `json:"kind" yaml:"kind"`
+	Fields []string `json:"fields,omitempty" yaml:"fields,omitempty"`
+}
+
 // ModuleSchema describes the full configuration schema for a module type.
+//
+// Grammar fields (D7 — extends ModuleSchema, one source of truth):
+//   - Category A (declarative-emittable): Provides/Requires/Attaches/RouteMiddlewares/Fragment.
+//   - Category B (documented runtime preconditions, ⊥ emit): RuntimeHooks (D3).
 type ModuleSchema struct {
-	Type          string           `json:"type"`
-	Label         string           `json:"label"`
-	Category      string           `json:"category"`
-	Description   string           `json:"description,omitempty"`
-	Inputs        []ServiceIODef   `json:"inputs,omitempty"`
-	Outputs       []ServiceIODef   `json:"outputs,omitempty"`
-	ConfigFields  []ConfigFieldDef `json:"configFields"`
-	DefaultConfig map[string]any   `json:"defaultConfig,omitempty"`
-	MaxIncoming   *int             `json:"maxIncoming,omitempty"` // nil=unlimited, 0=none, N=limit
-	MaxOutgoing   *int             `json:"maxOutgoing,omitempty"`
+	Type          string           `json:"type" yaml:"type"`
+	Label         string           `json:"label" yaml:"label"`
+	Category      string           `json:"category" yaml:"category"`
+	Description   string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Inputs        []ServiceIODef   `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Outputs       []ServiceIODef   `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	ConfigFields  []ConfigFieldDef `json:"configFields" yaml:"configFields"`
+	DefaultConfig map[string]any   `json:"defaultConfig,omitempty" yaml:"defaultConfig,omitempty"`
+	MaxIncoming   *int             `json:"maxIncoming,omitempty" yaml:"maxIncoming,omitempty"` // nil=unlimited, 0=none, N=limit
+	MaxOutgoing   *int             `json:"maxOutgoing,omitempty" yaml:"maxOutgoing,omitempty"`
+
+	// Assembly Grammar (D7). Additive; all optional (omitzero via omitempty).
+	Provides         []string      `json:"provides,omitempty" yaml:"provides,omitempty"`
+	Requires         []string      `json:"requires,omitempty" yaml:"requires,omitempty"`
+	Attaches         *AttachSpec   `json:"attaches,omitempty" yaml:"attaches,omitempty"`
+	RouteMiddlewares []string      `json:"routeMiddlewares,omitempty" yaml:"routeMiddlewares,omitempty"`
+	Fragment         *FragmentSpec `json:"fragment,omitempty" yaml:"fragment,omitempty"`
+	RuntimeHooks     []string      `json:"runtimeHooks,omitempty" yaml:"runtimeHooks,omitempty"`
+}
+
+// GrammarDecl is the plugin-manifest grammar subset (a ModuleSchema minus the
+// non-grammar fields) — used in PluginManifest.Grammar map[string]GrammarDecl (Task 2).
+type GrammarDecl struct {
+	Provides         []string      `json:"provides,omitempty" yaml:"provides,omitempty"`
+	Requires         []string      `json:"requires,omitempty" yaml:"requires,omitempty"`
+	Attaches         *AttachSpec   `json:"attaches,omitempty" yaml:"attaches,omitempty"`
+	RouteMiddlewares []string      `json:"routeMiddlewares,omitempty" yaml:"routeMiddlewares,omitempty"`
+	Fragment         *FragmentSpec `json:"fragment,omitempty" yaml:"fragment,omitempty"`
+	RuntimeHooks     []string      `json:"runtimeHooks,omitempty" yaml:"runtimeHooks,omitempty"`
 }
 
 // ModuleSchemaRegistry holds all known module configuration schemas.


### PR DESCRIPTION
## Summary

PR 1/5 of the locked `wfctl scaffold` Platform (Milestone 1) plan. Introduces the **Assembly Grammar** model + loader — the data substrate that PRs 2–5 build on (grammar-driven wire, glue sweep, authed-CRUD vertical). No behavior change yet for existing `wfctl` commands; this PR is purely additive types + a new self-contained package.

Design: \`docs/plans/2026-06-22-scaffold-platform-design.md\` (adversarial Cycle 3 PASS). Plan: \`docs/plans/2026-06-22-scaffold-platform.md\` (Locked, 5 PRs / 12 tasks). ADRs 0049 (Assembly Grammar extends ModuleSchema) + 0050.

## What's in this PR (Tasks 1–4)

- **Task 1** — \`schema.ModuleSchema\` grammar fields + \`AttachSpec\` / \`FragmentSpec\` / \`GrammarDecl\` (Category A emittable: Provides/Requires/Attaches/RouteMiddlewares/Fragment; Category B documented: RuntimeHooks). Additive, \`omitempty\`.
- **Task 2** — \`PluginManifest.Grammar\` as a **sibling top-level** field (⊥ nested under \`moduleTypes\`, which is \`[]string\` — design D1) + inventory retention: \`Provider.Grammar\`, plumbed through \`collectLocalProviders\`, single-source via \`mergeProvider\` first-insert (P5/D26). Registry grammar deferred to M2.
- **Task 3** — new \`capability/scaffold\` package: \`MergeGrammar\` (engine ∪ plugins, engine-wins D25, V10 deterministic order), per-field conflict policy (D22; FragmentSpec compared by value since it holds a \`[]string\`), phantom-target load-error (D23), Tarjan SCC cycle detection (D17), RuntimeHooks collection (D3). Engine-wins drops are surfaced to stderr (P9/P15, ⊥ silent loss).
- **Task 4** — \`mcp\` \`get_module_schema\` hand-map refactored into a pure \`moduleSchemaToMap\` serializing ALL fields (D24 — the prior literal dropped \`maxIncoming\`/\`maxOutgoing\` and would have dropped the new grammar fields).

## Verification

- \`GOWORK=off go build ./...\` — clean
- \`GOWORK=off go test ./...\` — all packages green
- \`GOWORK=off golangci-lint run --new-from-rev=origin/main\` — 0 issues
- New tests: schema grammar round-trip; inventory grammar retention + single-source; scaffold merge determinism / cycle / scalar-conflict / identical-redecl no-op / phantom-target / empty-no-op / engine-wins / RuntimeHook collection; mcp full-field serialization.

## Retro #1 discipline applied

Embedded plan code scanned for correctness, not just structure. Two issues caught + fixed: (a) \`FragmentSpec\` contains \`[]string\` so structs aren't \`!=\`-comparable — compared by value; (b) the plan's \`TestMerge_EmptyGrammarNoOp\` asserted \`len(merged) != 1\` for a bare no-grammar builtin, but under the D8 \`hasGrammar\` filter merged is empty — corrected the assertion to \`!= 0\` (\`GrammarWire\` takes the registry separately for type lookups, so merged carries only grammar-bearing types).

Out of scope (M2+): non-HTTP compositions, registry-manifest grammar, MCP twin, data-model plugin. Tracked in the design Roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)