### PR TITLE
fix: align app deploy output schema

### DIFF
--- a/module/app_container_test.go
+++ b/module/app_container_test.go
@@ -467,6 +467,9 @@ func TestAppContainer_AppDeployStepFactory(t *testing.T) {
 	if result.Output["status"] != "active" {
 		t.Errorf("expected status=active, got %v", result.Output["status"])
 	}
+	if result.Output["deployed"] != true {
+		t.Errorf("expected deployed=true, got %v", result.Output["deployed"])
+	}
 	if result.Output["app"] != "my-api" {
 		t.Errorf("expected app=my-api, got %v", result.Output["app"])
 	}

--- a/module/pipeline_step_app.go
+++ b/module/pipeline_step_app.go
@@ -67,6 +67,7 @@ func (s *AppDeployStep) Execute(_ context.Context, pc *PipelineContext) (*StepRe
 		return nil, fmt.Errorf("app_deploy step %q: %w", s.name, err)
 	}
 	return &StepResult{Output: map[string]any{
+		"deployed": true,
 		"result":   result,
 		"app":      s.app,
 		"status":   result.Status,


### PR DESCRIPTION
## Summary
- Add the `deployed: true` runtime output from `step.app_deploy` so it matches the advertised step schema.
- Add a regression assertion to the app deploy step test.

## Verification
- RED before implementation: `GOWORK=off go test ./module -run 'TestAppContainer_AppDeployStepFactory' -count=1` failed with `expected deployed=true, got <nil>`.
- GREEN after implementation: `GOWORK=off go test ./module -run 'TestAppContainer_AppDeployStepFactory|TestAppContainer_AppDeployStepSpecFrom' -count=1` passed.
- `GOWORK=off go test ./module ./schema ./cmd/wfctl -count=1`
- `git diff --check`

## Context
This addresses a late Copilot review finding from workflow#988 that was discovered as #988 merged.
