### PR TITLE
[codex] Add external plugin pipeline loading

### DIFF
--- a/cmd/wfctl/local_external_plugins.go
+++ b/cmd/wfctl/local_external_plugins.go
@@ -14,6 +14,8 @@ import (
 
 type localExternalPluginLoader func(*workflow.StdEngine, string, *slog.Logger) (func(), error)
 
+// NOTE: package-level state. Tests overriding this MUST NOT call t.Parallel(),
+// or they can leak the override into other wfctl tests.
 var loadExternalPluginsForLocalEngine localExternalPluginLoader = loadExternalPluginsFromDir
 
 func loadExternalPluginsFromDir(eng *workflow.StdEngine, pluginDir string, logger *slog.Logger) (func(), error) {

--- a/cmd/wfctl/local_external_plugins.go
+++ b/cmd/wfctl/local_external_plugins.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"log/slog"
-	"os"
 	"sort"
+	"strings"
 
 	"github.com/GoCodeAlone/workflow"
 	pluginexternal "github.com/GoCodeAlone/workflow/plugin/external"
@@ -20,10 +21,10 @@ func loadExternalPluginsFromDir(eng *workflow.StdEngine, pluginDir string, logge
 		return func() {}, nil
 	}
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 
-	extMgr := pluginexternal.NewExternalPluginManager(pluginDir, log.Default())
+	extMgr := pluginexternal.NewExternalPluginManager(pluginDir, newLocalExternalPluginStdLogger(logger))
 	discovered, err := extMgr.DiscoverPlugins()
 	if err != nil {
 		return nil, fmt.Errorf("discover external plugins: %w", err)
@@ -44,4 +45,23 @@ func loadExternalPluginsFromDir(eng *workflow.StdEngine, pluginDir string, logge
 	}
 
 	return extMgr.Shutdown, nil
+}
+
+func newLocalExternalPluginStdLogger(logger *slog.Logger) *log.Logger {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return log.New(localExternalPluginLogWriter{logger: logger}, "", 0)
+}
+
+type localExternalPluginLogWriter struct {
+	logger *slog.Logger
+}
+
+func (w localExternalPluginLogWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimSpace(string(p))
+	if msg != "" {
+		w.logger.Debug(msg)
+	}
+	return len(p), nil
 }

--- a/cmd/wfctl/local_external_plugins.go
+++ b/cmd/wfctl/local_external_plugins.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"sort"
+
+	"github.com/GoCodeAlone/workflow"
+	pluginexternal "github.com/GoCodeAlone/workflow/plugin/external"
+)
+
+type localExternalPluginLoader func(*workflow.StdEngine, string, *slog.Logger) (func(), error)
+
+var loadExternalPluginsForLocalEngine localExternalPluginLoader = loadExternalPluginsFromDir
+
+func loadExternalPluginsFromDir(eng *workflow.StdEngine, pluginDir string, logger *slog.Logger) (func(), error) {
+	if pluginDir == "" {
+		return func() {}, nil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+
+	extMgr := pluginexternal.NewExternalPluginManager(pluginDir, log.Default())
+	discovered, err := extMgr.DiscoverPlugins()
+	if err != nil {
+		return nil, fmt.Errorf("discover external plugins: %w", err)
+	}
+	sort.Strings(discovered)
+
+	for _, name := range discovered {
+		adapter, err := extMgr.LoadPlugin(name)
+		if err != nil {
+			extMgr.Shutdown()
+			return nil, fmt.Errorf("load external plugin %q: %w", name, err)
+		}
+		if err := eng.LoadPlugin(adapter); err != nil {
+			extMgr.Shutdown()
+			return nil, fmt.Errorf("register external plugin %q: %w", name, err)
+		}
+		logger.Debug("Loaded external plugin", "plugin", name)
+	}
+
+	return extMgr.Shutdown, nil
+}

--- a/cmd/wfctl/local_external_plugins_test.go
+++ b/cmd/wfctl/local_external_plugins_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/modular"
@@ -35,6 +38,33 @@ func overrideLocalExternalPluginLoader(t *testing.T, wantPluginDir string) func(
 			t.Fatal("external plugin shutdown was not called")
 		}
 	}
+}
+
+func TestLocalExternalPluginStdLoggerUsesProvidedSlog(t *testing.T) {
+	var defaultLog bytes.Buffer
+	defaultWriter := log.Writer()
+	log.SetOutput(&defaultLog)
+	defer log.SetOutput(defaultWriter)
+
+	var slogOutput bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&slogOutput, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	stdLogger := newLocalExternalPluginStdLogger(logger)
+
+	stdLogger.Print("external plugin detail")
+
+	if defaultLog.Len() != 0 {
+		t.Fatalf("external plugin logger wrote to process default logger: %q", defaultLog.String())
+	}
+	if got := slogOutput.String(); !strings.Contains(got, "external plugin detail") {
+		t.Fatalf("external plugin log was not routed to provided slog logger: %q", got)
+	}
+}
+
+func TestLocalExternalPluginStdLoggerNilLoggerDiscards(t *testing.T) {
+	t.Parallel()
+
+	stdLogger := newLocalExternalPluginStdLogger(nil)
+	stdLogger.Print("discarded detail")
 }
 
 type testExternalMarkerPlugin struct {

--- a/cmd/wfctl/local_external_plugins_test.go
+++ b/cmd/wfctl/local_external_plugins_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/GoCodeAlone/modular"
+	"github.com/GoCodeAlone/workflow"
+	"github.com/GoCodeAlone/workflow/module"
+	"github.com/GoCodeAlone/workflow/plugin"
+)
+
+func overrideLocalExternalPluginLoader(t *testing.T, wantPluginDir string) func() {
+	t.Helper()
+	old := loadExternalPluginsForLocalEngine
+	called := false
+	shutdownCalled := false
+	loadExternalPluginsForLocalEngine = func(eng *workflow.StdEngine, gotPluginDir string, _ *slog.Logger) (func(), error) {
+		called = true
+		if gotPluginDir != wantPluginDir {
+			t.Fatalf("plugin dir = %q, want %q", gotPluginDir, wantPluginDir)
+		}
+		if err := eng.LoadPlugin(&testExternalMarkerPlugin{shutdown: &shutdownCalled}); err != nil {
+			return nil, err
+		}
+		return func() { shutdownCalled = true }, nil
+	}
+	return func() {
+		loadExternalPluginsForLocalEngine = old
+		if !called {
+			t.Fatal("external plugin loader was not called")
+		}
+		if !shutdownCalled {
+			t.Fatal("external plugin shutdown was not called")
+		}
+	}
+}
+
+type testExternalMarkerPlugin struct {
+	plugin.BaseEnginePlugin
+	shutdown *bool
+}
+
+func (testExternalMarkerPlugin) Name() string        { return "test-external-marker" }
+func (testExternalMarkerPlugin) Version() string     { return "0.0.0" }
+func (testExternalMarkerPlugin) Description() string { return "test external marker plugin" }
+
+func (testExternalMarkerPlugin) EngineManifest() *plugin.PluginManifest {
+	return &plugin.PluginManifest{
+		Name:        "test-external-marker",
+		Version:     "0.0.0",
+		Author:      "GoCodeAlone",
+		Description: "test external marker plugin",
+	}
+}
+
+func (p *testExternalMarkerPlugin) StepFactories() map[string]plugin.StepFactory {
+	return map[string]plugin.StepFactory{
+		"step.test_external_marker": func(name string, cfg map[string]any, _ modular.Application) (any, error) {
+			value, _ := cfg["value"].(string)
+			return &testExternalMarkerStep{name: name, value: value, shutdown: p.shutdown}, nil
+		},
+	}
+}
+
+type testExternalMarkerStep struct {
+	name     string
+	value    string
+	shutdown *bool
+}
+
+func (s *testExternalMarkerStep) Name() string { return s.name }
+
+func (s *testExternalMarkerStep) Execute(context.Context, *module.PipelineContext) (*module.StepResult, error) {
+	if s.shutdown != nil && *s.shutdown {
+		return nil, context.Canceled
+	}
+	return &module.StepResult{Output: map[string]any{
+		"external_marker_loaded": true,
+		"external_marker_value":  s.value,
+	}}, nil
+}

--- a/cmd/wfctl/pipeline.go
+++ b/cmd/wfctl/pipeline.go
@@ -124,7 +124,7 @@ Examples:
   wfctl pipeline run -c app.yaml -p build-and-deploy
   wfctl pipeline run -c app.yaml -p deploy --var env=staging --var version=1.2.3
   wfctl pipeline run -c app.yaml -p process-data --input '{"items":[1,2,3]}'
-  wfctl pipeline run -c app.yaml -p verify --plugin-dir .workflow/plugins
+  wfctl pipeline run -c app.yaml -p verify --plugin-dir .wfctl/plugins
 
 Options:
 `)
@@ -201,6 +201,9 @@ Options:
 	shutdownExternalPlugins, err := loadExternalPluginsForLocalEngine(eng, *pluginDir, logger)
 	if err != nil {
 		return err
+	}
+	if shutdownExternalPlugins == nil {
+		shutdownExternalPlugins = func() {}
 	}
 	defer shutdownExternalPlugins()
 	if err := eng.BuildFromConfig(cfg); err != nil {

--- a/cmd/wfctl/pipeline.go
+++ b/cmd/wfctl/pipeline.go
@@ -110,6 +110,7 @@ func runPipelineRun(args []string) error {
 	fs := flag.NewFlagSet("pipeline run", flag.ContinueOnError)
 	configPath := fs.String("c", "", "Path to workflow config YAML file (required)")
 	pipelineName := fs.String("p", "", "Name of the pipeline to run (required)")
+	pluginDir := fs.String("plugin-dir", "", "Directory containing installed external plugins")
 	inputJSON := fs.String("input", "", "Input data as JSON object")
 	verbose := fs.Bool("verbose", false, "Show detailed step output")
 	var vars stringSliceFlag
@@ -123,6 +124,7 @@ Examples:
   wfctl pipeline run -c app.yaml -p build-and-deploy
   wfctl pipeline run -c app.yaml -p deploy --var env=staging --var version=1.2.3
   wfctl pipeline run -c app.yaml -p process-data --input '{"items":[1,2,3]}'
+  wfctl pipeline run -c app.yaml -p verify --plugin-dir .workflow/plugins
 
 Options:
 `)
@@ -192,8 +194,16 @@ Options:
 		WithLogger(logger).
 		WithHandler(handlers.NewPipelineWorkflowHandler()).
 		WithPlugin(pluginpipeline.New()).
-		BuildFromConfig(cfg)
+		Build()
 	if err != nil {
+		return fmt.Errorf("failed to build engine: %w", err)
+	}
+	shutdownExternalPlugins, err := loadExternalPluginsForLocalEngine(eng, *pluginDir, logger)
+	if err != nil {
+		return err
+	}
+	defer shutdownExternalPlugins()
+	if err := eng.BuildFromConfig(cfg); err != nil {
 		return fmt.Errorf("failed to build engine from config: %w", err)
 	}
 

--- a/cmd/wfctl/pipeline_test.go
+++ b/cmd/wfctl/pipeline_test.go
@@ -285,6 +285,33 @@ func TestRunPipelineRunEchoPipeline(t *testing.T) {
 	}
 }
 
+func TestRunPipelineRunWithExternalPluginDir(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.Mkdir(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	path := writePipelineConfig(t, dir, "external.yaml", `
+modules: []
+
+pipelines:
+  external:
+    steps:
+      - name: marker
+        type: step.test_external_marker
+        config:
+          value: loaded
+    on_error: stop
+`)
+
+	restore := overrideLocalExternalPluginLoader(t, pluginDir)
+	defer restore()
+
+	if err := runPipelineRun([]string{"-c", path, "-p", "external", "--plugin-dir", pluginDir}); err != nil {
+		t.Fatalf("pipeline run with external plugin dir failed: %v", err)
+	}
+}
+
 // --- stringSliceFlag ---
 
 func TestStringSliceFlag(t *testing.T) {

--- a/cmd/wfctl/test.go
+++ b/cmd/wfctl/test.go
@@ -234,10 +234,11 @@ func printBDDGuidance(featureFiles []string) {
 
 // testFile mirrors wftest.TestFile without the testing.T dependency.
 type testFile struct {
-	Config string              `yaml:"config"`
-	YAML   string              `yaml:"yaml"`
-	Mocks  testMockConfig      `yaml:"mocks"`
-	Tests  map[string]testCase `yaml:"tests"`
+	Config    string              `yaml:"config"`
+	YAML      string              `yaml:"yaml"`
+	PluginDir string              `yaml:"plugin_dir"`
+	Mocks     testMockConfig      `yaml:"mocks"`
+	Tests     map[string]testCase `yaml:"tests"`
 }
 
 type testMockConfig struct {
@@ -305,6 +306,9 @@ func runTestFile(path string, verbose bool) (pass, fail int, err error) {
 	if tf.Config != "" && !filepath.IsAbs(tf.Config) {
 		tf.Config = filepath.Join(filepath.Dir(path), tf.Config)
 	}
+	if tf.PluginDir != "" && !filepath.IsAbs(tf.PluginDir) {
+		tf.PluginDir = filepath.Join(filepath.Dir(path), tf.PluginDir)
+	}
 
 	fmt.Printf("%s\n", filepath.Base(path))
 
@@ -338,12 +342,13 @@ func runTestCase(name string, tf *testFile, tc *testCase) *testResult {
 	merged := mergeTestMocks(&tf.Mocks, tc.Mocks)
 
 	// Build engine.
-	eng, err := buildTestEngine(tf, merged)
+	eng, cleanup, err := buildTestEngine(tf, merged)
 	if err != nil {
 		r.failures = append(r.failures, fmt.Sprintf("engine setup: %v", err))
 		r.duration = time.Since(start)
 		return r
 	}
+	defer cleanup()
 
 	// Execute the trigger.
 	result, stepOutputs, err := executeTestTrigger(eng, tc)
@@ -360,7 +365,7 @@ func runTestCase(name string, tf *testFile, tc *testCase) *testResult {
 }
 
 // buildTestEngine creates a StdEngine from the TestFile config and mocks.
-func buildTestEngine(tf *testFile, mocks *testMockConfig) (*workflow.StdEngine, error) {
+func buildTestEngine(tf *testFile, mocks *testMockConfig) (*workflow.StdEngine, func(), error) {
 	logger := &testDiscardLogger{}
 	app := modular.NewStdApplication(nil, logger)
 	eng := workflow.NewStdEngine(app, logger)
@@ -368,8 +373,12 @@ func buildTestEngine(tf *testFile, mocks *testMockConfig) (*workflow.StdEngine, 
 	// Load all built-in plugins.
 	for _, p := range testBuiltinPlugins() {
 		if err := eng.LoadPlugin(p); err != nil {
-			return nil, fmt.Errorf("LoadPlugin(%s): %w", p.Name(), err)
+			return nil, nil, fmt.Errorf("LoadPlugin(%s): %w", p.Name(), err)
 		}
+	}
+	shutdownExternalPlugins, loadErr := loadExternalPluginsForLocalEngine(eng, tf.PluginDir, slog.Default())
+	if loadErr != nil {
+		return nil, nil, loadErr
 	}
 
 	// Register mock step factories.
@@ -389,17 +398,20 @@ func buildTestEngine(tf *testFile, mocks *testMockConfig) (*workflow.StdEngine, 
 	case tf.Config != "":
 		cfg, err = config.LoadFromFile(tf.Config)
 	default:
-		return nil, fmt.Errorf("test file must set 'yaml' or 'config'")
+		shutdownExternalPlugins()
+		return nil, nil, fmt.Errorf("test file must set 'yaml' or 'config'")
 	}
 	if err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
+		shutdownExternalPlugins()
+		return nil, nil, fmt.Errorf("load config: %w", err)
 	}
 
 	if err := eng.BuildFromConfig(cfg); err != nil {
-		return nil, fmt.Errorf("BuildFromConfig: %w", err)
+		shutdownExternalPlugins()
+		return nil, nil, fmt.Errorf("BuildFromConfig: %w", err)
 	}
 
-	return eng, nil
+	return eng, shutdownExternalPlugins, nil
 }
 
 // executeTestTrigger runs the trigger and returns output, step outputs, and any error.

--- a/cmd/wfctl/test.go
+++ b/cmd/wfctl/test.go
@@ -380,6 +380,9 @@ func buildTestEngine(tf *testFile, mocks *testMockConfig) (*workflow.StdEngine, 
 	if loadErr != nil {
 		return nil, nil, loadErr
 	}
+	if shutdownExternalPlugins == nil {
+		shutdownExternalPlugins = func() {}
+	}
 
 	// Register mock step factories.
 	if mocks != nil {

--- a/cmd/wfctl/test_test.go
+++ b/cmd/wfctl/test_test.go
@@ -283,6 +283,46 @@ tests:
 	}
 }
 
+func TestRunTestFile_WithExternalPluginDir(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.Mkdir(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	writeTestYAML(t, dir, "external_test.yaml", `
+plugin_dir: plugins
+yaml: |
+  pipelines:
+    external:
+      steps:
+        - name: marker
+          type: step.test_external_marker
+          config:
+            value: loaded
+tests:
+  external-step:
+    trigger:
+      type: pipeline
+      name: external
+    assertions:
+      - step: marker
+        output:
+          external_marker_loaded: true
+          external_marker_value: loaded
+`)
+
+	restore := overrideLocalExternalPluginLoader(t, pluginDir)
+	defer restore()
+
+	pass, fail, err := runTestFile(filepath.Join(dir, "external_test.yaml"), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pass != 1 || fail != 0 {
+		t.Fatalf("expected pass=1 fail=0, got pass=%d fail=%d", pass, fail)
+	}
+}
+
 // --- runTest (integration) ---
 
 func TestRunTest_DirectoryTarget(t *testing.T) {

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -1119,7 +1119,7 @@ wfctl pipeline run -c <config.yaml> -p <pipeline-name> [options]
 |------|---------|-------------|
 | `-c` | _(required)_ | Path to workflow config YAML file |
 | `-p` | _(required)_ | Name of the pipeline to run |
-| `-plugin-dir` | _(none)_ | Directory containing installed external plugins; plugin module and step types are loaded before config compilation |
+| `--plugin-dir` | _(none)_ | Directory containing installed external plugins; plugin module and step types are loaded before config compilation |
 | `-input` | _(none)_ | Input data as a JSON object |
 | `-verbose` | `false` | Show detailed step output |
 | `-var` | _(none)_ | Variable in `key=value` format (repeatable) |

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -45,6 +45,7 @@ graph TD
     wfctl --> validate
     wfctl --> inspect
     wfctl --> run
+    wfctl --> test
     wfctl --> plugin
     wfctl --> pipeline
     wfctl --> schema
@@ -179,7 +180,7 @@ graph TD
 |----------|----------|
 | **Project Setup** | `init`, `run`, `wizard` |
 | **Local Development** | `dev up/down/logs/status/restart` (--local, --k8s, --expose) |
-| **Validation & Inspection** | `validate`, `inspect`, `schema`, `compat check`, `template validate`, `editor-schemas`, `dsl-reference` |
+| **Validation & Inspection** | `validate`, `inspect`, `test`, `schema`, `compat check`, `template validate`, `editor-schemas`, `dsl-reference` |
 | **API & Contract** | `api extract`, `contract test`, `diff` |
 | **Deployment** | `deploy docker/kubernetes/helm/cloud`, `build-ui`, `generate github-actions` |
 | **Infrastructure** | `infra derive/plan/apply/destroy/status/drift/import/bootstrap/outputs/owners/test`, `infra state list/export/import` |
@@ -1118,6 +1119,7 @@ wfctl pipeline run -c <config.yaml> -p <pipeline-name> [options]
 |------|---------|-------------|
 | `-c` | _(required)_ | Path to workflow config YAML file |
 | `-p` | _(required)_ | Name of the pipeline to run |
+| `-plugin-dir` | _(none)_ | Directory containing installed external plugins; plugin module and step types are loaded before config compilation |
 | `-input` | _(none)_ | Input data as a JSON object |
 | `-verbose` | `false` | Show detailed step output |
 | `-var` | _(none)_ | Variable in `key=value` format (repeatable) |
@@ -1128,6 +1130,58 @@ wfctl pipeline run -c <config.yaml> -p <pipeline-name> [options]
 wfctl pipeline run -c app.yaml -p build-and-deploy
 wfctl pipeline run -c app.yaml -p deploy --var env=staging --var version=1.2.3
 wfctl pipeline run -c app.yaml -p process-data --input '{"items":[1,2,3]}'
+wfctl pipeline run -c app.yaml -p verify --plugin-dir .wfctl/plugins
+```
+
+---
+
+### `test`
+
+Run YAML-based Workflow integration tests. Each `*_test.yaml` file embeds or
+references a Workflow config, triggers one or more pipelines, and asserts final
+pipeline output or individual step output.
+
+```
+wfctl test [options] <file_or_dir> [file_or_dir ...]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-v` | `false` | Print each passing assertion |
+| `--coverage` | `false` | Print pipeline and BDD scenario coverage instead of executing tests |
+| `--strict` | `false` | Fail coverage mode when any pipeline is uncovered |
+
+Test files can set `plugin_dir` to load installed external plugins before the
+Workflow config is compiled. Relative `config` and `plugin_dir` values resolve
+relative to the test file.
+
+```yaml
+plugin_dir: .wfctl/plugins
+yaml: |
+  pipelines:
+    verify:
+      steps:
+        - name: external-step
+          type: step.example_external
+          config:
+            value: ok
+tests:
+  external-step:
+    trigger:
+      type: pipeline
+      name: verify
+    assertions:
+      - step: external-step
+        output:
+          value: ok
+```
+
+**Examples:**
+
+```bash
+wfctl test tests/
+wfctl test -v tests/pipeline_test.yaml
+wfctl test --coverage config.yaml features/
 ```
 
 ---

--- a/module/pipeline_step_request_parse.go
+++ b/module/pipeline_step_request_parse.go
@@ -22,6 +22,13 @@ type RequestParseStep struct {
 	parseHeaders []string
 }
 
+var requestParseReservedOutputKeys = map[string]struct{}{
+	"body":        {},
+	"headers":     {},
+	"path_params": {},
+	"query":       {},
+}
+
 // NewRequestParseStepFactory returns a StepFactory that creates RequestParseStep instances.
 func NewRequestParseStepFactory() StepFactory {
 	return func(name string, config map[string]any, _ modular.Application) (PipelineStep, error) {
@@ -212,6 +219,12 @@ func (s *RequestParseStep) addBodyOutput(output map[string]any, body map[string]
 		return
 	}
 	for k, v := range body {
+		if _, reserved := requestParseReservedOutputKeys[k]; reserved {
+			continue
+		}
+		if _, exists := output[k]; exists {
+			continue
+		}
 		output[k] = v
 	}
 }

--- a/module/pipeline_step_request_parse.go
+++ b/module/pipeline_step_request_parse.go
@@ -18,6 +18,7 @@ type RequestParseStep struct {
 	pathParams   []string
 	queryParams  []string
 	parseBody    bool
+	mergeBody    bool
 	parseHeaders []string
 }
 
@@ -50,6 +51,7 @@ func NewRequestParseStepFactory() StepFactory {
 		if format, _ := config["format"].(string); strings.EqualFold(format, "json") || strings.EqualFold(format, "form") {
 			parseBody = true
 		}
+		mergeBody, _ := config["merge_body"].(bool)
 
 		var parseHeaders []string
 		if ph, ok := config["parse_headers"]; ok {
@@ -67,6 +69,7 @@ func NewRequestParseStepFactory() StepFactory {
 			pathParams:   pathParams,
 			queryParams:  queryParams,
 			parseBody:    parseBody,
+			mergeBody:    mergeBody,
 			parseHeaders: parseHeaders,
 		}, nil
 	}
@@ -154,9 +157,9 @@ func (s *RequestParseStep) Execute(_ context.Context, pc *PipelineContext) (*Ste
 	// then fall back to reading from the HTTP request directly
 	if s.parseBody {
 		if body, ok := pc.TriggerData["body"].(map[string]any); ok {
-			output["body"] = body
+			s.addBodyOutput(output, body)
 		} else if body, ok := pc.Current["body"].(map[string]any); ok {
-			output["body"] = body
+			s.addBodyOutput(output, body)
 		} else {
 			req, _ := pc.Metadata["_http_request"].(*http.Request)
 			if req != nil {
@@ -187,12 +190,12 @@ func (s *RequestParseStep) Execute(_ context.Context, pc *PipelineContext) (*Ste
 									bodyData[k] = v
 								}
 							}
-							output["body"] = bodyData
+							s.addBodyOutput(output, bodyData)
 						}
 					} else {
 						var bodyData map[string]any
 						if json.Unmarshal(bodyBytes, &bodyData) == nil {
-							output["body"] = bodyData
+							s.addBodyOutput(output, bodyData)
 						}
 					}
 				}
@@ -201,4 +204,14 @@ func (s *RequestParseStep) Execute(_ context.Context, pc *PipelineContext) (*Ste
 	}
 
 	return &StepResult{Output: output}, nil
+}
+
+func (s *RequestParseStep) addBodyOutput(output map[string]any, body map[string]any) {
+	output["body"] = body
+	if !s.mergeBody {
+		return
+	}
+	for k, v := range body {
+		output[k] = v
+	}
 }

--- a/module/pipeline_step_request_parse_test.go
+++ b/module/pipeline_step_request_parse_test.go
@@ -98,6 +98,48 @@ func TestRequestParseStep_ParseBody(t *testing.T) {
 	}
 }
 
+func TestRequestParseStep_MergeBodyPromotesJSONFields(t *testing.T) {
+	factory := NewRequestParseStepFactory()
+	step, err := factory("parse-body", map[string]any{
+		"parse_body": true,
+		"merge_body": true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"remote_id":"bob@example.test","remote_bundle":{"device_id":1},"plaintext":"cHJpdmF0ZQ=="}`)
+	req, _ := http.NewRequest("POST", "/messages", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	pc := NewPipelineContext(nil, map[string]any{
+		"_http_request": req,
+	})
+
+	result, err := step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+
+	bodyData, ok := result.Output["body"].(map[string]any)
+	if !ok {
+		t.Fatal("expected body in output")
+	}
+	if bodyData["remote_id"] != "bob@example.test" {
+		t.Errorf("expected body.remote_id='bob@example.test', got %v", bodyData["remote_id"])
+	}
+	if result.Output["remote_id"] != "bob@example.test" {
+		t.Errorf("expected promoted remote_id='bob@example.test', got %v", result.Output["remote_id"])
+	}
+	bundle, ok := result.Output["remote_bundle"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected promoted remote_bundle map, got %T", result.Output["remote_bundle"])
+	}
+	if bundle["device_id"] != float64(1) {
+		t.Errorf("expected promoted remote_bundle.device_id=1, got %v", bundle["device_id"])
+	}
+}
+
 func TestRequestParseStep_FormatJSONAlias(t *testing.T) {
 	factory := NewRequestParseStepFactory()
 	step, err := factory("parse-body", map[string]any{

--- a/module/pipeline_step_request_parse_test.go
+++ b/module/pipeline_step_request_parse_test.go
@@ -101,15 +101,16 @@ func TestRequestParseStep_ParseBody(t *testing.T) {
 func TestRequestParseStep_MergeBodyPromotesJSONFields(t *testing.T) {
 	factory := NewRequestParseStepFactory()
 	step, err := factory("parse-body", map[string]any{
-		"parse_body": true,
-		"merge_body": true,
+		"parse_body":   true,
+		"merge_body":   true,
+		"query_params": []any{"trace"},
 	}, nil)
 	if err != nil {
 		t.Fatalf("factory error: %v", err)
 	}
 
-	body := bytes.NewBufferString(`{"remote_id":"bob@example.test","remote_bundle":{"device_id":1},"plaintext":"cHJpdmF0ZQ=="}`)
-	req, _ := http.NewRequest("POST", "/messages", body)
+	body := bytes.NewBufferString(`{"remote_id":"bob@example.test","remote_bundle":{"device_id":1},"plaintext":"cHJpdmF0ZQ==","body":"reserved","query":"reserved"}`)
+	req, _ := http.NewRequest("POST", "/messages?trace=req-123", body)
 	req.Header.Set("Content-Type", "application/json")
 
 	pc := NewPipelineContext(nil, map[string]any{
@@ -137,6 +138,16 @@ func TestRequestParseStep_MergeBodyPromotesJSONFields(t *testing.T) {
 	}
 	if bundle["device_id"] != float64(1) {
 		t.Errorf("expected promoted remote_bundle.device_id=1, got %v", bundle["device_id"])
+	}
+	if result.Output["body"] == "reserved" {
+		t.Fatal("expected reserved body output to remain parsed body map")
+	}
+	query, ok := result.Output["query"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected reserved query output to remain query map, got %T", result.Output["query"])
+	}
+	if query["trace"] != "req-123" {
+		t.Errorf("expected query.trace='req-123', got %v", query["trace"])
 	}
 }
 

--- a/secrets/redactor.go
+++ b/secrets/redactor.go
@@ -93,6 +93,7 @@ func (r *Redactor) LoadFromProvider(ctx context.Context, p Provider) error {
 	keys, err := p.List(ctx)
 	if err != nil {
 		// Graceful-degrade: leave the existing set untouched.
+		//nolint:nilerr // LoadFromProvider intentionally degrades on provider list errors.
 		return nil
 	}
 	fresh := make(map[string]string, len(keys))


### PR DESCRIPTION
## Summary
- Add shared external plugin loading for local `wfctl pipeline run` and `wfctl test` paths.
- Add `wfctl pipeline run --plugin-dir` and test YAML `plugin_dir` support so external plugin steps execute inside local Workflow engines.
- Add opt-in `step.request_parse` `merge_body` support so HTTP API pipelines can promote JSON body fields into typed plugin step input state.
- Document intentional redactor graceful-degrade behavior for existing lint policy.

## Verification
- `GOWORK=off go test ./module -count=1`
- `GOWORK=off go test ./cmd/wfctl -count=1`
- `GOWORK=off go build -o bin/workflow-server ./cmd/server`
- `golangci-lint run --timeout=10m ./module/...`
- `golangci-lint run --timeout=10m ./cmd/wfctl/...`
- `GOWORK=off go test ./secrets/...`
- `golangci-lint run --timeout=10m ./secrets/...`