### PR TITLE
Add context artifact content steps

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -265,7 +265,7 @@ string content from the pipeline context. `content_encoding` accepts `raw`,
 | `content_encoding` | string | one of `dest`/`content_encoding` | Output encoding when returning content: `raw`, `text`, or `base64`. |
 
 **Output fields:** file mode returns `key`, `dest`, `size`, `metadata`; content
-mode returns `key`, `content`, `size`, `metadata`.
+mode returns `key`, `artifact_content`, `size`, `metadata`.
 
 ### CI/CD Pipeline Steps
 | Type | Description | Plugin |

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -208,8 +208,8 @@ flowchart TD
 | `step.nosql_put` | Writes a document to a NoSQL store | datastores |
 | `step.nosql_delete` | Deletes a document from a NoSQL store by key | datastores |
 | `step.nosql_query` | Queries a NoSQL store with filter expressions | datastores |
-| `step.artifact_upload` | Uploads a file to the artifact store | storage |
-| `step.artifact_download` | Downloads a file from the artifact store | storage |
+| `step.artifact_upload` | Uploads file-backed or context-backed content to the artifact store | storage |
+| `step.artifact_download` | Downloads artifact content to a file or pipeline output | storage |
 | `step.artifact_list` | Lists artifacts in the store for a given prefix | storage |
 | `step.artifact_delete` | Deletes an artifact from the store | storage |
 | `step.secret_rotate` | Rotates a secret in the configured secrets backend | secrets |
@@ -234,6 +234,38 @@ flowchart TD
 | `step.marketplace_installed` | Lists installed marketplace plugins | marketplace |
 | `step.marketplace_uninstall` | Uninstalls a marketplace plugin | marketplace |
 | `step.marketplace_update` | Updates a marketplace plugin to the latest version | marketplace |
+
+### Artifact Pipeline Steps
+
+`step.artifact_upload` stores artifact content in a configured `storage.artifact`
+module. Use `source` to upload a server-local file, or `content_from` to upload
+string content from the pipeline context. `content_encoding` accepts `raw`,
+`text`, or `base64`; omitted encoding is treated as raw text for uploads.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `store` | string | yes | Artifact store service name. |
+| `key` | string | yes | Artifact key; templates are resolved against the pipeline context. |
+| `source` | string | one of `source`/`content_from` | Server-local file path to upload. |
+| `content_from` | string | one of `source`/`content_from` | Pipeline context path containing artifact content as a string. |
+| `content_encoding` | string | no | Content encoding for `content_from`: `raw`, `text`, or `base64`. |
+| `metadata` | object | no | String metadata values; templates are resolved against the pipeline context. |
+
+**Output fields:** `key`, `store`, `size`.
+
+`step.artifact_download` retrieves artifact content from a configured
+`storage.artifact` module. Use `dest` to write a server-local file, or
+`content_encoding` without `dest` to return artifact bytes in the step output.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `store` | string | yes | Artifact store service name. |
+| `key` | string | yes | Artifact key; templates are resolved against the pipeline context. |
+| `dest` | string | one of `dest`/`content_encoding` | Server-local file path to write. |
+| `content_encoding` | string | one of `dest`/`content_encoding` | Output encoding when returning content: `raw`, `text`, or `base64`. |
+
+**Output fields:** file mode returns `key`, `dest`, `size`, `metadata`; content
+mode returns `key`, `content`, `size`, `metadata`.
 
 ### CI/CD Pipeline Steps
 | Type | Description | Plugin |

--- a/module/pipeline_step_artifact.go
+++ b/module/pipeline_step_artifact.go
@@ -57,13 +57,19 @@ func NewArtifactUploadStepFactory() StepFactory {
 		}
 		source, _ := config["source"].(string)
 		contentFrom, _ := config["content_from"].(string)
+		contentEncoding, _ := config["content_encoding"].(string)
 		if source == "" && contentFrom == "" {
 			return nil, fmt.Errorf("artifact_upload step %q: either 'source' or 'content_from' is required", name)
 		}
 		if source != "" && contentFrom != "" {
 			return nil, fmt.Errorf("artifact_upload step %q: only one of 'source' or 'content_from' may be set", name)
 		}
-		contentEncoding, _ := config["content_encoding"].(string)
+		if source != "" && contentEncoding != "" {
+			return nil, fmt.Errorf("artifact_upload step %q: 'content_encoding' may only be set with 'content_from'", name)
+		}
+		if contentFrom != "" && !isSupportedArtifactContentEncoding(contentEncoding, true) {
+			return nil, fmt.Errorf("artifact_upload step %q: unsupported content_encoding %q", name, contentEncoding)
+		}
 
 		md := map[string]string{}
 		if raw, ok := config["metadata"].(map[string]any); ok {
@@ -189,6 +195,9 @@ func NewArtifactDownloadStepFactory() StepFactory {
 		if dest != "" && contentEncoding != "" {
 			return nil, fmt.Errorf("artifact_download step %q: only one of 'dest' or 'content_encoding' may be set", name)
 		}
+		if contentEncoding != "" && !isSupportedArtifactContentEncoding(contentEncoding, false) {
+			return nil, fmt.Errorf("artifact_download step %q: unsupported content_encoding %q", name, contentEncoding)
+		}
 
 		return &ArtifactDownloadStep{
 			name:            name,
@@ -231,10 +240,10 @@ func (s *ArtifactDownloadStep) Execute(ctx context.Context, pc *PipelineContext)
 			return nil, fmt.Errorf("artifact_download step %q: %w", s.name, err)
 		}
 		return &StepResult{Output: map[string]any{
-			"key":      key,
-			"content":  content,
-			"size":     int64(len(data)),
-			"metadata": md,
+			"key":              key,
+			"artifact_content": content,
+			"size":             int64(len(data)),
+			"metadata":         md,
 		}}, nil
 	}
 
@@ -278,6 +287,17 @@ func decodeArtifactContent(content, encoding string) ([]byte, error) {
 		return data, nil
 	default:
 		return nil, fmt.Errorf("unsupported content_encoding %q", encoding)
+	}
+}
+
+func isSupportedArtifactContentEncoding(encoding string, allowEmpty bool) bool {
+	switch strings.ToLower(encoding) {
+	case "":
+		return allowEmpty
+	case "raw", "text", "base64":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/module/pipeline_step_artifact.go
+++ b/module/pipeline_step_artifact.go
@@ -1,7 +1,9 @@
 package module
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -29,15 +31,17 @@ func resolveArtifactStore(app modular.Application, storeName, stepName string) (
 
 // ─── step.artifact_upload ───────────────────────────────────────────────────
 
-// ArtifactUploadStep uploads a local file to a named ArtifactStore.
+// ArtifactUploadStep uploads file-backed or context-backed content to a named ArtifactStore.
 type ArtifactUploadStep struct {
-	name     string
-	store    string
-	key      string
-	source   string
-	metadata map[string]string
-	app      modular.Application
-	tmpl     *TemplateEngine
+	name            string
+	store           string
+	key             string
+	source          string
+	contentFrom     string
+	contentEncoding string
+	metadata        map[string]string
+	app             modular.Application
+	tmpl            *TemplateEngine
 }
 
 // NewArtifactUploadStepFactory returns a StepFactory for step.artifact_upload.
@@ -52,9 +56,14 @@ func NewArtifactUploadStepFactory() StepFactory {
 			return nil, fmt.Errorf("artifact_upload step %q: 'key' is required", name)
 		}
 		source, _ := config["source"].(string)
-		if source == "" {
-			return nil, fmt.Errorf("artifact_upload step %q: 'source' is required", name)
+		contentFrom, _ := config["content_from"].(string)
+		if source == "" && contentFrom == "" {
+			return nil, fmt.Errorf("artifact_upload step %q: either 'source' or 'content_from' is required", name)
 		}
+		if source != "" && contentFrom != "" {
+			return nil, fmt.Errorf("artifact_upload step %q: only one of 'source' or 'content_from' may be set", name)
+		}
+		contentEncoding, _ := config["content_encoding"].(string)
 
 		md := map[string]string{}
 		if raw, ok := config["metadata"].(map[string]any); ok {
@@ -64,13 +73,15 @@ func NewArtifactUploadStepFactory() StepFactory {
 		}
 
 		return &ArtifactUploadStep{
-			name:     name,
-			store:    store,
-			key:      key,
-			source:   source,
-			metadata: md,
-			app:      app,
-			tmpl:     NewTemplateEngine(),
+			name:            name,
+			store:           store,
+			key:             key,
+			source:          source,
+			contentFrom:     contentFrom,
+			contentEncoding: contentEncoding,
+			metadata:        md,
+			app:             app,
+			tmpl:            NewTemplateEngine(),
 		}, nil
 	}
 }
@@ -88,11 +99,6 @@ func (s *ArtifactUploadStep) Execute(ctx context.Context, pc *PipelineContext) (
 		return nil, fmt.Errorf("artifact_upload step %q: key template: %w", s.name, err)
 	}
 
-	source, err := s.tmpl.Resolve(s.source, pc)
-	if err != nil {
-		return nil, fmt.Errorf("artifact_upload step %q: source template: %w", s.name, err)
-	}
-
 	// Resolve metadata templates.
 	md := make(map[string]string, len(s.metadata))
 	for k, v := range s.metadata {
@@ -103,38 +109,65 @@ func (s *ArtifactUploadStep) Execute(ctx context.Context, pc *PipelineContext) (
 		md[k] = resolved
 	}
 
-	f, err := os.Open(source)
+	reader, size, err := s.openContent(pc)
 	if err != nil {
-		return nil, fmt.Errorf("artifact_upload step %q: failed to open source %q: %w", s.name, source, err)
+		return nil, err
 	}
-	defer f.Close()
+	defer reader.Close()
 
-	stat, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("artifact_upload step %q: failed to stat source %q: %w", s.name, source, err)
-	}
-
-	if err := store.Upload(ctx, key, f, md); err != nil {
+	if err := store.Upload(ctx, key, reader, md); err != nil {
 		return nil, fmt.Errorf("artifact_upload step %q: %w", s.name, err)
 	}
 
 	return &StepResult{Output: map[string]any{
 		"key":   key,
 		"store": s.store,
-		"size":  stat.Size(),
+		"size":  size,
 	}}, nil
+}
+
+func (s *ArtifactUploadStep) openContent(pc *PipelineContext) (io.ReadCloser, int64, error) {
+	if s.source != "" {
+		source, err := s.tmpl.Resolve(s.source, pc)
+		if err != nil {
+			return nil, 0, fmt.Errorf("artifact_upload step %q: source template: %w", s.name, err)
+		}
+		f, err := os.Open(source)
+		if err != nil {
+			return nil, 0, fmt.Errorf("artifact_upload step %q: failed to open source %q: %w", s.name, source, err)
+		}
+		stat, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			return nil, 0, fmt.Errorf("artifact_upload step %q: failed to stat source %q: %w", s.name, source, err)
+		}
+		return f, stat.Size(), nil
+	}
+
+	raw := resolveBodyFrom(s.contentFrom, pc)
+	content, ok := raw.(string)
+	if !ok {
+		return nil, 0, fmt.Errorf("artifact_upload step %q: content_from %q resolved to %T, want string", s.name, s.contentFrom, raw)
+	}
+
+	data, err := decodeArtifactContent(content, s.contentEncoding)
+	if err != nil {
+		return nil, 0, fmt.Errorf("artifact_upload step %q: %w", s.name, err)
+	}
+	return io.NopCloser(bytes.NewReader(data)), int64(len(data)), nil
 }
 
 // ─── step.artifact_download ─────────────────────────────────────────────────
 
-// ArtifactDownloadStep downloads an artifact from a named ArtifactStore to a local path.
+// ArtifactDownloadStep downloads an artifact from a named ArtifactStore to a local path or step output.
 type ArtifactDownloadStep struct {
-	name  string
-	store string
-	key   string
-	dest  string
-	app   modular.Application
-	tmpl  *TemplateEngine
+	name            string
+	store           string
+	key             string
+	dest            string
+	contentEncoding string
+	app             modular.Application
+	tmpl            *TemplateEngine
 }
 
 // NewArtifactDownloadStepFactory returns a StepFactory for step.artifact_download.
@@ -149,17 +182,22 @@ func NewArtifactDownloadStepFactory() StepFactory {
 			return nil, fmt.Errorf("artifact_download step %q: 'key' is required", name)
 		}
 		dest, _ := config["dest"].(string)
-		if dest == "" {
-			return nil, fmt.Errorf("artifact_download step %q: 'dest' is required", name)
+		contentEncoding, _ := config["content_encoding"].(string)
+		if dest == "" && contentEncoding == "" {
+			return nil, fmt.Errorf("artifact_download step %q: either 'dest' or 'content_encoding' is required", name)
+		}
+		if dest != "" && contentEncoding != "" {
+			return nil, fmt.Errorf("artifact_download step %q: only one of 'dest' or 'content_encoding' may be set", name)
 		}
 
 		return &ArtifactDownloadStep{
-			name:  name,
-			store: store,
-			key:   key,
-			dest:  dest,
-			app:   app,
-			tmpl:  NewTemplateEngine(),
+			name:            name,
+			store:           store,
+			key:             key,
+			dest:            dest,
+			contentEncoding: contentEncoding,
+			app:             app,
+			tmpl:            NewTemplateEngine(),
 		}, nil
 	}
 }
@@ -177,16 +215,33 @@ func (s *ArtifactDownloadStep) Execute(ctx context.Context, pc *PipelineContext)
 		return nil, fmt.Errorf("artifact_download step %q: key template: %w", s.name, err)
 	}
 
-	dest, err := s.tmpl.Resolve(s.dest, pc)
-	if err != nil {
-		return nil, fmt.Errorf("artifact_download step %q: dest template: %w", s.name, err)
-	}
-
 	reader, md, err := store.Download(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("artifact_download step %q: %w", s.name, err)
 	}
 	defer reader.Close()
+
+	if s.dest == "" {
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("artifact_download step %q: failed to read artifact content: %w", s.name, err)
+		}
+		content, err := encodeArtifactContent(data, s.contentEncoding)
+		if err != nil {
+			return nil, fmt.Errorf("artifact_download step %q: %w", s.name, err)
+		}
+		return &StepResult{Output: map[string]any{
+			"key":      key,
+			"content":  content,
+			"size":     int64(len(data)),
+			"metadata": md,
+		}}, nil
+	}
+
+	dest, err := s.tmpl.Resolve(s.dest, pc)
+	if err != nil {
+		return nil, fmt.Errorf("artifact_download step %q: dest template: %w", s.name, err)
+	}
 
 	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
 		return nil, fmt.Errorf("artifact_download step %q: failed to create destination directory: %w", s.name, err)
@@ -209,6 +264,32 @@ func (s *ArtifactDownloadStep) Execute(ctx context.Context, pc *PipelineContext)
 		"size":     written,
 		"metadata": md,
 	}}, nil
+}
+
+func decodeArtifactContent(content, encoding string) ([]byte, error) {
+	switch strings.ToLower(encoding) {
+	case "", "raw", "text":
+		return []byte(content), nil
+	case "base64":
+		data, err := base64.StdEncoding.DecodeString(content)
+		if err != nil {
+			return nil, fmt.Errorf("decode base64 content: %w", err)
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("unsupported content_encoding %q", encoding)
+	}
+}
+
+func encodeArtifactContent(data []byte, encoding string) (string, error) {
+	switch strings.ToLower(encoding) {
+	case "raw", "text":
+		return string(data), nil
+	case "base64":
+		return base64.StdEncoding.EncodeToString(data), nil
+	default:
+		return "", fmt.Errorf("unsupported content_encoding %q", encoding)
+	}
 }
 
 // ─── step.artifact_list ─────────────────────────────────────────────────────

--- a/module/step_output_redactor.go
+++ b/module/step_output_redactor.go
@@ -14,6 +14,8 @@ var SensitiveFieldPatterns = []string{
 	"signature",
 	"request_body",
 	"raw_body",
+	"artifact_content",
+	"content_b64",
 	"transmission_sig",
 	"api_key",
 	"api-key",

--- a/module/step_output_redactor_test.go
+++ b/module/step_output_redactor_test.go
@@ -30,6 +30,9 @@ func TestRedactStepOutput_SensitiveFields(t *testing.T) {
 		{"webhook_signature", true},
 		{"request_body", true},
 		{"raw_body", true},
+		{"artifact_content", true},
+		{"artifact_content_b64", true},
+		{"content_b64", true},
 		{"paypal_transmission_sig", true},
 		// safe fields
 		{"username", false},

--- a/module/storage_artifact_test.go
+++ b/module/storage_artifact_test.go
@@ -423,6 +423,24 @@ func TestArtifactUploadStep_MissingRequiredConfig(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for source and content_from")
 	}
+	_, err = factory("x", map[string]any{
+		"store":            "s",
+		"key":              "k",
+		"source":           "f",
+		"content_encoding": "base64",
+	}, nil)
+	if err == nil {
+		t.Error("expected error for content_encoding with source")
+	}
+	_, err = factory("x", map[string]any{
+		"store":            "s",
+		"key":              "k",
+		"content_from":     "content",
+		"content_encoding": "gzip",
+	}, nil)
+	if err == nil {
+		t.Error("expected error for unsupported content_encoding")
+	}
 }
 
 func TestArtifactDownloadStep_Basic(t *testing.T) {
@@ -486,8 +504,8 @@ func TestArtifactDownloadStep_ContentBase64Output(t *testing.T) {
 	}
 
 	wantContent := base64.StdEncoding.EncodeToString([]byte("downloaded client artifact"))
-	if result.Output["content"] != wantContent {
-		t.Errorf("content: got %v, want %s", result.Output["content"], wantContent)
+	if result.Output["artifact_content"] != wantContent {
+		t.Errorf("artifact_content: got %v, want %s", result.Output["artifact_content"], wantContent)
 	}
 	if result.Output["size"] != int64(len("downloaded client artifact")) {
 		t.Errorf("size: got %v", result.Output["size"])
@@ -524,6 +542,14 @@ func TestArtifactDownloadStep_MissingRequiredConfig(t *testing.T) {
 	}, nil)
 	if err == nil {
 		t.Error("expected error for dest and content_encoding")
+	}
+	_, err = factory("x", map[string]any{
+		"store":            "s",
+		"key":              "k",
+		"content_encoding": "gzip",
+	}, nil)
+	if err == nil {
+		t.Error("expected error for unsupported content_encoding")
 	}
 }
 

--- a/module/storage_artifact_test.go
+++ b/module/storage_artifact_test.go
@@ -3,6 +3,7 @@ package module
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"os"
 	"path/filepath"
@@ -356,6 +357,48 @@ func TestArtifactUploadStep_Basic(t *testing.T) {
 	}
 }
 
+func TestArtifactUploadStep_ContentFromBase64(t *testing.T) {
+	store := newMockArtifactStore()
+	app := mockAppWithArtifactStore("artifacts", store)
+
+	factory := NewArtifactUploadStepFactory()
+	step, err := factory("upload-app", map[string]any{
+		"store":            "artifacts",
+		"key":              "{{ .artifact_key }}",
+		"content_from":     "content_b64",
+		"content_encoding": "base64",
+		"metadata": map[string]any{
+			"version": "{{ .version }}",
+		},
+	}, app)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	pc := NewPipelineContext(map[string]any{
+		"artifact_key": "builds/v1/app.bin",
+		"content_b64":  base64.StdEncoding.EncodeToString([]byte("client supplied artifact")),
+		"version":      "1.2.3",
+	}, nil)
+	result, err := step.Execute(t.Context(), pc)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if result.Output["key"] != "builds/v1/app.bin" {
+		t.Errorf("key: got %v", result.Output["key"])
+	}
+	if result.Output["size"] != int64(len("client supplied artifact")) {
+		t.Errorf("size: got %v", result.Output["size"])
+	}
+	if string(store.data["builds/v1/app.bin"]) != "client supplied artifact" {
+		t.Errorf("stored content mismatch: %q", store.data["builds/v1/app.bin"])
+	}
+	if store.metadata["builds/v1/app.bin"]["version"] != "1.2.3" {
+		t.Errorf("metadata version: got %q", store.metadata["builds/v1/app.bin"]["version"])
+	}
+}
+
 func TestArtifactUploadStep_MissingRequiredConfig(t *testing.T) {
 	factory := NewArtifactUploadStepFactory()
 
@@ -370,6 +413,15 @@ func TestArtifactUploadStep_MissingRequiredConfig(t *testing.T) {
 	_, err = factory("x", map[string]any{"store": "s", "key": "k"}, nil)
 	if err == nil {
 		t.Error("expected error for missing source")
+	}
+	_, err = factory("x", map[string]any{
+		"store":        "s",
+		"key":          "k",
+		"source":       "f",
+		"content_from": "content",
+	}, nil)
+	if err == nil {
+		t.Error("expected error for source and content_from")
 	}
 }
 
@@ -408,6 +460,70 @@ func TestArtifactDownloadStep_Basic(t *testing.T) {
 	}
 	if string(content) != "downloaded content" {
 		t.Errorf("content mismatch: %q", content)
+	}
+}
+
+func TestArtifactDownloadStep_ContentBase64Output(t *testing.T) {
+	store := newMockArtifactStore()
+	store.data["builds/v1/app.bin"] = []byte("downloaded client artifact")
+	store.metadata["builds/v1/app.bin"] = map[string]string{"version": "1.2.3"}
+	app := mockAppWithArtifactStore("artifacts", store)
+
+	factory := NewArtifactDownloadStepFactory()
+	step, err := factory("download-app", map[string]any{
+		"store":            "artifacts",
+		"key":              "{{ .artifact_key }}",
+		"content_encoding": "base64",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	pc := NewPipelineContext(map[string]any{"artifact_key": "builds/v1/app.bin"}, nil)
+	result, err := step.Execute(t.Context(), pc)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	wantContent := base64.StdEncoding.EncodeToString([]byte("downloaded client artifact"))
+	if result.Output["content"] != wantContent {
+		t.Errorf("content: got %v, want %s", result.Output["content"], wantContent)
+	}
+	if result.Output["size"] != int64(len("downloaded client artifact")) {
+		t.Errorf("size: got %v", result.Output["size"])
+	}
+	md, ok := result.Output["metadata"].(map[string]string)
+	if !ok {
+		t.Fatalf("metadata type: %T", result.Output["metadata"])
+	}
+	if md["version"] != "1.2.3" {
+		t.Errorf("metadata version: got %q", md["version"])
+	}
+}
+
+func TestArtifactDownloadStep_MissingRequiredConfig(t *testing.T) {
+	factory := NewArtifactDownloadStepFactory()
+
+	_, err := factory("x", map[string]any{"key": "k", "dest": "d"}, nil)
+	if err == nil {
+		t.Error("expected error for missing store")
+	}
+	_, err = factory("x", map[string]any{"store": "s", "dest": "d"}, nil)
+	if err == nil {
+		t.Error("expected error for missing key")
+	}
+	_, err = factory("x", map[string]any{"store": "s", "key": "k"}, nil)
+	if err == nil {
+		t.Error("expected error for missing dest or content_encoding")
+	}
+	_, err = factory("x", map[string]any{
+		"store":            "s",
+		"key":              "k",
+		"dest":             "d",
+		"content_encoding": "base64",
+	}, nil)
+	if err == nil {
+		t.Error("expected error for dest and content_encoding")
 	}
 }
 

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1620,15 +1620,18 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 	r.Register(&StepSchema{
 		Type:        "step.artifact_download",
 		Plugin:      "storage",
-		Description: "Downloads an artifact from the artifact store.",
+		Description: "Downloads artifact content from the artifact store to a file or pipeline output.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "store", Type: FieldTypeString, Description: "Name of the storage.artifact module", Required: true},
 			{Key: "key", Type: FieldTypeString, Description: "Artifact key to download", Required: true},
-			{Key: "dest", Type: FieldTypeString, Description: "Local path to write the artifact"},
+			{Key: "dest", Type: FieldTypeString, Description: "Local path to write the artifact; mutually exclusive with content_encoding"},
+			{Key: "content_encoding", Type: FieldTypeString, Description: "Return content in step output using this encoding when dest is omitted (raw, text, base64)"},
 		},
 		Outputs: []StepOutputDef{
-			{Key: "path", Type: "string", Description: "Local path where artifact was written"},
+			{Key: "dest", Type: "string", Description: "Local path where artifact was written"},
+			{Key: "content", Type: "string", Description: "Artifact content when content_encoding is used"},
 			{Key: "size", Type: "number", Description: "Artifact size in bytes"},
+			{Key: "metadata", Type: "object", Description: "Artifact metadata"},
 		},
 	})
 
@@ -1653,16 +1656,19 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 	r.Register(&StepSchema{
 		Type:        "step.artifact_upload",
 		Plugin:      "storage",
-		Description: "Uploads a file as an artifact to the artifact store.",
+		Description: "Uploads file-backed or context-backed content to the artifact store.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "store", Type: FieldTypeString, Description: "Name of the storage.artifact module", Required: true},
 			{Key: "key", Type: FieldTypeString, Description: "Artifact key (storage path)", Required: true},
-			{Key: "source", Type: FieldTypeString, Description: "Local file path to upload", Required: true},
+			{Key: "source", Type: FieldTypeString, Description: "Local file path to upload; mutually exclusive with content_from"},
+			{Key: "content_from", Type: FieldTypeString, Description: "Pipeline context path containing artifact content as a string; mutually exclusive with source"},
+			{Key: "content_encoding", Type: FieldTypeString, Description: "Encoding for content_from (raw, text, base64)"},
 			{Key: "metadata", Type: FieldTypeMap, Description: "Additional metadata to attach"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "key", Type: "string", Description: "Stored artifact key"},
 			{Key: "store", Type: "string", Description: "Name of the store used"},
+			{Key: "size", Type: "number", Description: "Stored artifact size in bytes"},
 		},
 	})
 

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1629,7 +1629,7 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		},
 		Outputs: []StepOutputDef{
 			{Key: "dest", Type: "string", Description: "Local path where artifact was written"},
-			{Key: "content", Type: "string", Description: "Artifact content when content_encoding is used"},
+			{Key: "artifact_content", Type: "string", Description: "Artifact content when content_encoding is used"},
 			{Key: "size", Type: "number", Description: "Artifact size in bytes"},
 			{Key: "metadata", Type: "object", Description: "Artifact metadata"},
 		},

--- a/schema/step_schema_test.go
+++ b/schema/step_schema_test.go
@@ -39,6 +39,56 @@ func TestStepSchemaRegistry_Outputs(t *testing.T) {
 	}
 }
 
+func TestStepSchemaRegistry_ArtifactContentFields(t *testing.T) {
+	reg := NewStepSchemaRegistry()
+
+	upload := reg.Get("step.artifact_upload")
+	if upload == nil {
+		t.Fatal("missing step.artifact_upload schema")
+	}
+	for _, key := range []string{"source", "content_from", "content_encoding"} {
+		if !hasConfigField(upload, key) {
+			t.Errorf("step.artifact_upload missing config field %q", key)
+		}
+	}
+	if !hasStepOutput(upload, "size") {
+		t.Error("step.artifact_upload missing size output")
+	}
+
+	download := reg.Get("step.artifact_download")
+	if download == nil {
+		t.Fatal("missing step.artifact_download schema")
+	}
+	for _, key := range []string{"dest", "content_encoding"} {
+		if !hasConfigField(download, key) {
+			t.Errorf("step.artifact_download missing config field %q", key)
+		}
+	}
+	for _, key := range []string{"dest", "content", "size", "metadata"} {
+		if !hasStepOutput(download, key) {
+			t.Errorf("step.artifact_download missing output %q", key)
+		}
+	}
+}
+
+func hasConfigField(s *StepSchema, key string) bool {
+	for _, field := range s.ConfigFields {
+		if field.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func hasStepOutput(s *StepSchema, key string) bool {
+	for _, output := range s.Outputs {
+		if output.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 func TestStepSchemaRegistry_RegisterCustom(t *testing.T) {
 	reg := NewStepSchemaRegistry()
 	custom := &StepSchema{

--- a/schema/step_schema_test.go
+++ b/schema/step_schema_test.go
@@ -64,7 +64,7 @@ func TestStepSchemaRegistry_ArtifactContentFields(t *testing.T) {
 			t.Errorf("step.artifact_download missing config field %q", key)
 		}
 	}
-	for _, key := range []string{"dest", "content", "size", "metadata"} {
+	for _, key := range []string{"dest", "artifact_content", "size", "metadata"} {
 		if !hasStepOutput(download, key) {
 			t.Errorf("step.artifact_download missing output %q", key)
 		}


### PR DESCRIPTION
## Summary
- allow step.artifact_upload to upload content from pipeline context via content_from/content_encoding
- allow step.artifact_download to return artifact content in pipeline output when dest is omitted
- document artifact upload/download modes and add focused tests

## Verification
- GOWORK=off go test ./module -run 'TestArtifact' -count=1
- GOWORK=off go test ./module -count=1
- git diff --check