### PR TITLE
feat(wfctl): scaffold command evolution (primary capability-driven + dockerfile + template fold)

### DIFF
--- a/cmd/wfctl/init.go
+++ b/cmd/wfctl/init.go
@@ -114,20 +114,42 @@ var projectTemplates = map[string]projectTemplate{
 	},
 }
 
+// runInit is now a deprecation alias for `wfctl scaffold template` (design D5,
+// ADR 0050; the live precedent is runMigrateDeprecated). It prints a one-release
+// notice to stderr then delegates to the shared template-scaffold core, so
+// existing `wfctl init` scripts keep working unchanged.
 func runInit(args []string) error {
-	fs2 := flag.NewFlagSet("init", flag.ContinueOnError)
+	fmt.Fprintln(os.Stderr,
+		"wfctl init is being folded into wfctl scaffold template. "+
+			"The old form is supported for one release; please update your scripts.")
+	return scaffoldFromTemplate("init", args)
+}
+
+// runScaffoldTemplate implements `wfctl scaffold template` — the template owner
+// after the init fold (D5). It shares the scaffoldFromTemplate core with the
+// deprecated `wfctl init`.
+func runScaffoldTemplate(args []string) error {
+	return scaffoldFromTemplate("scaffold template", args)
+}
+
+// scaffoldFromTemplate is the shared project-template core: parse flags, render
+// the chosen template, print next steps. flagSetName names the FlagSet (and thus
+// the help text) so the deprecated `init` and the canonical `scaffold template`
+// share one implementation.
+func scaffoldFromTemplate(flagSetName string, args []string) error {
+	fs2 := flag.NewFlagSet(flagSetName, flag.ContinueOnError)
 	tmplName := fs2.String("template", "api-service", "Project template to use")
 	author := fs2.String("author", "", "Author (GitHub username or org, used in go.mod module path)")
 	desc := fs2.String("description", "", "Project description")
 	output := fs2.String("output", "", "Output directory (defaults to project name)")
 	listTemplates := fs2.Bool("list", false, "List available templates and exit")
 	fs2.Usage = func() {
-		fmt.Fprintf(fs2.Output(), `Usage: wfctl init [options] <project-name>
+		fmt.Fprintf(fs2.Output(), `Usage: wfctl %s [options] <project-name>
 
-Scaffold a new workflow application project.
+Scaffold a new workflow application project from a template.
 
 Options:
-`)
+`, flagSetName)
 		fs2.PrintDefaults()
 		fmt.Fprintln(fs2.Output())
 		printTemplateList(fs2.Output())

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -156,7 +156,7 @@ var commands = map[string]func([]string) error{
 	"wizard":          runWizard,
 	"dev":             runDev,
 	"build":           runBuild,
-	"scaffold":        runScaffold,
+	"scaffold":        runScaffoldCmd,
 	"tenant":          runTenant,
 	"capability":      runCapability,
 }

--- a/cmd/wfctl/scaffold_dockerfile.go
+++ b/cmd/wfctl/scaffold_dockerfile.go
@@ -44,25 +44,6 @@ type scaffoldDockerfileArgs struct {
 }
 
 // runScaffold dispatches wfctl scaffold subcommands.
-func runScaffold(args []string) error {
-	if len(args) == 0 {
-		fmt.Fprintf(os.Stderr, `Usage: wfctl scaffold <subcommand> [options]
-
-Subcommands:
-  dockerfile   Generate a hardened Dockerfile.prebuilt
-
-Run 'wfctl scaffold <subcommand> -h' for subcommand-specific help.
-`)
-		return fmt.Errorf("subcommand required")
-	}
-	switch args[0] {
-	case "dockerfile":
-		return runScaffoldDockerfile(args[1:])
-	default:
-		return fmt.Errorf("unknown scaffold subcommand %q", args[0])
-	}
-}
-
 // runScaffoldDockerfile implements `wfctl scaffold dockerfile`.
 func runScaffoldDockerfile(args []string) error {
 	fs := flag.NewFlagSet("scaffold dockerfile", flag.ContinueOnError)

--- a/cmd/wfctl/scaffold_dockerfile.go
+++ b/cmd/wfctl/scaffold_dockerfile.go
@@ -43,7 +43,6 @@ type scaffoldDockerfileArgs struct {
 	outputDir  string // where to write Dockerfile.prebuilt (default: ".")
 }
 
-// runScaffold dispatches wfctl scaffold subcommands.
 // runScaffoldDockerfile implements `wfctl scaffold dockerfile`.
 func runScaffoldDockerfile(args []string) error {
 	fs := flag.NewFlagSet("scaffold dockerfile", flag.ContinueOnError)

--- a/cmd/wfctl/scaffold_platform.go
+++ b/cmd/wfctl/scaffold_platform.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// runScaffoldCmd is the primary capability-driven scaffolder (the evolved
+// `wfctl scaffold`, ADR 0050). It dispatches subcommands and otherwise runs the
+// capability-driven assemble (the successor to `wfctl capability assemble`):
+//
+//	wfctl scaffold --set <caps.json> --out <dir>   # primary: capability-driven
+//	wfctl scaffold dockerfile ...                  # legacy hardened Dockerfile
+//	wfctl scaffold template [name] ...             # project templates (folds init)
+//
+// `wfctl capability assemble ...` remains as a backward-compatible alias for the
+// primary path.
+//
+// Note (design D5/P4): `wfctl scaffold` already required a subcommand before
+// this change (it dispatched `dockerfile`), so there is no bare-scaffold-
+// produces-Dockerfile behavior to deprecate — bare scaffold now points at the
+// primary capability path.
+func runScaffoldCmd(args []string) error {
+	if len(args) == 0 {
+		printScaffoldPlatformUsage(os.Stderr)
+		return errors.New("scaffold: provide a subcommand (dockerfile|template) or assemble flags (--set/--out)")
+	}
+	switch args[0] {
+	case "dockerfile":
+		return runScaffoldDockerfile(args[1:])
+	case "template":
+		return runScaffoldTemplate(args[1:])
+	case "-h", "--help", "help":
+		printScaffoldPlatformUsage(os.Stderr)
+		return nil
+	}
+	// Primary: capability-driven assemble (no subcommand consumed). Delegates to
+	// the assemble path, which errors helpfully if --set/--out are absent.
+	return runCapabilityAssemble(args, os.Stdout)
+}
+
+// printScaffoldPlatformUsage prints the evolved scaffold command surface.
+func printScaffoldPlatformUsage(out *os.File) {
+	fmt.Fprintln(out, `Usage: wfctl scaffold <subcommand|flags> [options]
+
+wfctl scaffold is the capability-driven app scaffolder.
+
+Primary (no subcommand):
+  wfctl scaffold --set <caps.json> --out <dir> [--force]
+	Assemble a minimal workflow app from a capability set (Assembly Grammar).
+
+Subcommands:
+  dockerfile   Generate a hardened Dockerfile.prebuilt (legacy)
+  template     Scaffold a project from a template (folds wfctl init)
+
+'wfctl capability assemble ...' is a backward-compatible alias for the primary path.
+
+Run 'wfctl scaffold <subcommand> -h' for subcommand-specific help.`)
+}

--- a/cmd/wfctl/scaffold_platform.go
+++ b/cmd/wfctl/scaffold_platform.go
@@ -32,7 +32,8 @@ func runScaffoldCmd(args []string) error {
 	case "template":
 		return runScaffoldTemplate(args[1:])
 	case "-h", "--help", "help":
-		printScaffoldPlatformUsage(os.Stderr)
+		// Help is not an error — print to stdout, matching runCapabilityWithOutput.
+		printScaffoldPlatformUsage(os.Stdout)
 		return nil
 	}
 	// Primary: capability-driven assemble (no subcommand consumed). Delegates to

--- a/cmd/wfctl/scaffold_platform_test.go
+++ b/cmd/wfctl/scaffold_platform_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunScaffoldCmd_DockerfileSubcommand (Task 9): `wfctl scaffold dockerfile`
+// still generates a hardened Dockerfile.prebuilt (the legacy behavior, now
+// reached via the dockerfile subcommand).
+func TestRunScaffoldCmd_DockerfileSubcommand(t *testing.T) {
+	out := t.TempDir()
+	if err := runScaffoldCmd([]string{"dockerfile", "--output", out}); err != nil {
+		t.Fatalf("scaffold dockerfile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "Dockerfile.prebuilt")); os.IsNotExist(err) {
+		t.Fatalf("Dockerfile.prebuilt not generated in %s", out)
+	}
+}
+
+// TestRunScaffoldCmd_PrimaryDelegatesToAssemble (Task 9): `wfctl scaffold` with
+// assemble flags (no subcommand) is the primary capability-driven path — it
+// delegates to the assemble logic, which requires --set/--out. Invoking without
+// --set surfaces the assemble requirement (proving delegation, not a dockerfile
+// fallback).
+func TestRunScaffoldCmd_PrimaryDelegatesToAssemble(t *testing.T) {
+	err := runScaffoldCmd([]string{"--out", t.TempDir()})
+	if err == nil {
+		t.Fatal("expected assemble requirement error without --set")
+	}
+	if !strings.Contains(err.Error(), "set") {
+		t.Fatalf("primary path must delegate to assemble (mention --set); got: %v", err)
+	}
+}
+
+// TestRunScaffoldCmd_BareUsage (Task 9): bare `wfctl scaffold` prints usage +
+// errors (it is no longer a dockerfile-only command; the user must pick a
+// subcommand or pass assemble flags).
+func TestRunScaffoldCmd_BareUsage(t *testing.T) {
+	err := runScaffoldCmd([]string{})
+	if err == nil {
+		t.Fatal("expected usage error for bare scaffold")
+	}
+}
+
+// TestRunScaffoldCmd_Help (Task 9): -h lists the modes.
+func TestRunScaffoldCmd_Help(t *testing.T) {
+	if err := runScaffoldCmd([]string{"-h"}); err != nil {
+		t.Fatalf("scaffold -h: %v", err)
+	}
+}

--- a/cmd/wfctl/scaffold_template_test.go
+++ b/cmd/wfctl/scaffold_template_test.go
@@ -48,9 +48,9 @@ func TestRunScaffoldTemplate_List(t *testing.T) {
 
 // TestRunScaffoldTemplate_UnknownErrors (Task 10): an unknown template errors.
 func TestRunScaffoldTemplate_UnknownErrors(t *testing.T) {
-	// Flags must precede the positional project name (Go flag parsing stops at
-	// the first non-flag argument).
-	err := runScaffoldTemplate([]string{"-template", "no-such-template", "x", "-output", t.TempDir()})
+	// Errors before any rendering, so no output dir is needed. Flags must precede
+	// the positional project name (Go flag parsing stops at the first non-flag).
+	err := runScaffoldTemplate([]string{"-template", "no-such-template", "x"})
 	if err == nil || !strings.Contains(err.Error(), "unknown template") {
 		t.Fatalf("expected unknown-template error, got: %v", err)
 	}

--- a/cmd/wfctl/scaffold_template_test.go
+++ b/cmd/wfctl/scaffold_template_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunScaffoldCmd_Template (Task 10): `wfctl scaffold template` scaffolds a
+// project from a template — the same output the old `wfctl init` produced
+// (init is folded here per design D5).
+func TestRunScaffoldCmd_Template(t *testing.T) {
+	out := t.TempDir()
+	// Flags must precede the positional project name (Go flag parsing stops at
+	// the first non-flag argument).
+	if err := runScaffoldCmd([]string{"template", "-output", out, "my-api"}); err != nil {
+		t.Fatalf("scaffold template: %v", err)
+	}
+	// api-service is the default template; main.go + workflow.yaml are rendered.
+	for _, f := range []string{"main.go", "workflow.yaml", "go.mod"} {
+		if _, err := os.Stat(filepath.Join(out, f)); os.IsNotExist(err) {
+			t.Errorf("template did not render %s in %s", f, out)
+		}
+	}
+}
+
+// TestRunInit_DeprecatedAlias (Task 10, D5): `wfctl init` still works (delegates
+// to the shared template core) — backward-compatible for one release.
+func TestRunInit_DeprecatedAlias(t *testing.T) {
+	out := t.TempDir()
+	if err := runInit([]string{"-output", out, "legacy-api"}); err != nil {
+		t.Fatalf("runInit deprecated alias: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "main.go")); os.IsNotExist(err) {
+		t.Errorf("deprecated init did not render main.go in %s", out)
+	}
+}
+
+// TestRunScaffoldTemplate_List (Task 10): -list enumerates templates.
+func TestRunScaffoldTemplate_List(t *testing.T) {
+	// -list writes to stdout + returns nil; just assert no error + it doesn't
+	// require a project name.
+	if err := runScaffoldTemplate([]string{"-list"}); err != nil {
+		t.Fatalf("scaffold template -list: %v", err)
+	}
+}
+
+// TestRunScaffoldTemplate_UnknownErrors (Task 10): an unknown template errors.
+func TestRunScaffoldTemplate_UnknownErrors(t *testing.T) {
+	// Flags must precede the positional project name (Go flag parsing stops at
+	// the first non-flag argument).
+	err := runScaffoldTemplate([]string{"-template", "no-such-template", "x", "-output", t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "unknown template") {
+		t.Fatalf("expected unknown-template error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

PR 4/5 of the locked \`wfctl scaffold\` Platform (M1) plan. Evolves the \`wfctl scaffold\` command surface into the capability-driven app scaffolder (ADR 0050; plan Tasks 9–10). Builds on PRs #968/#970/#975 (all merged).

## Changes (Tasks 9 + 10)

- **\`runScaffoldCmd\` (new \`scaffold_platform.go\`)** — the primary dispatcher:
  - \`wfctl scaffold --set <caps> --out <dir>\` → capability-driven assemble (delegates to \`runCapabilityAssemble\`; \`wfctl capability assemble\` stays a backward-compatible alias).
  - \`wfctl scaffold dockerfile\` → legacy hardened Dockerfile (unchanged).
  - \`wfctl scaffold template\` → project templates (folds \`wfctl init\`, D5).
- \`main.go\` routes \`"scaffold"\` → \`runScaffoldCmd\`; the old \`runScaffold\` dispatcher (\`scaffold_dockerfile.go\`) is removed.
- \`init.go\`: template core extracted into \`scaffoldFromTemplate\`; \`runInit\` becomes a one-release **deprecation alias** (stderr notice + delegate — the \`runMigrateDeprecated\` precedent); \`runScaffoldTemplate\` shares the same core.

## Note on D5/P4

The plan assumed bare \`wfctl scaffold\` produced a Dockerfile (needing a deprecation alias). The code already required a subcommand (it dispatched \`dockerfile\`), so there was no bare-scaffold-produces-Dockerfile behavior to deprecate — bare scaffold now points at the primary capability path. This premise drift is noted in code comments (retro-#1 discipline: verify embedded assumptions).

## Verification

- \`go build ./cmd/wfctl\` clean; full \`cmd/wfctl\` suite green (111s); \`golangci-lint --new-from-rev=origin/main\` 0 issues; gofmt clean.
- CLI smoke: \`scaffold -h\` (new usage), \`init\` (deprecation notice + still lists templates), \`scaffold template -list\` all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)