### PR TITLE
feat(capability): glue-gap sweep + selection-facts + agent wizard-state

### DIFF
--- a/capability/recommend/recommend.go
+++ b/capability/recommend/recommend.go
@@ -66,7 +66,7 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 	req := normalize(opts.Capabilities)
 	cats := normalize(opts.Categories)
 	r.Requested = append([]string(nil), keysSorted(req)...)
-	defaults := normalizeSet(opts.DefaultPlugins)
+	defaults := normalize(opts.DefaultPlugins)
 
 	// matchedTerms records which REQUESTED terms found at least one capability.
 	// A requested term may match by id, name, tag, or description substring, so
@@ -136,12 +136,13 @@ func buildHit(cap *inventory.Capability, defaults map[string]bool) CapabilityHit
 
 // installRequired computes the D10 selection-fact: a provider needs explicit
 // install/setup when its Kind is external or local-plugin AND it is not a
-// built-in default.
+// built-in default. The name is normalized (lower-cased + trimmed) to match how
+// the defaults set is keyed.
 func installRequired(kind, name string, defaults map[string]bool) bool {
 	if kind != "external" && kind != "local-plugin" {
 		return false
 	}
-	return !defaults[name]
+	return !defaults[strings.ToLower(strings.TrimSpace(name))]
 }
 
 // termMatches reports whether a single requested term matches cap by id, name,
@@ -172,16 +173,6 @@ func normalize(ss []string) map[string]bool {
 		if s = strings.ToLower(strings.TrimSpace(s)); s != "" {
 			m[s] = true
 		}
-	}
-	return m
-}
-
-// normalizeSet lower-cases + trims ss into a set (keeps empty-name entries as
-// "not present"). Used for the DefaultPlugins membership check (names).
-func normalizeSet(ss []string) map[string]bool {
-	m := make(map[string]bool, len(ss))
-	for _, s := range ss {
-		m[strings.ToLower(strings.TrimSpace(s))] = true
 	}
 	return m
 }

--- a/capability/recommend/recommend.go
+++ b/capability/recommend/recommend.go
@@ -20,6 +20,13 @@ type Options struct {
 	Capabilities         []string
 	Categories           []string
 	IncludeUncategorized bool
+
+	// DefaultPlugins is the set of always-available (built-in) plugin names, used
+	// to derive the installRequired selection-fact (D10/AS5). Injected by the
+	// caller (e.g. from all.DefaultPlugins) so this package stays pure (⊥ a heavy
+	// plugins/all import). A provider is installRequired when its Kind is
+	// "external" or "local-plugin" AND its name is not in this set.
+	DefaultPlugins []string
 }
 
 // Recommendation is the filtered + grouped result.
@@ -43,6 +50,12 @@ type ProviderSummary struct {
 	Kind          string `json:"kind"`
 	ReleaseStatus string `json:"releaseStatus,omitempty"`
 	Source        string `json:"source,omitempty"`
+
+	// InstallRequired (D10) is a selection FACT: true when this provider needs
+	// explicit install/setup — Kind is "external" or "local-plugin" AND the name
+	// is not a built-in default. Raw Kind/ReleaseStatus above let the consumer
+	// interpret further; ⊥ wiring-implications (M2) and ⊥ quality-rank (D13).
+	InstallRequired bool `json:"installRequired,omitempty"`
 }
 
 // Recommend filters inv to requested capabilities and groups their providers.
@@ -53,6 +66,7 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 	req := normalize(opts.Capabilities)
 	cats := normalize(opts.Categories)
 	r.Requested = append([]string(nil), keysSorted(req)...)
+	defaults := normalizeSet(opts.DefaultPlugins)
 
 	// matchedTerms records which REQUESTED terms found at least one capability.
 	// A requested term may match by id, name, tag, or description substring, so
@@ -79,7 +93,7 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 				continue
 			}
 		}
-		r.Capabilities = append(r.Capabilities, buildHit(cap))
+		r.Capabilities = append(r.Capabilities, buildHit(cap, defaults))
 	}
 	sort.Slice(r.Capabilities, func(i, j int) bool {
 		if r.Capabilities[i].Category != r.Capabilities[j].Category {
@@ -95,7 +109,7 @@ func Recommend(inv *inventory.Inventory, opts Options) *Recommendation {
 	return r
 }
 
-func buildHit(cap *inventory.Capability) CapabilityHit {
+func buildHit(cap *inventory.Capability, defaults map[string]bool) CapabilityHit {
 	h := CapabilityHit{ID: cap.ID, Category: cap.Category, Name: cap.Name}
 	seen := map[string]bool{}
 	for i := range cap.Providers {
@@ -109,14 +123,25 @@ func buildHit(cap *inventory.Capability) CapabilityHit {
 		}
 		seen[key] = true
 		h.Providers = append(h.Providers, ProviderSummary{
-			Name:          p.Name,
-			Kind:          p.Kind,
-			ReleaseStatus: p.ReleaseStatus,
-			Source:        p.Source,
+			Name:            p.Name,
+			Kind:            p.Kind,
+			ReleaseStatus:   p.ReleaseStatus,
+			Source:          p.Source,
+			InstallRequired: installRequired(p.Kind, p.Name, defaults),
 		})
 	}
 	sort.Slice(h.Providers, func(i, j int) bool { return h.Providers[i].Name < h.Providers[j].Name })
 	return h
+}
+
+// installRequired computes the D10 selection-fact: a provider needs explicit
+// install/setup when its Kind is external or local-plugin AND it is not a
+// built-in default.
+func installRequired(kind, name string, defaults map[string]bool) bool {
+	if kind != "external" && kind != "local-plugin" {
+		return false
+	}
+	return !defaults[name]
 }
 
 // termMatches reports whether a single requested term matches cap by id, name,
@@ -147,6 +172,16 @@ func normalize(ss []string) map[string]bool {
 		if s = strings.ToLower(strings.TrimSpace(s)); s != "" {
 			m[s] = true
 		}
+	}
+	return m
+}
+
+// normalizeSet lower-cases + trims ss into a set (keeps empty-name entries as
+// "not present"). Used for the DefaultPlugins membership check (names).
+func normalizeSet(ss []string) map[string]bool {
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		m[strings.ToLower(strings.TrimSpace(s))] = true
 	}
 	return m
 }

--- a/capability/recommend/recommend_facts_test.go
+++ b/capability/recommend/recommend_facts_test.go
@@ -1,0 +1,63 @@
+package recommend_test
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/capability/recommend"
+)
+
+// TestRecommend_InstallRequiredFacts (D10/AS5): each ProviderSummary carries a
+// selection FACT — installRequired — computed as (Kind=="external" or
+// "local-plugin") AND name NOT in the default (built-in) plugin set. Raw
+// Kind/ReleaseStatus are also surfaced as-is for the consumer to interpret.
+// ⊥ "wiring implications" (M2) and ⊥ quality-rank (D13).
+func TestRecommend_InstallRequiredFacts(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "auth.authz", Category: "auth", Name: "Authorization", Providers: []inventory.Provider{
+			{Name: "auth", Kind: "external", ReleaseStatus: "released"},         // built-in name → not required
+			{Name: "custom", Kind: "local-plugin", ReleaseStatus: "local-only"}, // not built-in + local → required
+			{Name: "authz-pro", Kind: "registry", ReleaseStatus: "released"},    // registry kind → not required (formula)
+		}},
+	}}
+
+	rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"auth"}, DefaultPlugins: []string{"auth"}})
+	hit := findHit(t, rec, "auth.authz")
+
+	want := map[string]bool{
+		"auth":      false, // "auth" is a default plugin name
+		"custom":    true,  // not a default; local-plugin
+		"authz-pro": false, // registry kind (not external/local-plugin)
+	}
+	got := map[string]bool{}
+	for _, p := range hit.Providers {
+		// Raw Kind/ReleaseStatus must still be surfaced (D10).
+		if p.Kind == "" {
+			t.Fatalf("provider %q missing raw Kind", p.Name)
+		}
+		got[p.Name] = p.InstallRequired
+	}
+	for name, exp := range want {
+		if g, ok := got[name]; !ok {
+			t.Fatalf("provider %q missing from recommendation", name)
+		} else if g != exp {
+			t.Fatalf("provider %q installRequired: got %v want %v", name, g, exp)
+		}
+	}
+}
+
+// TestRecommend_InstallRequiredNoDefaults: with no DefaultPlugins provided,
+// every external/local-plugin provider is installRequired (nothing is
+// pre-considered built-in).
+func TestRecommend_InstallRequiredNoDefaults(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x.y", Category: "x", Name: "X", Providers: []inventory.Provider{
+			{Name: "ext", Kind: "external", ReleaseStatus: "released"},
+		}},
+	}}
+	rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"x"}})
+	hit := findHit(t, rec, "x.y")
+	if len(hit.Providers) != 1 || !hit.Providers[0].InstallRequired {
+		t.Fatalf("external provider with no defaults must be installRequired: %+v", hit.Providers)
+	}
+}

--- a/capability/recommend/state.go
+++ b/capability/recommend/state.go
@@ -1,0 +1,67 @@
+package recommend
+
+import (
+	"fmt"
+)
+
+// WizardState is the agent-consumable scaffold wizard state (design G4/§C4).
+// Transport-agnostic JSON: the MCP/ACP twin is deferred to M4; M1 emits this
+// directly so any host (CLI, agent) can consume it. It composes the chosen
+// capability providers (+ facts) with the grammar wire's glue-gaps and
+// Category-B runtime-hook preconditions, surfaced as actionable NextSteps.
+type WizardState struct {
+	Chosen       []WizardProvider `json:"chosen"`
+	Alternatives []WizardProvider `json:"alternatives,omitempty"`
+	GlueGaps     []string         `json:"glueGaps,omitempty"`
+	NextSteps    []string         `json:"nextSteps,omitempty"`
+}
+
+// WizardProvider is a single provider within the wizard state, carrying the
+// selection facts (raw Kind/ReleaseStatus + installRequired).
+type WizardProvider struct {
+	CapabilityID    string `json:"capabilityId"`
+	Category        string `json:"category,omitempty"`
+	Name            string `json:"name"`
+	Kind            string `json:"kind"`
+	ReleaseStatus   string `json:"releaseStatus,omitempty"`
+	InstallRequired bool   `json:"installRequired,omitempty"`
+}
+
+// BuildWizardState composes a WizardState from a Recommendation. For each
+// capability the first provider is "chosen" and the rest are "alternatives",
+// each carrying its facts. glueGaps (unselected Attaches.To from the grammar
+// wire) pass through; hooks (Category-B RuntimeHooks) become NextSteps, as does
+// an explicit "install <name>" step for every installRequired provider.
+func BuildWizardState(rec *Recommendation, glueGaps, hooks []string) *WizardState {
+	ws := &WizardState{GlueGaps: append([]string(nil), glueGaps...)}
+
+	seenInstall := map[string]bool{}
+	for _, cap := range rec.Capabilities {
+		for i, p := range cap.Providers {
+			wp := WizardProvider{
+				CapabilityID:    cap.ID,
+				Category:        cap.Category,
+				Name:            p.Name,
+				Kind:            p.Kind,
+				ReleaseStatus:   p.ReleaseStatus,
+				InstallRequired: p.InstallRequired,
+			}
+			if i == 0 {
+				ws.Chosen = append(ws.Chosen, wp)
+			} else {
+				ws.Alternatives = append(ws.Alternatives, wp)
+			}
+			if p.InstallRequired && !seenInstall[p.Name] {
+				seenInstall[p.Name] = true
+				ws.NextSteps = append(ws.NextSteps, fmt.Sprintf("install provider %q (%s) — not a built-in default", p.Name, p.Kind))
+			}
+		}
+	}
+	for _, h := range hooks {
+		ws.NextSteps = append(ws.NextSteps, fmt.Sprintf("runtime precondition: %s (fired at boot)", h))
+	}
+	for _, g := range glueGaps {
+		ws.NextSteps = append(ws.NextSteps, fmt.Sprintf("glue gap: %s", g))
+	}
+	return ws
+}

--- a/capability/recommend/state_test.go
+++ b/capability/recommend/state_test.go
@@ -1,0 +1,93 @@
+package recommend_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/capability/recommend"
+)
+
+// TestBuildWizardState (design G4/§C4): the wizard-state emitter produces an
+// agent-consumable JSON — Chosen (first provider per capability, with facts),
+// Alternatives (the rest), GlueGaps, and NextSteps (Category-B hooks +
+// install steps for installRequired providers). An agent can parse + read it.
+func TestBuildWizardState(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "auth.authn", Category: "auth", Name: "Authentication", Providers: []inventory.Provider{
+			{Name: "auth", Kind: "external", ReleaseStatus: "released"},           // chosen (first)
+			{Name: "auth-alt", Kind: "local-plugin", ReleaseStatus: "local-only"}, // alternative
+		}},
+	}}
+	rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"auth"}})
+
+	ws := recommend.BuildWizardState(rec,
+		[]string{"auth attaches to http.router (not selected)"}, // glue-gaps from the grammar wire
+		[]string{"auth-provider-registration"},                  // Category-B RuntimeHooks
+	)
+
+	// Chosen = first provider of the capability, carrying facts.
+	if len(ws.Chosen) != 1 || ws.Chosen[0].CapabilityID != "auth.authn" || ws.Chosen[0].Name != "auth" {
+		t.Fatalf("chosen wrong: %+v", ws.Chosen)
+	}
+	if ws.Chosen[0].Kind != "external" {
+		t.Fatalf("chosen must carry raw Kind: %+v", ws.Chosen[0])
+	}
+	// Alternatives = the remaining providers.
+	if len(ws.Alternatives) != 1 || ws.Alternatives[0].Name != "auth-alt" {
+		t.Fatalf("alternatives wrong: %+v", ws.Alternatives)
+	}
+	// GlueGaps pass through.
+	if len(ws.GlueGaps) != 1 || !strings.Contains(ws.GlueGaps[0], "http.router") {
+		t.Fatalf("glueGaps wrong: %+v", ws.GlueGaps)
+	}
+	// NextSteps carry the Category-B hook.
+	foundHook := false
+	for _, s := range ws.NextSteps {
+		if strings.Contains(s, "auth-provider-registration") {
+			foundHook = true
+		}
+	}
+	if !foundHook {
+		t.Fatalf("nextSteps must surface the Category-B hook: %+v", ws.NextSteps)
+	}
+
+	// Agent-consumable: JSON round-trips + has the documented top-level keys.
+	b, err := json.Marshal(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("wizard-state JSON not agent-parseable: %v", err)
+	}
+	for _, key := range []string{"chosen", "alternatives", "glueGaps", "nextSteps"} {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("wizard-state JSON missing top-level key %q: %s", key, b)
+		}
+	}
+}
+
+// TestBuildWizardState_InstallSteps: an installRequired alternative provider
+// surfaces a NextStep telling the agent to install it.
+func TestBuildWizardState_InstallSteps(t *testing.T) {
+	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
+		{ID: "x.y", Category: "x", Name: "X", Providers: []inventory.Provider{
+			{Name: "builtin", Kind: "registry", ReleaseStatus: "released"},
+			{Name: "needs-install", Kind: "local-plugin", ReleaseStatus: "local-only"},
+		}},
+	}}
+	rec := recommend.Recommend(inv, recommend.Options{Categories: []string{"x"}})
+	ws := recommend.BuildWizardState(rec, nil, nil)
+
+	foundInstall := false
+	for _, s := range ws.NextSteps {
+		if strings.Contains(s, "needs-install") && strings.Contains(strings.ToLower(s), "install") {
+			foundInstall = true
+		}
+	}
+	if !foundInstall {
+		t.Fatalf("installRequired provider must surface an install NextStep: %+v", ws.NextSteps)
+	}
+}

--- a/capability/scaffold/grammar_test.go
+++ b/capability/scaffold/grammar_test.go
@@ -122,7 +122,7 @@ func TestMerge_PhantomRequiresIsLoadError(t *testing.T) {
 // (GrammarWire receives the registry separately for type lookups, so merged
 // carries only grammar-bearing types.)
 func TestMerge_EmptyGrammarNoOp(t *testing.T) {
-	r := schema.NewModuleSchemaRegistry()
+	r := schema.NewModuleSchemaRegistryWithoutBuiltins()
 	r.Register(&schema.ModuleSchema{Type: "http.server"}) // bare: no grammar
 	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
 		{ID: "x", Providers: []inventory.Provider{{Name: "p"}}}, // no Grammar
@@ -183,7 +183,7 @@ func TestMerge_EngineWinsEvenWithoutGrammar(t *testing.T) {
 // TestMerge_CollectsRuntimeHooks asserts Category B RuntimeHooks are collected
 // (sorted, de-duplicated) for NEXT_STEPS documentation (D3).
 func TestMerge_CollectsRuntimeHooks(t *testing.T) {
-	r := schema.NewModuleSchemaRegistry()
+	r := schema.NewModuleSchemaRegistryWithoutBuiltins()
 	r.Register(&schema.ModuleSchema{Type: "auth.jwt", RuntimeHooks: []string{"auth-provider-registration"}})
 	inv := &inventory.Inventory{Capabilities: []inventory.Capability{
 		{ID: "x", Providers: []inventory.Provider{

--- a/capability/scaffold/real_registry_parity_test.go
+++ b/capability/scaffold/real_registry_parity_test.go
@@ -1,0 +1,79 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/capability/assembler"
+	"github.com/GoCodeAlone/workflow/capability/inventory"
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/schema"
+)
+
+// TestWire_RealRegistryParity (plan Task 6 verification): the grammar-driven
+// wire must reproduce v0.82.0 wire() wiring when the merged grammar comes from
+// the REAL engine registry (post glue-gap sweep), not a hand-built synthetic.
+// This is the proof that the sweep encoded the v0.82.0 rules faithfully — the
+// same MC-parity guard as TestWire_ParityWithV082 but against real builtins.
+func TestWire_RealRegistryParity(t *testing.T) {
+	reg := schema.NewModuleSchemaRegistry()
+	merged, _, err := MergeGrammar(reg, &inventory.Inventory{})
+	if err != nil {
+		t.Fatalf("MergeGrammar(real registry): %v", err)
+	}
+	alwaysSelect := []string{"http.router", "health.checker"} // P2: entry-point + /healthz
+
+	cases := []struct {
+		name string
+		mods []config.ModuleConfig
+	}{
+		{"db-only", []config.ModuleConfig{{Name: "db", Type: "database.workflow"}}},
+		{"with-middleware", []config.ModuleConfig{
+			{Name: "db", Type: "database.workflow"},
+			{Name: "logging", Type: "http.middleware.logging"},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldMods := assembler.WirePublic(append([]config.ModuleConfig{}, tc.mods...))
+			oldWF := assembler.HttpWorkflowPublic(oldMods)
+
+			res := GrammarWire(append([]config.ModuleConfig{}, tc.mods...), merged, reg, alwaysSelect)
+
+			if !moduleGraphsEqual(res.Modules, oldMods) {
+				t.Fatalf("%s: real-registry module graph drift\ngrammar=%s\nv082=%s",
+					tc.name, dumpGraph(res.Modules), dumpGraph(oldMods))
+			}
+			if !workflowsEqual(res.Workflows, oldWF) {
+				t.Fatalf("%s: real-registry workflows.http drift\ngrammar=%#v\nv082=%#v", tc.name, res.Workflows, oldWF)
+			}
+		})
+	}
+}
+
+// TestWire_RealRegistryAuthedCRUDRoutes (D4): a real-registry api.handler
+// scaffold emits the crud-route routes attached to the router with the auth
+// middleware. (The full boot + 401 proof is Task 12; this asserts the grammar
+// produces the correct route shape from real builtins.)
+func TestWire_RealRegistryAuthedCRUDRoutes(t *testing.T) {
+	reg := schema.NewModuleSchemaRegistry()
+	merged, _, err := MergeGrammar(reg, &inventory.Inventory{})
+	if err != nil {
+		t.Fatalf("MergeGrammar: %v", err)
+	}
+	mods := []config.ModuleConfig{{Name: "api", Type: "api.handler", Config: map[string]any{"resourceName": "orders"}}}
+	res := GrammarWire(mods, merged, reg, []string{"http.router", "health.checker"})
+
+	if !hasType(res.Modules, "http.router") || !hasType(res.Modules, "http.middleware.auth") {
+		t.Fatalf("api.handler scaffold must ensure router + auth middleware: %s", dumpGraph(res.Modules))
+	}
+	routes := wfRoutes(res.Workflows)
+	if len(routes) != 5 {
+		t.Fatalf("want 5 crud routes, got %d: %+v", len(routes), routes)
+	}
+	for _, r := range routes {
+		mw, _ := r["middlewares"].([]string)
+		if len(mw) != 1 || mw[0] != "auth" {
+			t.Fatalf("real-registry crud route must carry auth middleware: %+v", r)
+		}
+	}
+}

--- a/cmd/wfctl/capability.go
+++ b/cmd/wfctl/capability.go
@@ -265,7 +265,11 @@ func runCapabilityRecommend(args []string, out io.Writer) error {
 	var buf bytes.Buffer
 	switch format {
 	case "json":
-		if err := writeCapabilityJSON(&buf, rec); err != nil {
+		// Emit the agent-consumable wizard state (G4/§C4): chosen providers
+		// (+facts), alternatives, glue-gaps, and NextSteps. The plain recommend
+		// command has no grammar wire in flight, so glue-gaps/hooks are empty
+		// here; the scaffold flow populates them when it runs the wire.
+		if err := writeCapabilityJSON(&buf, recommend.BuildWizardState(rec, nil, nil)); err != nil {
 			return err
 		}
 	case "md", "markdown":

--- a/cmd/wfctl/capability.go
+++ b/cmd/wfctl/capability.go
@@ -15,7 +15,21 @@ import (
 
 	"github.com/GoCodeAlone/workflow/capability/inventory"
 	"github.com/GoCodeAlone/workflow/capability/recommend"
+	allplugins "github.com/GoCodeAlone/workflow/plugins/all"
 )
+
+// defaultPluginNames returns the names of the engine's built-in (always-
+// available) plugins, used to derive the recommend installRequired selection-
+// fact (D10): a recommended provider is installRequired when it is external or
+// local-plugin AND its name is not in this set.
+func defaultPluginNames() []string {
+	plugins := allplugins.DefaultPlugins()
+	names := make([]string, 0, len(plugins))
+	for _, p := range plugins {
+		names = append(names, p.Name())
+	}
+	return names
+}
 
 func runCapability(args []string) error {
 	return runCapabilityWithOutput(args, os.Stdout)
@@ -246,6 +260,7 @@ func runCapabilityRecommend(args []string, out io.Writer) error {
 		Capabilities:         capabilities,
 		Categories:           categories,
 		IncludeUncategorized: includeUncat,
+		DefaultPlugins:       defaultPluginNames(),
 	})
 	var buf bytes.Buffer
 	switch format {

--- a/cmd/wfctl/capability_build.go
+++ b/cmd/wfctl/capability_build.go
@@ -43,7 +43,7 @@ func (s *buildSelection) recommendation() *recommend.Recommendation {
 	if len(ids) == 0 {
 		return &recommend.Recommendation{}
 	}
-	return recommend.Recommend(s.inv, recommend.Options{Capabilities: ids})
+	return recommend.Recommend(s.inv, recommend.Options{Capabilities: ids, DefaultPlugins: defaultPluginNames()})
 }
 
 // capabilities returns the sorted inventory capabilities presented on the

--- a/cmd/wfctl/capability_recommend_test.go
+++ b/cmd/wfctl/capability_recommend_test.go
@@ -15,8 +15,10 @@ func TestCapabilityRecommend_JSON(t *testing.T) {
 	if err := runCapabilityWithOutput(args, &out); err != nil {
 		t.Fatalf("runCapability recommend: %v", err)
 	}
-	if !strings.Contains(out.String(), `"capabilities"`) {
-		t.Fatalf("expected JSON capabilities, got: %s", out.String())
+	// recommend --format json emits the agent-consumable wizard state (Task 8),
+	// whose top-level key is "chosen" (the selected providers + facts).
+	if !strings.Contains(out.String(), `"chosen"`) {
+		t.Fatalf("expected wizard-state JSON with \"chosen\", got: %s", out.String())
 	}
 	if !strings.Contains(out.String(), "auth") {
 		t.Fatalf("expected auth provider in output: %s", out.String())

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -106,6 +106,14 @@ func NewModuleSchemaRegistry() *ModuleSchemaRegistry {
 	return r
 }
 
+// NewModuleSchemaRegistryWithoutBuiltins returns an empty registry with no
+// pre-registered builtins, so callers (notably grammar-mechanics tests) can
+// control exactly which types carry grammar without the builtin sweep
+// contributing.
+func NewModuleSchemaRegistryWithoutBuiltins() *ModuleSchemaRegistry {
+	return &ModuleSchemaRegistry{schemas: make(map[string]*ModuleSchema)}
+}
+
 // Register adds or replaces a module schema.
 func (r *ModuleSchemaRegistry) Register(s *ModuleSchema) {
 	r.schemas[s.Type] = s
@@ -168,6 +176,9 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 		},
 		DefaultConfig: map[string]any{"address": ":8080"},
 		MaxIncoming:   intPtr(0),
+		// Assembly Grammar: HTTP entry-point module (provides the server service
+		// that http.router Requires + Attaches to).
+		Provides: []string{"http.Server"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -192,6 +203,10 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 		Inputs:       []ServiceIODef{{Name: "request", Type: "http.Request", Description: "Incoming HTTP request to route"}},
 		Outputs:      []ServiceIODef{{Name: "routed", Type: "http.Request", Description: "Routed HTTP request dispatched to handler"}},
 		ConfigFields: []ConfigFieldDef{},
+		// Assembly Grammar: requires the entry-point server; attaching emits the
+		// workflows.http section (server.AddRouter(router) at boot).
+		Requires: []string{"http.server"},
+		Attaches: &AttachSpec{To: "http.server", Emit: "workflows.http"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -278,6 +293,11 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "summaryFields", Label: "Summary Fields", Type: FieldTypeArray, ArrayItemType: "string", Description: "Field names to include in list/summary responses", Group: "advanced"},
 		},
 		DefaultConfig: map[string]any{"resourceName": "resources"},
+		// Assembly Grammar: attaches to the router, applies the auth middleware to
+		// its routes, and emits a crud-route fragment (per-method routes).
+		Attaches:         &AttachSpec{To: "http.router"},
+		RouteMiddlewares: []string{"http.middleware.auth"},
+		Fragment:         &FragmentSpec{Kind: "crud-route", Fields: []string{"resourceName"}},
 	})
 
 	// ---- CQRS API Category ----
@@ -321,6 +341,8 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "authType", Label: "Auth Type", Type: FieldTypeSelect, Options: []string{"Bearer", "Basic", "ApiKey"}, DefaultValue: "Bearer", Description: "Authentication scheme to enforce"},
 		},
 		DefaultConfig: map[string]any{"authType": "Bearer"},
+		// Assembly Grammar: attaches to the router (middleware chain).
+		Attaches: &AttachSpec{To: "http.router"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -334,6 +356,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "logLevel", Label: "Log Level", Type: FieldTypeSelect, Options: []string{"debug", "info", "warn", "error"}, DefaultValue: "info", Description: "Minimum log level for request logging"},
 		},
 		DefaultConfig: map[string]any{"logLevel": "info"},
+		Attaches:      &AttachSpec{To: "http.router"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -348,6 +371,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "burstSize", Label: "Burst Size", Type: FieldTypeNumber, DefaultValue: 10, Description: "Maximum burst of requests allowed above the rate limit"},
 		},
 		DefaultConfig: map[string]any{"requestsPerMinute": 60, "burstSize": 10},
+		Attaches:      &AttachSpec{To: "http.router"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -365,6 +389,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			"allowedOrigins": []string{"*"},
 			"allowedMethods": []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		},
+		Attaches: &AttachSpec{To: "http.router"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -375,6 +400,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 		Inputs:       []ServiceIODef{{Name: "request", Type: "http.Request", Description: "HTTP request without request ID"}},
 		Outputs:      []ServiceIODef{{Name: "tagged", Type: "http.Request", Description: "HTTP request with X-Request-ID header"}},
 		ConfigFields: []ConfigFieldDef{},
+		Attaches:     &AttachSpec{To: "http.router"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -399,6 +425,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			"referrerPolicy":     "strict-origin-when-cross-origin",
 			"permissionsPolicy":  "camera=(), microphone=(), geolocation=()",
 		},
+		Attaches: &AttachSpec{To: "http.router"},
 	})
 
 	// ---- Messaging Category ----
@@ -632,6 +659,10 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "autoDiscover", Label: "Auto-Discover", Type: FieldTypeBool, DefaultValue: true, Description: "Automatically discover HealthCheckable services"},
 		},
 		DefaultConfig: map[string]any{"healthPath": "/healthz", "readyPath": "/readyz", "livePath": "/livez", "checkTimeout": "5s", "autoDiscover": true},
+		// Assembly Grammar (Category B — documented runtime precondition): the
+		// observability health-endpoints hook binds /healthz when a health.checker
+		// + http.router are co-selected (fired at boot, ⊥ offline-emit).
+		RuntimeHooks: []string{"observability.health-endpoints"},
 	})
 
 	r.Register(&ModuleSchema{
@@ -681,6 +712,10 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "allowRegistration", Label: "Allow Open Registration", Type: FieldTypeBool, DefaultValue: false, Description: "When true, any visitor may register without admin intervention"},
 		},
 		DefaultConfig: map[string]any{"tokenExpiry": "24h", "issuer": "workflow"},
+		// Assembly Grammar (Category B — documented runtime precondition): the
+		// auth-provider-registration hook wires auth.jwt → http.middleware.auth
+		// enforcement when both are co-selected (fired at boot, ⊥ offline-emit).
+		RuntimeHooks: []string{"auth-provider-registration"},
 	})
 
 	// ---- Integration Category ----

--- a/schema/module_schema_grammar_sweep_test.go
+++ b/schema/module_schema_grammar_sweep_test.go
@@ -1,0 +1,73 @@
+package schema
+
+import "testing"
+
+// TestBuiltinGrammarSweep asserts the glue-gap sweep encoded the v0.82.0 in-code
+// wire() rules + the Category-A crud-route fragment as Assembly Grammar on the
+// engine builtins (design §C1/§C2, plan Task 6). The real registry is the single
+// source of truth so the grammar-driven wire reproduces v0.82.0 wiring without a
+// hand-maintained rule table.
+func TestBuiltinGrammarSweep(t *testing.T) {
+	r := NewModuleSchemaRegistry()
+
+	t.Run("http.server entry-point", func(t *testing.T) {
+		s := r.Get("http.server")
+		if s == nil {
+			t.Fatal("http.server missing")
+		}
+		if len(s.Provides) == 0 {
+			t.Fatalf("http.server must Provide an entry-point service: %+v", s)
+		}
+	})
+
+	t.Run("http.router requires + attaches server", func(t *testing.T) {
+		rt := r.Get("http.router")
+		if rt == nil {
+			t.Fatal("http.router missing")
+		}
+		if len(rt.Requires) != 1 || rt.Requires[0] != "http.server" {
+			t.Fatalf("http.router must Require [http.server]: %+v", rt.Requires)
+		}
+		if rt.Attaches == nil || rt.Attaches.To != "http.server" || rt.Attaches.Emit != "workflows.http" {
+			t.Fatalf("http.router Attaches want {To:http.server,Emit:workflows.http}: %+v", rt.Attaches)
+		}
+	})
+
+	t.Run("middlewares attach to router", func(t *testing.T) {
+		for _, typ := range []string{"http.middleware.auth", "http.middleware.logging", "http.middleware.cors", "http.middleware.ratelimit"} {
+			m := r.Get(typ)
+			if m == nil {
+				t.Fatalf("%s missing", typ)
+			}
+			if m.Attaches == nil || m.Attaches.To != "http.router" {
+				t.Fatalf("%s must Attach to http.router: %+v", typ, m.Attaches)
+			}
+		}
+	})
+
+	t.Run("api.handler attaches router + crud-route fragment", func(t *testing.T) {
+		api := r.Get("api.handler")
+		if api == nil {
+			t.Fatal("api.handler missing")
+		}
+		if api.Attaches == nil || api.Attaches.To != "http.router" {
+			t.Fatalf("api.handler must Attach to http.router: %+v", api.Attaches)
+		}
+		if api.Fragment == nil || api.Fragment.Kind != "crud-route" {
+			t.Fatalf("api.handler must have a crud-route fragment: %+v", api.Fragment)
+		}
+	})
+
+	t.Run("category B runtime hooks documented", func(t *testing.T) {
+		// Category B preconditions are DOCUMENTED (⊥ emitted); the MC-functional
+		// proof runs a real engine where the hooks fire (design V13).
+		hc := r.Get("health.checker")
+		if hc == nil || len(hc.RuntimeHooks) == 0 {
+			t.Fatalf("health.checker must document RuntimeHooks: %+v", hc)
+		}
+		jwt := r.Get("auth.jwt")
+		if jwt == nil || len(jwt.RuntimeHooks) == 0 {
+			t.Fatalf("auth.jwt must document RuntimeHooks: %+v", jwt)
+		}
+	})
+}

--- a/schema/testdata/editor-schemas.golden.json
+++ b/schema/testdata/editor-schemas.golden.json
@@ -288,6 +288,18 @@
       ],
       "defaultConfig": {
         "resourceName": "resources"
+      },
+      "attaches": {
+        "to": "http.router"
+      },
+      "routeMiddlewares": [
+        "http.middleware.auth"
+      ],
+      "fragment": {
+        "kind": "crud-route",
+        "fields": [
+          "resourceName"
+        ]
       }
     },
     "api.query": {
@@ -505,7 +517,10 @@
       "defaultConfig": {
         "issuer": "workflow",
         "tokenExpiry": "24h"
-      }
+      },
+      "runtimeHooks": [
+        "auth-provider-registration"
+      ]
     },
     "auth.m2m": {
       "type": "auth.m2m",
@@ -1292,7 +1307,10 @@
         "healthPath": "/healthz",
         "livePath": "/livez",
         "readyPath": "/readyz"
-      }
+      },
+      "runtimeHooks": [
+        "observability.health-endpoints"
+      ]
     },
     "http.client": {
       "type": "http.client",
@@ -1407,6 +1425,9 @@
       ],
       "defaultConfig": {
         "authType": "Bearer"
+      },
+      "attaches": {
+        "to": "http.router"
       }
     },
     "http.middleware.cors": {
@@ -1465,6 +1486,9 @@
         "allowedOrigins": [
           "*"
         ]
+      },
+      "attaches": {
+        "to": "http.router"
       }
     },
     "http.middleware.logging": {
@@ -1503,6 +1527,9 @@
       ],
       "defaultConfig": {
         "logLevel": "info"
+      },
+      "attaches": {
+        "to": "http.router"
       }
     },
     "http.middleware.otel": {
@@ -1572,6 +1599,9 @@
       "defaultConfig": {
         "burstSize": 10,
         "requestsPerMinute": 60
+      },
+      "attaches": {
+        "to": "http.router"
       }
     },
     "http.middleware.requestid": {
@@ -1593,7 +1623,10 @@
           "description": "HTTP request with X-Request-ID header"
         }
       ],
-      "configFields": []
+      "configFields": [],
+      "attaches": {
+        "to": "http.router"
+      }
     },
     "http.middleware.securityheaders": {
       "type": "http.middleware.securityheaders",
@@ -1684,6 +1717,9 @@
         "hstsMaxAge": 31536000,
         "permissionsPolicy": "camera=(), microphone=(), geolocation=()",
         "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "attaches": {
+        "to": "http.router"
       }
     },
     "http.proxy": {
@@ -1726,7 +1762,14 @@
           "description": "Routed HTTP request dispatched to handler"
         }
       ],
-      "configFields": []
+      "configFields": [],
+      "requires": [
+        "http.server"
+      ],
+      "attaches": {
+        "to": "http.server",
+        "emit": "workflows.http"
+      }
     },
     "http.server": {
       "type": "http.server",
@@ -1760,7 +1803,10 @@
       "defaultConfig": {
         "address": ":8080"
       },
-      "maxIncoming": 0
+      "maxIncoming": 0,
+      "provides": [
+        "http.Server"
+      ]
     },
     "http.simple_proxy": {
       "type": "http.simple_proxy",


### PR DESCRIPTION
## Summary

PR 3/5 of the locked \`wfctl scaffold\` Platform (M1) plan. Three capability-layer pieces: the **glue-gap sweep** (engine builtins carry Assembly Grammar), **selection-facts** in \`recommend\`, and the **agent-consumable wizard state**. Builds on PRs #968 (grammar model) + #970 (grammar-driven wire), both merged.

Design \`docs/plans/2026-06-22-scaffold-platform-design.md\` §C1/C3/C4; plan Tasks 6–8.

## Tasks

**T6 — glue-gap sweep (\`schema\`):** encode the v0.82.0 in-code \`wire()\` rules + the Category-A crud-route fragment as Assembly Grammar on engine builtins (single source of truth — no hand-maintained rule table):
- http.server → Provides (entry point); http.router → Requires+Attaches server (emits workflows.http).
- http.middleware.* → Attaches router; api.handler → Attaches router + RouteMiddlewares [auth] + Fragment {crud-route}.
- health.checker / auth.jwt → Category-B RuntimeHooks (documented, fired at boot).
- \`TestWire_RealRegistryParity\` proves the grammar wire reproduces v0.82.0 wiring from the REAL registry (post-sweep). Editor-contract golden regenerated (additive: grammar keys). \`NewModuleSchemaRegistryWithoutBuiltins()\` added for grammar-mechanics tests.

**T7 — selection-facts (\`capability/recommend\`, D10):** \`ProviderSummary.InstallRequired\` — true when Kind is external/local-plugin AND name not a built-in default. Raw Kind/ReleaseStatus already surfaced. \`Options.DefaultPlugins\` injects the built-in name set (keeps the package pure); CLI callers populate it from \`all.DefaultPlugins()\`. Facts, ⊥ wiring-implications (M2) + ⊥ quality-rank (D13).

**T8 — wizard state (\`capability/recommend\`, G4):** \`BuildWizardState\` — agent-consumable JSON {Chosen, Alternatives, GlueGaps, NextSteps} composed from a Recommendation + the wire's glue-gaps/Category-B hooks. \`wfctl capability recommend --format json\` now emits it (markdown unchanged).

## Verification

- \`GOWORK=off go build ./...\` clean; \`go test ./...\` all green; \`golangci-lint --new-from-rev=origin/main\` 0 issues; gofmt clean.
- CLI smoke: \`wfctl capability recommend auth --format json\` emits the wizard-state keys (chosen/alternatives/nextSteps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)