### PR TITLE
feat: add typed IaC provider module

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -387,8 +387,16 @@ YAML from the pipeline context, such as an HTTP route's `request_body`.
 
 **DigitalOcean IaC steps** were removed from workflow core in v0.52.0 and moved to the
 [workflow-plugin-digitalocean](https://github.com/GoCodeAlone/workflow-plugin-digitalocean)
-external plugin. After loading the plugin, use the generic `step.iac_*` pipeline steps.
+external plugin. After loading the plugin, prefer typed `step.iac_provider_*`
+pipeline steps with named `infra.*` resources.
 See [v0.52.0 migration guide](docs/migrations/v0.52.0-godo-removal.md).
+
+Typed IaC provider steps (`step.iac_provider_plan`, `step.iac_provider_apply`,
+`step.iac_provider_list`, and `step.iac_provider_destroy`) can operate on named
+`infra.*` app modules with `resources: [module-name]`. That keeps resource
+configuration in the module graph while pipelines expose application actions.
+Use `specs` or `specs_from` only when the desired resources are authored or
+provided by the request itself.
 
 ### Expression Syntax
 
@@ -572,12 +580,13 @@ Strict mode applies to **both** direct dot-access (`{{ .steps.auth.field }}`) an
 **DigitalOcean IaC modules** were removed from workflow core in v0.52.0 and moved to the
 [workflow-plugin-digitalocean](https://github.com/GoCodeAlone/workflow-plugin-digitalocean)
 external plugin. After loading the plugin, use the generic `infra.*` module
-types with `provider: digitalocean` and the generic `step.iac_*` pipeline
-steps. See [v0.52.0 migration guide](docs/migrations/v0.52.0-godo-removal.md).
+types with an `iac.provider` module and the typed `step.iac_provider_*`
+pipeline steps. See [v0.52.0 migration guide](docs/migrations/v0.52.0-godo-removal.md).
 
 **AWS IaC modules** (`platform.ecs`, `platform.networking`, `platform.apigateway`, `platform.autoscaling`) were removed from workflow core in v0.53.0 and are provided by the
 [workflow-plugin-aws](https://github.com/GoCodeAlone/workflow-plugin-aws) v0.2.0+ plugin.
-Use the generic `infra.*` module types with `provider: aws` and `step.iac_*` pipeline steps.
+Use the generic `infra.*` module types with an `iac.provider` module and
+typed `step.iac_provider_*` pipeline steps.
 See [v0.53.0 migration guide](docs/migrations/v0.53.0-aws-iac-removal.md).
 | `iac.provider` | Cloud provider configuration (aws, gcp, azure, digitalocean) for IaC operations | platform |
 | `iac.state` | IaC state persistence (memory + filesystem + postgres in-core; spaces / s3 / gcs / azure_blob via plugins) | platform |

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -1415,7 +1415,7 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.iac_provider_list": {
 			Type:       "step.iac_provider_list",
 			Plugin:     "platform",
-			ConfigKeys: []string{"provider", "refs"},
+			ConfigKeys: []string{"provider", "refs", "resources"},
 		},
 		"step.iac_provider_catalog": {
 			Type:       "step.iac_provider_catalog",
@@ -1425,17 +1425,17 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.iac_provider_plan": {
 			Type:       "step.iac_provider_plan",
 			Plugin:     "platform",
-			ConfigKeys: []string{"provider", "specs", "env"},
+			ConfigKeys: []string{"provider", "specs", "specs_from", "resources", "env"},
 		},
 		"step.iac_provider_apply": {
 			Type:       "step.iac_provider_apply",
 			Plugin:     "platform",
-			ConfigKeys: []string{"provider", "specs", "desired_hash"},
+			ConfigKeys: []string{"provider", "specs", "specs_from", "resources", "desired_hash", "desired_hash_from"},
 		},
 		"step.iac_provider_destroy": {
 			Type:       "step.iac_provider_destroy",
 			Plugin:     "platform",
-			ConfigKeys: []string{"provider", "refs"},
+			ConfigKeys: []string{"provider", "refs", "resources"},
 		},
 		"step.iac_provider_drift": {
 			Type:       "step.iac_provider_drift",

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -108,6 +108,38 @@ modules:
 - `http.server.config.address` is the canonical listen address. `port: 8080` is accepted as an authoring alias and normalizes to `":8080"` when `address` is omitted.
 - Use `wfctl modernize --apply` to rewrite accepted aliases back to canonical fields before committing long-lived config.
 
+### Typed IaC Provider Modules
+Use `iac.provider` to alias an external typed IaC plugin into the app service
+graph, then point `infra.*` resources at that provider module. Typed IaC
+pipeline steps can use `resources` to operate on those named app resources
+without duplicating resource specs inside every route.
+
+```yaml
+modules:
+  - name: aws-provider
+    type: iac.provider
+    config:
+      plugin: workflow-plugin-aws
+      mode: mock
+      region: us-east-1
+
+  - name: staging-ecs
+    type: infra.container_service
+    config:
+      provider: aws-provider
+      image: public.ecr.aws/nginx/nginx:latest
+      replicas: 2
+
+pipelines:
+  plan-service:
+    steps:
+      - name: plan
+        type: step.iac_provider_plan
+        config:
+          provider: aws-provider
+          resources: [staging-ecs]
+```
+
 ---
 
 <!-- section: workflows -->
@@ -699,7 +731,29 @@ The `infrastructure:` section declares infrastructure resources the application 
     - `connection` (object) — connection details when `strategy: existing`:
       - `host` (string, required) — hostname or IP
       - `port` (int) — port number
-      - `auth` (string) — authentication reference (e.g., a secret name)
+    - `auth` (string) — authentication reference (e.g., a secret name)
+
+### `iac.provider` Modules
+
+`iac.provider` aliases an external typed-IaC provider plugin into the application service graph for `infra.*` modules and IaC pipeline steps. Use `plugin` for the exact external plugin service name, or `provider` as a shorthand for the common provider plugins.
+
+```yaml
+modules:
+  - name: aws-provider
+    type: iac.provider
+    config:
+      plugin: workflow-plugin-aws
+      mode: mock
+      region: us-east-1
+
+  - name: web
+    type: infra.container_service
+    config:
+      provider: aws-provider
+      image: public.ecr.aws/nginx/nginx:latest
+```
+
+Supported provider shorthands are `aws`, `azure`, `digitalocean`, and `gcp`; for example `provider: aws` resolves to `workflow-plugin-aws` while preserving `provider: aws` in the config passed to the provider.
 
 ### `sidecars` Fields
 - `sidecars` (array) — list of sidecar container definitions

--- a/engine.go
+++ b/engine.go
@@ -657,6 +657,13 @@ func (e *StdEngine) BuildFromConfig(cfg *config.WorkflowConfig) error {
 	}
 
 	// Initialize all modules
+	if e.pluginLoader != nil {
+		for _, hook := range e.pluginLoader.PreInitWiringHooks() {
+			if err := hook.Hook(e.app, cfg); err != nil {
+				return fmt.Errorf("pre-init wiring hook %q failed: %w", hook.Name, err)
+			}
+		}
+	}
 	if err := e.app.Init(); err != nil {
 		return fmt.Errorf("failed to initialize modules: %w", err)
 	}

--- a/engine_iac_provider_preinit_test.go
+++ b/engine_iac_provider_preinit_test.go
@@ -1,0 +1,98 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoCodeAlone/modular"
+	"github.com/GoCodeAlone/workflow/config"
+	"github.com/GoCodeAlone/workflow/iac/iactest"
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/mock"
+	"github.com/GoCodeAlone/workflow/plugin"
+	pluginplatform "github.com/GoCodeAlone/workflow/plugins/platform"
+)
+
+type preInitProviderPlugin struct {
+	plugin.BaseEnginePlugin
+	provider interfaces.IaCProvider
+}
+
+func newPreInitProviderPlugin(provider interfaces.IaCProvider) *preInitProviderPlugin {
+	return &preInitProviderPlugin{
+		BaseEnginePlugin: plugin.BaseEnginePlugin{
+			BaseNativePlugin: plugin.BaseNativePlugin{
+				PluginName:        "test-iac-provider-plugin",
+				PluginVersion:     "1.0.0",
+				PluginDescription: "test provider plugin",
+			},
+			Manifest: plugin.PluginManifest{
+				Name:        "test-iac-provider-plugin",
+				Version:     "1.0.0",
+				Author:      "GoCodeAlone",
+				Description: "test provider plugin",
+			},
+		},
+		provider: provider,
+	}
+}
+
+func (p *preInitProviderPlugin) PreInitWiringHooks() []plugin.WiringHook {
+	return []plugin.WiringHook{{
+		Name:     "test-provider-preinit",
+		Priority: 50,
+		Hook: func(app modular.Application, _ *config.WorkflowConfig) error {
+			return app.RegisterService("workflow-plugin-aws", p.provider)
+		},
+	}}
+}
+
+type engineRecordingIaCProvider struct {
+	iactest.NoopProvider
+	initCfg map[string]any
+}
+
+func (p *engineRecordingIaCProvider) Initialize(_ context.Context, cfg map[string]any) error {
+	p.initCfg = cfg
+	return nil
+}
+
+func TestEngineBuildFromConfig_RunsIaCProviderPreInitHookBeforeModuleInit(t *testing.T) {
+	provider := &engineRecordingIaCProvider{}
+	app := modular.NewStdApplication(modular.NewStdConfigProvider(nil), &mock.Logger{})
+	engine := NewStdEngine(app, &mock.Logger{})
+	if err := engine.LoadPlugin(pluginplatform.New()); err != nil {
+		t.Fatalf("LoadPlugin(platform): %v", err)
+	}
+	if err := engine.LoadPlugin(newPreInitProviderPlugin(provider)); err != nil {
+		t.Fatalf("LoadPlugin(provider): %v", err)
+	}
+
+	cfg := &config.WorkflowConfig{
+		Modules: []config.ModuleConfig{{
+			Name: "aws-provider",
+			Type: "iac.provider",
+			Config: map[string]any{
+				"plugin": "workflow-plugin-aws",
+				"mode":   "mock",
+				"region": "us-east-1",
+			},
+		}},
+		Workflows: map[string]any{},
+	}
+
+	if err := engine.BuildFromConfig(cfg); err != nil {
+		t.Fatalf("BuildFromConfig: %v", err)
+	}
+
+	var got interfaces.IaCProvider
+	if err := app.GetService("aws-provider", &got); err != nil {
+		t.Fatalf("GetService(aws-provider): %v", err)
+	}
+	if got != provider {
+		t.Fatalf("provider alias = %T %p, want %p", got, got, provider)
+	}
+	if provider.initCfg["mode"] != "mock" || provider.initCfg["region"] != "us-east-1" {
+		t.Fatalf("Initialize config = %#v", provider.initCfg)
+	}
+}

--- a/module/iac_provider_module.go
+++ b/module/iac_provider_module.go
@@ -1,0 +1,130 @@
+package module
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoCodeAlone/modular"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// IaCProviderModule aliases an external plugin-served IaC provider into the
+// application service graph under an app-local module name.
+//
+// Config keys:
+//   - plugin: external plugin service name to use, for example workflow-plugin-aws
+//   - service: fallback spelling for plugin
+//   - provider: legacy/provider shorthand such as aws or digitalocean
+//   - remaining keys are passed to provider.Initialize
+type IaCProviderModule struct {
+	name       string
+	config     map[string]any
+	pluginName string
+	provider   interfaces.IaCProvider
+}
+
+// NewIaCProviderModule creates an iac.provider module.
+func NewIaCProviderModule(name string, cfg map[string]any) *IaCProviderModule {
+	return &IaCProviderModule{name: name, config: cfg}
+}
+
+func (m *IaCProviderModule) Name() string { return m.name }
+
+// Init resolves the external provider service, initializes it with the
+// provider-specific config, and registers the provider under this module name.
+func (m *IaCProviderModule) Init(app modular.Application) error {
+	m.pluginName = iacProviderString(m.config, "plugin")
+	if m.pluginName == "" {
+		m.pluginName = iacProviderString(m.config, "service")
+	}
+	if m.pluginName == "" {
+		m.pluginName = pluginNameFromProvider(iacProviderString(m.config, "provider"))
+	}
+	if m.pluginName == "" {
+		return fmt.Errorf("iac.provider %q: 'plugin' config is required (or provider shorthand such as aws)", m.name)
+	}
+
+	var svc any
+	if err := app.GetService(m.pluginName, &svc); err != nil {
+		return fmt.Errorf("iac.provider %q: plugin service %q not found: %w", m.name, m.pluginName, err)
+	}
+
+	provider, ok := svc.(interfaces.IaCProvider)
+	if !ok {
+		return fmt.Errorf("iac.provider %q: service %q does not implement IaCProvider", m.name, m.pluginName)
+	}
+	m.provider = provider
+
+	if err := provider.Initialize(context.Background(), m.providerConfig()); err != nil {
+		return fmt.Errorf("iac.provider %q: initialize plugin %q: %w", m.name, m.pluginName, err)
+	}
+
+	if m.name == m.pluginName {
+		return nil
+	}
+	if err := app.RegisterService(m.name, provider); err != nil {
+		return fmt.Errorf("iac.provider %q: register provider alias: %w", m.name, err)
+	}
+	return nil
+}
+
+func (m *IaCProviderModule) providerConfig() map[string]any {
+	out := make(map[string]any, len(m.config))
+	for k, v := range m.config {
+		switch k {
+		case "plugin", "service", "_config_dir":
+			continue
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func iacProviderString(cfg map[string]any, key string) string {
+	if cfg == nil {
+		return ""
+	}
+	v, _ := cfg[key].(string)
+	return v
+}
+
+func pluginNameFromProvider(provider string) string {
+	switch provider {
+	case "aws", "azure", "digitalocean", "gcp":
+		return "workflow-plugin-" + provider
+	default:
+		return ""
+	}
+}
+
+// ProvidesServices declares the app-local IaCProvider service alias.
+func (m *IaCProviderModule) ProvidesServices() []modular.ServiceProvider {
+	return []modular.ServiceProvider{{
+		Name:        m.name,
+		Description: "IaC provider alias: " + m.name,
+		Instance:    m.provider,
+	}}
+}
+
+// RequiresServices declares the external plugin service dependency.
+func (m *IaCProviderModule) RequiresServices() []modular.ServiceDependency {
+	pluginName := iacProviderString(m.config, "plugin")
+	if pluginName == "" {
+		pluginName = iacProviderString(m.config, "service")
+	}
+	if pluginName == "" {
+		pluginName = pluginNameFromProvider(iacProviderString(m.config, "provider"))
+	}
+	if pluginName == "" {
+		return nil
+	}
+	return []modular.ServiceDependency{{Name: pluginName, Required: true}}
+}
+
+func (m *IaCProviderModule) Start(context.Context) error { return nil }
+
+func (m *IaCProviderModule) Stop(context.Context) error { return nil }
+
+// Provider returns the resolved provider after Init.
+func (m *IaCProviderModule) Provider() interfaces.IaCProvider { return m.provider }

--- a/module/iac_provider_module_test.go
+++ b/module/iac_provider_module_test.go
@@ -1,0 +1,116 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/iac/iactest"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+type recordingIaCProvider struct {
+	iactest.NoopProvider
+	initCfg map[string]any
+	initErr error
+}
+
+func (p *recordingIaCProvider) Initialize(_ context.Context, cfg map[string]any) error {
+	p.initCfg = cfg
+	return p.initErr
+}
+
+func TestIaCProviderModule_InitAliasesAndInitializesExternalProvider(t *testing.T) {
+	provider := &recordingIaCProvider{}
+	app := NewMockApplication()
+	if err := app.RegisterService("workflow-plugin-aws", provider); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+
+	m := NewIaCProviderModule("aws-provider", map[string]any{
+		"plugin":      "workflow-plugin-aws",
+		"mode":        "mock",
+		"region":      "us-east-1",
+		"_config_dir": "/tmp/app",
+	})
+
+	if err := m.Init(app); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var got interfaces.IaCProvider
+	if err := app.GetService("aws-provider", &got); err != nil {
+		t.Fatalf("GetService(alias): %v", err)
+	}
+	if got != provider {
+		t.Fatalf("alias service = %T %p, want provider %p", got, got, provider)
+	}
+
+	wantCfg := map[string]any{"mode": "mock", "region": "us-east-1"}
+	if !reflect.DeepEqual(provider.initCfg, wantCfg) {
+		t.Fatalf("Initialize config = %#v, want %#v", provider.initCfg, wantCfg)
+	}
+}
+
+func TestIaCProviderModule_InitAcceptsProviderShorthand(t *testing.T) {
+	provider := &recordingIaCProvider{}
+	app := NewMockApplication()
+	if err := app.RegisterService("workflow-plugin-aws", provider); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+
+	m := NewIaCProviderModule("aws-provider", map[string]any{
+		"provider": "aws",
+		"mode":     "mock",
+	})
+	if err := m.Init(app); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if provider.initCfg["provider"] != "aws" || provider.initCfg["mode"] != "mock" {
+		t.Fatalf("Initialize config = %#v", provider.initCfg)
+	}
+}
+
+func TestIaCProviderModule_InitRequiresPluginService(t *testing.T) {
+	m := NewIaCProviderModule("aws-provider", map[string]any{"mode": "mock"})
+	err := m.Init(NewMockApplication())
+	if err == nil {
+		t.Fatal("Init must fail without plugin config")
+	}
+	if !strings.Contains(err.Error(), "plugin") {
+		t.Fatalf("Init error = %v, want plugin guidance", err)
+	}
+}
+
+func TestIaCProviderModule_InitRejectsNonProviderService(t *testing.T) {
+	app := NewMockApplication()
+	if err := app.RegisterService("not-provider", "nope"); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+
+	m := NewIaCProviderModule("aws-provider", map[string]any{"plugin": "not-provider"})
+	err := m.Init(app)
+	if err == nil {
+		t.Fatal("Init must fail when plugin service is not an IaCProvider")
+	}
+	if !strings.Contains(err.Error(), "does not implement IaCProvider") {
+		t.Fatalf("Init error = %v", err)
+	}
+}
+
+func TestIaCProviderModule_InitWrapsProviderInitializeError(t *testing.T) {
+	sentinel := errors.New("bad provider config")
+	provider := &recordingIaCProvider{initErr: sentinel}
+	app := NewMockApplication()
+	if err := app.RegisterService("workflow-plugin-aws", provider); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+
+	m := NewIaCProviderModule("aws-provider", map[string]any{"plugin": "workflow-plugin-aws"})
+	err := m.Init(app)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Init error = %v, want wrapping %v", err, sentinel)
+	}
+}

--- a/module/iac_provider_module_test.go
+++ b/module/iac_provider_module_test.go
@@ -73,6 +73,28 @@ func TestIaCProviderModule_InitAcceptsProviderShorthand(t *testing.T) {
 	}
 }
 
+func TestIaCProviderModule_InitAcceptsServiceAlias(t *testing.T) {
+	provider := &recordingIaCProvider{}
+	app := NewMockApplication()
+	if err := app.RegisterService("workflow-plugin-aws", provider); err != nil {
+		t.Fatalf("RegisterService: %v", err)
+	}
+
+	m := NewIaCProviderModule("aws-provider", map[string]any{
+		"service": "workflow-plugin-aws",
+		"mode":    "mock",
+	})
+	if err := m.Init(app); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if _, ok := provider.initCfg["service"]; ok {
+		t.Fatalf("Initialize config leaked service alias: %#v", provider.initCfg)
+	}
+	if provider.initCfg["mode"] != "mock" {
+		t.Fatalf("Initialize config = %#v", provider.initCfg)
+	}
+}
+
 func TestIaCProviderModule_InitRequiresPluginService(t *testing.T) {
 	m := NewIaCProviderModule("aws-provider", map[string]any{"mode": "mock"})
 	err := m.Init(NewMockApplication())

--- a/module/infra_module.go
+++ b/module/infra_module.go
@@ -201,6 +201,19 @@ func (m *InfraModule) ResourceConfig() map[string]any {
 	return out
 }
 
+// ResourceSpec returns the desired IaC resource spec represented by this
+// module. Pipeline steps use this to operate on named app resources without
+// duplicating their infrastructure config.
+func (m *InfraModule) ResourceSpec() interfaces.ResourceSpec {
+	return m.buildSpec()
+}
+
+// ResourceRef returns the live IaC resource reference represented by this
+// module.
+func (m *InfraModule) ResourceRef() interfaces.ResourceRef {
+	return interfaces.ResourceRef{Name: m.name, Type: m.infraType}
+}
+
 // Create provisions a new resource by delegating to the underlying driver.
 func (m *InfraModule) Create(ctx context.Context) (*interfaces.ResourceOutput, error) {
 	return m.driver.Create(ctx, m.buildSpec())

--- a/module/pipeline_step_iac_provider_apply.go
+++ b/module/pipeline_step_iac_provider_apply.go
@@ -25,6 +25,7 @@ type IaCProviderApplyStep struct {
 	desiredHashFrom string // dotted context path; mutually exclusive with submittedHash
 	specs           []interfaces.ResourceSpec
 	specsFrom       string // dotted context path; mutually exclusive with specs
+	resources       []string
 	app             modular.Application
 	applyFn         func(ctx context.Context, p interfaces.IaCProvider, plan *interfaces.IaCPlan) (*interfaces.ApplyResult, error)
 }
@@ -45,8 +46,22 @@ func NewIaCProviderApplyStepFactory(applyFn func(ctx context.Context, p interfac
 
 		specsFrom, _ := cfg["specs_from"].(string)
 		_, hasStaticSpecs := cfg["specs"]
-		if specsFrom != "" && hasStaticSpecs {
-			return nil, fmt.Errorf("iac_provider_apply step %q: 'specs' and 'specs_from' are mutually exclusive", name)
+		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_apply step %q: parse resources: %w", name, err)
+		}
+		inputSources := 0
+		if hasStaticSpecs {
+			inputSources++
+		}
+		if specsFrom != "" {
+			inputSources++
+		}
+		if hasResources {
+			inputSources++
+		}
+		if inputSources > 1 {
+			return nil, fmt.Errorf("iac_provider_apply step %q: 'specs', 'specs_from', and 'resources' are mutually exclusive", name)
 		}
 
 		desiredHashFrom, _ := cfg["desired_hash_from"].(string)
@@ -80,6 +95,7 @@ func NewIaCProviderApplyStepFactory(applyFn func(ctx context.Context, p interfac
 			desiredHashFrom: desiredHashFrom,
 			specs:           specs,
 			specsFrom:       specsFrom,
+			resources:       resources,
 			app:             app,
 			applyFn:         applyFn,
 		}, nil
@@ -103,6 +119,13 @@ func (s *IaCProviderApplyStep) Execute(ctx context.Context, pc *PipelineContext)
 		// applying over zero specs is a destroy-everything footgun.
 		if len(specs) == 0 {
 			return nil, fmt.Errorf("iac_provider_apply step %q: specs_from %q resolved to empty/zero specs", s.name, s.specsFrom)
+		}
+	}
+	if len(s.resources) > 0 {
+		var err error
+		specs, err = resolveResourceSpecs(s.app, s.resources)
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_apply step %q: resolve resources: %w", s.name, err)
 		}
 	}
 

--- a/module/pipeline_step_iac_provider_apply.go
+++ b/module/pipeline_step_iac_provider_apply.go
@@ -46,7 +46,8 @@ func NewIaCProviderApplyStepFactory(applyFn func(ctx context.Context, p interfac
 
 		specsFrom, _ := cfg["specs_from"].(string)
 		_, hasStaticSpecs := cfg["specs"]
-		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		rawResources, hasResourcesKey := cfg["resources"]
+		resources, hasResources, err := parseResourceNames(rawResources, hasResourcesKey)
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_apply step %q: parse resources: %w", name, err)
 		}

--- a/module/pipeline_step_iac_provider_apply_test.go
+++ b/module/pipeline_step_iac_provider_apply_test.go
@@ -194,6 +194,64 @@ func TestIaCProviderApplyStep_Factory_RequiresHash(t *testing.T) {
 	}
 }
 
+func TestIaCProviderApplyStep_ResourcesResolveInfraModules(t *testing.T) {
+	app := module.NewMockApplication()
+	provider := &stubIaCProvider{
+		planResult: &interfaces.IaCPlan{
+			ID: "plan-resource",
+			Actions: []interfaces.PlanAction{
+				{Action: "create", Resource: interfaces.ResourceSpec{Name: "staging-ecs", Type: "infra.container_service"}},
+			},
+		},
+	}
+	if err := app.RegisterService("my-provider", provider); err != nil {
+		t.Fatal(err)
+	}
+	infra := module.NewInfraModule("staging-ecs", "infra.container_service", map[string]any{
+		"provider": "my-provider",
+		"image":    "public.ecr.aws/nginx/nginx:latest",
+		"replicas": 2,
+	})
+	if err := app.RegisterService("staging-ecs.driver", infra); err != nil {
+		t.Fatal(err)
+	}
+
+	planStep, err := module.NewIaCProviderPlanStepFactory()("plan-step", map[string]any{
+		"provider":  "my-provider",
+		"resources": []any{"staging-ecs"},
+	}, app)
+	if err != nil {
+		t.Fatalf("plan factory error: %v", err)
+	}
+	planResult, err := planStep.Execute(context.Background(), &module.PipelineContext{})
+	if err != nil {
+		t.Fatalf("plan Execute error: %v", err)
+	}
+	correctHash := planResult.Output["desired_hash"].(string)
+
+	applyStep, err := module.NewIaCProviderApplyStepFactory(noopApplyFn)("apply-step", map[string]any{
+		"provider":     "my-provider",
+		"resources":    []any{"staging-ecs"},
+		"desired_hash": correctHash,
+	}, app)
+	if err != nil {
+		t.Fatalf("apply factory error: %v", err)
+	}
+	result, err := applyStep.Execute(context.Background(), &module.PipelineContext{})
+	if err != nil {
+		t.Fatalf("apply Execute error: %v", err)
+	}
+	if result.Output["action_count"] != 1 {
+		t.Fatalf("expected action_count=1, got %v", result.Output["action_count"])
+	}
+	if len(provider.planDesired) != 1 {
+		t.Fatalf("expected one desired spec, got %d", len(provider.planDesired))
+	}
+	if got := provider.planDesired[0].Config["image"]; got != "public.ecr.aws/nginx/nginx:latest" {
+		t.Fatalf("unexpected desired image: %v", got)
+	}
+}
+
 // ─── specs_from / desired_hash_from (dynamic input) tests ────────────────────
 
 // parseRequestBodyOutputs builds StepOutputs that mirror the canonical

--- a/module/pipeline_step_iac_provider_destroy.go
+++ b/module/pipeline_step_iac_provider_destroy.go
@@ -13,10 +13,11 @@ import (
 // IaCProviderDestroyStep resolves an IaCProvider and destroys the specified
 // resources by ref list.
 type IaCProviderDestroyStep struct {
-	name     string
-	provider string
-	refs     []interfaces.ResourceRef
-	app      modular.Application
+	name      string
+	provider  string
+	refs      []interfaces.ResourceRef
+	resources []string
+	app       modular.Application
 }
 
 // NewIaCProviderDestroyStepFactory returns a StepFactory for step.iac_provider_destroy.
@@ -26,15 +27,24 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		if providerName == "" {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: 'provider' is required", name)
 		}
+		_, hasRefs := cfg["refs"]
 		refs, err := parseResourceRefs(cfg["refs"])
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: parse refs: %w", name, err)
 		}
+		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_destroy step %q: parse resources: %w", name, err)
+		}
+		if hasRefs && hasResources {
+			return nil, fmt.Errorf("iac_provider_destroy step %q: 'refs' and 'resources' are mutually exclusive", name)
+		}
 		return &IaCProviderDestroyStep{
-			name:     name,
-			provider: providerName,
-			refs:     refs,
-			app:      app,
+			name:      name,
+			provider:  providerName,
+			refs:      refs,
+			resources: resources,
+			app:       app,
 		}, nil
 	}
 }
@@ -47,7 +57,15 @@ func (s *IaCProviderDestroyStep) Execute(ctx context.Context, _ *PipelineContext
 		return nil, err
 	}
 
-	result, err := provider.Destroy(ctx, s.refs)
+	refs := s.refs
+	if len(s.resources) > 0 {
+		refs, err = resolveResourceRefs(s.app, s.resources)
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_destroy step %q: resolve resources: %w", s.name, err)
+		}
+	}
+
+	result, err := provider.Destroy(ctx, refs)
 	if err != nil {
 		return nil, fmt.Errorf("iac_provider_destroy step %q: Destroy: %w", s.name, err)
 	}

--- a/module/pipeline_step_iac_provider_destroy.go
+++ b/module/pipeline_step_iac_provider_destroy.go
@@ -32,7 +32,8 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: parse refs: %w", name, err)
 		}
-		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		rawResources, hasResourcesKey := cfg["resources"]
+		resources, hasResources, err := parseResourceNames(rawResources, hasResourcesKey)
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: parse resources: %w", name, err)
 		}

--- a/module/pipeline_step_iac_provider_destroy_drift_test.go
+++ b/module/pipeline_step_iac_provider_destroy_drift_test.go
@@ -47,6 +47,41 @@ func TestIaCProviderDestroyStep_Execute_ReturnsDestroyed(t *testing.T) {
 	}
 }
 
+func TestIaCProviderDestroyStep_ResourcesResolveInfraModuleRefs(t *testing.T) {
+	app := module.NewMockApplication()
+	provider := &stubIaCProvider{
+		destroyResult: &interfaces.DestroyResult{
+			Destroyed: []string{"staging-ecs"},
+		},
+	}
+	if err := app.RegisterService("my-provider", provider); err != nil {
+		t.Fatal(err)
+	}
+	infra := module.NewInfraModule("staging-ecs", "infra.container_service", map[string]any{"provider": "my-provider"})
+	if err := app.RegisterService("staging-ecs.driver", infra); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := module.NewIaCProviderDestroyStepFactory()
+	step, err := factory("destroy-step", map[string]any{
+		"provider":  "my-provider",
+		"resources": []any{"staging-ecs"},
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	if _, err := step.Execute(context.Background(), &module.PipelineContext{}); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if len(provider.destroyRefs) != 1 {
+		t.Fatalf("expected one destroy ref, got %d", len(provider.destroyRefs))
+	}
+	if provider.destroyRefs[0].Name != "staging-ecs" || provider.destroyRefs[0].Type != "infra.container_service" {
+		t.Fatalf("unexpected destroy refs: %#v", provider.destroyRefs)
+	}
+}
+
 func TestIaCProviderDestroyStep_Execute_UnregisteredProvider(t *testing.T) {
 	app := module.NewMockApplication()
 	factory := module.NewIaCProviderDestroyStepFactory()

--- a/module/pipeline_step_iac_provider_list.go
+++ b/module/pipeline_step_iac_provider_list.go
@@ -29,10 +29,11 @@ func resolveIaCProvider(app modular.Application, providerName, stepName, stepTyp
 
 // IaCProviderListStep resolves an IaCProvider and lists current resource statuses.
 type IaCProviderListStep struct {
-	name     string
-	provider string
-	refs     []interfaces.ResourceRef
-	app      modular.Application
+	name      string
+	provider  string
+	refs      []interfaces.ResourceRef
+	resources []string
+	app       modular.Application
 }
 
 // NewIaCProviderListStepFactory returns a StepFactory for step.iac_provider_list.
@@ -48,6 +49,7 @@ func NewIaCProviderListStepFactory() StepFactory {
 		// factory returns a config error — silently widening to list-all would mask a
 		// misconfigured step that was intended to be a filtered query.
 		var refs []interfaces.ResourceRef
+		_, hasRefs := cfg["refs"]
 		if rawRefs, ok := cfg["refs"]; ok {
 			refList, ok := rawRefs.([]any)
 			if !ok {
@@ -71,11 +73,19 @@ func NewIaCProviderListStepFactory() StepFactory {
 				refs = append(refs, ref)
 			}
 		}
+		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_list step %q: parse resources: %w", name, err)
+		}
+		if hasRefs && hasResources {
+			return nil, fmt.Errorf("iac_provider_list step %q: 'refs' and 'resources' are mutually exclusive", name)
+		}
 		return &IaCProviderListStep{
-			name:     name,
-			provider: providerName,
-			refs:     refs,
-			app:      app,
+			name:      name,
+			provider:  providerName,
+			refs:      refs,
+			resources: resources,
+			app:       app,
 		}, nil
 	}
 }
@@ -88,7 +98,15 @@ func (s *IaCProviderListStep) Execute(ctx context.Context, _ *PipelineContext) (
 		return nil, err
 	}
 
-	statuses, err := provider.Status(ctx, s.refs)
+	refs := s.refs
+	if len(s.resources) > 0 {
+		refs, err = resolveResourceRefs(s.app, s.resources)
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_list step %q: resolve resources: %w", s.name, err)
+		}
+	}
+
+	statuses, err := provider.Status(ctx, refs)
 	if err != nil {
 		return nil, fmt.Errorf("iac_provider_list step %q: Status: %w", s.name, err)
 	}

--- a/module/pipeline_step_iac_provider_list.go
+++ b/module/pipeline_step_iac_provider_list.go
@@ -73,7 +73,8 @@ func NewIaCProviderListStepFactory() StepFactory {
 				refs = append(refs, ref)
 			}
 		}
-		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		rawResources, hasResourcesKey := cfg["resources"]
+		resources, hasResources, err := parseResourceNames(rawResources, hasResourcesKey)
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_list step %q: parse resources: %w", name, err)
 		}

--- a/module/pipeline_step_iac_provider_list_test.go
+++ b/module/pipeline_step_iac_provider_list_test.go
@@ -12,11 +12,14 @@ import (
 type stubIaCProvider struct {
 	statusResult  []interfaces.ResourceStatus
 	statusErr     error
+	statusRefs    []interfaces.ResourceRef
 	caps          []interfaces.IaCCapabilityDeclaration
 	planResult    *interfaces.IaCPlan
 	planErr       error
+	planDesired   []interfaces.ResourceSpec
 	destroyResult *interfaces.DestroyResult
 	destroyErr    error
+	destroyRefs   []interfaces.ResourceRef
 	driftResult   []interfaces.DriftResult
 	driftErr      error
 }
@@ -25,13 +28,16 @@ func (s *stubIaCProvider) Name() string                                         
 func (s *stubIaCProvider) Version() string                                      { return "0.0.0" }
 func (s *stubIaCProvider) Initialize(_ context.Context, _ map[string]any) error { return nil }
 func (s *stubIaCProvider) Capabilities() []interfaces.IaCCapabilityDeclaration  { return s.caps }
-func (s *stubIaCProvider) Plan(_ context.Context, _ []interfaces.ResourceSpec, _ []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+func (s *stubIaCProvider) Plan(_ context.Context, desired []interfaces.ResourceSpec, _ []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+	s.planDesired = append([]interfaces.ResourceSpec(nil), desired...)
 	return s.planResult, s.planErr
 }
-func (s *stubIaCProvider) Destroy(_ context.Context, _ []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
+func (s *stubIaCProvider) Destroy(_ context.Context, refs []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
+	s.destroyRefs = append([]interfaces.ResourceRef(nil), refs...)
 	return s.destroyResult, s.destroyErr
 }
-func (s *stubIaCProvider) Status(_ context.Context, _ []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
+func (s *stubIaCProvider) Status(_ context.Context, refs []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
+	s.statusRefs = append([]interfaces.ResourceRef(nil), refs...)
 	return s.statusResult, s.statusErr
 }
 func (s *stubIaCProvider) DetectDrift(_ context.Context, _ []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
@@ -92,6 +98,41 @@ func TestIaCProviderListStep_Execute_ReturnsSummaries(t *testing.T) {
 	}
 	if result.Output["count"] != 2 {
 		t.Errorf("expected count=2, got %v", result.Output["count"])
+	}
+}
+
+func TestIaCProviderListStep_ResourcesResolveInfraModuleRefs(t *testing.T) {
+	app := module.NewMockApplication()
+	provider := &stubIaCProvider{
+		statusResult: []interfaces.ResourceStatus{
+			{Name: "staging-ecs", Type: "infra.container_service", ProviderID: "pid-ecs", Status: "running"},
+		},
+	}
+	if err := app.RegisterService("my-provider", provider); err != nil {
+		t.Fatal(err)
+	}
+	infra := module.NewInfraModule("staging-ecs", "infra.container_service", map[string]any{"provider": "my-provider"})
+	if err := app.RegisterService("staging-ecs.driver", infra); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := module.NewIaCProviderListStepFactory()
+	step, err := factory("list-step", map[string]any{
+		"provider":  "my-provider",
+		"resources": []any{"staging-ecs"},
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	if _, err := step.Execute(context.Background(), &module.PipelineContext{}); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if len(provider.statusRefs) != 1 {
+		t.Fatalf("expected one status ref, got %d", len(provider.statusRefs))
+	}
+	if provider.statusRefs[0].Name != "staging-ecs" || provider.statusRefs[0].Type != "infra.container_service" {
+		t.Fatalf("unexpected status refs: %#v", provider.statusRefs)
 	}
 }
 

--- a/module/pipeline_step_iac_provider_plan.go
+++ b/module/pipeline_step_iac_provider_plan.go
@@ -24,6 +24,7 @@ type IaCProviderPlanStep struct {
 	env       string
 	specs     []interfaces.ResourceSpec
 	specsFrom string // dotted context path; mutually exclusive with specs
+	resources []string
 	app       modular.Application
 }
 
@@ -38,10 +39,24 @@ func NewIaCProviderPlanStepFactory() StepFactory {
 
 		specsFrom, _ := cfg["specs_from"].(string)
 		_, hasStaticSpecs := cfg["specs"]
+		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_plan step %q: parse resources: %w", name, err)
+		}
 
-		// specs and specs_from are mutually exclusive.
-		if specsFrom != "" && hasStaticSpecs {
-			return nil, fmt.Errorf("iac_provider_plan step %q: 'specs' and 'specs_from' are mutually exclusive", name)
+		// specs, specs_from, and resources are mutually exclusive.
+		inputSources := 0
+		if hasStaticSpecs {
+			inputSources++
+		}
+		if specsFrom != "" {
+			inputSources++
+		}
+		if hasResources {
+			inputSources++
+		}
+		if inputSources > 1 {
+			return nil, fmt.Errorf("iac_provider_plan step %q: 'specs', 'specs_from', and 'resources' are mutually exclusive", name)
 		}
 
 		// Parse static specs from config (nil-safe; skipped when specs_from is set).
@@ -60,6 +75,7 @@ func NewIaCProviderPlanStepFactory() StepFactory {
 			env:       env,
 			specs:     specs,
 			specsFrom: specsFrom,
+			resources: resources,
 			app:       app,
 		}, nil
 	}
@@ -104,6 +120,94 @@ func parseResourceRefs(raw any) ([]interfaces.ResourceRef, error) {
 	return refs, nil
 }
 
+func parseResourceNames(raw any) ([]string, bool, error) {
+	if raw == nil {
+		return nil, false, nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, true, fmt.Errorf("resources must be a list, got %T", raw)
+	}
+	names := make([]string, 0, len(list))
+	for i, item := range list {
+		name, ok := item.(string)
+		if !ok || name == "" {
+			return nil, true, fmt.Errorf("resources[%d] must be a non-empty string, got %T", i, item)
+		}
+		names = append(names, name)
+	}
+	return names, true, nil
+}
+
+type resourceSpecProvider interface {
+	ResourceSpec() interfaces.ResourceSpec
+}
+
+type resourceRefProvider interface {
+	ResourceRef() interfaces.ResourceRef
+}
+
+func resolveResourceService(app modular.Application, name string) (any, error) {
+	if app == nil {
+		return nil, fmt.Errorf("no application context")
+	}
+	for _, serviceName := range []string{name + ".driver", name} {
+		var svc any
+		if err := app.GetService(serviceName, &svc); err == nil && svc != nil {
+			return svc, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q is not registered as %q or %q", name, name+".driver", name)
+}
+
+func resolveResourceSpecs(app modular.Application, names []string) ([]interfaces.ResourceSpec, error) {
+	specs := make([]interfaces.ResourceSpec, 0, len(names))
+	for _, name := range names {
+		svc, err := resolveResourceService(app, name)
+		if err != nil {
+			return nil, err
+		}
+		provider, ok := svc.(resourceSpecProvider)
+		if !ok {
+			return nil, fmt.Errorf("resource %q service does not expose ResourceSpec (got %T)", name, svc)
+		}
+		spec := provider.ResourceSpec()
+		if spec.Name == "" || spec.Type == "" {
+			return nil, fmt.Errorf("resource %q produced incomplete spec", name)
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func resolveResourceRefs(app modular.Application, names []string) ([]interfaces.ResourceRef, error) {
+	refs := make([]interfaces.ResourceRef, 0, len(names))
+	for _, name := range names {
+		svc, err := resolveResourceService(app, name)
+		if err != nil {
+			return nil, err
+		}
+		if provider, ok := svc.(resourceRefProvider); ok {
+			ref := provider.ResourceRef()
+			if ref.Name == "" || ref.Type == "" {
+				return nil, fmt.Errorf("resource %q produced incomplete ref", name)
+			}
+			refs = append(refs, ref)
+			continue
+		}
+		if provider, ok := svc.(resourceSpecProvider); ok {
+			spec := provider.ResourceSpec()
+			if spec.Name == "" || spec.Type == "" {
+				return nil, fmt.Errorf("resource %q produced incomplete spec", name)
+			}
+			refs = append(refs, interfaces.ResourceRef{Name: spec.Name, Type: spec.Type})
+			continue
+		}
+		return nil, fmt.Errorf("resource %q service does not expose ResourceRef or ResourceSpec (got %T)", name, svc)
+	}
+	return refs, nil
+}
+
 func (s *IaCProviderPlanStep) Name() string { return s.name }
 
 func (s *IaCProviderPlanStep) Execute(ctx context.Context, pc *PipelineContext) (*StepResult, error) {
@@ -121,6 +225,13 @@ func (s *IaCProviderPlanStep) Execute(ctx context.Context, pc *PipelineContext) 
 		// planning over zero specs is a destroy-everything footgun.
 		if len(specs) == 0 {
 			return nil, fmt.Errorf("iac_provider_plan step %q: specs_from %q resolved to empty/zero specs", s.name, s.specsFrom)
+		}
+	}
+	if len(s.resources) > 0 {
+		var err error
+		specs, err = resolveResourceSpecs(s.app, s.resources)
+		if err != nil {
+			return nil, fmt.Errorf("iac_provider_plan step %q: resolve resources: %w", s.name, err)
 		}
 	}
 

--- a/module/pipeline_step_iac_provider_plan.go
+++ b/module/pipeline_step_iac_provider_plan.go
@@ -39,7 +39,8 @@ func NewIaCProviderPlanStepFactory() StepFactory {
 
 		specsFrom, _ := cfg["specs_from"].(string)
 		_, hasStaticSpecs := cfg["specs"]
-		resources, hasResources, err := parseResourceNames(cfg["resources"])
+		rawResources, hasResourcesKey := cfg["resources"]
+		resources, hasResources, err := parseResourceNames(rawResources, hasResourcesKey)
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_plan step %q: parse resources: %w", name, err)
 		}
@@ -120,9 +121,12 @@ func parseResourceRefs(raw any) ([]interfaces.ResourceRef, error) {
 	return refs, nil
 }
 
-func parseResourceNames(raw any) ([]string, bool, error) {
-	if raw == nil {
+func parseResourceNames(raw any, present bool) ([]string, bool, error) {
+	if !present {
 		return nil, false, nil
+	}
+	if raw == nil {
+		return nil, true, fmt.Errorf("resources must be a list, got <nil>")
 	}
 	list, ok := raw.([]any)
 	if !ok {

--- a/module/pipeline_step_iac_provider_plan_test.go
+++ b/module/pipeline_step_iac_provider_plan_test.go
@@ -68,6 +68,45 @@ func TestIaCProviderPlanStep_Execute_ReturnsPlanAndHash(t *testing.T) {
 	}
 }
 
+func TestIaCProviderPlanStep_ResourcesResolveInfraModules(t *testing.T) {
+	app := module.NewMockApplication()
+	provider := makePlanProvider(t)
+	if err := app.RegisterService("my-provider", provider); err != nil {
+		t.Fatal(err)
+	}
+	infra := module.NewInfraModule("staging-ecs", "infra.container_service", map[string]any{
+		"provider": "my-provider",
+		"image":    "public.ecr.aws/nginx/nginx:latest",
+		"replicas": 2,
+	})
+	if err := app.RegisterService("staging-ecs.driver", infra); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := module.NewIaCProviderPlanStepFactory()
+	step, err := factory("plan-step", map[string]any{
+		"provider":  "my-provider",
+		"resources": []any{"staging-ecs"},
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	if _, err := step.Execute(context.Background(), &module.PipelineContext{}); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if len(provider.planDesired) != 1 {
+		t.Fatalf("expected one desired spec, got %d", len(provider.planDesired))
+	}
+	spec := provider.planDesired[0]
+	if spec.Name != "staging-ecs" || spec.Type != "infra.container_service" {
+		t.Fatalf("unexpected desired spec identity: %#v", spec)
+	}
+	if spec.Config["image"] != "public.ecr.aws/nginx/nginx:latest" || spec.Config["replicas"] != 2 {
+		t.Fatalf("unexpected desired spec config: %#v", spec.Config)
+	}
+}
+
 func TestIaCProviderPlanStep_HashStableWhenEnvVarChanges(t *testing.T) {
 	// The NO-OP env resolver in DesiredStateHash must preserve ${ENV_VAR}
 	// placeholders verbatim so the hash is identical regardless of env value.

--- a/module/pipeline_step_iac_provider_plan_test.go
+++ b/module/pipeline_step_iac_provider_plan_test.go
@@ -107,6 +107,20 @@ func TestIaCProviderPlanStep_ResourcesResolveInfraModules(t *testing.T) {
 	}
 }
 
+func TestIaCProviderPlanStep_FactoryRejectsNullResources(t *testing.T) {
+	factory := module.NewIaCProviderPlanStepFactory()
+	_, err := factory("plan-step", map[string]any{
+		"provider":  "my-provider",
+		"resources": nil,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected factory error for null resources")
+	}
+	if want := "resources must be a list"; !containsString(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %v", want, err)
+	}
+}
+
 func TestIaCProviderPlanStep_HashStableWhenEnvVarChanges(t *testing.T) {
 	// The NO-OP env resolver in DesiredStateHash must preserve ${ENV_VAR}
 	// placeholders verbatim so the hash is identical regardless of env value.

--- a/plugin/engine_plugin.go
+++ b/plugin/engine_plugin.go
@@ -80,11 +80,17 @@ type TriggerFactory func() any
 // (CanHandle, ConfigureWorkflow, ExecuteWorkflow).
 type WorkflowHandlerFactory func() any
 
-// WiringHook is called after module initialization to wire cross-module integrations.
+// WiringHook wires cross-module integrations.
 type WiringHook struct {
 	Name     string
 	Priority int // higher priority runs first
 	Hook     func(app modular.Application, cfg *config.WorkflowConfig) error
+}
+
+// PreInitWiringHookProvider is optionally implemented by plugins that need to
+// register services after modules are registered but before app.Init runs.
+type PreInitWiringHookProvider interface {
+	PreInitWiringHooks() []WiringHook
 }
 
 // ConfigTransformHook runs BEFORE module registration in BuildFromConfig,

--- a/plugin/external/adapter.go
+++ b/plugin/external/adapter.go
@@ -471,6 +471,9 @@ func (a *ExternalPluginAdapter) ModuleFactories() map[string]plugin.ModuleFactor
 	factories := make(map[string]plugin.ModuleFactory, len(resp.Types))
 	for _, typeName := range resp.Types {
 		tn := typeName // capture
+		if tn == "iac.provider" && a.advertisesIaCProviderRequiredService() {
+			continue
+		}
 		factories[tn] = func(name string, cfg map[string]any) modular.Module {
 			config, typedConfig, configErr := createTypedConfigRequest(a.contracts.module(tn), cfg, a.contractTypes)
 			if configErr != nil {
@@ -675,7 +678,7 @@ func (a *ExternalPluginAdapter) advertisedOptionalIaCServices() map[string]bool 
 // adapter's capability accessors (RegionLister(), DriftDetector(), Runner(),
 // ResourceDriver()) return nil / ErrProviderMethodUnimplemented for unadvertised
 // services — ensuring fallback paths remain reachable.
-func (a *ExternalPluginAdapter) WiringHooks() []plugin.WiringHook {
+func (a *ExternalPluginAdapter) iacProviderWiringHooks() []plugin.WiringHook {
 	if !a.advertisesIaCProviderRequiredService() {
 		return nil
 	}
@@ -702,6 +705,10 @@ func (a *ExternalPluginAdapter) WiringHooks() []plugin.WiringHook {
 				if conn == nil {
 					return fmt.Errorf("plugin %q advertises IaCProviderRequired but has no gRPC connection", name)
 				}
+				var existing any
+				if err := app.GetService(name, &existing); err == nil && existing != nil {
+					return nil
+				}
 				adapter := providerclient.New(conn, optionalServices)
 				if err := app.RegisterService(name, adapter); err != nil {
 					return fmt.Errorf("plugin %q: register IaCProvider service: %w", name, err)
@@ -710,6 +717,14 @@ func (a *ExternalPluginAdapter) WiringHooks() []plugin.WiringHook {
 			},
 		},
 	}
+}
+
+func (a *ExternalPluginAdapter) PreInitWiringHooks() []plugin.WiringHook {
+	return a.iacProviderWiringHooks()
+}
+
+func (a *ExternalPluginAdapter) WiringHooks() []plugin.WiringHook {
+	return a.iacProviderWiringHooks()
 }
 
 func (a *ExternalPluginAdapter) DeployTargets() map[string]deploy.DeployTarget {

--- a/plugin/external/adapter_test.go
+++ b/plugin/external/adapter_test.go
@@ -407,6 +407,29 @@ func TestModuleFactoriesPropagatesPluginError(t *testing.T) {
 	}
 }
 
+func TestModuleFactoriesFiltersImplicitIaCProviderForTypedProviderPlugins(t *testing.T) {
+	client := &adapterTestPluginServiceClient{
+		manifest:    &pb.Manifest{Name: "workflow-plugin-aws"},
+		moduleTypes: []string{"iac.provider", "aws.credentials"},
+		registry: &pb.ContractRegistry{Contracts: []*pb.ContractDescriptor{{
+			Kind:        pb.ContractKind_CONTRACT_KIND_SERVICE,
+			ServiceName: pb.IaCProviderRequired_ServiceDesc.ServiceName,
+		}}},
+	}
+	a, err := NewExternalPluginAdapter("workflow-plugin-aws", &PluginClient{client: client}, nil)
+	if err != nil {
+		t.Fatalf("NewExternalPluginAdapter: %v", err)
+	}
+
+	factories := a.ModuleFactories()
+	if _, ok := factories["iac.provider"]; ok {
+		t.Fatal("typed IaC provider plugins must not register remote iac.provider; core owns the alias module")
+	}
+	if _, ok := factories["aws.credentials"]; !ok {
+		t.Fatal("non-implicit module factory was filtered")
+	}
+}
+
 func TestExternalPluginAdapter_ServiceContractsAttachByModuleType(t *testing.T) {
 	registry := &pb.ContractRegistry{
 		Contracts: []*pb.ContractDescriptor{

--- a/plugin/loader.go
+++ b/plugin/loader.go
@@ -28,6 +28,7 @@ type PluginLoader struct {
 	triggerFactories     map[string]TriggerFactory
 	handlerFactories     map[string]WorkflowHandlerFactory
 	wiringHooks          []WiringHook
+	preInitWiringHooks   []WiringHook
 	configTransformHooks []ConfigTransformHook
 	schemaRegistry       *schema.ModuleSchemaRegistry
 	stepSchemaRegistry   *schema.StepSchemaRegistry
@@ -275,6 +276,9 @@ func (l *PluginLoader) loadPlugin(p EnginePlugin, allowOverride bool) error {
 
 	// Collect wiring hooks.
 	l.wiringHooks = append(l.wiringHooks, p.WiringHooks()...)
+	if preInitProvider, ok := p.(PreInitWiringHookProvider); ok {
+		l.preInitWiringHooks = append(l.preInitWiringHooks, preInitProvider.PreInitWiringHooks()...)
+	}
 
 	// Collect config transform hooks.
 	l.configTransformHooks = append(l.configTransformHooks, p.ConfigTransformHooks()...)
@@ -368,6 +372,16 @@ func (l *PluginLoader) WorkflowHandlerFactories() map[string]WorkflowHandlerFact
 func (l *PluginLoader) WiringHooks() []WiringHook {
 	hooks := make([]WiringHook, len(l.wiringHooks))
 	copy(hooks, l.wiringHooks)
+	sort.Slice(hooks, func(i, j int) bool {
+		return hooks[i].Priority > hooks[j].Priority
+	})
+	return hooks
+}
+
+// PreInitWiringHooks returns all registered pre-init wiring hooks sorted by priority (highest first).
+func (l *PluginLoader) PreInitWiringHooks() []WiringHook {
+	hooks := make([]WiringHook, len(l.preInitWiringHooks))
+	copy(hooks, l.preInitWiringHooks)
 	sort.Slice(hooks, func(i, j int) bool {
 		return hooks[i].Priority > hooks[j].Priority
 	})

--- a/plugins/platform/plugin.go
+++ b/plugins/platform/plugin.go
@@ -94,7 +94,7 @@ func New() *Plugin {
 				Author:        "GoCodeAlone",
 				Description:   "Platform infrastructure modules, workflow handler, reconciliation trigger, and template step",
 				Tier:          plugin.TierCore,
-				ModuleTypes:   []string{"platform.provider", "platform.resource", "platform.context", "platform.kubernetes", "platform.dns", "platform.region", "platform.region_router", "iac.state", "app.container", "argo.workflows"},
+				ModuleTypes:   []string{"platform.provider", "platform.resource", "platform.context", "platform.kubernetes", "platform.dns", "platform.region", "platform.region_router", "iac.provider", "iac.state", "app.container", "argo.workflows"},
 				StepTypes:     []string{"step.platform_template", "step.k8s_plan", "step.k8s_apply", "step.k8s_status", "step.k8s_destroy", "step.iac_plan", "step.iac_apply", "step.iac_status", "step.iac_destroy", "step.iac_drift_detect", "step.iac_provider_list", "step.iac_provider_catalog", "step.iac_provider_plan", "step.iac_provider_apply", "step.iac_provider_destroy", "step.iac_provider_drift", "step.iac_secret_reachability", "step.iac_commit_back", "step.iac_provider_reconcile", "step.dns_plan", "step.dns_apply", "step.dns_status", "step.app_deploy", "step.app_status", "step.app_rollback", "step.region_deploy", "step.region_promote", "step.region_failover", "step.region_status", "step.region_weight", "step.region_sync", "step.argo_submit", "step.argo_status", "step.argo_logs", "step.argo_delete", "step.argo_list"},
 				TriggerTypes:  []string{"reconciliation"},
 				WorkflowTypes: []string{"platform"},
@@ -114,6 +114,9 @@ func (p *Plugin) ModuleFactories() map[string]plugin.ModuleFactory {
 		},
 		"iac.state": func(name string, cfg map[string]any) modular.Module {
 			return module.NewIaCModule(name, cfg)
+		},
+		"iac.provider": func(name string, cfg map[string]any) modular.Module {
+			return module.NewIaCProviderModule(name, cfg)
 		},
 		"platform.provider": func(name string, cfg map[string]any) modular.Module {
 			providerName := ""

--- a/plugins/platform/plugin_test.go
+++ b/plugins/platform/plugin_test.go
@@ -87,6 +87,7 @@ func TestModuleFactories(t *testing.T) {
 	expectedModules := []string{
 		"platform.kubernetes",
 		"platform.dns",
+		"iac.provider",
 		"iac.state",
 		"platform.provider",
 		"platform.resource",

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -2655,6 +2655,22 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 	// ---- IaC State ----
 
 	r.Register(&ModuleSchema{
+		Type:        "iac.provider",
+		Label:       "IaC Provider",
+		Category:    "infrastructure",
+		Description: "Aliases an external plugin-served IaC provider into the application service graph",
+		Inputs:      []ServiceIODef{{Name: "provider", Type: "IaCProvider", Description: "External plugin-served provider"}},
+		Outputs:     []ServiceIODef{{Name: "provider", Type: "IaCProvider", Description: "App-local IaC provider service"}},
+		ConfigFields: []ConfigFieldDef{
+			{Key: "plugin", Label: "Plugin", Type: FieldTypeString, Required: true, Description: "External plugin service name, for example workflow-plugin-aws"},
+			{Key: "provider", Label: "Provider", Type: FieldTypeString, Description: "Provider shorthand: aws, azure, digitalocean, or gcp"},
+			{Key: "mode", Label: "Mode", Type: FieldTypeString, Description: "Provider-specific mode such as mock"},
+			{Key: "region", Label: "Region", Type: FieldTypeString, Description: "Primary provider region"},
+			{Key: "credentials", Label: "Credentials", Type: FieldTypeMap, Description: "Provider-specific credential configuration"},
+		},
+	})
+
+	r.Register(&ModuleSchema{
 		Type:        "iac.state",
 		Label:       "IaC State Store",
 		Category:    "infrastructure",

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -2662,8 +2662,9 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 		Inputs:      []ServiceIODef{{Name: "provider", Type: "IaCProvider", Description: "External plugin-served provider"}},
 		Outputs:     []ServiceIODef{{Name: "provider", Type: "IaCProvider", Description: "App-local IaC provider service"}},
 		ConfigFields: []ConfigFieldDef{
-			{Key: "plugin", Label: "Plugin", Type: FieldTypeString, Required: true, Description: "External plugin service name, for example workflow-plugin-aws"},
-			{Key: "provider", Label: "Provider", Type: FieldTypeString, Description: "Provider shorthand: aws, azure, digitalocean, or gcp"},
+			{Key: "plugin", Label: "Plugin", Type: FieldTypeString, Description: "External plugin service name, for example workflow-plugin-aws; one of plugin, service, or provider is required"},
+			{Key: "service", Label: "Service", Type: FieldTypeString, Description: "Alias for plugin: external IaC provider service name"},
+			{Key: "provider", Label: "Provider", Type: FieldTypeString, Description: "Provider shorthand: aws, azure, digitalocean, or gcp; one of plugin, service, or provider is required"},
 			{Key: "mode", Label: "Mode", Type: FieldTypeString, Description: "Provider-specific mode such as mock"},
 			{Key: "region", Label: "Region", Type: FieldTypeString, Description: "Primary provider region"},
 			{Key: "credentials", Label: "Credentials", Type: FieldTypeMap, Description: "Provider-specific credential configuration"},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -182,6 +182,7 @@ var coreModuleTypes = []string{
 	"http.router",
 	"http.server",
 	"http.simple_proxy",
+	"iac.provider",
 	"iac.state",
 	"jsonschema.modular",
 	"license.validator",

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -2062,7 +2062,8 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Lists current resource statuses from an IaCProvider service.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "provider", Type: FieldTypeString, Description: "Name of the registered IaCProvider service", Required: true},
-			{Key: "refs", Type: FieldTypeArray, Description: "Optional list of resource refs to query; empty queries all"},
+			{Key: "refs", Type: FieldTypeArray, Description: "Optional list of resource refs to query; mutually exclusive with resources"},
+			{Key: "resources", Type: FieldTypeArray, Description: "Optional list of named app infra resources to query; mutually exclusive with refs"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "provider", Type: "string", Description: "Provider service name"},
@@ -2097,8 +2098,9 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Plans infrastructure changes against an IaCProvider service; computes a stable desired-state hash using a no-op env resolver.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "provider", Type: FieldTypeString, Description: "Name of the registered IaCProvider service", Required: true},
-			{Key: "specs", Type: FieldTypeArray, Description: "Desired resource specs (list of {name, type, config, size}); mutually exclusive with specs_from"},
-			{Key: "specs_from", Type: FieldTypeString, Description: "Dotted context path to resolve specs at Execute time (e.g. steps.parse-request.body.specs); mutually exclusive with specs"},
+			{Key: "specs", Type: FieldTypeArray, Description: "Desired resource specs (list of {name, type, config, size}); mutually exclusive with specs_from and resources"},
+			{Key: "specs_from", Type: FieldTypeString, Description: "Dotted context path to resolve specs at Execute time (e.g. steps.parse-request.body.specs); mutually exclusive with specs and resources"},
+			{Key: "resources", Type: FieldTypeArray, Description: "Named app infra resources to resolve into desired specs; mutually exclusive with specs and specs_from"},
 			{Key: "env", Type: FieldTypeString, Description: "Environment name (reserved; unused by hash computation)"},
 		},
 		Outputs: []StepOutputDef{
@@ -2116,8 +2118,9 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Applies an IaC plan via two-phase hash guard: recomputes DesiredStateHash and rejects with 'plan hash mismatch' when hashes diverge.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "provider", Type: FieldTypeString, Description: "Name of the registered IaCProvider service", Required: true},
-			{Key: "specs", Type: FieldTypeArray, Description: "Desired resource specs passed to plan and hash recomputation; mutually exclusive with specs_from"},
-			{Key: "specs_from", Type: FieldTypeString, Description: "Dotted context path to resolve specs at Execute time (e.g. steps.parse-request.body.specs); mutually exclusive with specs"},
+			{Key: "specs", Type: FieldTypeArray, Description: "Desired resource specs passed to plan and hash recomputation; mutually exclusive with specs_from and resources"},
+			{Key: "specs_from", Type: FieldTypeString, Description: "Dotted context path to resolve specs at Execute time (e.g. steps.parse-request.body.specs); mutually exclusive with specs and resources"},
+			{Key: "resources", Type: FieldTypeArray, Description: "Named app infra resources to resolve into desired specs; mutually exclusive with specs and specs_from"},
 			{Key: "desired_hash", Type: FieldTypeString, Description: "Client-submitted hash from the plan step; must match recomputed hash; mutually exclusive with desired_hash_from"},
 			{Key: "desired_hash_from", Type: FieldTypeString, Description: "Dotted context path to resolve the client-submitted hash at Execute time (e.g. steps.parse-request.body.desired_hash); mutually exclusive with desired_hash"},
 		},
@@ -2137,7 +2140,8 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Destroys resources via an IaCProvider service.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "provider", Type: FieldTypeString, Description: "Name of the registered IaCProvider service", Required: true},
-			{Key: "refs", Type: FieldTypeArray, Description: "Resource refs to destroy (list of {name, type, provider_id})"},
+			{Key: "refs", Type: FieldTypeArray, Description: "Resource refs to destroy (list of {name, type, provider_id}); mutually exclusive with resources"},
+			{Key: "resources", Type: FieldTypeArray, Description: "Named app infra resources to destroy; mutually exclusive with refs"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "destroyed", Type: "[]any", Description: "Names of destroyed resources"},

--- a/schema/testdata/editor-schemas.golden.json
+++ b/schema/testdata/editor-schemas.golden.json
@@ -1862,14 +1862,19 @@
           "key": "plugin",
           "label": "Plugin",
           "type": "string",
-          "description": "External plugin service name, for example workflow-plugin-aws",
-          "required": true
+          "description": "External plugin service name, for example workflow-plugin-aws; one of plugin, service, or provider is required"
+        },
+        {
+          "key": "service",
+          "label": "Service",
+          "type": "string",
+          "description": "Alias for plugin: external IaC provider service name"
         },
         {
           "key": "provider",
           "label": "Provider",
           "type": "string",
-          "description": "Provider shorthand: aws, azure, digitalocean, or gcp"
+          "description": "Provider shorthand: aws, azure, digitalocean, or gcp; one of plugin, service, or provider is required"
         },
         {
           "key": "mode",

--- a/schema/testdata/editor-schemas.golden.json
+++ b/schema/testdata/editor-schemas.golden.json
@@ -1838,6 +1838,59 @@
         }
       ]
     },
+    "iac.provider": {
+      "type": "iac.provider",
+      "label": "IaC Provider",
+      "category": "infrastructure",
+      "description": "Aliases an external plugin-served IaC provider into the application service graph",
+      "inputs": [
+        {
+          "name": "provider",
+          "type": "IaCProvider",
+          "description": "External plugin-served provider"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "provider",
+          "type": "IaCProvider",
+          "description": "App-local IaC provider service"
+        }
+      ],
+      "configFields": [
+        {
+          "key": "plugin",
+          "label": "Plugin",
+          "type": "string",
+          "description": "External plugin service name, for example workflow-plugin-aws",
+          "required": true
+        },
+        {
+          "key": "provider",
+          "label": "Provider",
+          "type": "string",
+          "description": "Provider shorthand: aws, azure, digitalocean, or gcp"
+        },
+        {
+          "key": "mode",
+          "label": "Mode",
+          "type": "string",
+          "description": "Provider-specific mode such as mock"
+        },
+        {
+          "key": "region",
+          "label": "Region",
+          "type": "string",
+          "description": "Primary provider region"
+        },
+        {
+          "key": "credentials",
+          "label": "Credentials",
+          "type": "map",
+          "description": "Provider-specific credential configuration"
+        }
+      ]
+    },
     "iac.state": {
       "type": "iac.state",
       "label": "IaC State Store",


### PR DESCRIPTION
## Summary
- add core `iac.provider` alias module for external typed IaC providers
- run external provider wiring before module init so `infra.*` modules can resolve plugin providers at app startup
- let typed IaC provider steps operate on named app resources via `resources: [...]`
- update schema, wfctl type registry, and docs for typed provider usage

## Verification
- `UPDATE_GOLDEN=1 GOWORK=off go test ./schema -run TestEditorSchemasGoldenFile -count=1`
- `GOWORK=off go test ./module -run 'TestIaCProvider(PlanStep|ApplyStep|ListStep|DestroyStep)' -count=1`\n- `GOWORK=off go test . -run 'TestEngineBuildFromConfig_RunsIaCProviderPreInitHookBeforeModuleInit' -count=1`\n- `GOWORK=off go test ./... -count=1`\n- `GOWORK=off go build ./cmd/server`\n- `git diff --check`\n- workflow-scenarios scenario 30 with local Workflow/AWS worktrees: `30 passed, 0 failed`