### PR TITLE
feat: allow dynamic iac provider refs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -395,8 +395,9 @@ Typed IaC provider steps (`step.iac_provider_plan`, `step.iac_provider_apply`,
 `step.iac_provider_list`, and `step.iac_provider_destroy`) can operate on named
 `infra.*` app modules with `resources: [module-name]`. That keeps resource
 configuration in the module graph while pipelines expose application actions.
-Use `specs` or `specs_from` only when the desired resources are authored or
-provided by the request itself.
+Use `specs`/`specs_from` when desired resources are authored or provided by the
+request itself; use `refs`/`refs_from` when a request selects existing resources
+to inspect or destroy.
 
 ### Expression Syntax
 

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -1415,7 +1415,7 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.iac_provider_list": {
 			Type:       "step.iac_provider_list",
 			Plugin:     "platform",
-			ConfigKeys: []string{"provider", "refs", "resources"},
+			ConfigKeys: []string{"provider", "refs", "refs_from", "resources"},
 		},
 		"step.iac_provider_catalog": {
 			Type:       "step.iac_provider_catalog",
@@ -1435,7 +1435,7 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.iac_provider_destroy": {
 			Type:       "step.iac_provider_destroy",
 			Plugin:     "platform",
-			ConfigKeys: []string{"provider", "refs", "resources"},
+			ConfigKeys: []string{"provider", "refs", "refs_from", "resources"},
 		},
 		"step.iac_provider_drift": {
 			Type:       "step.iac_provider_drift",

--- a/module/pipeline_step_iac_provider_destroy.go
+++ b/module/pipeline_step_iac_provider_destroy.go
@@ -16,6 +16,7 @@ type IaCProviderDestroyStep struct {
 	name      string
 	provider  string
 	refs      []interfaces.ResourceRef
+	refsFrom  string
 	resources []string
 	app       modular.Application
 }
@@ -27,6 +28,7 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		if providerName == "" {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: 'provider' is required", name)
 		}
+		refsFrom, _ := cfg["refs_from"].(string)
 		_, hasRefs := cfg["refs"]
 		refs, err := parseResourceRefs(cfg["refs"])
 		if err != nil {
@@ -37,13 +39,24 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: parse resources: %w", name, err)
 		}
-		if hasRefs && hasResources {
-			return nil, fmt.Errorf("iac_provider_destroy step %q: 'refs' and 'resources' are mutually exclusive", name)
+		inputSources := 0
+		if hasRefs {
+			inputSources++
+		}
+		if refsFrom != "" {
+			inputSources++
+		}
+		if hasResources {
+			inputSources++
+		}
+		if inputSources > 1 {
+			return nil, fmt.Errorf("iac_provider_destroy step %q: 'refs', 'refs_from', and 'resources' are mutually exclusive", name)
 		}
 		return &IaCProviderDestroyStep{
 			name:      name,
 			provider:  providerName,
 			refs:      refs,
+			refsFrom:  refsFrom,
 			resources: resources,
 			app:       app,
 		}, nil
@@ -52,13 +65,19 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 
 func (s *IaCProviderDestroyStep) Name() string { return s.name }
 
-func (s *IaCProviderDestroyStep) Execute(ctx context.Context, _ *PipelineContext) (*StepResult, error) {
+func (s *IaCProviderDestroyStep) Execute(ctx context.Context, pc *PipelineContext) (*StepResult, error) {
 	provider, err := resolveIaCProvider(s.app, s.provider, s.name, "iac_provider_destroy")
 	if err != nil {
 		return nil, err
 	}
 
 	refs := s.refs
+	if s.refsFrom != "" {
+		refs, err = resolveResourceRefsFrom(s.refsFrom, s.name, "iac_provider_destroy", pc)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if len(s.resources) > 0 {
 		refs, err = resolveResourceRefs(s.app, s.resources)
 		if err != nil {

--- a/module/pipeline_step_iac_provider_destroy.go
+++ b/module/pipeline_step_iac_provider_destroy.go
@@ -28,7 +28,8 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		if providerName == "" {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: 'provider' is required", name)
 		}
-		refsFrom, _ := cfg["refs_from"].(string)
+		rawRefsFrom, hasRefsFrom := cfg["refs_from"]
+		refsFrom, refsFromOK := rawRefsFrom.(string)
 		_, hasRefs := cfg["refs"]
 		refs, err := parseResourceRefs(cfg["refs"])
 		if err != nil {
@@ -43,7 +44,7 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		if hasRefs {
 			inputSources++
 		}
-		if refsFrom != "" {
+		if hasRefsFrom {
 			inputSources++
 		}
 		if hasResources {
@@ -51,6 +52,9 @@ func NewIaCProviderDestroyStepFactory() StepFactory {
 		}
 		if inputSources > 1 {
 			return nil, fmt.Errorf("iac_provider_destroy step %q: 'refs', 'refs_from', and 'resources' are mutually exclusive", name)
+		}
+		if hasRefsFrom && (!refsFromOK || refsFrom == "") {
+			return nil, fmt.Errorf("iac_provider_destroy step %q: 'refs_from' must be a non-empty string", name)
 		}
 		return &IaCProviderDestroyStep{
 			name:      name,

--- a/module/pipeline_step_iac_provider_destroy_drift_test.go
+++ b/module/pipeline_step_iac_provider_destroy_drift_test.go
@@ -82,6 +82,48 @@ func TestIaCProviderDestroyStep_ResourcesResolveInfraModuleRefs(t *testing.T) {
 	}
 }
 
+func TestIaCProviderDestroyStep_RefsFromContext(t *testing.T) {
+	app := module.NewMockApplication()
+	provider := &stubIaCProvider{
+		destroyResult: &interfaces.DestroyResult{
+			Destroyed: []string{"web-vpc"},
+		},
+	}
+	if err := app.RegisterService("my-provider", provider); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := module.NewIaCProviderDestroyStepFactory()
+	step, err := factory("destroy-step", map[string]any{
+		"provider":  "my-provider",
+		"refs_from": "steps.parse-request.body.refs",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	pc := &module.PipelineContext{StepOutputs: parseRequestRefsOutputs([]any{
+		map[string]any{"name": "web-vpc", "type": "infra.vpc"},
+	})}
+	result, err := step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	destroyed, ok := result.Output["destroyed"].([]string)
+	if !ok {
+		t.Fatalf("expected []string destroyed, got %T", result.Output["destroyed"])
+	}
+	if len(destroyed) != 1 || destroyed[0] != "web-vpc" {
+		t.Fatalf("unexpected destroyed resources: %#v", destroyed)
+	}
+	if len(provider.destroyRefs) != 1 {
+		t.Fatalf("expected one destroy ref, got %d", len(provider.destroyRefs))
+	}
+	if provider.destroyRefs[0].Name != "web-vpc" || provider.destroyRefs[0].Type != "infra.vpc" {
+		t.Fatalf("unexpected destroy refs: %#v", provider.destroyRefs)
+	}
+}
+
 func TestIaCProviderDestroyStep_Execute_UnregisteredProvider(t *testing.T) {
 	app := module.NewMockApplication()
 	factory := module.NewIaCProviderDestroyStepFactory()
@@ -104,6 +146,84 @@ func TestIaCProviderDestroyStep_Factory_RequiresProvider(t *testing.T) {
 	_, err := factory("destroy-step", map[string]any{}, nil)
 	if err == nil {
 		t.Fatal("expected error when 'provider' missing")
+	}
+}
+
+func TestIaCProviderDestroyStep_Factory_RefsFromMutuallyExclusive(t *testing.T) {
+	factory := module.NewIaCProviderDestroyStepFactory()
+	for _, cfg := range []map[string]any{
+		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "refs": []any{}},
+		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "resources": []any{"db"}},
+	} {
+		_, err := factory("destroy-step", cfg, nil)
+		if err == nil {
+			t.Fatal("expected mutually exclusive refs_from factory error, got nil")
+		}
+		if !containsString(err.Error(), "mutually exclusive") {
+			t.Errorf("expected mutually exclusive error, got: %v", err)
+		}
+	}
+}
+
+func TestIaCProviderDestroyStep_RefsFromFailures(t *testing.T) {
+	cases := []struct {
+		name        string
+		stepOutputs map[string]map[string]any
+		wantErrSub  string
+	}{
+		{
+			name:        "path missing from context",
+			stepOutputs: nil,
+			wantErrSub:  "resolved to empty/zero refs",
+		},
+		{
+			name: "body present but lacks refs key",
+			stepOutputs: map[string]map[string]any{
+				"parse-request": {"body": map[string]any{}},
+			},
+			wantErrSub: "resolved to empty/zero refs",
+		},
+		{
+			name: "refs resolves to a non-list scalar",
+			stepOutputs: map[string]map[string]any{
+				"parse-request": {"body": map[string]any{"refs": "not-a-list"}},
+			},
+			wantErrSub: "resolve refs_from",
+		},
+		{
+			name:        "refs resolves to an empty list",
+			stepOutputs: parseRequestRefsOutputs([]any{}),
+			wantErrSub:  "resolved to empty/zero refs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := module.NewMockApplication()
+			provider := &stubIaCProvider{}
+			if err := app.RegisterService("my-provider", provider); err != nil {
+				t.Fatal(err)
+			}
+			factory := module.NewIaCProviderDestroyStepFactory()
+			step, err := factory("destroy-step", map[string]any{
+				"provider":  "my-provider",
+				"refs_from": "steps.parse-request.body.refs",
+			}, app)
+			if err != nil {
+				t.Fatalf("factory error: %v", err)
+			}
+
+			_, err = step.Execute(context.Background(), &module.PipelineContext{StepOutputs: tc.stepOutputs})
+			if err == nil {
+				t.Fatal("expected error, got nil (must not proceed with nil/zero refs)")
+			}
+			if !containsString(err.Error(), tc.wantErrSub) {
+				t.Errorf("expected error containing %q, got: %v", tc.wantErrSub, err)
+			}
+			if provider.destroyRefs != nil {
+				t.Errorf("Destroy must not be called on refs_from failure, got refs %#v", provider.destroyRefs)
+			}
+		})
 	}
 }
 

--- a/module/pipeline_step_iac_provider_destroy_drift_test.go
+++ b/module/pipeline_step_iac_provider_destroy_drift_test.go
@@ -153,7 +153,9 @@ func TestIaCProviderDestroyStep_Factory_RefsFromMutuallyExclusive(t *testing.T) 
 	factory := module.NewIaCProviderDestroyStepFactory()
 	for _, cfg := range []map[string]any{
 		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "refs": []any{}},
+		{"provider": "my-provider", "refs_from": "", "refs": []any{}},
 		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "resources": []any{"db"}},
+		{"provider": "my-provider", "refs_from": "", "resources": []any{"db"}},
 	} {
 		_, err := factory("destroy-step", cfg, nil)
 		if err == nil {
@@ -161,6 +163,22 @@ func TestIaCProviderDestroyStep_Factory_RefsFromMutuallyExclusive(t *testing.T) 
 		}
 		if !containsString(err.Error(), "mutually exclusive") {
 			t.Errorf("expected mutually exclusive error, got: %v", err)
+		}
+	}
+}
+
+func TestIaCProviderDestroyStep_Factory_RefsFromRequiresNonEmptyString(t *testing.T) {
+	factory := module.NewIaCProviderDestroyStepFactory()
+	for _, raw := range []any{"", nil, 123} {
+		_, err := factory("destroy-step", map[string]any{
+			"provider":  "my-provider",
+			"refs_from": raw,
+		}, nil)
+		if err == nil {
+			t.Fatalf("expected refs_from factory error for %#v, got nil", raw)
+		}
+		if !containsString(err.Error(), "refs_from' must be a non-empty string") {
+			t.Errorf("expected non-empty string error, got: %v", err)
 		}
 	}
 }
@@ -195,6 +213,11 @@ func TestIaCProviderDestroyStep_RefsFromFailures(t *testing.T) {
 			stepOutputs: parseRequestRefsOutputs([]any{}),
 			wantErrSub:  "resolved to empty/zero refs",
 		},
+		{
+			name:        "pipeline context is nil",
+			stepOutputs: nil,
+			wantErrSub:  "requires a non-nil pipeline context",
+		},
 	}
 
 	for _, tc := range cases {
@@ -213,7 +236,11 @@ func TestIaCProviderDestroyStep_RefsFromFailures(t *testing.T) {
 				t.Fatalf("factory error: %v", err)
 			}
 
-			_, err = step.Execute(context.Background(), &module.PipelineContext{StepOutputs: tc.stepOutputs})
+			pc := &module.PipelineContext{StepOutputs: tc.stepOutputs}
+			if tc.name == "pipeline context is nil" {
+				pc = nil
+			}
+			_, err = step.Execute(context.Background(), pc)
 			if err == nil {
 				t.Fatal("expected error, got nil (must not proceed with nil/zero refs)")
 			}

--- a/module/pipeline_step_iac_provider_list.go
+++ b/module/pipeline_step_iac_provider_list.go
@@ -32,6 +32,7 @@ type IaCProviderListStep struct {
 	name      string
 	provider  string
 	refs      []interfaces.ResourceRef
+	refsFrom  string
 	resources []string
 	app       modular.Application
 }
@@ -43,6 +44,7 @@ func NewIaCProviderListStepFactory() StepFactory {
 		if providerName == "" {
 			return nil, fmt.Errorf("iac_provider_list step %q: 'provider' is required", name)
 		}
+		refsFrom, _ := cfg["refs_from"].(string)
 		// Optional: list of refs to query; absent means pass nil to Status
 		// (providers should return all resources when refs is nil/empty).
 		// If "refs" is present but malformed (wrong type or wrong item shape), the
@@ -78,13 +80,24 @@ func NewIaCProviderListStepFactory() StepFactory {
 		if err != nil {
 			return nil, fmt.Errorf("iac_provider_list step %q: parse resources: %w", name, err)
 		}
-		if hasRefs && hasResources {
-			return nil, fmt.Errorf("iac_provider_list step %q: 'refs' and 'resources' are mutually exclusive", name)
+		inputSources := 0
+		if hasRefs {
+			inputSources++
+		}
+		if refsFrom != "" {
+			inputSources++
+		}
+		if hasResources {
+			inputSources++
+		}
+		if inputSources > 1 {
+			return nil, fmt.Errorf("iac_provider_list step %q: 'refs', 'refs_from', and 'resources' are mutually exclusive", name)
 		}
 		return &IaCProviderListStep{
 			name:      name,
 			provider:  providerName,
 			refs:      refs,
+			refsFrom:  refsFrom,
 			resources: resources,
 			app:       app,
 		}, nil
@@ -93,13 +106,19 @@ func NewIaCProviderListStepFactory() StepFactory {
 
 func (s *IaCProviderListStep) Name() string { return s.name }
 
-func (s *IaCProviderListStep) Execute(ctx context.Context, _ *PipelineContext) (*StepResult, error) {
+func (s *IaCProviderListStep) Execute(ctx context.Context, pc *PipelineContext) (*StepResult, error) {
 	provider, err := resolveIaCProvider(s.app, s.provider, s.name, "iac_provider_list")
 	if err != nil {
 		return nil, err
 	}
 
 	refs := s.refs
+	if s.refsFrom != "" {
+		refs, err = resolveResourceRefsFrom(s.refsFrom, s.name, "iac_provider_list", pc)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if len(s.resources) > 0 {
 		refs, err = resolveResourceRefs(s.app, s.resources)
 		if err != nil {

--- a/module/pipeline_step_iac_provider_list.go
+++ b/module/pipeline_step_iac_provider_list.go
@@ -44,7 +44,8 @@ func NewIaCProviderListStepFactory() StepFactory {
 		if providerName == "" {
 			return nil, fmt.Errorf("iac_provider_list step %q: 'provider' is required", name)
 		}
-		refsFrom, _ := cfg["refs_from"].(string)
+		rawRefsFrom, hasRefsFrom := cfg["refs_from"]
+		refsFrom, refsFromOK := rawRefsFrom.(string)
 		// Optional: list of refs to query; absent means pass nil to Status
 		// (providers should return all resources when refs is nil/empty).
 		// If "refs" is present but malformed (wrong type or wrong item shape), the
@@ -84,7 +85,7 @@ func NewIaCProviderListStepFactory() StepFactory {
 		if hasRefs {
 			inputSources++
 		}
-		if refsFrom != "" {
+		if hasRefsFrom {
 			inputSources++
 		}
 		if hasResources {
@@ -92,6 +93,9 @@ func NewIaCProviderListStepFactory() StepFactory {
 		}
 		if inputSources > 1 {
 			return nil, fmt.Errorf("iac_provider_list step %q: 'refs', 'refs_from', and 'resources' are mutually exclusive", name)
+		}
+		if hasRefsFrom && (!refsFromOK || refsFrom == "") {
+			return nil, fmt.Errorf("iac_provider_list step %q: 'refs_from' must be a non-empty string", name)
 		}
 		return &IaCProviderListStep{
 			name:      name,

--- a/module/pipeline_step_iac_provider_list_test.go
+++ b/module/pipeline_step_iac_provider_list_test.go
@@ -234,7 +234,9 @@ func TestIaCProviderListStep_Factory_RefsFromMutuallyExclusive(t *testing.T) {
 	factory := module.NewIaCProviderListStepFactory()
 	for _, cfg := range []map[string]any{
 		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "refs": []any{}},
+		{"provider": "my-provider", "refs_from": "", "refs": []any{}},
 		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "resources": []any{"db"}},
+		{"provider": "my-provider", "refs_from": "", "resources": []any{"db"}},
 	} {
 		_, err := factory("list-step", cfg, nil)
 		if err == nil {
@@ -242,6 +244,22 @@ func TestIaCProviderListStep_Factory_RefsFromMutuallyExclusive(t *testing.T) {
 		}
 		if !containsString(err.Error(), "mutually exclusive") {
 			t.Errorf("expected mutually exclusive error, got: %v", err)
+		}
+	}
+}
+
+func TestIaCProviderListStep_Factory_RefsFromRequiresNonEmptyString(t *testing.T) {
+	factory := module.NewIaCProviderListStepFactory()
+	for _, raw := range []any{"", nil, 123} {
+		_, err := factory("list-step", map[string]any{
+			"provider":  "my-provider",
+			"refs_from": raw,
+		}, nil)
+		if err == nil {
+			t.Fatalf("expected refs_from factory error for %#v, got nil", raw)
+		}
+		if !containsString(err.Error(), "refs_from' must be a non-empty string") {
+			t.Errorf("expected non-empty string error, got: %v", err)
 		}
 	}
 }
@@ -276,6 +294,11 @@ func TestIaCProviderListStep_RefsFromFailures(t *testing.T) {
 			stepOutputs: parseRequestRefsOutputs([]any{}),
 			wantErrSub:  "resolved to empty/zero refs",
 		},
+		{
+			name:        "pipeline context is nil",
+			stepOutputs: nil,
+			wantErrSub:  "requires a non-nil pipeline context",
+		},
 	}
 
 	for _, tc := range cases {
@@ -294,7 +317,11 @@ func TestIaCProviderListStep_RefsFromFailures(t *testing.T) {
 				t.Fatalf("factory error: %v", err)
 			}
 
-			_, err = step.Execute(context.Background(), &module.PipelineContext{StepOutputs: tc.stepOutputs})
+			pc := &module.PipelineContext{StepOutputs: tc.stepOutputs}
+			if tc.name == "pipeline context is nil" {
+				pc = nil
+			}
+			_, err = step.Execute(context.Background(), pc)
 			if err == nil {
 				t.Fatal("expected error, got nil (must not proceed with nil/zero refs)")
 			}

--- a/module/pipeline_step_iac_provider_list_test.go
+++ b/module/pipeline_step_iac_provider_list_test.go
@@ -136,6 +136,44 @@ func TestIaCProviderListStep_ResourcesResolveInfraModuleRefs(t *testing.T) {
 	}
 }
 
+func TestIaCProviderListStep_RefsFromContext(t *testing.T) {
+	app := module.NewMockApplication()
+	provider := &stubIaCProvider{
+		statusResult: []interfaces.ResourceStatus{
+			{Name: "web-vpc", Type: "infra.vpc", ProviderID: "pid-vpc", Status: "running"},
+		},
+	}
+	if err := app.RegisterService("my-provider", provider); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := module.NewIaCProviderListStepFactory()
+	step, err := factory("list-step", map[string]any{
+		"provider":  "my-provider",
+		"refs_from": "steps.parse-request.body.refs",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	pc := &module.PipelineContext{StepOutputs: parseRequestRefsOutputs([]any{
+		map[string]any{"name": "web-vpc", "type": "infra.vpc"},
+	})}
+	result, err := step.Execute(context.Background(), pc)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Output["count"] != 1 {
+		t.Errorf("expected count=1, got %v", result.Output["count"])
+	}
+	if len(provider.statusRefs) != 1 {
+		t.Fatalf("expected one status ref, got %d", len(provider.statusRefs))
+	}
+	if provider.statusRefs[0].Name != "web-vpc" || provider.statusRefs[0].Type != "infra.vpc" {
+		t.Fatalf("unexpected status refs: %#v", provider.statusRefs)
+	}
+}
+
 func TestIaCProviderListStep_Execute_UnregisteredProvider(t *testing.T) {
 	app := module.NewMockApplication()
 	factory := module.NewIaCProviderListStepFactory()
@@ -192,6 +230,84 @@ func TestIaCProviderListStep_Factory_MalformedRefs_WrongItemType(t *testing.T) {
 	}
 }
 
+func TestIaCProviderListStep_Factory_RefsFromMutuallyExclusive(t *testing.T) {
+	factory := module.NewIaCProviderListStepFactory()
+	for _, cfg := range []map[string]any{
+		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "refs": []any{}},
+		{"provider": "my-provider", "refs_from": "steps.parse-request.body.refs", "resources": []any{"db"}},
+	} {
+		_, err := factory("list-step", cfg, nil)
+		if err == nil {
+			t.Fatal("expected mutually exclusive refs_from factory error, got nil")
+		}
+		if !containsString(err.Error(), "mutually exclusive") {
+			t.Errorf("expected mutually exclusive error, got: %v", err)
+		}
+	}
+}
+
+func TestIaCProviderListStep_RefsFromFailures(t *testing.T) {
+	cases := []struct {
+		name        string
+		stepOutputs map[string]map[string]any
+		wantErrSub  string
+	}{
+		{
+			name:        "path missing from context",
+			stepOutputs: nil,
+			wantErrSub:  "resolved to empty/zero refs",
+		},
+		{
+			name: "body present but lacks refs key",
+			stepOutputs: map[string]map[string]any{
+				"parse-request": {"body": map[string]any{}},
+			},
+			wantErrSub: "resolved to empty/zero refs",
+		},
+		{
+			name: "refs resolves to a non-list scalar",
+			stepOutputs: map[string]map[string]any{
+				"parse-request": {"body": map[string]any{"refs": "not-a-list"}},
+			},
+			wantErrSub: "resolve refs_from",
+		},
+		{
+			name:        "refs resolves to an empty list",
+			stepOutputs: parseRequestRefsOutputs([]any{}),
+			wantErrSub:  "resolved to empty/zero refs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := module.NewMockApplication()
+			provider := &stubIaCProvider{}
+			if err := app.RegisterService("my-provider", provider); err != nil {
+				t.Fatal(err)
+			}
+			factory := module.NewIaCProviderListStepFactory()
+			step, err := factory("list-step", map[string]any{
+				"provider":  "my-provider",
+				"refs_from": "steps.parse-request.body.refs",
+			}, app)
+			if err != nil {
+				t.Fatalf("factory error: %v", err)
+			}
+
+			_, err = step.Execute(context.Background(), &module.PipelineContext{StepOutputs: tc.stepOutputs})
+			if err == nil {
+				t.Fatal("expected error, got nil (must not proceed with nil/zero refs)")
+			}
+			if !containsString(err.Error(), tc.wantErrSub) {
+				t.Errorf("expected error containing %q, got: %v", tc.wantErrSub, err)
+			}
+			if provider.statusRefs != nil {
+				t.Errorf("Status must not be called on refs_from failure, got refs %#v", provider.statusRefs)
+			}
+		})
+	}
+}
+
 func TestIaCProviderListStep_Factory_AbsentRefs_ListsAll(t *testing.T) {
 	// Absent refs key is fine — the step queries all resources.
 	app := module.NewMockApplication()
@@ -214,6 +330,12 @@ func TestIaCProviderListStep_Factory_AbsentRefs_ListsAll(t *testing.T) {
 	}
 	if result.Output["count"] != 1 {
 		t.Errorf("expected count=1 for list-all, got %v", result.Output["count"])
+	}
+}
+
+func parseRequestRefsOutputs(refs []any) map[string]map[string]any {
+	return map[string]map[string]any{
+		"parse-request": {"body": map[string]any{"refs": refs}},
 	}
 }
 

--- a/module/pipeline_step_iac_provider_plan.go
+++ b/module/pipeline_step_iac_provider_plan.go
@@ -121,6 +121,21 @@ func parseResourceRefs(raw any) ([]interfaces.ResourceRef, error) {
 	return refs, nil
 }
 
+func resolveResourceRefsFrom(path, stepName, stepType string, pc *PipelineContext) ([]interfaces.ResourceRef, error) {
+	if pc == nil {
+		return nil, fmt.Errorf("%s step %q: refs_from %q resolved to empty/zero refs", stepType, stepName, path)
+	}
+	raw := resolveBodyFrom(path, pc)
+	refs, err := parseResourceRefs(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s step %q: resolve refs_from %q: %w", stepType, stepName, path, err)
+	}
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("%s step %q: refs_from %q resolved to empty/zero refs", stepType, stepName, path)
+	}
+	return refs, nil
+}
+
 func parseResourceNames(raw any, present bool) ([]string, bool, error) {
 	if !present {
 		return nil, false, nil

--- a/module/pipeline_step_iac_provider_plan.go
+++ b/module/pipeline_step_iac_provider_plan.go
@@ -123,7 +123,7 @@ func parseResourceRefs(raw any) ([]interfaces.ResourceRef, error) {
 
 func resolveResourceRefsFrom(path, stepName, stepType string, pc *PipelineContext) ([]interfaces.ResourceRef, error) {
 	if pc == nil {
-		return nil, fmt.Errorf("%s step %q: refs_from %q resolved to empty/zero refs", stepType, stepName, path)
+		return nil, fmt.Errorf("%s step %q: refs_from %q requires a non-nil pipeline context", stepType, stepName, path)
 	}
 	raw := resolveBodyFrom(path, pc)
 	refs, err := parseResourceRefs(raw)

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -2062,8 +2062,9 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Lists current resource statuses from an IaCProvider service.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "provider", Type: FieldTypeString, Description: "Name of the registered IaCProvider service", Required: true},
-			{Key: "refs", Type: FieldTypeArray, Description: "Optional list of resource refs to query; mutually exclusive with resources"},
-			{Key: "resources", Type: FieldTypeArray, Description: "Optional list of named app infra resources to query; mutually exclusive with refs"},
+			{Key: "refs", Type: FieldTypeArray, Description: "Optional list of resource refs to query; mutually exclusive with refs_from and resources"},
+			{Key: "refs_from", Type: FieldTypeString, Description: "Dotted context path to resolve resource refs at Execute time (e.g. steps.parse-request.body.refs); mutually exclusive with refs and resources"},
+			{Key: "resources", Type: FieldTypeArray, Description: "Optional list of named app infra resources to query; mutually exclusive with refs and refs_from"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "provider", Type: "string", Description: "Provider service name"},
@@ -2140,8 +2141,9 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Destroys resources via an IaCProvider service.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "provider", Type: FieldTypeString, Description: "Name of the registered IaCProvider service", Required: true},
-			{Key: "refs", Type: FieldTypeArray, Description: "Resource refs to destroy (list of {name, type, provider_id}); mutually exclusive with resources"},
-			{Key: "resources", Type: FieldTypeArray, Description: "Named app infra resources to destroy; mutually exclusive with refs"},
+			{Key: "refs", Type: FieldTypeArray, Description: "Resource refs to destroy (list of {name, type, provider_id}); mutually exclusive with refs_from and resources"},
+			{Key: "refs_from", Type: FieldTypeString, Description: "Dotted context path to resolve resource refs at Execute time (e.g. steps.parse-request.body.refs); mutually exclusive with refs and resources"},
+			{Key: "resources", Type: FieldTypeArray, Description: "Named app infra resources to destroy; mutually exclusive with refs and refs_from"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "destroyed", Type: "[]any", Description: "Names of destroyed resources"},


### PR DESCRIPTION
## Summary
- add refs_from support to step.iac_provider_list and step.iac_provider_destroy
- keep refs, refs_from, and resources mutually exclusive for both steps
- update wfctl type registry, step schema metadata, and docs

## Verification
- go test ./module -run 'TestIaCProvider(List|Destroy)Step_RefsFrom|TestIaCProvider(List|Destroy)Step_Factory_RefsFrom' -count=1
- go test ./module -run 'TestIaCProvider(List|Destroy|Plan|Apply)Step' -count=1
- UPDATE_GOLDEN=1 go test ./schema/ -run TestEditorSchemasGoldenFile -count=1
- go test ./module ./schema ./cmd/wfctl -count=1
- git diff --check

## TDD regression proof
With fix reverted:
- go test ./module -run 'TestIaCProvider(List|Destroy)Step_RefsFrom|TestIaCProvider(List|Destroy)Step_Factory_RefsFrom' -count=1
- FAIL: refs_from was ignored; list/destroy received zero refs and factory did not reject mixed sources

With fix restored:
- go test ./module -run 'TestIaCProvider(List|Destroy)Step_RefsFrom|TestIaCProvider(List|Destroy)Step_Factory_RefsFrom' -count=1
- PASS