### PR TITLE
Tighten artifact content downloads

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -263,7 +263,7 @@ string content from the pipeline context. `content_encoding` accepts `raw`,
 | `key` | string | yes | Artifact key; templates are resolved against the pipeline context. |
 | `dest` | string | one of `dest`/`content_encoding` | Server-local file path to write. |
 | `content_encoding` | string | one of `dest`/`content_encoding` | Output encoding when returning content: `raw`, `text`, or `base64`. |
-| `max_bytes` | number | no | Maximum bytes to load in content-output mode; `0` means unlimited. |
+| `max_bytes` | number | no | Maximum whole-number bytes to load in content-output mode; `0` means unlimited. |
 
 **Output fields:** file mode returns `key`, `dest`, `size`, `metadata`; content
 mode returns `key`, `artifact_content`, `size`, `metadata`.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -263,6 +263,7 @@ string content from the pipeline context. `content_encoding` accepts `raw`,
 | `key` | string | yes | Artifact key; templates are resolved against the pipeline context. |
 | `dest` | string | one of `dest`/`content_encoding` | Server-local file path to write. |
 | `content_encoding` | string | one of `dest`/`content_encoding` | Output encoding when returning content: `raw`, `text`, or `base64`. |
+| `max_bytes` | number | no | Maximum bytes to load in content-output mode; `0` means unlimited. |
 
 **Output fields:** file mode returns `key`, `dest`, `size`, `metadata`; content
 mode returns `key`, `artifact_content`, `size`, `metadata`.

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -1153,12 +1153,12 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.artifact_upload": {
 			Type:       "step.artifact_upload",
 			Plugin:     "storage",
-			ConfigKeys: []string{"store", "key", "source", "metadata"},
+			ConfigKeys: []string{"store", "key", "source", "content_from", "content_encoding", "metadata"},
 		},
 		"step.artifact_download": {
 			Type:       "step.artifact_download",
 			Plugin:     "storage",
-			ConfigKeys: []string{"store", "key", "dest"},
+			ConfigKeys: []string{"store", "key", "dest", "content_encoding", "max_bytes"},
 		},
 		"step.artifact_list": {
 			Type:       "step.artifact_list",

--- a/module/pipeline_step_artifact.go
+++ b/module/pipeline_step_artifact.go
@@ -258,10 +258,7 @@ func (s *ArtifactDownloadStep) Execute(ctx context.Context, pc *PipelineContext)
 	if err != nil {
 		return nil, fmt.Errorf("artifact_download step %q: dest template: %w", s.name, err)
 	}
-	if strings.TrimSpace(dest) == "" ||
-		dest == "<no value>" ||
-		strings.Contains(dest, "{{") ||
-		strings.Contains(dest, "}}") {
+	if strings.TrimSpace(dest) == "" || strings.Contains(dest, "<no value>") {
 		return nil, fmt.Errorf("artifact_download step %q: resolved dest is empty", s.name)
 	}
 
@@ -359,7 +356,7 @@ func readArtifactContent(reader io.Reader, maxBytes int64) ([]byte, error) {
 		return nil, err
 	}
 	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("artifact size %d exceeds max_bytes %d", len(data), maxBytes)
+		return nil, fmt.Errorf("artifact content exceeds max_bytes %d", maxBytes)
 	}
 	return data, nil
 }

--- a/module/pipeline_step_artifact.go
+++ b/module/pipeline_step_artifact.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/GoCodeAlone/modular"
@@ -172,6 +173,7 @@ type ArtifactDownloadStep struct {
 	key             string
 	dest            string
 	contentEncoding string
+	maxBytes        int64
 	app             modular.Application
 	tmpl            *TemplateEngine
 }
@@ -198,6 +200,10 @@ func NewArtifactDownloadStepFactory() StepFactory {
 		if contentEncoding != "" && !isSupportedArtifactContentEncoding(contentEncoding, false) {
 			return nil, fmt.Errorf("artifact_download step %q: unsupported content_encoding %q", name, contentEncoding)
 		}
+		maxBytes, err := parseArtifactMaxBytes(config["max_bytes"])
+		if err != nil {
+			return nil, fmt.Errorf("artifact_download step %q: %w", name, err)
+		}
 
 		return &ArtifactDownloadStep{
 			name:            name,
@@ -205,6 +211,7 @@ func NewArtifactDownloadStepFactory() StepFactory {
 			key:             key,
 			dest:            dest,
 			contentEncoding: contentEncoding,
+			maxBytes:        maxBytes,
 			app:             app,
 			tmpl:            NewTemplateEngine(),
 		}, nil
@@ -231,7 +238,7 @@ func (s *ArtifactDownloadStep) Execute(ctx context.Context, pc *PipelineContext)
 	defer reader.Close()
 
 	if s.dest == "" {
-		data, err := io.ReadAll(reader)
+		data, err := readArtifactContent(reader, s.maxBytes)
 		if err != nil {
 			return nil, fmt.Errorf("artifact_download step %q: failed to read artifact content: %w", s.name, err)
 		}
@@ -250,6 +257,12 @@ func (s *ArtifactDownloadStep) Execute(ctx context.Context, pc *PipelineContext)
 	dest, err := s.tmpl.Resolve(s.dest, pc)
 	if err != nil {
 		return nil, fmt.Errorf("artifact_download step %q: dest template: %w", s.name, err)
+	}
+	if strings.TrimSpace(dest) == "" ||
+		dest == "<no value>" ||
+		strings.Contains(dest, "{{") ||
+		strings.Contains(dest, "}}") {
+		return nil, fmt.Errorf("artifact_download step %q: resolved dest is empty", s.name)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
@@ -299,6 +312,56 @@ func isSupportedArtifactContentEncoding(encoding string, allowEmpty bool) bool {
 	default:
 		return false
 	}
+}
+
+func parseArtifactMaxBytes(raw any) (int64, error) {
+	if raw == nil {
+		return 0, nil
+	}
+	var maxBytes int64
+	switch v := raw.(type) {
+	case int:
+		maxBytes = int64(v)
+	case int64:
+		maxBytes = v
+	case int32:
+		maxBytes = int64(v)
+	case float64:
+		if v != float64(int64(v)) {
+			return 0, fmt.Errorf("max_bytes must be a whole number")
+		}
+		maxBytes = int64(v)
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return 0, nil
+		}
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("max_bytes must be a whole number: %w", err)
+		}
+		maxBytes = parsed
+	default:
+		return 0, fmt.Errorf("max_bytes has unsupported type %T", raw)
+	}
+	if maxBytes < 0 {
+		return 0, fmt.Errorf("max_bytes must be >= 0")
+	}
+	return maxBytes, nil
+}
+
+func readArtifactContent(reader io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return io.ReadAll(reader)
+	}
+	limited := io.LimitReader(reader, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("artifact size %d exceeds max_bytes %d", len(data), maxBytes)
+	}
+	return data, nil
 }
 
 func encodeArtifactContent(data []byte, encoding string) (string, error) {

--- a/module/storage_artifact_test.go
+++ b/module/storage_artifact_test.go
@@ -519,6 +519,55 @@ func TestArtifactDownloadStep_ContentBase64Output(t *testing.T) {
 	}
 }
 
+func TestArtifactDownloadStep_ContentOutputMaxBytes(t *testing.T) {
+	store := newMockArtifactStore()
+	store.data["builds/v1/app.bin"] = []byte("too large")
+	app := mockAppWithArtifactStore("artifacts", store)
+
+	factory := NewArtifactDownloadStepFactory()
+	step, err := factory("download-app", map[string]any{
+		"store":            "artifacts",
+		"key":              "builds/v1/app.bin",
+		"content_encoding": "base64",
+		"max_bytes":        3,
+	}, app)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	_, err = step.Execute(t.Context(), NewPipelineContext(nil, nil))
+	if err == nil {
+		t.Fatal("expected max_bytes error")
+	}
+	if !strings.Contains(err.Error(), "exceeds max_bytes") {
+		t.Fatalf("expected max_bytes error, got %v", err)
+	}
+}
+
+func TestArtifactDownloadStep_EmptyResolvedDest(t *testing.T) {
+	store := newMockArtifactStore()
+	store.data["builds/v1/app.bin"] = []byte("downloaded content")
+	app := mockAppWithArtifactStore("artifacts", store)
+
+	factory := NewArtifactDownloadStepFactory()
+	step, err := factory("download-app", map[string]any{
+		"store": "artifacts",
+		"key":   "builds/v1/app.bin",
+		"dest":  "{{ .missing_dest }}",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	_, err = step.Execute(t.Context(), NewPipelineContext(nil, nil))
+	if err == nil {
+		t.Fatal("expected empty dest error")
+	}
+	if !strings.Contains(err.Error(), "resolved dest is empty") {
+		t.Fatalf("expected empty dest error, got %v", err)
+	}
+}
+
 func TestArtifactDownloadStep_MissingRequiredConfig(t *testing.T) {
 	factory := NewArtifactDownloadStepFactory()
 
@@ -550,6 +599,15 @@ func TestArtifactDownloadStep_MissingRequiredConfig(t *testing.T) {
 	}, nil)
 	if err == nil {
 		t.Error("expected error for unsupported content_encoding")
+	}
+	_, err = factory("x", map[string]any{
+		"store":            "s",
+		"key":              "k",
+		"content_encoding": "base64",
+		"max_bytes":        -1,
+	}, nil)
+	if err == nil {
+		t.Error("expected error for negative max_bytes")
 	}
 }
 

--- a/module/storage_artifact_test.go
+++ b/module/storage_artifact_test.go
@@ -553,7 +553,7 @@ func TestArtifactDownloadStep_EmptyResolvedDest(t *testing.T) {
 	step, err := factory("download-app", map[string]any{
 		"store": "artifacts",
 		"key":   "builds/v1/app.bin",
-		"dest":  "{{ .missing_dest }}",
+		"dest":  "{{ .missing_dest }}.bin",
 	}, app)
 	if err != nil {
 		t.Fatalf("factory: %v", err)

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1626,8 +1626,10 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 			{Key: "key", Type: FieldTypeString, Description: "Artifact key to download", Required: true},
 			{Key: "dest", Type: FieldTypeString, Description: "Local path to write the artifact; mutually exclusive with content_encoding"},
 			{Key: "content_encoding", Type: FieldTypeString, Description: "Return content in step output using this encoding when dest is omitted (raw, text, base64)"},
+			{Key: "max_bytes", Type: FieldTypeNumber, Description: "Maximum bytes to load in content-output mode; 0 means unlimited"},
 		},
 		Outputs: []StepOutputDef{
+			{Key: "key", Type: "string", Description: "Artifact key"},
 			{Key: "dest", Type: "string", Description: "Local path where artifact was written"},
 			{Key: "artifact_content", Type: "string", Description: "Artifact content when content_encoding is used"},
 			{Key: "size", Type: "number", Description: "Artifact size in bytes"},

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1626,11 +1626,11 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 			{Key: "key", Type: FieldTypeString, Description: "Artifact key to download", Required: true},
 			{Key: "dest", Type: FieldTypeString, Description: "Local path to write the artifact; mutually exclusive with content_encoding"},
 			{Key: "content_encoding", Type: FieldTypeString, Description: "Return content in step output using this encoding when dest is omitted (raw, text, base64)"},
-			{Key: "max_bytes", Type: FieldTypeNumber, Description: "Maximum bytes to load in content-output mode; 0 means unlimited"},
+			{Key: "max_bytes", Type: FieldTypeNumber, Description: "Maximum whole-number bytes to load in content-output mode; 0 means unlimited"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "key", Type: "string", Description: "Artifact key"},
-			{Key: "dest", Type: "string", Description: "Local path where artifact was written"},
+			{Key: "dest", Type: "string", Description: "Local path where artifact was written in file mode"},
 			{Key: "artifact_content", Type: "string", Description: "Artifact content when content_encoding is used"},
 			{Key: "size", Type: "number", Description: "Artifact size in bytes"},
 			{Key: "metadata", Type: "object", Description: "Artifact metadata"},

--- a/schema/step_schema_test.go
+++ b/schema/step_schema_test.go
@@ -59,12 +59,12 @@ func TestStepSchemaRegistry_ArtifactContentFields(t *testing.T) {
 	if download == nil {
 		t.Fatal("missing step.artifact_download schema")
 	}
-	for _, key := range []string{"dest", "content_encoding"} {
+	for _, key := range []string{"dest", "content_encoding", "max_bytes"} {
 		if !hasConfigField(download, key) {
 			t.Errorf("step.artifact_download missing config field %q", key)
 		}
 	}
-	for _, key := range []string{"dest", "artifact_content", "size", "metadata"} {
+	for _, key := range []string{"key", "dest", "artifact_content", "size", "metadata"} {
 		if !hasStepOutput(download, key) {
 			t.Errorf("step.artifact_download missing output %q", key)
 		}


### PR DESCRIPTION
## Summary
- add max_bytes guard for content-mode artifact downloads
- reject empty or unresolved templated dest values with a clear error
- include artifact_download key/max_bytes in schema and wfctl metadata

## Verification
- GOWORK=off go test ./module -run 'TestArtifactDownloadStep_(ContentOutputMaxBytes|EmptyResolvedDest|MissingRequiredConfig|ContentBase64Output|Basic)' -count=1
- GOWORK=off go test ./schema -run 'TestStepSchemaRegistry_ArtifactContentFields' -count=1
- GOWORK=off go test ./module -count=1
- GOWORK=off go test ./schema ./cmd/wfctl -count=1
- git diff --check