### PR TITLE
feat: allow app deploy runtime specs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -370,7 +370,7 @@ YAML from the pipeline context, such as an HTTP route's `request_body`.
 | `step.dns_plan` | Plans DNS record changes | platform |
 | `step.dns_apply` | Applies DNS record changes | platform |
 | `step.dns_status` | Retrieves the current DNS records for a domain | platform |
-| `step.app_deploy` | Deploys a containerized application | platform |
+| `step.app_deploy` | Deploys a containerized application; supports static `spec` or runtime `spec_from` overrides | platform |
 | `step.app_status` | Retrieves deployment status of an application | platform |
 | `step.app_rollback` | Rolls back an application to a previous deployment | platform |
 | `step.region_deploy` | Deploys workloads to a specific cloud region | platform |

--- a/cmd/wfctl/type_registry.go
+++ b/cmd/wfctl/type_registry.go
@@ -1464,7 +1464,7 @@ func KnownStepTypes() map[string]StepTypeInfo {
 		"step.app_deploy": {
 			Type:       "step.app_deploy",
 			Plugin:     "platform",
-			ConfigKeys: []string{"app"},
+			ConfigKeys: []string{"app", "spec", "spec_from"},
 		},
 		"step.app_status": {
 			Type:       "step.app_status",

--- a/module/app_container.go
+++ b/module/app_container.go
@@ -205,12 +205,24 @@ func (m *AppContainerModule) RequiresServices() []modular.ServiceDependency {
 // Deploy stores the previous deployment state and creates a new deployment.
 // The mock backend immediately transitions to "active".
 func (m *AppContainerModule) Deploy() (*AppDeployResult, error) {
+	return m.deployWithSpec(m.spec)
+}
+
+// DeployWithSpec deploys using an operation-specific spec without changing the
+// module's configured default spec.
+func (m *AppContainerModule) DeployWithSpec(spec AppContainerSpec) (*AppDeployResult, error) {
+	return m.deployWithSpec(spec)
+}
+
+func (m *AppContainerModule) deployWithSpec(spec AppContainerSpec) (*AppDeployResult, error) {
 	// Preserve current as previous for rollback.
 	if m.current != nil {
 		prev := *m.current
 		m.previous = &prev
 	}
-	result, err := m.backend.deploy(m)
+	deployTarget := *m
+	deployTarget.spec = spec
+	result, err := m.backend.deploy(&deployTarget)
 	if err != nil {
 		return nil, err
 	}

--- a/module/app_container.go
+++ b/module/app_container.go
@@ -248,13 +248,11 @@ func (m *AppContainerModule) Rollback() (*AppDeployResult, error) {
 	if m.previous == nil {
 		return nil, fmt.Errorf("app.container %q: no previous deployment to roll back to", m.name)
 	}
-	result, err := m.backend.rollback(m, m.previous.Image)
-	if err != nil {
-		return nil, err
-	}
-	m.current = result
+	result := *m.previous
+	result.Status = "rolled_back"
+	m.current = &result
 	m.previous = nil
-	return result, nil
+	return &result, nil
 }
 
 // Manifests returns the generated platform-specific resource manifests.

--- a/module/app_container_test.go
+++ b/module/app_container_test.go
@@ -2,6 +2,7 @@ package module_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/module"
@@ -435,6 +436,82 @@ func TestAppContainer_AppDeployStepFactory(t *testing.T) {
 	}
 	if result.Output["app"] != "my-api" {
 		t.Errorf("expected app=my-api, got %v", result.Output["app"])
+	}
+}
+
+// TestAppContainer_AppDeployStepSpecFrom verifies that app deployment can use
+// caller-supplied deployment specs from the pipeline context.
+func TestAppContainer_AppDeployStepSpecFrom(t *testing.T) {
+	app, _ := setupAppContainerWithK8s(t)
+
+	factory := module.NewAppDeployStepFactory()
+	step, err := factory("deploy", map[string]any{
+		"app":       "my-api",
+		"spec_from": "body.spec",
+	}, app)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	result, err := step.Execute(context.Background(), &module.PipelineContext{
+		Current: map[string]any{
+			"body": map[string]any{
+				"spec": map[string]any{
+					"image":       "registry.example.com/my-api:v2.0.0",
+					"replicas":    5,
+					"ports":       []any{9090},
+					"cpu":         "750m",
+					"memory":      "768Mi",
+					"health_path": "/readyz",
+					"health_port": 9090,
+					"env": map[string]any{
+						"LOG_LEVEL": "debug",
+					},
+				},
+			},
+		},
+		StepOutputs: map[string]map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Output["status"] != "active" {
+		t.Errorf("expected status=active, got %v", result.Output["status"])
+	}
+	if result.Output["image"] != "registry.example.com/my-api:v2.0.0" {
+		t.Errorf("expected override image, got %v", result.Output["image"])
+	}
+	if result.Output["replicas"] != 5 {
+		t.Errorf("expected override replicas=5, got %v", result.Output["replicas"])
+	}
+
+	statusStep, err := module.NewAppStatusStepFactory()("status", map[string]any{"app": "my-api"}, app)
+	if err != nil {
+		t.Fatalf("status factory: %v", err)
+	}
+	status, err := statusStep.Execute(context.Background(), &module.PipelineContext{Current: map[string]any{}})
+	if err != nil {
+		t.Fatalf("status Execute: %v", err)
+	}
+	if status.Output["image"] != "registry.example.com/my-api:v2.0.0" {
+		t.Errorf("expected status to expose override image, got %v", status.Output["image"])
+	}
+	if status.Output["replicas"] != 5 {
+		t.Errorf("expected status to expose override replicas=5, got %v", status.Output["replicas"])
+	}
+}
+
+func TestAppDeployStep_SpecAndSpecFromMutuallyExclusive(t *testing.T) {
+	_, err := module.NewAppDeployStepFactory()("deploy", map[string]any{
+		"app":       "my-api",
+		"spec":      map[string]any{"image": "registry.example.com/my-api:v2.0.0"},
+		"spec_from": "body.spec",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive spec and spec_from")
+	}
+	if !strings.Contains(err.Error(), "'spec' and 'spec_from' are mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/module/app_container_test.go
+++ b/module/app_container_test.go
@@ -241,6 +241,39 @@ func TestAppContainer_RollbackRevertsToPreviewImage(t *testing.T) {
 	}
 }
 
+// TestAppContainer_RollbackRestoresPreviousRuntimeReplicas verifies rollback
+// restores the previous operation-specific deploy result, not the static module
+// default replica count.
+func TestAppContainer_RollbackRestoresPreviousRuntimeReplicas(t *testing.T) {
+	_, m := setupAppContainerWithK8s(t)
+	base := m.Spec()
+
+	first := base
+	first.Image = "registry.example.com/my-api:v1"
+	first.Replicas = 4
+	if _, err := m.DeployWithSpec(first); err != nil {
+		t.Fatalf("first DeployWithSpec: %v", err)
+	}
+
+	second := base
+	second.Image = "registry.example.com/my-api:v2"
+	second.Replicas = 6
+	if _, err := m.DeployWithSpec(second); err != nil {
+		t.Fatalf("second DeployWithSpec: %v", err)
+	}
+
+	rolledBack, err := m.Rollback()
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if rolledBack.Image != first.Image {
+		t.Errorf("expected rollback image=%q, got %q", first.Image, rolledBack.Image)
+	}
+	if rolledBack.Replicas != first.Replicas {
+		t.Errorf("expected rollback replicas=%d, got %d", first.Replicas, rolledBack.Replicas)
+	}
+}
+
 // TestAppContainer_RollbackNoPreviousReturnsError verifies Rollback fails when no previous exists.
 func TestAppContainer_RollbackNoPreviousReturnsError(t *testing.T) {
 	_, m := setupAppContainerWithK8s(t)

--- a/module/pipeline_step_app.go
+++ b/module/pipeline_step_app.go
@@ -83,6 +83,7 @@ func appContainerSpecWithOverrides(base AppContainerSpec, raw any) (AppContainer
 		return base, fmt.Errorf("spec must be a map, got %T", raw)
 	}
 	spec := base
+	_, hasHealthPortOverride := firstOverride(overrides, "health_port", "healthPort")
 	if image, ok := overrides["image"].(string); ok {
 		if image == "" {
 			return base, fmt.Errorf("image must be non-empty")
@@ -102,7 +103,7 @@ func appContainerSpecWithOverrides(base AppContainerSpec, raw any) (AppContainer
 			return base, err
 		}
 		spec.Ports = ports
-		if spec.HealthPort == 0 && len(ports) > 0 {
+		if !hasHealthPortOverride && len(ports) > 0 {
 			spec.HealthPort = ports[0]
 		}
 	}

--- a/module/pipeline_step_app.go
+++ b/module/pipeline_step_app.go
@@ -11,9 +11,11 @@ import (
 
 // AppDeployStep deploys an app.container module.
 type AppDeployStep struct {
-	name   string
-	app    string
-	appMod modular.Application
+	name     string
+	app      string
+	rawSpec  any
+	specFrom string
+	appMod   modular.Application
 }
 
 // NewAppDeployStepFactory returns a StepFactory for step.app_deploy.
@@ -23,18 +25,44 @@ func NewAppDeployStepFactory() StepFactory {
 		if appName == "" {
 			return nil, fmt.Errorf("app_deploy step %q: 'app' is required", name)
 		}
-		return &AppDeployStep{name: name, app: appName, appMod: app}, nil
+		specFrom, _ := cfg["spec_from"].(string)
+		rawSpec, hasSpec := cfg["spec"]
+		if hasSpec && specFrom != "" {
+			return nil, fmt.Errorf("app_deploy step %q: 'spec' and 'spec_from' are mutually exclusive", name)
+		}
+		return &AppDeployStep{name: name, app: appName, rawSpec: rawSpec, specFrom: specFrom, appMod: app}, nil
 	}
 }
 
 func (s *AppDeployStep) Name() string { return s.name }
 
-func (s *AppDeployStep) Execute(_ context.Context, _ *PipelineContext) (*StepResult, error) {
+func (s *AppDeployStep) Execute(_ context.Context, pc *PipelineContext) (*StepResult, error) {
 	m, err := resolveAppContainerModule(s.appMod, s.app, s.name)
 	if err != nil {
 		return nil, err
 	}
-	result, err := m.Deploy()
+	spec := m.Spec()
+	if s.rawSpec != nil {
+		spec, err = appContainerSpecWithOverrides(spec, s.rawSpec)
+		if err != nil {
+			return nil, fmt.Errorf("app_deploy step %q: parse spec: %w", s.name, err)
+		}
+	}
+	if s.specFrom != "" {
+		if pc == nil {
+			return nil, fmt.Errorf("app_deploy step %q: spec_from %q requires a non-nil pipeline context", s.name, s.specFrom)
+		}
+		raw := resolveBodyFrom(s.specFrom, pc)
+		if raw == nil {
+			return nil, fmt.Errorf("app_deploy step %q: spec_from %q resolved to nil", s.name, s.specFrom)
+		}
+		spec, err = appContainerSpecWithOverrides(spec, raw)
+		if err != nil {
+			return nil, fmt.Errorf("app_deploy step %q: parse spec_from %q: %w", s.name, s.specFrom, err)
+		}
+	}
+
+	result, err := m.DeployWithSpec(spec)
 	if err != nil {
 		return nil, fmt.Errorf("app_deploy step %q: %w", s.name, err)
 	}
@@ -47,6 +75,135 @@ func (s *AppDeployStep) Execute(_ context.Context, _ *PipelineContext) (*StepRes
 		"replicas": result.Replicas,
 		"platform": result.Platform,
 	}}, nil
+}
+
+func appContainerSpecWithOverrides(base AppContainerSpec, raw any) (AppContainerSpec, error) {
+	overrides, ok := raw.(map[string]any)
+	if !ok {
+		return base, fmt.Errorf("spec must be a map, got %T", raw)
+	}
+	spec := base
+	if image, ok := overrides["image"].(string); ok {
+		if image == "" {
+			return base, fmt.Errorf("image must be non-empty")
+		}
+		spec.Image = image
+	}
+	if rawReplicas, ok := overrides["replicas"]; ok {
+		replicas, ok := intFromAny(rawReplicas)
+		if !ok || replicas <= 0 {
+			return base, fmt.Errorf("replicas must be a positive integer")
+		}
+		spec.Replicas = replicas
+	}
+	if rawPorts, ok := overrides["ports"]; ok {
+		ports, err := parseAppContainerPorts(rawPorts)
+		if err != nil {
+			return base, err
+		}
+		spec.Ports = ports
+		if spec.HealthPort == 0 && len(ports) > 0 {
+			spec.HealthPort = ports[0]
+		}
+	}
+	if cpu, ok := overrides["cpu"].(string); ok {
+		if cpu == "" {
+			return base, fmt.Errorf("cpu must be non-empty")
+		}
+		spec.CPU = cpu
+	}
+	if memory, ok := overrides["memory"].(string); ok {
+		if memory == "" {
+			return base, fmt.Errorf("memory must be non-empty")
+		}
+		spec.Memory = memory
+	}
+	if healthPath, ok := stringOverride(overrides, "health_path", "healthPath"); ok {
+		if healthPath == "" {
+			return base, fmt.Errorf("health_path must be non-empty")
+		}
+		spec.HealthPath = healthPath
+	}
+	if rawHealthPort, ok := firstOverride(overrides, "health_port", "healthPort"); ok {
+		healthPort, ok := intFromAny(rawHealthPort)
+		if !ok || healthPort <= 0 {
+			return base, fmt.Errorf("health_port must be a positive integer")
+		}
+		spec.HealthPort = healthPort
+	}
+	if rawEnv, ok := overrides["env"]; ok {
+		env, err := parseAppContainerEnv(rawEnv)
+		if err != nil {
+			return base, err
+		}
+		spec.Env = env
+	}
+	if spec.Image == "" {
+		return base, fmt.Errorf("image is required")
+	}
+	return spec, nil
+}
+
+func parseAppContainerPorts(raw any) ([]int, error) {
+	var items []any
+	switch v := raw.(type) {
+	case []any:
+		items = v
+	case []int:
+		items = make([]any, 0, len(v))
+		for _, item := range v {
+			items = append(items, item)
+		}
+	default:
+		return nil, fmt.Errorf("ports must be a list, got %T", raw)
+	}
+	ports := make([]int, 0, len(items))
+	for i, item := range items {
+		port, ok := intFromAny(item)
+		if !ok || port <= 0 {
+			return nil, fmt.Errorf("ports[%d] must be a positive integer", i)
+		}
+		ports = append(ports, port)
+	}
+	return ports, nil
+}
+
+func parseAppContainerEnv(raw any) (map[string]string, error) {
+	var items map[string]any
+	switch v := raw.(type) {
+	case map[string]any:
+		items = v
+	case map[string]string:
+		items = make(map[string]any, len(v))
+		for key, value := range v {
+			items[key] = value
+		}
+	default:
+		return nil, fmt.Errorf("env must be a map, got %T", raw)
+	}
+	env := make(map[string]string, len(items))
+	for key, value := range items {
+		env[key] = fmt.Sprintf("%v", value)
+	}
+	return env, nil
+}
+
+func firstOverride(overrides map[string]any, keys ...string) (any, bool) {
+	for _, key := range keys {
+		if value, ok := overrides[key]; ok {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func stringOverride(overrides map[string]any, keys ...string) (string, bool) {
+	raw, ok := firstOverride(overrides, keys...)
+	if !ok {
+		return "", false
+	}
+	value, ok := raw.(string)
+	return value, ok
 }
 
 // ─── app_status ───────────────────────────────────────────────────────────────

--- a/module/pipeline_step_app_test.go
+++ b/module/pipeline_step_app_test.go
@@ -29,6 +29,28 @@ func TestAppDeployStep_ValidConfig(t *testing.T) {
 	}
 }
 
+func TestAppContainerSpecWithOverrides_PortsDefaultHealthPort(t *testing.T) {
+	base := AppContainerSpec{
+		Image:      "registry.example.com/app:v1",
+		Replicas:   1,
+		Ports:      []int{8080},
+		HealthPort: 8080,
+	}
+
+	spec, err := appContainerSpecWithOverrides(base, map[string]any{
+		"ports": []any{9090},
+	})
+	if err != nil {
+		t.Fatalf("appContainerSpecWithOverrides: %v", err)
+	}
+	if spec.Ports[0] != 9090 {
+		t.Fatalf("expected port 9090, got %d", spec.Ports[0])
+	}
+	if spec.HealthPort != 9090 {
+		t.Fatalf("expected health port to follow overridden first port, got %d", spec.HealthPort)
+	}
+}
+
 // ── app_status ─────────────────────────────────────────────────────────────
 
 func TestAppStatusStep_MissingApp(t *testing.T) {

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1484,8 +1484,8 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Deploys an application container to the target platform.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "app", Type: FieldTypeString, Description: "Name of the app.container module", Required: true},
-			{Key: "spec", Type: FieldTypeMap, Description: "Optional deployment spec overrides for this deploy call"},
-			{Key: "spec_from", Type: FieldTypeString, Description: "Dotted pipeline context path resolving to deployment spec overrides"},
+			{Key: "spec", Type: FieldTypeMap, Description: "Optional deployment spec overrides for this deploy call; mutually exclusive with spec_from"},
+			{Key: "spec_from", Type: FieldTypeString, Description: "Dotted pipeline context path resolving to deployment spec overrides; mutually exclusive with spec"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "deployed", Type: "boolean", Description: "Whether deployment succeeded"},

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -1484,6 +1484,8 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Description: "Deploys an application container to the target platform.",
 		ConfigFields: []ConfigFieldDef{
 			{Key: "app", Type: FieldTypeString, Description: "Name of the app.container module", Required: true},
+			{Key: "spec", Type: FieldTypeMap, Description: "Optional deployment spec overrides for this deploy call"},
+			{Key: "spec_from", Type: FieldTypeString, Description: "Dotted pipeline context path resolving to deployment spec overrides"},
 		},
 		Outputs: []StepOutputDef{
 			{Key: "deployed", Type: "boolean", Description: "Whether deployment succeeded"},


### PR DESCRIPTION
## Summary
- Add `spec` and `spec_from` support to `step.app_deploy` so Workflow apps can deploy caller-supplied container specs through pipeline context data.
- Add operation-scoped `AppContainerModule.DeployWithSpec` so runtime overrides update current deployment status without mutating the module's configured default spec.
- Update wfctl type registry, step schema metadata, and documentation for the new step fields.

## Verification
- RED before implementation: `GOWORK=off go test ./module -run 'TestAppContainer_AppDeployStepSpecFrom|TestAppDeployStep_SpecAndSpecFromMutuallyExclusive' -count=1` failed with static image/replicas and missing mutual-exclusion validation.
- GREEN after implementation: `GOWORK=off go test ./module -run 'TestAppContainer_AppDeployStepSpecFrom|TestAppDeployStep_SpecAndSpecFromMutuallyExclusive' -count=1` passed.
- Regression invariant: with only production implementation reverted, the same test command failed on static image/replicas and missing mutual-exclusion validation; restored implementation passed.
- `GOWORK=off go test ./module ./schema ./cmd/wfctl -count=1`
- `git diff --check`

## Scenario Follow-up
This unblocks scenario 34 from using runtime-provided app deployment specs instead of a fixed app-container fixture.
