### PR TITLE
fix: honor WFCTL_PLUGIN_DIR for pipeline run

### DIFF
--- a/cmd/wfctl/pipeline.go
+++ b/cmd/wfctl/pipeline.go
@@ -141,6 +141,9 @@ Options:
 		fs.Usage()
 		return fmt.Errorf("-p (pipeline name) is required")
 	}
+	if *pluginDir == "" {
+		*pluginDir = os.Getenv("WFCTL_PLUGIN_DIR")
+	}
 
 	// Build initial trigger data from --input JSON
 	triggerData := make(map[string]any)

--- a/cmd/wfctl/pipeline.go
+++ b/cmd/wfctl/pipeline.go
@@ -142,7 +142,7 @@ Options:
 		return fmt.Errorf("-p (pipeline name) is required")
 	}
 	if *pluginDir == "" {
-		*pluginDir = os.Getenv("WFCTL_PLUGIN_DIR")
+		*pluginDir = strings.TrimSpace(os.Getenv("WFCTL_PLUGIN_DIR"))
 	}
 
 	// Build initial trigger data from --input JSON

--- a/cmd/wfctl/pipeline_test.go
+++ b/cmd/wfctl/pipeline_test.go
@@ -312,6 +312,34 @@ pipelines:
 	}
 }
 
+func TestRunPipelineRunUsesExternalPluginDirEnv(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "plugins")
+	if err := os.Mkdir(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	t.Setenv("WFCTL_PLUGIN_DIR", pluginDir)
+	path := writePipelineConfig(t, dir, "external.yaml", `
+modules: []
+
+pipelines:
+  external:
+    steps:
+      - name: marker
+        type: step.test_external_marker
+        config:
+          value: loaded
+    on_error: stop
+`)
+
+	restore := overrideLocalExternalPluginLoader(t, pluginDir)
+	defer restore()
+
+	if err := runPipelineRun([]string{"-c", path, "-p", "external"}); err != nil {
+		t.Fatalf("pipeline run with WFCTL_PLUGIN_DIR failed: %v", err)
+	}
+}
+
 // --- stringSliceFlag ---
 
 func TestStringSliceFlag(t *testing.T) {

--- a/cmd/wfctl/pipeline_test.go
+++ b/cmd/wfctl/pipeline_test.go
@@ -318,7 +318,7 @@ func TestRunPipelineRunUsesExternalPluginDirEnv(t *testing.T) {
 	if err := os.Mkdir(pluginDir, 0o755); err != nil {
 		t.Fatalf("mkdir plugin dir: %v", err)
 	}
-	t.Setenv("WFCTL_PLUGIN_DIR", pluginDir)
+	t.Setenv("WFCTL_PLUGIN_DIR", "  "+pluginDir+"  ")
 	path := writePipelineConfig(t, dir, "external.yaml", `
 modules: []
 
@@ -337,6 +337,38 @@ pipelines:
 
 	if err := runPipelineRun([]string{"-c", path, "-p", "external"}); err != nil {
 		t.Fatalf("pipeline run with WFCTL_PLUGIN_DIR failed: %v", err)
+	}
+}
+
+func TestRunPipelineRunPluginDirFlagTakesPrecedenceOverEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPluginDir := filepath.Join(dir, "env-plugins")
+	flagPluginDir := filepath.Join(dir, "flag-plugins")
+	if err := os.Mkdir(envPluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir env plugin dir: %v", err)
+	}
+	if err := os.Mkdir(flagPluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir flag plugin dir: %v", err)
+	}
+	t.Setenv("WFCTL_PLUGIN_DIR", envPluginDir)
+	path := writePipelineConfig(t, dir, "external.yaml", `
+modules: []
+
+pipelines:
+  external:
+    steps:
+      - name: marker
+        type: step.test_external_marker
+        config:
+          value: loaded
+    on_error: stop
+`)
+
+	restore := overrideLocalExternalPluginLoader(t, flagPluginDir)
+	defer restore()
+
+	if err := runPipelineRun([]string{"-c", path, "-p", "external", "--plugin-dir", flagPluginDir}); err != nil {
+		t.Fatalf("pipeline run with --plugin-dir precedence failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- lets wfctl pipeline run discover external plugins from WFCTL_PLUGIN_DIR when --plugin-dir is omitted
- keeps CLI behavior aligned with pipeline-test fixtures

## Verification
- GOWORK=off go test ./cmd/wfctl -run 'TestRunPipelineRunWithExternalPluginDir|TestRunPipelineRunUsesExternalPluginDirEnv'
- GOWORK=off go test ./cmd/wfctl