### PR TITLE
Support JSON responses from root pipeline context

### DIFF
--- a/module/pipeline_step_json_response.go
+++ b/module/pipeline_step_json_response.go
@@ -254,6 +254,10 @@ func decodeJSONObjectOrArray(value string) any {
 // pipeline context. It looks in StepOutputs first (for "steps.X.Y" paths),
 // then in Current.
 func resolveBodyFrom(path string, pc *PipelineContext) any {
+	if path == "." {
+		return pc.Current
+	}
+
 	parts := strings.SplitN(path, ".", 2)
 	if len(parts) < 2 {
 		// Single key — look in Current

--- a/module/pipeline_step_json_response.go
+++ b/module/pipeline_step_json_response.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -255,7 +256,7 @@ func decodeJSONObjectOrArray(value string) any {
 // then in Current.
 func resolveBodyFrom(path string, pc *PipelineContext) any {
 	if path == "." {
-		return pc.Current
+		return maps.Clone(pc.Current)
 	}
 
 	parts := strings.SplitN(path, ".", 2)

--- a/module/pipeline_step_json_response_test.go
+++ b/module/pipeline_step_json_response_test.go
@@ -149,6 +149,45 @@ func TestJSONResponseStep_BodyFrom(t *testing.T) {
 	}
 }
 
+func TestJSONResponseStep_BodyFromCurrentContext(t *testing.T) {
+	factory := NewJSONResponseStepFactory()
+	step, err := factory("from-current", map[string]any{
+		"status":    200,
+		"body_from": ".",
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	pc := NewPipelineContext(map[string]any{"request_id": "req-1"}, map[string]any{
+		"_http_response_writer": recorder,
+	})
+	pc.MergeStepOutput("plan", map[string]any{
+		"cluster":  "production-cluster",
+		"provider": "kind",
+	})
+
+	_, err = step.Execute(t.Context(), pc)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(recorder.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["request_id"] != "req-1" {
+		t.Errorf("expected request_id='req-1', got %v", body["request_id"])
+	}
+	if body["cluster"] != "production-cluster" {
+		t.Errorf("expected cluster='production-cluster', got %v", body["cluster"])
+	}
+	if body["provider"] != "kind" {
+		t.Errorf("expected provider='kind', got %v", body["provider"])
+	}
+}
+
 func TestJSONResponseStep_TemplateBody(t *testing.T) {
 	factory := NewJSONResponseStepFactory()
 	step, err := factory("templated", map[string]any{

--- a/module/pipeline_step_json_response_test.go
+++ b/module/pipeline_step_json_response_test.go
@@ -188,6 +188,33 @@ func TestJSONResponseStep_BodyFromCurrentContext(t *testing.T) {
 	}
 }
 
+func TestJSONResponseStep_BodyFromCurrentContextNoWriterDoesNotCreateCycle(t *testing.T) {
+	factory := NewJSONResponseStepFactory()
+	step, err := factory("from-current", map[string]any{
+		"status":    200,
+		"body_from": ".",
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	pc := NewPipelineContext(map[string]any{"request_id": "req-1"}, nil)
+	pc.MergeStepOutput("plan", map[string]any{
+		"cluster":  "production-cluster",
+		"provider": "kind",
+	})
+
+	result, err := step.Execute(t.Context(), pc)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	pc.MergeStepOutput(step.Name(), result.Output)
+
+	if _, err := json.Marshal(pc.Current); err != nil {
+		t.Fatalf("marshal merged pipeline context: %v", err)
+	}
+}
+
 func TestJSONResponseStep_TemplateBody(t *testing.T) {
 	factory := NewJSONResponseStepFactory()
 	step, err := factory("templated", map[string]any{

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -1207,7 +1207,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "status_from", Label: "Status From", Type: FieldTypeString, Description: "Dotted path to resolve HTTP status code dynamically (e.g., steps.call_upstream.status_code). Takes precedence over 'status' when resolved to a valid HTTP status code (100-599).", Placeholder: "steps.call_upstream.status_code"},
 			{Key: "headers", Label: "Headers", Type: FieldTypeMap, MapValueType: "string", Description: "Additional response headers"},
 			{Key: "body", Label: "Body", Type: FieldTypeMap, Description: "Response body as JSON (supports template expressions)"},
-			{Key: "body_from", Label: "Body From", Type: FieldTypeString, Description: "Dotted path to resolve body from step outputs (e.g., steps.get-company.row)", Placeholder: "steps.get-company.row"},
+			{Key: "body_from", Label: "Body From", Type: FieldTypeString, Description: "Dotted path to resolve body from pipeline context or step outputs; use . for the full current context (e.g., steps.get-company.row)", Placeholder: "steps.get-company.row"},
 		},
 	})
 
@@ -1223,7 +1223,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 			{Key: "status_from", Label: "Status From", Type: FieldTypeString, Description: "Dotted path to resolve HTTP status code dynamically (e.g., steps.call_upstream.status_code). Takes precedence over 'status' when resolved to a valid HTTP status code (100-599).", Placeholder: "steps.call_upstream.status_code"},
 			{Key: "headers", Label: "Headers", Type: FieldTypeMap, MapValueType: "string", Description: "Additional response headers"},
 			{Key: "body", Label: "Body", Type: FieldTypeMap, Description: "Response body as JSON (supports template expressions)"},
-			{Key: "body_from", Label: "Body From", Type: FieldTypeString, Description: "Dotted path to resolve body from step outputs (e.g., steps.get-company.row)", Placeholder: "steps.get-company.row"},
+			{Key: "body_from", Label: "Body From", Type: FieldTypeString, Description: "Dotted path to resolve body from pipeline context or step outputs; use . for the full current context (e.g., steps.get-company.row)", Placeholder: "steps.get-company.row"},
 		},
 	})
 

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -100,7 +100,7 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 			{Key: "status", Type: FieldTypeNumber, Description: "HTTP status code (default 200)", DefaultValue: "200"},
 			{Key: "status_from", Type: FieldTypeString, Description: "Dotted path to resolve HTTP status code dynamically (e.g. 'steps.call_upstream.status_code'). Takes precedence over 'status' when resolved to a valid HTTP status code (100-599)."},
 			{Key: "body", Type: FieldTypeMap, Description: "Response body (static JSON object or template expression)"},
-			{Key: "body_from", Type: FieldTypeString, Description: "Template expression to build body from step outputs (e.g. 'steps.query.rows')"},
+			{Key: "body_from", Type: FieldTypeString, Description: "Dotted path to resolve body from pipeline context or step outputs; use '.' for the full current context (e.g. 'steps.query.rows')"},
 			{Key: "headers", Type: FieldTypeMap, Description: "Additional response headers"},
 		},
 		Outputs: []StepOutputDef{
@@ -116,7 +116,7 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 			{Key: "status", Type: FieldTypeNumber, Description: "HTTP status code (default 200)", DefaultValue: "200"},
 			{Key: "status_from", Type: FieldTypeString, Description: "Dotted path to resolve HTTP status code dynamically (e.g. 'steps.call_upstream.status_code'). Takes precedence over 'status' when resolved to a valid HTTP status code (100-599)."},
 			{Key: "body", Type: FieldTypeMap, Description: "Response body (static JSON object or template expression)"},
-			{Key: "body_from", Type: FieldTypeString, Description: "Template expression to build body from step outputs (e.g. 'steps.query.rows')"},
+			{Key: "body_from", Type: FieldTypeString, Description: "Dotted path to resolve body from pipeline context or step outputs; use '.' for the full current context (e.g. 'steps.query.rows')"},
 			{Key: "headers", Type: FieldTypeMap, Description: "Additional response headers"},
 		},
 		Outputs: []StepOutputDef{

--- a/schema/testdata/editor-schemas.golden.json
+++ b/schema/testdata/editor-schemas.golden.json
@@ -6199,7 +6199,7 @@
           "key": "body_from",
           "label": "Body From",
           "type": "string",
-          "description": "Dotted path to resolve body from step outputs (e.g., steps.get-company.row)",
+          "description": "Dotted path to resolve body from pipeline context or step outputs; use . for the full current context (e.g., steps.get-company.row)",
           "placeholder": "steps.get-company.row"
         }
       ]
@@ -7011,7 +7011,7 @@
           "key": "body_from",
           "label": "Body From",
           "type": "string",
-          "description": "Dotted path to resolve body from step outputs (e.g., steps.get-company.row)",
+          "description": "Dotted path to resolve body from pipeline context or step outputs; use . for the full current context (e.g., steps.get-company.row)",
           "placeholder": "steps.get-company.row"
         }
       ]


### PR DESCRIPTION
## Summary
- allow `step.json_response` / `step.response` to resolve `body_from: "."` as the full current pipeline context
- add regression coverage for root-context response bodies
- update schema metadata and editor golden output so the new body source is discoverable

## Verification
- Red proof before implementation: `GOWORK=off go test ./module -run TestJSONResponseStep_BodyFromCurrentContext -count=1` failed with `decode response: EOF`
- `GOWORK=off go test ./module -run 'TestJSONResponseStep_(BodyFromCurrentContext|BodyFrom|TemplateBody)' -count=1`
- `UPDATE_GOLDEN=1 GOWORK=off go test ./schema -run TestEditorSchemasGoldenFile -count=1`
- `GOWORK=off go test ./module -run 'TestJSONResponseStep|TestK8s|TestPlatformKubernetes' -count=1`
- `GOWORK=off go test ./schema -count=1`
- `GOWORK=off go test ./module -count=1`
- `git diff --check`
- Scenario proof against this branch: `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/json-response-root-context make test SCENARIO=27-platform-kubernetes` => `RESULT: ALL TESTS PASSED (20/20)`
