### PR TITLE
Allow build_binary config from context

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -318,8 +318,8 @@ YAML from the pipeline context, such as an HTTP route's `request_body`.
 
 | Key | Type | Required | Description |
 |-----|------|----------|-------------|
-| `config_file` | string | one of `config_file`/`config_from` | Workflow config file to embed. |
-| `config_from` | string | one of `config_file`/`config_from` | Pipeline context path resolving to workflow config YAML. |
+| `config_file` | string | exactly one of `config_file`/`config_from` | Workflow config file to embed. |
+| `config_from` | string | exactly one of `config_file`/`config_from` | Pipeline context path resolving to workflow config YAML. |
 | `output` | string | no | Output binary path; defaults to `bin/app`. |
 | `module_path` | string | no | Generated Go module path; defaults to `app`. |
 | `go_version` | string | no | Generated `go.mod` Go version; defaults to `1.22`. |

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -295,7 +295,7 @@ summary fields such as `project_id`, `tenant_id`, or `subscription_id`.
 | `step.artifact_push` | Stores a file in the artifact store for cross-step sharing | cicd |
 | `step.artifact_pull` | Retrieves an artifact from a prior execution, URL, or S3 | cicd |
 | `step.shell_exec` | Executes an arbitrary shell command | cicd |
-| `step.build_binary` | Builds a Go binary using `go build` | cicd |
+| `step.build_binary` | Generates a Workflow Go project from config and optionally builds a binary | cicd |
 | `step.build_from_config` | Builds the workflow server binary from a YAML config | cicd |
 | `step.build_ui` | Builds the UI assets from a frontend config | cicd |
 | `step.deploy` | Deploys a built artifact to an environment | cicd |
@@ -311,6 +311,26 @@ summary fields such as `project_id`, `tenant_id`, or `subscription_id`.
 | `step.codebuild_logs` | Fetches logs from an AWS CodeBuild build | cicd |
 | `step.codebuild_list_builds` | Lists recent AWS CodeBuild builds for a project | cicd |
 | `step.codebuild_delete_project` | Deletes an AWS CodeBuild project | cicd |
+
+`step.build_binary` generates a self-contained Go project from Workflow config.
+Use `config_file` to read config from disk, or `config_from` to resolve config
+YAML from the pipeline context, such as an HTTP route's `request_body`.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `config_file` | string | one of `config_file`/`config_from` | Workflow config file to embed. |
+| `config_from` | string | one of `config_file`/`config_from` | Pipeline context path resolving to workflow config YAML. |
+| `output` | string | no | Output binary path; defaults to `bin/app`. |
+| `module_path` | string | no | Generated Go module path; defaults to `app`. |
+| `go_version` | string | no | Generated `go.mod` Go version; defaults to `1.22`. |
+| `embed_config` | boolean | no | Embed `app.yaml` in the generated binary; defaults to `true`. |
+| `dry_run` | boolean | no | Return generated files without compiling. |
+| `os` | string | no | Target OS (`GOOS`); defaults to the current OS. |
+| `arch` | string | no | Target architecture (`GOARCH`); defaults to the current architecture. |
+
+**Output fields:** dry-run mode returns `dry_run`, `files`, `file_contents`,
+`module_path`, `go_version`, `target_os`, `target_arch`; build mode returns
+`binary_path`, `binary_size`, `target_os`, `target_arch`.
 
 ### Platform & Infrastructure Pipeline Steps
 | Type | Description | Plugin |

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -1182,7 +1182,7 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.build_binary": {
 			Type:       "step.build_binary",
 			Plugin:     "cicd",
-			ConfigKeys: []string{"config_file", "output", "os", "arch"},
+			ConfigKeys: []string{"config_file", "config_from", "output", "module_path", "go_version", "embed_config", "dry_run", "os", "arch"},
 		},
 		"step.codebuild_create_project": {
 			Type:       "step.codebuild_create_project",

--- a/cmd/wfctl/type_registry_test.go
+++ b/cmd/wfctl/type_registry_test.go
@@ -215,6 +215,17 @@ func TestKnownStepTypesRequestParseConfigKeys(t *testing.T) {
 	}
 }
 
+func TestKnownStepTypesBuildBinaryConfigKeys(t *testing.T) {
+	info, ok := KnownStepTypes()["step.build_binary"]
+	if !ok {
+		t.Fatal("step.build_binary not found")
+	}
+	want := []string{"config_file", "config_from", "output", "module_path", "go_version", "embed_config", "dry_run", "os", "arch"}
+	if !sameStringSet(info.ConfigKeys, want) {
+		t.Fatalf("step.build_binary ConfigKeys = %v, want %v", info.ConfigKeys, want)
+	}
+}
+
 func TestKnownStepTypesResponseAliasesMatchConfigKeys(t *testing.T) {
 	types := KnownStepTypes()
 	jsonInfo, ok := types["step.json_response"]

--- a/module/pipeline_step_build_binary.go
+++ b/module/pipeline_step_build_binary.go
@@ -18,6 +18,7 @@ import (
 type BuildBinaryStep struct {
 	name        string
 	configFile  string
+	configFrom  string
 	output      string
 	targetOS    string
 	targetArch  string
@@ -32,8 +33,9 @@ type BuildBinaryStep struct {
 func NewBuildBinaryStepFactory() StepFactory {
 	return func(name string, config map[string]any, _ modular.Application) (PipelineStep, error) {
 		configFile, _ := config["config_file"].(string)
-		if configFile == "" {
-			return nil, fmt.Errorf("build_binary step %q: 'config_file' is required", name)
+		configFrom, _ := config["config_from"].(string)
+		if configFile == "" && configFrom == "" {
+			return nil, fmt.Errorf("build_binary step %q: either 'config_file' or 'config_from' is required", name)
 		}
 
 		output, _ := config["output"].(string)
@@ -71,6 +73,7 @@ func NewBuildBinaryStepFactory() StepFactory {
 		return &BuildBinaryStep{
 			name:        name,
 			configFile:  configFile,
+			configFrom:  configFrom,
 			output:      output,
 			targetOS:    targetOS,
 			targetArch:  targetArch,
@@ -108,9 +111,13 @@ func (s *BuildBinaryStep) Execute(ctx context.Context, pc *PipelineContext) (*St
 	return s.compileProject(ctx, files)
 }
 
-// resolveConfigContent reads the config file from disk, falling back to the
-// pipeline context body if the file is not found.
+// resolveConfigContent reads config from an explicit context path, a file, or
+// the historical pipeline body fallback when a configured file does not exist.
 func (s *BuildBinaryStep) resolveConfigContent(pc *PipelineContext) ([]byte, error) {
+	if s.configFrom != "" {
+		return s.resolveConfigFromContext(pc)
+	}
+
 	if s.configFile != "" {
 		data, err := os.ReadFile(s.configFile) //nolint:gosec // G304: path from trusted pipeline config
 		if err == nil {
@@ -133,6 +140,27 @@ func (s *BuildBinaryStep) resolveConfigContent(pc *PipelineContext) ([]byte, err
 	}
 
 	return nil, fmt.Errorf("config_file %q not found and no body in pipeline context", s.configFile)
+}
+
+func (s *BuildBinaryStep) resolveConfigFromContext(pc *PipelineContext) ([]byte, error) {
+	if pc == nil {
+		return nil, fmt.Errorf("config_from %q requires a pipeline context", s.configFrom)
+	}
+	raw := resolveBodyFrom(s.configFrom, pc)
+	switch v := raw.(type) {
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil, fmt.Errorf("config_from %q resolved to empty string", s.configFrom)
+		}
+		return []byte(v), nil
+	case []byte:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("config_from %q resolved to empty bytes", s.configFrom)
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf("config_from %q resolved to %T, want non-empty string or []byte", s.configFrom, raw)
+	}
 }
 
 // generatedFile holds the path and content of a generated file.

--- a/module/pipeline_step_build_binary.go
+++ b/module/pipeline_step_build_binary.go
@@ -37,6 +37,9 @@ func NewBuildBinaryStepFactory() StepFactory {
 		if configFile == "" && configFrom == "" {
 			return nil, fmt.Errorf("build_binary step %q: either 'config_file' or 'config_from' is required", name)
 		}
+		if configFile != "" && configFrom != "" {
+			return nil, fmt.Errorf("build_binary step %q: only one of 'config_file' or 'config_from' may be set", name)
+		}
 
 		output, _ := config["output"].(string)
 		if output == "" {

--- a/module/pipeline_step_build_binary_test.go
+++ b/module/pipeline_step_build_binary_test.go
@@ -283,6 +283,20 @@ func TestBuildBinaryStep_DryRun_ConfigFromExplicitContextPath(t *testing.T) {
 	}
 }
 
+func TestBuildBinaryStep_ConfigFileAndConfigFromAreMutuallyExclusive(t *testing.T) {
+	factory := NewBuildBinaryStepFactory()
+	_, err := factory("bb", map[string]any{
+		"config_file": "app.yaml",
+		"config_from": "request_body",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error when config_file and config_from are both set")
+	}
+	if !strings.Contains(err.Error(), "only one of 'config_file' or 'config_from'") {
+		t.Fatalf("expected mutually exclusive config error, got %v", err)
+	}
+}
+
 func TestBuildBinaryStep_MissingConfigFileAndNoContext(t *testing.T) {
 	factory := NewBuildBinaryStepFactory()
 	step, err := factory("bb", map[string]any{

--- a/module/pipeline_step_build_binary_test.go
+++ b/module/pipeline_step_build_binary_test.go
@@ -256,6 +256,33 @@ func TestBuildBinaryStep_DryRun_ConfigFromPipelineContext(t *testing.T) {
 	}
 }
 
+func TestBuildBinaryStep_DryRun_ConfigFromExplicitContextPath(t *testing.T) {
+	yamlContent := "version: 1\nmodules: []\n"
+
+	factory := NewBuildBinaryStepFactory()
+	step, err := factory("bb", map[string]any{
+		"config_from": "request_body",
+		"dry_run":     true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected factory error: %v", err)
+	}
+
+	pc := &PipelineContext{
+		Current: map[string]any{"request_body": yamlContent},
+	}
+
+	result, err := step.Execute(testCtx(t), pc)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	contents := result.Output["file_contents"].(map[string]string)
+	if contents["app.yaml"] != yamlContent {
+		t.Errorf("app.yaml from config_from mismatch: got %q", contents["app.yaml"])
+	}
+}
+
 func TestBuildBinaryStep_MissingConfigFileAndNoContext(t *testing.T) {
 	factory := NewBuildBinaryStepFactory()
 	step, err := factory("bb", map[string]any{

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1681,8 +1681,8 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Plugin:      "cicd",
 		Description: "Generates a Workflow Go project from config and optionally builds a binary.",
 		ConfigFields: []ConfigFieldDef{
-			{Key: "config_file", Type: FieldTypeString, Description: "Workflow config file to embed; one of config_file or config_from is required"},
-			{Key: "config_from", Type: FieldTypeString, Description: "Pipeline context path resolving to workflow config YAML; one of config_file or config_from is required"},
+			{Key: "config_file", Type: FieldTypeString, Description: "Workflow config file to embed; exactly one of config_file or config_from is required"},
+			{Key: "config_from", Type: FieldTypeString, Description: "Pipeline context path resolving to workflow config YAML; exactly one of config_file or config_from is required"},
 			{Key: "output", Type: FieldTypeString, Description: "Output binary path"},
 			{Key: "module_path", Type: FieldTypeString, Description: "Generated Go module path"},
 			{Key: "go_version", Type: FieldTypeString, Description: "Generated go.mod Go version"},

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1679,16 +1679,28 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 	r.Register(&StepSchema{
 		Type:        "step.build_binary",
 		Plugin:      "cicd",
-		Description: "Builds a Go binary from source.",
+		Description: "Generates a Workflow Go project from config and optionally builds a binary.",
 		ConfigFields: []ConfigFieldDef{
-			{Key: "source", Type: FieldTypeString, Description: "Source directory or package path", Required: true},
+			{Key: "config_file", Type: FieldTypeString, Description: "Workflow config file to embed; one of config_file or config_from is required"},
+			{Key: "config_from", Type: FieldTypeString, Description: "Pipeline context path resolving to workflow config YAML; one of config_file or config_from is required"},
 			{Key: "output", Type: FieldTypeString, Description: "Output binary path"},
+			{Key: "module_path", Type: FieldTypeString, Description: "Generated Go module path"},
+			{Key: "go_version", Type: FieldTypeString, Description: "Generated go.mod Go version"},
+			{Key: "embed_config", Type: FieldTypeBool, Description: "Embed app.yaml in the generated binary", DefaultValue: true},
+			{Key: "dry_run", Type: FieldTypeBool, Description: "Return generated files without compiling"},
 			{Key: "os", Type: FieldTypeString, Description: "Target OS (GOOS)"},
 			{Key: "arch", Type: FieldTypeString, Description: "Target architecture (GOARCH)"},
-			{Key: "ldflags", Type: FieldTypeString, Description: "Linker flags"},
 		},
 		Outputs: []StepOutputDef{
+			{Key: "dry_run", Type: "boolean", Description: "Whether the step returned generated files without compiling"},
+			{Key: "files", Type: "array", Description: "Generated file paths in dry-run mode"},
+			{Key: "file_contents", Type: "object", Description: "Generated file contents keyed by path in dry-run mode"},
+			{Key: "module_path", Type: "string", Description: "Generated Go module path"},
+			{Key: "go_version", Type: "string", Description: "Generated go.mod Go version"},
+			{Key: "target_os", Type: "string", Description: "Target OS (GOOS)"},
+			{Key: "target_arch", Type: "string", Description: "Target architecture (GOARCH)"},
 			{Key: "binary_path", Type: "string", Description: "Path to the built binary"},
+			{Key: "binary_size", Type: "number", Description: "Built binary size in bytes"},
 		},
 	})
 

--- a/schema/step_schema_test.go
+++ b/schema/step_schema_test.go
@@ -87,6 +87,24 @@ func TestStepSchemaRegistry_CloudValidateAccountFrom(t *testing.T) {
 	}
 }
 
+func TestStepSchemaRegistry_BuildBinaryConfigFields(t *testing.T) {
+	reg := NewStepSchemaRegistry()
+	s := reg.Get("step.build_binary")
+	if s == nil {
+		t.Fatal("missing step.build_binary schema")
+	}
+	for _, key := range []string{"config_file", "config_from", "output", "module_path", "go_version", "embed_config", "dry_run", "os", "arch"} {
+		if !hasConfigField(s, key) {
+			t.Errorf("step.build_binary missing config field %q", key)
+		}
+	}
+	for _, key := range []string{"dry_run", "files", "file_contents", "module_path", "go_version", "target_os", "target_arch", "binary_path", "binary_size"} {
+		if !hasStepOutput(s, key) {
+			t.Errorf("step.build_binary missing output %q", key)
+		}
+	}
+}
+
 func hasConfigField(s *StepSchema, key string) bool {
 	for _, field := range s.ConfigFields {
 		if field.Key == key {


### PR DESCRIPTION
## Summary
- add `config_from` to `step.build_binary` so Workflow apps can generate a project from pipeline context data such as an HTTP raw request body
- update build-binary schema, `wfctl` metadata, and docs to match the actual step API
- add regression coverage for module behavior, schema metadata, and `wfctl` type registry keys

## TDD / regression proof
Initial red tests before implementation:
- `GOWORK=off go test ./module -run 'TestBuildBinaryStep_DryRun_ConfigFromExplicitContextPath' -count=1` failed with `build_binary step "bb": 'config_file' is required`
- `GOWORK=off go test ./schema -run 'TestStepSchemaRegistry_BuildBinaryConfigFields' -count=1` failed on missing `config_file`, `config_from`, dry-run outputs, and related metadata
- `GOWORK=off go test ./cmd/wfctl -run 'TestKnownStepTypesBuildBinaryConfigKeys' -count=1` failed because config keys were `[config_file output os arch]`

With production fix temporarily reverted and tests kept:
- same three commands failed for the same missing behavior/metadata reasons

With fix restored:
- `GOWORK=off go test ./module -run 'TestBuildBinaryStep_DryRun_ConfigFromExplicitContextPath' -count=1` passed
- `GOWORK=off go test ./schema -run 'TestStepSchemaRegistry_BuildBinaryConfigFields' -count=1` passed
- `GOWORK=off go test ./cmd/wfctl -run 'TestKnownStepTypesBuildBinaryConfigKeys' -count=1` passed

## Verification
- `GOWORK=off go test ./module -run 'TestBuildBinaryStep|TestCloudValidateStep|TestArtifactDownloadStep' -count=1`
- `GOWORK=off go test ./schema -run 'TestStepSchemaRegistry_(BuildBinaryConfigFields|CloudValidateAccountFrom|ArtifactContentFields)' -count=1`
- `GOWORK=off go test ./cmd/wfctl -run 'TestKnownStepTypes(BuildBinaryConfigKeys|RequestParseConfigKeys)' -count=1`
- `GOWORK=off go test ./module -count=1`
- `GOWORK=off go test ./schema ./cmd/wfctl -count=1`
- `git diff --check HEAD`
