### PR TITLE
Fix project plugin CLI lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Configs that still reference the legacy types now fail to load with an actionabl
 
 ### Fixed
 
+- Plugin-owned top-level wfctl commands now resolve project-local installs from
+  `WFCTL_PLUGIN_DIR` or `data/plugins` before falling back to global plugins, so
+  repo-pinned commands such as `wfctl dns ...` are not shadowed or missed by
+  global-only lookup.
 - `wfctl validate --plugin-dir` now registers plugin `resourceTypes` from both flat manifests and `capabilities.iacProvider.resourceTypes`, so plugin-backed `infra.*` resource modules validate the same way `wfctl infra plan/apply` consume them.
 
 ### Breaking changes (workflow#699 — IaCProvider.Apply hard-removal)

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -307,12 +307,21 @@ func lookupDynamicCLICommand(cmd string) (*CLIRegistryEntry, error) {
 	if _, isStatic := commands[cmd]; isStatic {
 		return nil, nil
 	}
-	pluginDir := defaultGlobalPluginDir()
-	registry, err := BuildCLIRegistry(pluginDir)
+	projectPluginDir := defaultPluginCommandDir()
+	projectRegistry, err := BuildCLIRegistry(projectPluginDir)
 	if err != nil {
-		return nil, fmt.Errorf("load global plugin CLI commands from %s: %w; inspect with 'wfctl plugin list -g' and remove conflicts with 'wfctl plugin remove -g <name>'", pluginDir, err)
+		return nil, fmt.Errorf("load project plugin CLI commands from %s: %w; inspect with 'wfctl plugin list --plugin-dir %s' and remove conflicts with 'wfctl plugin remove --plugin-dir %s <name>'", projectPluginDir, err, projectPluginDir, projectPluginDir)
 	}
-	return registry.LookupCLICommand(cmd), nil
+	if entry := projectRegistry.LookupCLICommand(cmd); entry != nil {
+		return entry, nil
+	}
+
+	globalPluginDir := defaultGlobalPluginDir()
+	globalRegistry, err := BuildCLIRegistry(globalPluginDir)
+	if err != nil {
+		return nil, fmt.Errorf("load global plugin CLI commands from %s: %w; inspect with 'wfctl plugin list -g' and remove conflicts with 'wfctl plugin remove -g <name>'", globalPluginDir, err)
+	}
+	return globalRegistry.LookupCLICommand(cmd), nil
 }
 
 func defaultPluginCommandDir() string {

--- a/cmd/wfctl/main.go
+++ b/cmd/wfctl/main.go
@@ -317,6 +317,9 @@ func lookupDynamicCLICommand(cmd string) (*CLIRegistryEntry, error) {
 	}
 
 	globalPluginDir := defaultGlobalPluginDir()
+	if globalPluginDir == projectPluginDir {
+		return nil, nil
+	}
 	globalRegistry, err := BuildCLIRegistry(globalPluginDir)
 	if err != nil {
 		return nil, fmt.Errorf("load global plugin CLI commands from %s: %w; inspect with 'wfctl plugin list -g' and remove conflicts with 'wfctl plugin remove -g <name>'", globalPluginDir, err)

--- a/cmd/wfctl/plugin_global_test.go
+++ b/cmd/wfctl/plugin_global_test.go
@@ -193,6 +193,27 @@ func TestLookupDynamicCLICommandUsesGlobalDir(t *testing.T) {
 	}
 }
 
+func TestLookupDynamicCLICommandUsesProjectDirBeforeGlobal(t *testing.T) {
+	project := t.TempDir()
+	global := t.TempDir()
+	t.Setenv("WFCTL_PLUGIN_DIR", project)
+	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)
+	writeInstalledCLIPlugin(t, project, "infra", "1.0.0", "dns")
+	writeInstalledCLIPlugin(t, global, "global-infra", "1.0.0", "dns")
+
+	entry, err := lookupDynamicCLICommand("dns")
+	if err != nil {
+		t.Fatalf("lookupDynamicCLICommand: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("lookupDynamicCLICommand returned nil entry")
+	}
+	wantBinary := filepath.Join(project, "infra", "infra")
+	if entry.BinaryPath != wantBinary {
+		t.Fatalf("BinaryPath = %q, want project-local binary %q", entry.BinaryPath, wantBinary)
+	}
+}
+
 func TestLookupDynamicCLICommandStaticCommandWins(t *testing.T) {
 	global := t.TempDir()
 	t.Setenv("WFCTL_GLOBAL_PLUGIN_DIR", global)

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -904,8 +904,11 @@ lifecycle commands install binaries and manifests only; they do not create or
 modify project `wfctl.yaml` or `.wfctl-lock.yaml`. Registry dependency closure
 is installed globally with the parent plugin, and existing global plugin dirs
 are swapped only after the staged parent and dependency set validates.
-Top-level wfctl commands are resolved before global plugin CLI commands, so a
-plugin cannot shadow built-in commands such as `validate` or `plugin`.
+Top-level wfctl commands are resolved before plugin CLI commands, so a plugin
+cannot shadow built-in commands such as `validate` or `plugin`. For
+plugin-owned top-level commands, project-local plugins from `WFCTL_PLUGIN_DIR`
+or `data/plugins` are checked before global plugins, ensuring repo-pinned
+plugins win over operator-global installs in CI and project worktrees.
 
 #### `plugin ci`
 


### PR DESCRIPTION
## Summary
- Resolve plugin-owned top-level wfctl commands from the project plugin directory before falling back to global plugins.
- Keep static wfctl commands highest priority so plugins still cannot shadow built-ins.
- Document the project-local then global lookup order and add an Unreleased changelog note.

## Root cause
`lookupDynamicCLICommand` only scanned the global plugin directory. Project-pinned commands installed under `WFCTL_PLUGIN_DIR` / `data/plugins`, such as `wfctl dns ...` from `workflow-plugin-infra`, were missed unless invoked through `wfctl plugin run ...`.

## Verification
- RED: `GOWORK=off go test ./cmd/wfctl -run TestLookupDynamicCLICommandUsesProjectDirBeforeGlobal -count=1` failed because lookup selected the global `dns` plugin binary instead of the project-local one.
- GREEN: `GOWORK=off go test ./cmd/wfctl -run 'TestLookupDynamicCLICommand|TestPluginCLIRegistry_DNSNamespaceCanBePluginOwned|TestPluginCLIRegistry_DirVsManifestNameMismatch' -count=1`
- GREEN: `GOWORK=off go test ./cmd/wfctl -count=1`
- Runtime check: built patched `wfctl` and verified `WFCTL_PLUGIN_DIR=data/plugins /tmp/wfctl-project-cli-fix dns intent compile ...` in `gocodealone-dns` emits `cf-redirect-gocodealone-com` as `infra.http_redirect` targeting `https://www.gocodealone.com`.