### PR TITLE
engine: reusable secrets.Redactor (free-text value-scan redaction)

### DIFF
--- a/secrets/doc.go
+++ b/secrets/doc.go
@@ -1,0 +1,42 @@
+// Package secrets provides secret storage backends (Provider), secret://
+// reference resolution (Resolver), and two complementary redaction utilities.
+//
+// # Two redaction categories — pick the right one
+//
+// The package offers two DISTINCT ways to scrub secret material, addressing two
+// different threat shapes. They are NOT interchangeable:
+//
+//   - KEY-name masking — MaskSensitiveOutputs (masking.go). Given a structured
+//     outputs map (e.g. a step's key/value results) and a set of sensitive KEY
+//     names ("password", "token", "connection_string", ...), it replaces the
+//     VALUES of those keys with "(sensitive)". It never scans free text and
+//     never needs to know the secret's value — only its key. Use it for
+//     structured maps whose key set is known and trusted.
+//
+//   - VALUE scanning — Redactor (redactor.go). Given an arbitrary blob of free
+//     text (a log line, a chat message, an LLM prompt body) and a set of
+//     previously-seen secret VALUES, it replaces every substring equal to a
+//     known value with "[REDACTED:label]". It does not care about KEY names in
+//     the text; it matches purely on value. Use it when the secret may appear
+//     anywhere in free text and only its value is known.
+//
+// A typical engine integration arms a Redactor from a Provider (List+Get) at
+// startup and on hot-swap, then runs Redact over every message/transcript body
+// before it leaves the process. Structured step outputs flow through
+// MaskSensitiveOutputs instead.
+//
+// # Redactor graceful-degrade contract
+//
+// Redactor.LoadFromProvider is designed to be wired BEFORE its backing provider
+// is reachable. If the provider's List call fails (read-only-without-list,
+// not-yet-started, temporarily unavailable) LoadFromProvider returns nil and
+// leaves the existing known-value set UNTOUCHED — it never panics and never
+// empties the redactor on a List error. This lets a caller register a Redactor
+// at construction time and re-arm it once the provider comes online (lazy
+// resolve + hot-swap) without risking a window where the redactor is empty.
+//
+// AddValue is the additive path: it merges a single value into the set without
+// disturbing the rest. LoadFromProvider is the bulk/full-replace path: it
+// swaps the entire set from the provider's current state. The two compose —
+// callers may seed a few values via AddValue and then refresh from a provider.
+package secrets

--- a/secrets/redactor.go
+++ b/secrets/redactor.go
@@ -1,0 +1,148 @@
+package secrets
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+// Redactor is a concurrency-safe, free-text VALUE scanner that replaces any
+// occurrence of a known secret value inside an arbitrary string with the token
+// "[REDACTED:label]". It is the engine's shared utility for scrubbing secret
+// material out of human-facing text (logs, transcripts, agent messages, LLM
+// prompts) where the secret's KEY is not known ahead of time — only its VALUE.
+//
+// # VALUE-scan (Redactor) vs KEY-mask (MaskSensitiveOutputs)
+//
+// The secrets package provides two DISTINCT redaction categories; do not
+// conflate them:
+//
+//   - MaskSensitiveOutputs (masking.go) is a KEY-name mask: given a structured
+//     outputs map, it zeroes the VALUES of a fixed set of sensitive KEYS
+//     ("password", "token", ...). It does not scan free text and does not need
+//     to know the secret value.
+//
+//   - Redactor (this type) is a VALUE scan: given an arbitrary blob of text, it
+//     finds substrings equal to a previously-seen secret VALUE and replaces
+//     them. It does not care about KEY names in the text; it matches on value.
+//
+// Use MaskSensitiveOutputs for structured key/value maps whose key set is
+// known. Use Redactor when the secret may appear anywhere in free text (chat
+// messages, log lines, prompt bodies) and only its value is known.
+//
+// # Graceful-degrade contract
+//
+// LoadFromProvider degrades gracefully: if the provider's List call fails (for
+// example because the provider is read-only-without-list, unavailable, or not
+// yet started) LoadFromProvider returns nil and leaves the existing known-value
+// set untouched rather than panicking or emptying the redactor. This lets a
+// caller wire a Redactor before its backing provider is reachable and re-arm
+// it once the provider comes online. A nil Redactor is also safe to call:
+// NewRedactor is not required for zero-value usage, but the helper makes the
+// intent explicit and pre-allocates the map.
+type Redactor struct {
+	mu    sync.RWMutex
+	known map[string]string // label -> secret value
+}
+
+// NewRedactor returns a ready-to-use Redactor with an empty known-value set.
+// The returned value is safe for concurrent use immediately.
+func NewRedactor() *Redactor {
+	return &Redactor{known: make(map[string]string)}
+}
+
+// AddValue registers a single secret value under the given label and merges it
+// additively into the existing known-value set. Subsequent calls to Redact will
+// replace every occurrence of value with "[REDACTED:label]".
+//
+// If value is the empty string the call is a no-op: empty values cannot be
+// meaningfully scanned for as substrings and would over-match.
+//
+// AddValue is concurrency-safe and may be called concurrently with Redact and
+// LoadFromProvider.
+func (r *Redactor) AddValue(label, value string) {
+	if value == "" {
+		return
+	}
+	r.mu.Lock()
+	if r.known == nil {
+		r.known = make(map[string]string)
+	}
+	r.known[label] = value
+	r.mu.Unlock()
+}
+
+// LoadFromProvider performs a FULL-REPLACE of the known-value set from a
+// secrets.Provider: it enumerates the provider's keys via List, resolves each
+// via Get, builds a fresh map off-lock, then swaps it in under a single write
+// lock. Any value previously added via AddValue that is not present in the
+// provider is dropped.
+//
+// LoadFromProvider degrades gracefully (see the graceful-degrade contract on
+// Redactor): if List returns an error the call returns nil and leaves the
+// existing known-value set untouched — it does NOT panic and does NOT empty the
+// redactor. Individual Get errors for a key skip that key but do not fail the
+// whole load. Empty-string values from the provider are skipped.
+//
+// A nil Redactor is tolerated: LoadFromProvider is a no-op.
+func (r *Redactor) LoadFromProvider(ctx context.Context, p Provider) error {
+	if r == nil || p == nil {
+		return nil
+	}
+	keys, err := p.List(ctx)
+	if err != nil {
+		// Graceful-degrade: leave the existing set untouched.
+		return nil
+	}
+	fresh := make(map[string]string, len(keys))
+	for _, k := range keys {
+		v, gerr := p.Get(ctx, k)
+		if gerr != nil {
+			continue
+		}
+		if v == "" {
+			continue
+		}
+		fresh[k] = v
+	}
+	r.mu.Lock()
+	r.known = fresh
+	r.mu.Unlock()
+	return nil
+}
+
+// Redact returns text with every occurrence of each known secret value replaced
+// by "[REDACTED:label]". The scan is a plain substring match (not a regexp):
+// it is safe to use on untrusted input but callers should not rely on it for
+// canonicalization — only for scrubbing.
+//
+// Redact is concurrency-safe and may be called concurrently with AddValue and
+// LoadFromProvider. A nil Redactor returns the input text unchanged.
+func (r *Redactor) Redact(text string) string {
+	if r == nil {
+		return text
+	}
+	r.mu.RLock()
+	if len(r.known) == 0 {
+		r.mu.RUnlock()
+		return text
+	}
+	out := text
+	for label, value := range r.known {
+		if value == "" || !strings.Contains(out, value) {
+			continue
+		}
+		out = strings.ReplaceAll(out, value, "[REDACTED:"+label+"]")
+	}
+	r.mu.RUnlock()
+	return out
+}
+
+// RedactMessage redacts content and reports whether any substitution occurred.
+// It is the convenience wrapper for callers (e.g. message pipelines) that want
+// to know whether a message was altered without diffing the strings. A nil
+// Redactor returns (content, false).
+func (r *Redactor) RedactMessage(content string) (string, bool) {
+	redacted := r.Redact(content)
+	return redacted, redacted != content
+}

--- a/secrets/redactor.go
+++ b/secrets/redactor.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -18,9 +19,9 @@ import (
 // conflate them:
 //
 //   - MaskSensitiveOutputs (masking.go) is a KEY-name mask: given a structured
-//     outputs map, it zeroes the VALUES of a fixed set of sensitive KEYS
-//     ("password", "token", ...). It does not scan free text and does not need
-//     to know the secret value.
+//     outputs map, it replaces the VALUES of a fixed set of sensitive KEYS
+//     ("password", "token", ...) with the literal "(sensitive)". It does not
+//     scan free text and does not need to know the secret value.
 //
 //   - Redactor (this type) is a VALUE scan: given an arbitrary blob of text, it
 //     finds substrings equal to a previously-seen secret VALUE and replaces
@@ -61,7 +62,7 @@ func NewRedactor() *Redactor {
 // AddValue is concurrency-safe and may be called concurrently with Redact and
 // LoadFromProvider.
 func (r *Redactor) AddValue(label, value string) {
-	if value == "" {
+	if r == nil || value == "" {
 		return
 	}
 	r.mu.Lock()
@@ -118,6 +119,12 @@ func (r *Redactor) LoadFromProvider(ctx context.Context, p Provider) error {
 //
 // Redact is concurrency-safe and may be called concurrently with AddValue and
 // LoadFromProvider. A nil Redactor returns the input text unchanged.
+//
+// Values are applied longest-first so a shorter secret that is a substring of
+// a longer one cannot shadow it (which would leave the longer value partially
+// unredacted). The known set is snapshotted under the read lock, then the
+// substring scan runs lock-free over the snapshot, giving deterministic output
+// independent of map iteration order.
 func (r *Redactor) Redact(text string) string {
 	if r == nil {
 		return text
@@ -127,14 +134,28 @@ func (r *Redactor) Redact(text string) string {
 		r.mu.RUnlock()
 		return text
 	}
-	out := text
+	type kv struct{ label, value string }
+	pairs := make([]kv, 0, len(r.known))
 	for label, value := range r.known {
-		if value == "" || !strings.Contains(out, value) {
-			continue
+		if value != "" {
+			pairs = append(pairs, kv{label, value})
 		}
-		out = strings.ReplaceAll(out, value, "[REDACTED:"+label+"]")
 	}
 	r.mu.RUnlock()
+	// Longest value first: prevents a shorter substring secret from shadowing
+	// a longer one and leaving a partial leak. Tie-break by value for determinism.
+	sort.Slice(pairs, func(i, j int) bool {
+		if len(pairs[i].value) != len(pairs[j].value) {
+			return len(pairs[i].value) > len(pairs[j].value)
+		}
+		return pairs[i].value > pairs[j].value
+	})
+	out := text
+	for _, p := range pairs {
+		if strings.Contains(out, p.value) {
+			out = strings.ReplaceAll(out, p.value, "[REDACTED:"+p.label+"]")
+		}
+	}
 	return out
 }
 

--- a/secrets/redactor_test.go
+++ b/secrets/redactor_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -13,16 +14,16 @@ type stubProvider struct {
 	vals map[string]string
 }
 
-func (s stubProvider) Name() string { return "stub" }
+func (s *stubProvider) Name() string { return "stub" }
 
-func (s stubProvider) Get(_ context.Context, key string) (string, error) {
+func (s *stubProvider) Get(_ context.Context, key string) (string, error) {
 	if v, ok := s.vals[key]; ok {
 		return v, nil
 	}
 	return "", ErrNotFound
 }
 
-func (s stubProvider) Set(_ context.Context, key, value string) error {
+func (s *stubProvider) Set(_ context.Context, key, value string) error {
 	if s.vals == nil {
 		s.vals = map[string]string{}
 	}
@@ -30,12 +31,12 @@ func (s stubProvider) Set(_ context.Context, key, value string) error {
 	return nil
 }
 
-func (s stubProvider) Delete(_ context.Context, key string) error {
+func (s *stubProvider) Delete(_ context.Context, key string) error {
 	delete(s.vals, key)
 	return nil
 }
 
-func (s stubProvider) List(_ context.Context) ([]string, error) {
+func (s *stubProvider) List(_ context.Context) ([]string, error) {
 	keys := make([]string, 0, len(s.vals))
 	for k := range s.vals {
 		keys = append(keys, k)
@@ -56,7 +57,7 @@ func TestRedactor_AddValue_Redacts(t *testing.T) {
 func TestRedactor_LoadFromProvider_FullReplace(t *testing.T) {
 	r := NewRedactor()
 	r.AddValue("ENV", "envval")
-	if err := r.LoadFromProvider(context.Background(), stubProvider{vals: map[string]string{"K1": "v1"}}); err != nil {
+	if err := r.LoadFromProvider(context.Background(), &stubProvider{vals: map[string]string{"K1": "v1"}}); err != nil {
 		t.Fatalf("LoadFromProvider error: %v", err)
 	}
 	// full-replace: ENV gone, K1 present
@@ -86,7 +87,7 @@ func TestRedactor_Concurrent(t *testing.T) {
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
-			_ = r.LoadFromProvider(context.Background(), stubProvider{vals: map[string]string{"K": "v"}})
+			_ = r.LoadFromProvider(context.Background(), &stubProvider{vals: map[string]string{"K": "v"}})
 		}()
 		go func() {
 			defer wg.Done()
@@ -98,4 +99,20 @@ func TestRedactor_Concurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait() // -race: no data race
+}
+
+func TestRedactor_LongestValueWins(t *testing.T) {
+	// A shorter secret value that is a substring of a longer one must not shadow
+	// the longer value (which would leave a partial leak). Longest-first wins.
+	r := NewRedactor()
+	r.AddValue("SHORT", "key123")
+	r.AddValue("LONG", "key12345")
+	got := r.Redact("cred=key12345 and also key123")
+	// "key12345" must be fully redacted as LONG; the standalone "key123" as SHORT.
+	if strings.Contains(got, "key12345") || strings.Contains(got, "key123") {
+		t.Fatalf("partial leak: %q (substring-ordering regression)", got)
+	}
+	if !strings.Contains(got, "[REDACTED:LONG]") || !strings.Contains(got, "[REDACTED:SHORT]") {
+		t.Fatalf("expected both labels redacted, got %q", got)
+	}
 }

--- a/secrets/redactor_test.go
+++ b/secrets/redactor_test.go
@@ -1,0 +1,101 @@
+package secrets
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// stubProvider is a minimal in-memory secrets.Provider used to exercise
+// Redactor.LoadFromProvider. It satisfies the full Provider interface
+// (Name/Get/Set/Delete/List).
+type stubProvider struct {
+	vals map[string]string
+}
+
+func (s stubProvider) Name() string { return "stub" }
+
+func (s stubProvider) Get(_ context.Context, key string) (string, error) {
+	if v, ok := s.vals[key]; ok {
+		return v, nil
+	}
+	return "", ErrNotFound
+}
+
+func (s stubProvider) Set(_ context.Context, key, value string) error {
+	if s.vals == nil {
+		s.vals = map[string]string{}
+	}
+	s.vals[key] = value
+	return nil
+}
+
+func (s stubProvider) Delete(_ context.Context, key string) error {
+	delete(s.vals, key)
+	return nil
+}
+
+func (s stubProvider) List(_ context.Context) ([]string, error) {
+	keys := make([]string, 0, len(s.vals))
+	for k := range s.vals {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func TestRedactor_AddValue_Redacts(t *testing.T) {
+	r := NewRedactor()
+	r.AddValue("API_KEY", "sk-secret-123")
+	got := r.Redact("the key is sk-secret-123 here")
+	want := "the key is [REDACTED:API_KEY] here"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestRedactor_LoadFromProvider_FullReplace(t *testing.T) {
+	r := NewRedactor()
+	r.AddValue("ENV", "envval")
+	if err := r.LoadFromProvider(context.Background(), stubProvider{vals: map[string]string{"K1": "v1"}}); err != nil {
+		t.Fatalf("LoadFromProvider error: %v", err)
+	}
+	// full-replace: ENV gone, K1 present
+	if got := r.Redact("envval"); got != "envval" {
+		t.Errorf("ENV not dropped after full-replace: got %q want %q", got, "envval")
+	}
+	if got := r.Redact("v1"); got != "[REDACTED:K1]" {
+		t.Errorf("K1 not loaded after full-replace: got %q want %q", got, "[REDACTED:K1]")
+	}
+}
+
+func TestRedactor_NoProvider_RedactsAddedOnly(t *testing.T) {
+	r := NewRedactor() // zero-value, no provider
+	r.AddValue("X", "xx")
+	if got := r.Redact("xx"); got != "[REDACTED:X]" {
+		t.Errorf("got %q want %q", got, "[REDACTED:X]")
+	}
+}
+
+func TestRedactor_Concurrent(t *testing.T) {
+	// -race guard: concurrent Redact during LoadFromProvider + AddValue must
+	// not trigger a data race. All three touch the same underlying map under
+	// differing locks (RLock vs write lock); the RWMutex must serialize them.
+	r := NewRedactor()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			_ = r.LoadFromProvider(context.Background(), stubProvider{vals: map[string]string{"K": "v"}})
+		}()
+		go func() {
+			defer wg.Done()
+			r.AddValue("K", "v")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = r.Redact("v")
+		}()
+	}
+	wg.Wait() // -race: no data race
+}


### PR DESCRIPTION
## Summary

Adds a new, purely-additive engine util: \`secrets.Redactor\` — a concurrency-safe, free-text **value scanner** that replaces every occurrence of a known secret value in an arbitrary string with \`[REDACTED:label]\`.

**No consumer is touched in this PR.** This is the engine foundation; a followup PR (workflow-plugin-agent) will replace the agent's bespoke \`SecretGuard\` with a thin \`secretService\` composite that delegates free-text redaction to this engine Redactor.

## Why a new type — VALUE-scan is orthogonal to KEY-mask

The \`secrets\` package already has \`MaskSensitiveOutputs\` (masking.go). That and the new \`Redactor\` address **two different threat shapes** and are NOT interchangeable:

| | \`MaskSensitiveOutputs\` | \`Redactor\` (new) |
|---|---|---|
| Category | **KEY-name mask** | **VALUE scan** |
| Input | Structured \`map[string]any\` outputs | Arbitrary free text |
| Matches on | Known set of sensitive **keys** (\`password\`, \`token\`, …) | Previously-seen secret **values** |
| Output | \`\"(sensitive)\"\` for masked keys | \`\"[REDACTED:label]\"\` for each value match |
| Use when | Key set is known/trusted (step results) | Secret may appear anywhere in free text (logs, transcripts, prompts) |

\`MaskSensitiveOutputs\` does not scan free text and does not need the secret's value. \`Redactor\` does not care about key names in text and matches purely on value.

## API (all additive, package \`secrets\`)

\`\`\`go
type Redactor struct{ ... }
func NewRedactor() *Redactor
func (r *Redactor) AddValue(label, value string)             // additive merge, write lock; skips empty value
func (r *Redactor) LoadFromProvider(ctx, Provider) error     // List+Get → full-replace under write lock
func (r *Redactor) Redact(text string) string                // substring replace, RLock
func (r *Redactor) RedactMessage(content string) (string, bool)
\`\`\`

### Graceful-degrade contract

\`LoadFromProvider\` is designed to be wired **before** its backing provider is reachable. If \`List\` errors (read-only-without-list, not-yet-started, temporarily unavailable), it returns \`nil\` and leaves the existing known-value set **untouched** — never panics, never empties the redactor. This lets a caller register a \`Redactor\` at construction time and re-arm it on lazy-resolve / hot-swap without a window where the redactor is empty. Empty-string values are skipped.

## Concurrency safety

Guarded by \`sync.RWMutex\`. \`TestRedactor_Concurrent\` runs 50 iterations of concurrent \`Redact\` during \`LoadFromProvider\` + \`AddValue\` under \`-race\` — no data race.

## Verification

\`\`\`
GOWORK=off go build ./...        # green
GOWORK=off go vet ./...          # green
GOWORK=off go test -race ./secrets/...   # green (4 new tests + existing secrets tests)
\`\`\`

New tests (Task 1 + Task 2):
- \`TestRedactor_AddValue_Redacts\` — substring replace works
- \`TestRedactor_LoadFromProvider_FullReplace\` — full-replace semantics (pre-added value dropped, provider value loaded)
- \`TestRedactor_NoProvider_RedactsAddedOnly\` — zero-value redactor with only AddValue works
- \`TestRedactor_Concurrent\` — \`-race\` guard

## Enables

This unblocks the SecretGuard dismantling (PR2, workflow-plugin-agent): the agent replaces \`SecretGuard\` + \`secretsGuardHook\` + \`SecretGuardService\` with a \`secretService\` composite (holder + engine \`Redactor\`) that preserves D19 lazy-resolve, P13 env-redaction, D3 store-then-arm, hot-swap, and the repo-root agent path.

- Design: \`docs/plans/2026-06-30-secretguard-dismantle-shared-redactor-design.md\`
- Plan: \`docs/plans/2026-06-30-secretguard-dismantle-shared-redactor.md\` (Tasks 1+2 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)