### PR TITLE
Allow dynamic cloud account validation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -267,6 +267,21 @@ string content from the pipeline context. `content_encoding` accepts `raw`,
 **Output fields:** file mode returns `key`, `dest`, `size`, `metadata`; content
 mode returns `key`, `artifact_content`, `size`, `metadata`.
 
+### Cloud Pipeline Steps
+
+`step.cloud_validate` validates a configured `cloud.account` module. Use
+`account` for a static account name, or `account_from` to resolve the account
+name from the pipeline context at execution time. Exactly one of the two fields
+is required.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `account` | string | one of `account`/`account_from` | Static `cloud.account` module name. |
+| `account_from` | string | one of `account`/`account_from` | Pipeline context path containing the `cloud.account` module name. |
+
+**Output fields:** `account`, `valid`, `provider`, `region`, and provider-specific
+summary fields such as `project_id`, `tenant_id`, or `subscription_id`.
+
 ### CI/CD Pipeline Steps
 | Type | Description | Plugin |
 |------|-------------|--------|

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -1175,7 +1175,7 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.cloud_validate": {
 			Type:       "step.cloud_validate",
 			Plugin:     "cloud",
-			ConfigKeys: []string{"account"},
+			ConfigKeys: []string{"account", "account_from"},
 		},
 
 		// cicd plugin steps (build_binary + codebuild)

--- a/module/cloud_account_test.go
+++ b/module/cloud_account_test.go
@@ -272,12 +272,58 @@ func TestCloudValidateStep(t *testing.T) {
 	}
 }
 
+func TestCloudValidateStep_AccountFromContext(t *testing.T) {
+	app := module.NewMockApplication()
+	for name, region := range map[string]string{
+		"prod-account":    "us-east-1",
+		"staging-account": "us-west-2",
+	} {
+		acc := module.NewCloudAccount(name, map[string]any{
+			"provider": "mock",
+			"region":   region,
+		})
+		if err := acc.Init(app); err != nil {
+			t.Fatalf("cloud account %q Init failed: %v", name, err)
+		}
+	}
+
+	factory := module.NewCloudValidateStepFactory()
+	step, err := factory("validate", map[string]any{"account_from": "account"}, app)
+	if err != nil {
+		t.Fatalf("factory failed: %v", err)
+	}
+
+	result, err := step.Execute(context.Background(), &module.PipelineContext{
+		Current: map[string]any{"account": "staging-account"},
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if result.Output["account"] != "staging-account" {
+		t.Errorf("expected account=staging-account, got %v", result.Output["account"])
+	}
+	if result.Output["region"] != "us-west-2" {
+		t.Errorf("expected region=us-west-2, got %v", result.Output["region"])
+	}
+	if result.Output["valid"] != true {
+		t.Errorf("expected valid=true, got %v", result.Output["valid"])
+	}
+}
+
 // TestCloudValidateStep_MissingAccount verifies the factory requires an account name.
 func TestCloudValidateStep_MissingAccount(t *testing.T) {
 	factory := module.NewCloudValidateStepFactory()
 	_, err := factory("validate", map[string]any{}, module.NewMockApplication())
 	if err == nil {
 		t.Error("expected error when account is missing")
+	}
+	_, err = factory("validate", map[string]any{
+		"account":      "static-account",
+		"account_from": "account",
+	}, module.NewMockApplication())
+	if err == nil {
+		t.Error("expected error when account and account_from are both set")
 	}
 }
 

--- a/module/cloud_account_test.go
+++ b/module/cloud_account_test.go
@@ -3,6 +3,7 @@ package module_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/module"
@@ -308,6 +309,22 @@ func TestCloudValidateStep_AccountFromContext(t *testing.T) {
 	}
 	if result.Output["valid"] != true {
 		t.Errorf("expected valid=true, got %v", result.Output["valid"])
+	}
+}
+
+func TestCloudValidateStep_AccountFromNilContext(t *testing.T) {
+	factory := module.NewCloudValidateStepFactory()
+	step, err := factory("validate", map[string]any{"account_from": "account"}, module.NewMockApplication())
+	if err != nil {
+		t.Fatalf("factory failed: %v", err)
+	}
+
+	_, err = step.Execute(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected nil context error")
+	}
+	if got, want := err.Error(), `account_from "account" requires a pipeline context`; !strings.Contains(got, want) {
+		t.Fatalf("expected %q in error, got %v", want, err)
 	}
 }
 

--- a/module/pipeline_step_cloud_validate.go
+++ b/module/pipeline_step_cloud_validate.go
@@ -94,6 +94,9 @@ func (s *CloudValidateStep) resolveAccount(pc *PipelineContext) (string, error) 
 	if s.account != "" {
 		return s.account, nil
 	}
+	if pc == nil {
+		return "", fmt.Errorf("account_from %q requires a pipeline context", s.accountFrom)
+	}
 	raw := resolveBodyFrom(s.accountFrom, pc)
 	account, ok := raw.(string)
 	if !ok || account == "" {

--- a/module/pipeline_step_cloud_validate.go
+++ b/module/pipeline_step_cloud_validate.go
@@ -11,22 +11,28 @@ import (
 // and non-empty. It looks up a CloudCredentialProvider from the service registry
 // by account name, calls GetCredentials, and returns a summary JSON result.
 type CloudValidateStep struct {
-	name    string
-	account string // service name of the CloudAccount module
-	app     modular.Application
+	name        string
+	account     string // service name of the CloudAccount module
+	accountFrom string // pipeline context path resolving to a CloudAccount service name
+	app         modular.Application
 }
 
 // NewCloudValidateStepFactory returns a StepFactory for step.cloud_validate.
 func NewCloudValidateStepFactory() StepFactory {
 	return func(name string, config map[string]any, app modular.Application) (PipelineStep, error) {
 		account, _ := config["account"].(string)
-		if account == "" {
-			return nil, fmt.Errorf("cloud_validate step %q: 'account' is required", name)
+		accountFrom, _ := config["account_from"].(string)
+		if account == "" && accountFrom == "" {
+			return nil, fmt.Errorf("cloud_validate step %q: either 'account' or 'account_from' is required", name)
+		}
+		if account != "" && accountFrom != "" {
+			return nil, fmt.Errorf("cloud_validate step %q: only one of 'account' or 'account_from' may be set", name)
 		}
 		return &CloudValidateStep{
-			name:    name,
-			account: account,
-			app:     app,
+			name:        name,
+			account:     account,
+			accountFrom: accountFrom,
+			app:         app,
 		}, nil
 	}
 }
@@ -35,8 +41,13 @@ func NewCloudValidateStepFactory() StepFactory {
 func (s *CloudValidateStep) Name() string { return s.name }
 
 // Execute validates the configured cloud account's credentials.
-func (s *CloudValidateStep) Execute(ctx context.Context, _ *PipelineContext) (*StepResult, error) {
-	provider, err := s.resolveProvider()
+func (s *CloudValidateStep) Execute(ctx context.Context, pc *PipelineContext) (*StepResult, error) {
+	account, err := s.resolveAccount(pc)
+	if err != nil {
+		return nil, fmt.Errorf("cloud_validate step %q: %w", s.name, err)
+	}
+
+	provider, err := s.resolveProvider(account)
 	if err != nil {
 		return nil, fmt.Errorf("cloud_validate step %q: %w", s.name, err)
 	}
@@ -51,7 +62,7 @@ func (s *CloudValidateStep) Execute(ctx context.Context, _ *PipelineContext) (*S
 	}
 
 	output := map[string]any{
-		"account":  s.account,
+		"account":  account,
 		"provider": provider.Provider(),
 		"region":   provider.Region(),
 		"valid":    valid,
@@ -79,18 +90,30 @@ func (s *CloudValidateStep) Execute(ctx context.Context, _ *PipelineContext) (*S
 	return &StepResult{Output: output}, nil
 }
 
+func (s *CloudValidateStep) resolveAccount(pc *PipelineContext) (string, error) {
+	if s.account != "" {
+		return s.account, nil
+	}
+	raw := resolveBodyFrom(s.accountFrom, pc)
+	account, ok := raw.(string)
+	if !ok || account == "" {
+		return "", fmt.Errorf("account_from %q resolved to %T, want non-empty string", s.accountFrom, raw)
+	}
+	return account, nil
+}
+
 // resolveProvider looks up the CloudCredentialProvider from the service registry.
-func (s *CloudValidateStep) resolveProvider() (CloudCredentialProvider, error) {
+func (s *CloudValidateStep) resolveProvider(account string) (CloudCredentialProvider, error) {
 	if s.app == nil {
 		return nil, fmt.Errorf("no application context")
 	}
-	svc, ok := s.app.SvcRegistry()[s.account]
+	svc, ok := s.app.SvcRegistry()[account]
 	if !ok {
-		return nil, fmt.Errorf("account service %q not found in registry", s.account)
+		return nil, fmt.Errorf("account service %q not found in registry", account)
 	}
 	provider, ok := svc.(CloudCredentialProvider)
 	if !ok {
-		return nil, fmt.Errorf("service %q does not implement CloudCredentialProvider", s.account)
+		return nil, fmt.Errorf("service %q does not implement CloudCredentialProvider", account)
 	}
 	return provider, nil
 }

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1713,9 +1713,11 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Plugin:      "cloud",
 		Description: "Validates cloud provider credentials and connectivity.",
 		ConfigFields: []ConfigFieldDef{
-			{Key: "account", Type: FieldTypeString, Description: "Name of the cloud.account module", Required: true},
+			{Key: "account", Type: FieldTypeString, Description: "Static name of the cloud.account module; mutually exclusive with account_from"},
+			{Key: "account_from", Type: FieldTypeString, Description: "Pipeline context path resolving to the cloud.account module name; mutually exclusive with account"},
 		},
 		Outputs: []StepOutputDef{
+			{Key: "account", Type: "string", Description: "Validated cloud account service name"},
 			{Key: "valid", Type: "boolean", Description: "Whether credentials are valid"},
 			{Key: "provider", Type: "string", Description: "Cloud provider name"},
 			{Key: "region", Type: "string", Description: "Configured region"},

--- a/schema/step_schema_test.go
+++ b/schema/step_schema_test.go
@@ -71,6 +71,22 @@ func TestStepSchemaRegistry_ArtifactContentFields(t *testing.T) {
 	}
 }
 
+func TestStepSchemaRegistry_CloudValidateAccountFrom(t *testing.T) {
+	reg := NewStepSchemaRegistry()
+	s := reg.Get("step.cloud_validate")
+	if s == nil {
+		t.Fatal("missing step.cloud_validate schema")
+	}
+	for _, key := range []string{"account", "account_from"} {
+		if !hasConfigField(s, key) {
+			t.Errorf("step.cloud_validate missing config field %q", key)
+		}
+	}
+	if !hasStepOutput(s, "account") {
+		t.Error("step.cloud_validate missing account output")
+	}
+}
+
 func hasConfigField(s *StepSchema, key string) bool {
 	for _, field := range s.ConfigFields {
 		if field.Key == key {


### PR DESCRIPTION
## Summary
- add account_from to step.cloud_validate so apps can validate a caller-selected account from pipeline context
- preserve static account behavior and reject configs that set both account and account_from
- update wfctl/schema/docs metadata and tests

## Verification
- GOWORK=off go test ./module -run 'TestCloudValidateStep|TestCloudAccount' -count=1
- GOWORK=off go test ./schema -run 'TestStepSchemaRegistry_(CloudValidateAccountFrom|ArtifactContentFields)' -count=1
- GOWORK=off go test ./module -count=1
- GOWORK=off go test ./schema ./cmd/wfctl -count=1
- git diff --check HEAD