### PR TITLE
feat(wfctl,lint): add doctor app probe and lock-across-I/O analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ Configs that still reference the legacy types now fail to load with an actionabl
 
 ### Added
 
+- **`wfctl doctor app <url>`**: explicitly-online, read-only probe of a deployed app's health
+  endpoint. Runs N sequential + M lightly-concurrent requests and reports latency (p50/p99),
+  failure-origin classification (platform-edge HTML vs. app-origin JSON, using content-type/body
+  shape only), and health flip-flop rate. Flags: `--health-path`, `--probes`, `--concurrency`,
+  `--timeout`, `--format text|json`, `--strict`. See ADR 0054.
+- **`lint/lockio` package**: a reusable `go/analysis`-style checker for "lock held across store
+  I/O," parameterized by lock acquire/release method names, restricted I/O method names, and an
+  allowlist. Exposes `FindViolations` (for a host app's own shrink-only allowlist test) and
+  `NewAnalyzer` (a real `analysis.Analyzer` for golangci-lint/go vet/multichecker integration).
+  See ADR 0054.
 - **GitHub environment secret destinations for IaC output sync**: `secretStores` can now use
   `provider: github` with `config.environment`, including `${WORKFLOW_ENV}`, so
   `wfctl infra apply --env staging` writes to GitHub Actions environment secrets instead of

--- a/cmd/wfctl/doctor.go
+++ b/cmd/wfctl/doctor.go
@@ -42,6 +42,14 @@ func runDoctor(args []string) error {
 }
 
 func runDoctorWithOutput(args []string, out io.Writer) error {
+	// "wfctl doctor app <url>" is an explicitly-online subcommand (see
+	// doctor_app.go); every other invocation is the checkout-only diagnostic
+	// below, per ADR 0052. Dispatching on a literal "app" is unambiguous
+	// because the checkout diagnostic takes no positional arguments.
+	if len(args) > 0 && args[0] == "app" {
+		return runDoctorAppWithOutput(args[1:], out)
+	}
+
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(out)
 	workflowPath := fs.String("workflow", "workflow.yaml", "Workflow config path")
@@ -54,8 +62,12 @@ func runDoctorWithOutput(args []string, out io.Writer) error {
 	strict := fs.Bool("strict", false, "Exit non-zero when warnings or errors are found")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), `Usage: wfctl doctor [options]
+       wfctl doctor app <url> [options]
 
 Check wfctl binary, project config, plugin manifest, lockfile, and installed plugin state.
+
+Use "wfctl doctor app <url>" to probe a deployed app's health endpoint instead
+(explicitly online; run "wfctl doctor app -h" for its options).
 
 Options:
 `)

--- a/cmd/wfctl/doctor_app.go
+++ b/cmd/wfctl/doctor_app.go
@@ -1,0 +1,432 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// doctorAppFailureClass classifies why an app-probe request did not return a
+// healthy 2xx response. Classification uses only the HTTP response's
+// Content-Type header and body shape — never a provider-specific marker — so
+// the same heuristic works unmodified in front of any edge proxy
+// (DigitalOcean App Platform, AWS ALB, nginx, or anything else fronting a
+// deployed app).
+type doctorAppFailureClass string
+
+const (
+	// doctorAppFailureHealthy means the probe returned a 2xx response.
+	doctorAppFailureHealthy doctorAppFailureClass = "healthy"
+	// doctorAppFailurePlatformEdge means the request never reached the app:
+	// a reverse proxy or load balancer answered with its own HTML error
+	// page. This is the distinction that cost hours during a real staging
+	// incident: an edge proxy's default HTML error page looks like a
+	// completely different failure than the app's own structured error, but
+	// both surface to a human as "the health check failed."
+	doctorAppFailurePlatformEdge doctorAppFailureClass = "platform-edge"
+	// doctorAppFailureAppOrigin means the request reached the app, which
+	// returned its own structured (JSON) error body.
+	doctorAppFailureAppOrigin doctorAppFailureClass = "app-origin"
+	// doctorAppFailureTransport means no HTTP response was ever received
+	// (connection refused, timeout, TLS failure, DNS failure, ...).
+	doctorAppFailureTransport doctorAppFailureClass = "transport-error"
+	// doctorAppFailureUnknown means a response was received but its
+	// content-type and body shape matched neither heuristic.
+	doctorAppFailureUnknown doctorAppFailureClass = "unknown"
+)
+
+// classifyAppProbeFailure distinguishes a platform-edge failure from an
+// app-origin failure using only the response's Content-Type header and body
+// shape. It intentionally contains no provider-specific logic (no check for
+// "DigitalOcean", "ALB", or "nginx" by name): every edge proxy's default
+// error page observed in practice is HTML, and every app-origin structured
+// error observed in practice is JSON, so the two generic heuristics below
+// cover all of them without hardcoding any one platform.
+func classifyAppProbeFailure(statusCode int, contentType string, body []byte) doctorAppFailureClass {
+	if statusCode >= 200 && statusCode < 300 {
+		return doctorAppFailureHealthy
+	}
+	trimmed := bytes.TrimSpace(body)
+	if hasJSONBodyShape(trimmed) || strings.Contains(strings.ToLower(contentType), "json") {
+		return doctorAppFailureAppOrigin
+	}
+	if hasHTMLBodyShape(trimmed) || strings.Contains(strings.ToLower(contentType), "text/html") {
+		return doctorAppFailurePlatformEdge
+	}
+	return doctorAppFailureUnknown
+}
+
+func hasJSONBodyShape(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	return body[0] == '{' || body[0] == '['
+}
+
+func hasHTMLBodyShape(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	lower := bytes.ToLower(body)
+	head := lower[:min(len(lower), 512)]
+	return bytes.Contains(head, []byte("<html")) || bytes.Contains(head, []byte("<!doctype html"))
+}
+
+// doctorAppProbeResult is one HTTP round trip against the health path.
+type doctorAppProbeResult struct {
+	Sequence   int
+	Concurrent bool
+	StartedAt  time.Time
+	Duration   time.Duration
+	StatusCode int
+	Class      doctorAppFailureClass
+	Err        error
+}
+
+type doctorAppOptions struct {
+	URL         string
+	HealthPath  string
+	Probes      int
+	Concurrency int
+	Timeout     time.Duration
+}
+
+// runDoctorAppProbes runs opts.Probes sequential requests followed by
+// opts.Concurrency lightly-concurrent requests (fired together, after the
+// sequential phase completes) against the target health path. It is
+// explicitly-online and read-only: every request is a GET against a
+// caller-supplied URL, with no retries beyond what net/http already does at
+// the transport layer, and no request volume beyond N+M total.
+func runDoctorAppProbes(ctx context.Context, client *http.Client, opts doctorAppOptions) []doctorAppProbeResult {
+	target := strings.TrimRight(opts.URL, "/") + opts.HealthPath
+	results := make([]doctorAppProbeResult, 0, opts.Probes+opts.Concurrency)
+
+	probeOnce := func(seq int, concurrent bool) doctorAppProbeResult {
+		reqCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+		start := time.Now()
+		//nolint:gosec // G107: target is explicitly provided by the operator as the doctor app probe URL
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, target, nil)
+		if err != nil {
+			return doctorAppProbeResult{
+				Sequence: seq, Concurrent: concurrent, StartedAt: start,
+				Duration: time.Since(start), Class: doctorAppFailureTransport, Err: err,
+			}
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return doctorAppProbeResult{
+				Sequence: seq, Concurrent: concurrent, StartedAt: start,
+				Duration: time.Since(start), Class: doctorAppFailureTransport, Err: err,
+			}
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		duration := time.Since(start)
+		return doctorAppProbeResult{
+			Sequence:   seq,
+			Concurrent: concurrent,
+			StartedAt:  start,
+			Duration:   duration,
+			StatusCode: resp.StatusCode,
+			Class:      classifyAppProbeFailure(resp.StatusCode, resp.Header.Get("Content-Type"), body),
+		}
+	}
+
+	for i := 0; i < opts.Probes; i++ {
+		results = append(results, probeOnce(i, false))
+	}
+
+	if opts.Concurrency > 0 {
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		wg.Add(opts.Concurrency)
+		for i := 0; i < opts.Concurrency; i++ {
+			go func(seq int) {
+				defer wg.Done()
+				r := probeOnce(seq, true)
+				mu.Lock()
+				results = append(results, r)
+				mu.Unlock()
+			}(opts.Probes + i)
+		}
+		wg.Wait()
+	}
+
+	return results
+}
+
+type doctorAppLatency struct {
+	P50Ms float64 `json:"p50Ms"`
+	P99Ms float64 `json:"p99Ms"`
+}
+
+func doctorAppLatencyStats(results []doctorAppProbeResult) doctorAppLatency {
+	durations := make([]float64, 0, len(results))
+	for _, r := range results {
+		durations = append(durations, float64(r.Duration.Microseconds())/1000.0)
+	}
+	sort.Float64s(durations)
+	return doctorAppLatency{
+		P50Ms: percentile(durations, 0.50),
+		P99Ms: percentile(durations, 0.99),
+	}
+}
+
+// percentile returns the p-th percentile (0..1) of sorted ascending values
+// using linear interpolation between the two nearest ranks. Returns 0 for an
+// empty slice.
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	rank := p * float64(len(sorted)-1)
+	lo := int(rank)
+	hi := lo + 1
+	if hi >= len(sorted) {
+		return sorted[len(sorted)-1]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + frac*(sorted[hi]-sorted[lo])
+}
+
+// doctorAppFlipFlopRate orders results by start time (spanning both the
+// sequential and concurrent phases) and reports the fraction of consecutive
+// pairs that cross the healthy/unhealthy boundary. A stably healthy or
+// stably unhealthy window scores 0; a service alternating on every probe
+// scores close to 1.
+func doctorAppFlipFlopRate(results []doctorAppProbeResult) float64 {
+	if len(results) < 2 {
+		return 0
+	}
+	ordered := make([]doctorAppProbeResult, len(results))
+	copy(ordered, results)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].StartedAt.Before(ordered[j].StartedAt) })
+
+	transitions := 0
+	prevHealthy := ordered[0].Class == doctorAppFailureHealthy
+	for _, r := range ordered[1:] {
+		healthy := r.Class == doctorAppFailureHealthy
+		if healthy != prevHealthy {
+			transitions++
+		}
+		prevHealthy = healthy
+	}
+	return float64(transitions) / float64(len(ordered)-1)
+}
+
+type doctorAppReport struct {
+	Status       doctorStatus     `json:"status"`
+	URL          string           `json:"url"`
+	HealthPath   string           `json:"healthPath"`
+	Sequential   int              `json:"sequentialProbes"`
+	Concurrent   int              `json:"concurrentProbes"`
+	Latency      doctorAppLatency `json:"latencyMs"`
+	FlipFlopRate float64          `json:"flipFlopRate"`
+	ClassCounts  map[string]int   `json:"classCounts"`
+	Findings     []doctorCheck    `json:"findings"`
+}
+
+// doctorAppClassOrder fixes the display/report order for failure-origin
+// counts so text and JSON output are stable across runs.
+var doctorAppClassOrder = []doctorAppFailureClass{
+	doctorAppFailureHealthy,
+	doctorAppFailurePlatformEdge,
+	doctorAppFailureAppOrigin,
+	doctorAppFailureTransport,
+	doctorAppFailureUnknown,
+}
+
+func buildDoctorAppReport(opts doctorAppOptions, results []doctorAppProbeResult) doctorAppReport {
+	counts := map[string]int{}
+	for _, r := range results {
+		counts[string(r.Class)]++
+	}
+	flipFlop := doctorAppFlipFlopRate(results)
+
+	report := doctorAppReport{
+		URL:          opts.URL,
+		HealthPath:   opts.HealthPath,
+		Sequential:   opts.Probes,
+		Concurrent:   opts.Concurrency,
+		Latency:      doctorAppLatencyStats(results),
+		FlipFlopRate: flipFlop,
+		ClassCounts:  counts,
+	}
+
+	total := len(results)
+	healthy := counts[string(doctorAppFailureHealthy)]
+	platformEdge := counts[string(doctorAppFailurePlatformEdge)]
+	appOrigin := counts[string(doctorAppFailureAppOrigin)]
+	transport := counts[string(doctorAppFailureTransport)]
+	unknown := counts[string(doctorAppFailureUnknown)]
+
+	var findings []doctorCheck
+	switch healthy {
+	case total:
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusOK,
+			Message: fmt.Sprintf("all %d probes returned a healthy 2xx response", total),
+		})
+	case 0:
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusError,
+			Message: fmt.Sprintf("0/%d probes were healthy — the service was unreachable or failing for the entire probe window", total),
+		})
+	default:
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("%d/%d probes were healthy; the rest failed during the probe window", healthy, total),
+		})
+	}
+	if platformEdge > 0 {
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("%d/%d probes classified as platform-edge (HTML error page; the request never reached the app)", platformEdge, total),
+			Fix:     "check the edge proxy or load balancer (health check config, timeouts, upstream target health), not the app",
+		})
+	}
+	if appOrigin > 0 {
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("%d/%d probes classified as app-origin (structured error from the app itself)", appOrigin, total),
+			Fix:     "check app logs for the reported error; under concurrency this often indicates lock/lease contention",
+		})
+	}
+	if transport > 0 {
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusError,
+			Message: fmt.Sprintf("%d/%d probes failed at the transport level (no HTTP response received)", transport, total),
+			Fix:     "check DNS, TLS, network reachability, or whether the app is running at all",
+		})
+	}
+	if unknown > 0 {
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("%d/%d probes returned a response that matched neither the platform-edge nor app-origin body shape", unknown, total),
+		})
+	}
+	if flipFlop > 0 {
+		findings = append(findings, doctorCheck{
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("health flip-flopped across the probe window (rate %.0f%%) — the service is not stably healthy", flipFlop*100),
+		})
+	}
+	report.Findings = findings
+
+	status := doctorStatusOK
+	for _, f := range findings {
+		status = worseDoctorStatus(status, f.Status)
+	}
+	report.Status = status
+	return report
+}
+
+func renderDoctorAppText(out io.Writer, report doctorAppReport) {
+	fmt.Fprintln(out, "wfctl doctor app")
+	fmt.Fprintf(out, "Overall: %s\n", report.Status)
+	fmt.Fprintf(out, "Target: %s%s\n", report.URL, report.HealthPath)
+	fmt.Fprintf(out, "Probes: %d sequential + %d concurrent\n", report.Sequential, report.Concurrent)
+	fmt.Fprintf(out, "Latency: p50=%.1fms p99=%.1fms\n", report.Latency.P50Ms, report.Latency.P99Ms)
+	fmt.Fprintf(out, "Flip-flop rate: %.0f%%\n", report.FlipFlopRate*100)
+
+	fmt.Fprintln(out, "\n[Failure origin]")
+	for _, class := range doctorAppClassOrder {
+		if count, ok := report.ClassCounts[string(class)]; ok {
+			fmt.Fprintf(out, "- %s: %d\n", class, count)
+		}
+	}
+
+	fmt.Fprintln(out, "\n[Findings]")
+	for _, f := range report.Findings {
+		fmt.Fprintf(out, "- %s %s\n", f.Status, f.Message)
+		if f.Fix != "" {
+			fmt.Fprintf(out, "  Fix: %s\n", f.Fix)
+		}
+	}
+}
+
+// runDoctorAppWithOutput implements "wfctl doctor app <url>". It is reached
+// only through runDoctor's dispatch on the literal "app" subcommand (see
+// doctor.go); there is no separate top-level "doctor-app" command wired into
+// main.go's commands map.
+func runDoctorAppWithOutput(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("doctor app", flag.ContinueOnError)
+	fs.SetOutput(out)
+	healthPath := fs.String("health-path", "/healthz", "Health check path to probe")
+	probes := fs.Int("probes", 5, "Number of sequential probes")
+	concurrency := fs.Int("concurrency", 3, "Number of lightly-concurrent probes fired after the sequential probes")
+	timeout := fs.Duration("timeout", 10*time.Second, "Per-request timeout")
+	format := fs.String("format", "text", "Output format: text or json")
+	strict := fs.Bool("strict", false, "Exit non-zero when warnings or errors are found")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage: wfctl doctor app <url> [options]
+
+Explicitly-online, read-only probe of a deployed app's health endpoint. Runs
+N sequential requests followed by M lightly-concurrent requests and reports
+latency spread (p50/p99), failure-origin classification (platform-edge HTML
+vs app-origin structured error), and health flip-flop rate across the probe
+window. Makes no state-changing requests.
+
+Options:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return fmt.Errorf("wfctl doctor app requires exactly one <url> argument, got %d", fs.NArg())
+	}
+	targetURL := fs.Arg(0)
+	if *probes < 1 {
+		return fmt.Errorf("--probes must be >= 1, got %d", *probes)
+	}
+	if *concurrency < 0 {
+		return fmt.Errorf("--concurrency must be >= 0, got %d", *concurrency)
+	}
+	if *timeout <= 0 {
+		return fmt.Errorf("--timeout must be > 0, got %s", *timeout)
+	}
+
+	opts := doctorAppOptions{
+		URL:         targetURL,
+		HealthPath:  *healthPath,
+		Probes:      *probes,
+		Concurrency: *concurrency,
+		Timeout:     *timeout,
+	}
+	client := &http.Client{Timeout: *timeout + time.Second} // safety net above the per-request context timeout
+	results := runDoctorAppProbes(context.Background(), client, opts)
+	report := buildDoctorAppReport(opts, results)
+
+	switch *format {
+	case "text":
+		renderDoctorAppText(out, report)
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return fmt.Errorf("encode doctor app report: %w", err)
+		}
+	default:
+		return fmt.Errorf("--format must be text or json, got %q", *format)
+	}
+
+	if *strict && report.Status != doctorStatusOK {
+		return fmt.Errorf("wfctl doctor app found %s diagnostics", report.Status)
+	}
+	return nil
+}

--- a/cmd/wfctl/doctor_app.go
+++ b/cmd/wfctl/doctor_app.go
@@ -80,6 +80,18 @@ func hasHTMLBodyShape(body []byte) bool {
 	return bytes.Contains(head, []byte("<html")) || bytes.Contains(head, []byte("<!doctype html"))
 }
 
+// normalizeHealthPath ensures path has a leading "/" before it is appended to
+// a base URL. Without this, a health path passed as "healthz" (no leading
+// slash) would concatenate directly onto the trimmed base URL with no
+// separator (e.g. "https://example.comhealthz"), producing an invalid URL
+// instead of a clear error.
+func normalizeHealthPath(path string) string {
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
+}
+
 // doctorAppProbeResult is one HTTP round trip against the health path.
 type doctorAppProbeResult struct {
 	Sequence   int
@@ -106,7 +118,7 @@ type doctorAppOptions struct {
 // caller-supplied URL, with no retries beyond what net/http already does at
 // the transport layer, and no request volume beyond N+M total.
 func runDoctorAppProbes(ctx context.Context, client *http.Client, opts doctorAppOptions) []doctorAppProbeResult {
-	target := strings.TrimRight(opts.URL, "/") + opts.HealthPath
+	target := strings.TrimRight(opts.URL, "/") + normalizeHealthPath(opts.HealthPath)
 	results := make([]doctorAppProbeResult, 0, opts.Probes+opts.Concurrency)
 
 	probeOnce := func(seq int, concurrent bool) doctorAppProbeResult {
@@ -129,8 +141,20 @@ func runDoctorAppProbes(ctx context.Context, client *http.Client, opts doctorApp
 			}
 		}
 		defer func() { _ = resp.Body.Close() }()
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		duration := time.Since(start)
+		if readErr != nil {
+			// A failed body read (truncated connection, mid-stream reset)
+			// leaves body incomplete; classifying against a partial body
+			// would misreport a transport failure as a healthy/platform-edge/
+			// app-origin response depending on what happened to be read
+			// before the failure. Report it as its own transport error
+			// instead of guessing from a partial read.
+			return doctorAppProbeResult{
+				Sequence: seq, Concurrent: concurrent, StartedAt: start,
+				Duration: duration, StatusCode: resp.StatusCode, Class: doctorAppFailureTransport, Err: readErr,
+			}
+		}
 		return doctorAppProbeResult{
 			Sequence:   seq,
 			Concurrent: concurrent,

--- a/cmd/wfctl/doctor_app_test.go
+++ b/cmd/wfctl/doctor_app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -264,6 +265,92 @@ func TestRunDoctorAppProbesTransportFailure(t *testing.T) {
 	}
 }
 
+func TestNormalizeHealthPath(t *testing.T) {
+	cases := map[string]string{
+		"/healthz": "/healthz",
+		"healthz":  "/healthz",
+		"":         "/",
+		"/":        "/",
+	}
+	for in, want := range cases {
+		if got := normalizeHealthPath(in); got != want {
+			t.Errorf("normalizeHealthPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestRunDoctorAppProbesHealthPathWithoutLeadingSlash proves the missing
+// separator is fixed end-to-end (not just in the unit-level
+// normalizeHealthPath): a --health-path value with no leading slash must
+// still hit the right route, not get silently concatenated onto the host.
+func TestRunDoctorAppProbesHealthPathWithoutLeadingSlash(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	results := runDoctorAppProbes(t.Context(), srv.Client(), doctorAppOptions{
+		URL: srv.URL, HealthPath: "healthz", Probes: 1, Concurrency: 0, Timeout: 5 * time.Second,
+	})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Class != doctorAppFailureHealthy {
+		t.Fatalf("class = %q, want healthy (request: %+v)", results[0].Class, results[0])
+	}
+	if gotPath != "/healthz" {
+		t.Fatalf("server saw path %q, want /healthz", gotPath)
+	}
+}
+
+// erroringBody is an io.ReadCloser that returns some bytes and then a fixed
+// error, simulating a truncated connection or mid-stream reset.
+type erroringBody struct {
+	remaining []byte
+	err       error
+}
+
+func (b *erroringBody) Read(p []byte) (int, error) {
+	if len(b.remaining) == 0 {
+		return 0, b.err
+	}
+	n := copy(p, b.remaining)
+	b.remaining = b.remaining[n:]
+	return n, nil
+}
+
+func (b *erroringBody) Close() error { return nil }
+
+// TestRunDoctorAppProbesBodyReadFailureIsTransportError proves a failed body
+// read (as opposed to a failed request/connection) is reported as its own
+// transport error rather than silently classifying against whatever partial
+// bytes were read before the failure.
+func TestRunDoctorAppProbesBodyReadFailureIsTransportError(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       &erroringBody{remaining: []byte(`{"stat`), err: io.ErrUnexpectedEOF},
+			}, nil
+		}),
+	}
+	results := runDoctorAppProbes(t.Context(), client, doctorAppOptions{
+		URL: "http://example.invalid", HealthPath: "/healthz", Probes: 1, Concurrency: 0, Timeout: time.Second,
+	})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Class != doctorAppFailureTransport {
+		t.Fatalf("class = %q, want transport-error (body read failed)", results[0].Class)
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected a non-nil Err when the body read fails")
+	}
+}
+
 func TestBuildDoctorAppReportAllHealthy(t *testing.T) {
 	results := []doctorAppProbeResult{
 		{Class: doctorAppFailureHealthy, StartedAt: time.Now(), Duration: 10 * time.Millisecond},
@@ -356,7 +443,14 @@ func TestDoctorAppCLIEndToEndTextAndJSON(t *testing.T) {
 	}
 }
 
-func TestDoctorAppStrictExitsNonZeroOnWarn(t *testing.T) {
+// TestDoctorAppStrictExitsNonZeroOnError covers the total-outage case: 0/1
+// probes healthy, which buildDoctorAppReport marks ERROR. Renamed from a
+// Copilot review finding on the upstream PR: the previous name and comment
+// said "WARN" for this exact fixture, but a single always-failing probe is
+// 0/1 healthy, i.e. ERROR, not WARN — see TestDoctorAppStrictExitsNonZeroOnGenuineWarn
+// below for the actual WARN case (partial degradation), which this fixture
+// never exercised.
+func TestDoctorAppStrictExitsNonZeroOnError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusBadGateway)
@@ -367,7 +461,37 @@ func TestDoctorAppStrictExitsNonZeroOnWarn(t *testing.T) {
 	var out bytes.Buffer
 	err := runDoctorAppWithOutput([]string{"--probes", "1", "--concurrency", "0", "--strict", srv.URL}, &out)
 	if err == nil {
+		t.Fatal("expected --strict to return an error on an ERROR report")
+	}
+	if !strings.Contains(out.String(), "Overall: ERROR") {
+		t.Fatalf("expected this fixture to actually produce ERROR, got:\n%s", out.String())
+	}
+}
+
+// TestDoctorAppStrictExitsNonZeroOnGenuineWarn covers partial degradation
+// (some probes healthy, some not) — the real WARN case that
+// TestDoctorAppStrictExitsNonZeroOnError's name previously claimed to cover
+// but didn't.
+func TestDoctorAppStrictExitsNonZeroOnGenuineWarn(t *testing.T) {
+	var count atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if count.Add(1) <= 2 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(edgeShapeNginxDefault))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := runDoctorAppWithOutput([]string{"--probes", "4", "--concurrency", "0", "--strict", srv.URL}, &out)
+	if err == nil {
 		t.Fatal("expected --strict to return an error on a WARN report")
+	}
+	if !strings.Contains(out.String(), "Overall: WARN") {
+		t.Fatalf("expected a genuine WARN report, got:\n%s", out.String())
 	}
 }
 

--- a/cmd/wfctl/doctor_app_test.go
+++ b/cmd/wfctl/doctor_app_test.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Real-world platform-edge default error page shapes. Each is HTML with a
+// non-2xx status and no JSON content-type — the generic body-shape/
+// content-type heuristic in classifyAppProbeFailure must classify all three
+// identically as platform-edge without any provider-specific matching, which
+// is exactly what these three regression fixtures prove.
+
+const edgeShapeDigitalOceanViaUpstream = `<html>
+<head><title>504 Gateway Time-out</title></head>
+<body>
+<center><h1>504 Gateway Time-out</h1></center>
+<hr><center>via_upstream</center>
+</body>
+</html>
+`
+
+const edgeShapeAWSALBDefault = `<html>
+<head><title>503 Service Temporarily Unavailable</title></head>
+<body bgcolor="white">
+<center><h1>503 Service Temporarily Unavailable</h1></center>
+</body>
+</html>
+`
+
+const edgeShapeNginxDefault = `<html>
+<head><title>502 Bad Gateway</title></head>
+<body>
+<center><h1>502 Bad Gateway</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+`
+
+const appOriginBusyJSON = `{"error":"auth state busy","retryAfter":1}`
+
+func TestClassifyAppProbeFailureHealthy(t *testing.T) {
+	class := classifyAppProbeFailure(200, "application/json", []byte(`{"status":"ok"}`))
+	if class != doctorAppFailureHealthy {
+		t.Fatalf("class = %q, want healthy", class)
+	}
+}
+
+func TestClassifyAppProbeFailurePlatformEdgeShapes(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+	}{
+		{"digitalocean_via_upstream", 504, "text/html", edgeShapeDigitalOceanViaUpstream},
+		{"aws_alb_default", 503, "text/html", edgeShapeAWSALBDefault},
+		{"nginx_default", 502, "text/html", edgeShapeNginxDefault},
+		{"html_body_no_content_type_header", 502, "", edgeShapeNginxDefault},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			class := classifyAppProbeFailure(tc.status, tc.contentType, []byte(tc.body))
+			if class != doctorAppFailurePlatformEdge {
+				t.Fatalf("class = %q, want platform-edge", class)
+			}
+		})
+	}
+}
+
+func TestClassifyAppProbeFailureAppOrigin(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+	}{
+		{"explicit_json_content_type", "application/json"},
+		{"no_content_type_but_json_body", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			class := classifyAppProbeFailure(503, tc.contentType, []byte(appOriginBusyJSON))
+			if class != doctorAppFailureAppOrigin {
+				t.Fatalf("class = %q, want app-origin", class)
+			}
+		})
+	}
+}
+
+func TestClassifyAppProbeFailureUnknown(t *testing.T) {
+	class := classifyAppProbeFailure(500, "text/plain", []byte("internal error, try again"))
+	if class != doctorAppFailureUnknown {
+		t.Fatalf("class = %q, want unknown", class)
+	}
+}
+
+func TestClassifyAppProbeFailureEmptyBody(t *testing.T) {
+	class := classifyAppProbeFailure(500, "", nil)
+	if class != doctorAppFailureUnknown {
+		t.Fatalf("class = %q, want unknown for empty body with no content-type", class)
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	sorted := []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	if p50 := percentile(sorted, 0.5); p50 != 55 {
+		t.Fatalf("p50 = %v, want 55", p50)
+	}
+	if p99 := percentile(sorted, 0.99); p99 < 99 || p99 > 100 {
+		t.Fatalf("p99 = %v, want in [99,100]", p99)
+	}
+	if got := percentile(nil, 0.5); got != 0 {
+		t.Fatalf("percentile(nil) = %v, want 0", got)
+	}
+	if got := percentile([]float64{42}, 0.99); got != 42 {
+		t.Fatalf("percentile(single) = %v, want 42", got)
+	}
+}
+
+func TestDoctorAppFlipFlopRate(t *testing.T) {
+	healthy := func(seq int, at time.Time) doctorAppProbeResult {
+		return doctorAppProbeResult{Sequence: seq, StartedAt: at, Class: doctorAppFailureHealthy}
+	}
+	unhealthy := func(seq int, at time.Time) doctorAppProbeResult {
+		return doctorAppProbeResult{Sequence: seq, StartedAt: at, Class: doctorAppFailurePlatformEdge}
+	}
+	base := time.Now()
+	at := func(offset int) time.Time { return base.Add(time.Duration(offset) * time.Millisecond) }
+
+	stable := []doctorAppProbeResult{healthy(0, at(0)), healthy(1, at(1)), healthy(2, at(2))}
+	if rate := doctorAppFlipFlopRate(stable); rate != 0 {
+		t.Fatalf("stable healthy rate = %v, want 0", rate)
+	}
+
+	allFlip := []doctorAppProbeResult{healthy(0, at(0)), unhealthy(1, at(1)), healthy(2, at(2)), unhealthy(3, at(3))}
+	if rate := doctorAppFlipFlopRate(allFlip); rate != 1 {
+		t.Fatalf("alternating rate = %v, want 1", rate)
+	}
+
+	oneFlip := []doctorAppProbeResult{healthy(0, at(0)), healthy(1, at(1)), unhealthy(2, at(2)), unhealthy(3, at(3))}
+	if rate := doctorAppFlipFlopRate(oneFlip); rate != 1.0/3.0 {
+		t.Fatalf("one-flip rate = %v, want %v", rate, 1.0/3.0)
+	}
+
+	if rate := doctorAppFlipFlopRate(nil); rate != 0 {
+		t.Fatalf("empty rate = %v, want 0", rate)
+	}
+	if rate := doctorAppFlipFlopRate([]doctorAppProbeResult{healthy(0, at(0))}); rate != 0 {
+		t.Fatalf("single-result rate = %v, want 0", rate)
+	}
+
+	// Ordering by StartedAt (not by Sequence/append order) must drive the
+	// transition count, since sequential and concurrent probes are appended
+	// in phase order, not timeline order.
+	outOfOrder := []doctorAppProbeResult{unhealthy(1, at(5)), healthy(0, at(0))}
+	if rate := doctorAppFlipFlopRate(outOfOrder); rate != 1 {
+		t.Fatalf("out-of-append-order rate = %v, want 1 (started-at order: healthy then unhealthy)", rate)
+	}
+}
+
+// TestRunDoctorAppProbesAgainstHealthyServer exercises the full HTTP path
+// (sequential + concurrent phases) against a real httptest server that is
+// always healthy, verifying probe counts and classification end-to-end.
+func TestRunDoctorAppProbesAgainstHealthyServer(t *testing.T) {
+	var requestCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if r.URL.Path != "/healthz" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	results := runDoctorAppProbes(t.Context(), srv.Client(), doctorAppOptions{
+		URL: srv.URL, HealthPath: "/healthz", Probes: 4, Concurrency: 3, Timeout: 5 * time.Second,
+	})
+	if len(results) != 7 {
+		t.Fatalf("got %d results, want 7", len(results))
+	}
+	if got := requestCount.Load(); got != 7 {
+		t.Fatalf("server saw %d requests, want 7", got)
+	}
+	sequential, concurrent := 0, 0
+	for _, r := range results {
+		if r.Class != doctorAppFailureHealthy {
+			t.Errorf("result %+v: class = %q, want healthy", r, r.Class)
+		}
+		if r.Concurrent {
+			concurrent++
+		} else {
+			sequential++
+		}
+	}
+	if sequential != 4 || concurrent != 3 {
+		t.Fatalf("sequential=%d concurrent=%d, want 4/3", sequential, concurrent)
+	}
+}
+
+// TestRunDoctorAppProbesAgainstEdgeAndAppOriginFailures runs the real HTTP
+// path against a server alternating between the three platform-edge fixture
+// shapes and an app-origin JSON error, proving classification survives an
+// actual round trip (headers, body reading, status codes) and not just the
+// pure classifier function.
+func TestRunDoctorAppProbesAgainstEdgeAndAppOriginFailures(t *testing.T) {
+	responses := []struct {
+		status      int
+		contentType string
+		body        string
+	}{
+		{504, "text/html", edgeShapeDigitalOceanViaUpstream},
+		{503, "text/html", edgeShapeAWSALBDefault},
+		{502, "text/html", edgeShapeNginxDefault},
+		{503, "application/json", appOriginBusyJSON},
+	}
+	var idx atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		i := int(idx.Add(1)-1) % len(responses)
+		resp := responses[i]
+		w.Header().Set("Content-Type", resp.contentType)
+		w.WriteHeader(resp.status)
+		_, _ = w.Write([]byte(resp.body))
+	}))
+	defer srv.Close()
+
+	results := runDoctorAppProbes(t.Context(), srv.Client(), doctorAppOptions{
+		URL: srv.URL, HealthPath: "/healthz", Probes: 4, Concurrency: 0, Timeout: 5 * time.Second,
+	})
+	if len(results) != 4 {
+		t.Fatalf("got %d results, want 4", len(results))
+	}
+	want := []doctorAppFailureClass{
+		doctorAppFailurePlatformEdge,
+		doctorAppFailurePlatformEdge,
+		doctorAppFailurePlatformEdge,
+		doctorAppFailureAppOrigin,
+	}
+	for i, r := range results {
+		if r.Class != want[i] {
+			t.Errorf("result[%d] class = %q, want %q", i, r.Class, want[i])
+		}
+	}
+}
+
+func TestRunDoctorAppProbesTransportFailure(t *testing.T) {
+	results := runDoctorAppProbes(t.Context(), http.DefaultClient, doctorAppOptions{
+		URL: "http://127.0.0.1:1", HealthPath: "/healthz", Probes: 1, Concurrency: 0, Timeout: time.Second,
+	})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Class != doctorAppFailureTransport {
+		t.Fatalf("class = %q, want transport-error", results[0].Class)
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected a non-nil Err for a transport failure")
+	}
+}
+
+func TestBuildDoctorAppReportAllHealthy(t *testing.T) {
+	results := []doctorAppProbeResult{
+		{Class: doctorAppFailureHealthy, StartedAt: time.Now(), Duration: 10 * time.Millisecond},
+		{Class: doctorAppFailureHealthy, StartedAt: time.Now(), Duration: 12 * time.Millisecond},
+	}
+	report := buildDoctorAppReport(doctorAppOptions{Probes: 2}, results)
+	if report.Status != doctorStatusOK {
+		t.Fatalf("status = %q, want OK", report.Status)
+	}
+	if report.FlipFlopRate != 0 {
+		t.Fatalf("flip-flop rate = %v, want 0", report.FlipFlopRate)
+	}
+}
+
+func TestBuildDoctorAppReportTotalOutageIsError(t *testing.T) {
+	results := []doctorAppProbeResult{
+		{Class: doctorAppFailureTransport, StartedAt: time.Now()},
+		{Class: doctorAppFailureTransport, StartedAt: time.Now()},
+	}
+	report := buildDoctorAppReport(doctorAppOptions{Probes: 2}, results)
+	if report.Status != doctorStatusError {
+		t.Fatalf("status = %q, want ERROR", report.Status)
+	}
+}
+
+func TestBuildDoctorAppReportMixedIsWarn(t *testing.T) {
+	results := []doctorAppProbeResult{
+		{Class: doctorAppFailureHealthy, StartedAt: time.Now()},
+		{Class: doctorAppFailurePlatformEdge, StartedAt: time.Now().Add(time.Millisecond)},
+	}
+	report := buildDoctorAppReport(doctorAppOptions{Probes: 2}, results)
+	if report.Status != doctorStatusWarn {
+		t.Fatalf("status = %q, want WARN", report.Status)
+	}
+	foundPlatformEdgeFinding := false
+	for _, f := range report.Findings {
+		if strings.Contains(f.Message, "platform-edge") {
+			foundPlatformEdgeFinding = true
+		}
+	}
+	if !foundPlatformEdgeFinding {
+		t.Fatalf("expected a platform-edge finding, got %+v", report.Findings)
+	}
+}
+
+// TestDoctorAppCLIEndToEndTextAndJSON drives runDoctorAppWithOutput exactly
+// as the CLI would, against a real server that is always unhealthy in the
+// platform-edge shape, verifying flag parsing, text rendering, and JSON
+// encoding together. Overall status is ERROR (not just WARN) because zero of
+// the probes were healthy across the whole window — the platform-edge
+// classification is an additional diagnostic detail about *why*, not a
+// downgrade of that severity.
+func TestDoctorAppCLIEndToEndTextAndJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(edgeShapeNginxDefault))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := runDoctorAppWithOutput([]string{
+		"--probes", "2", "--concurrency", "0", "--timeout", "2s", srv.URL,
+	}, &out)
+	if err != nil {
+		t.Fatalf("doctor app: %v\n%s", err, out.String())
+	}
+	for _, want := range []string{"wfctl doctor app", "Overall: ERROR", "platform-edge: 2", "Fix:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("text output missing %q:\n%s", want, out.String())
+		}
+	}
+
+	var jsonOut bytes.Buffer
+	err = runDoctorAppWithOutput([]string{
+		"--probes", "2", "--concurrency", "0", "--timeout", "2s", "--format", "json", srv.URL,
+	}, &jsonOut)
+	if err != nil {
+		t.Fatalf("doctor app json: %v\n%s", err, jsonOut.String())
+	}
+	var report doctorAppReport
+	if err := json.Unmarshal(jsonOut.Bytes(), &report); err != nil {
+		t.Fatalf("doctor app output is not valid JSON: %v\n%s", err, jsonOut.String())
+	}
+	if report.Status != doctorStatusError {
+		t.Fatalf("json status = %q, want ERROR", report.Status)
+	}
+	if report.ClassCounts["platform-edge"] != 2 {
+		t.Fatalf("json classCounts[platform-edge] = %d, want 2", report.ClassCounts["platform-edge"])
+	}
+}
+
+func TestDoctorAppStrictExitsNonZeroOnWarn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(edgeShapeNginxDefault))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := runDoctorAppWithOutput([]string{"--probes", "1", "--concurrency", "0", "--strict", srv.URL}, &out)
+	if err == nil {
+		t.Fatal("expected --strict to return an error on a WARN report")
+	}
+}
+
+func TestDoctorAppRequiresURLArgument(t *testing.T) {
+	var out bytes.Buffer
+	err := runDoctorAppWithOutput([]string{"--probes", "1"}, &out)
+	if err == nil {
+		t.Fatal("expected an error when no URL is given")
+	}
+}
+
+func TestDoctorAppRejectsInvalidFlagValues(t *testing.T) {
+	cases := [][]string{
+		{"--probes", "0", "http://example.com"},
+		{"--concurrency", "-1", "http://example.com"},
+		{"--timeout", "0s", "http://example.com"},
+	}
+	for _, args := range cases {
+		var out bytes.Buffer
+		if err := runDoctorAppWithOutput(args, &out); err == nil {
+			t.Fatalf("args %v: expected an error", args)
+		}
+	}
+}
+
+func TestDoctorAppRejectsInvalidFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := runDoctorAppWithOutput([]string{"--probes", "1", "--format", "yaml", srv.URL}, &out)
+	if err == nil {
+		t.Fatal("expected an error for an unsupported --format value")
+	}
+}
+
+// TestDoctorDispatchesAppSubcommand proves "wfctl doctor app <url>" reaches
+// the app-probe path through the top-level doctor entrypoint, not just
+// through runDoctorAppWithOutput directly.
+func TestDoctorDispatchesAppSubcommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := runDoctorWithOutput([]string{"app", "--probes", "1", "--concurrency", "0", srv.URL}, &out)
+	if err != nil {
+		t.Fatalf("doctor app dispatch: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "wfctl doctor app") {
+		t.Fatalf("expected doctor to dispatch to the app probe, got:\n%s", out.String())
+	}
+}

--- a/decisions/0054-doctor-app-probe-and-lockio-analyzer.md
+++ b/decisions/0054-doctor-app-probe-and-lockio-analyzer.md
@@ -1,0 +1,81 @@
+# 0054. Add `wfctl doctor app` probe and `lint/lockio` analyzer
+
+**Status:** Proposed — pending GoCodeAlone maintainer sign-off (see Scope note below)
+**Date:** 2026-07-04
+**Decision-makers:** codingsloth@pm.me (directed), Claude (Fable 5)
+**Related:** `decisions/0052-top-level-wfctl-doctor.md`, `GoCodeAlone/workflow-compute` `docs/plans/2026-07-04-durable-mutation-lifecycle-design.md` ("Upstream Guards" U1/U2)
+
+## Context
+
+A workflow-compute staging incident traced to a lock held across a slow store
+write, starving unrelated requests. Diagnosing it cost hours largely because
+two very different failure shapes looked identical from the outside: an edge
+proxy's own HTML error page (the request never reached the app) versus the
+app's own JSON structured error (the request reached the app, which was
+busy/contended). The same incident's fix relied on an in-repo `go/ast` checker
+that enforces "every lock acquisition has a release on every return path,"
+including a goroutine-opaque traversal bug found and fixed during review (a
+release call fired only inside an unawaited `go func(){}()` must not count as
+covering the return path).
+
+Both pieces are generic problems, not specific to workflow-compute:
+
+1. Distinguishing a platform-edge failure from an app-origin failure by
+   content-type/body-shape applies to any deployed HTTP app behind any edge
+   proxy.
+2. "No lock held across store I/O," and the specific goroutine-traversal bug
+   class, applies to any Go codebase using a begin/release critical-section
+   idiom, not just this one app's method names.
+
+## Decision
+
+Add two independent pieces to this repo:
+
+- **`wfctl doctor app <url>`** (`cmd/wfctl/doctor_app.go`): a new subcommand
+  under the existing `doctor` command. It runs N sequential + M
+  lightly-concurrent GET requests against `<url><health-path>` and reports
+  per-request latency (p50/p99), failure-origin classification
+  (platform-edge HTML vs. app-origin JSON, using content-type/body-shape
+  heuristics only — no provider-specific logic), and health flip-flop rate.
+  Flags follow existing `doctor` conventions: `--health-path`, `--probes`,
+  `--concurrency`, `--timeout`, `--format text|json`, `--strict`.
+- **`lint/lockio`** (`lint/lockio/`): a new top-level package containing a
+  `go/analysis`-style checker (`lockio.NewAnalyzer`) parameterized by
+  `Config{AcquireMethods, ReleaseMethods, RestrictedIOMethods,
+  PermanentIOCallers, PermanentReturnPathFunctions}` — all plain method-name
+  sets, no hardcoded vocabulary. It ports the workflow-compute checker's two
+  violation classes and the goroutine-opaque traversal fix, with a lower-level
+  `FindViolations` function for consumers who want to build their own
+  shrink-only allowlist test on top of it, plus the `analysis.Analyzer`
+  wiring for consumers who want to plug it into `golangci-lint`, `go vet`, or
+  a standalone checker binary.
+
+## Scope note (flagged for maintainer sign-off)
+
+ADR 0052 scoped `wfctl doctor` explicitly to checkout-only diagnostics
+("must avoid network access unless explicitly requested"). `doctor app` is a
+new, explicitly-invoked (`doctor app <url>`, not a flag on the base command)
+online mode that goes beyond that remit: it makes real HTTP requests to an
+operator-supplied URL. This is a deliberate scope expansion, not an oversight,
+and is called out here for maintainer review rather than assumed.
+
+Separately, `lint/` is a new top-level directory. `docs/REPO_LAYOUT.md`'s Main
+Roots table did not have a home for reusable static-analysis tooling before
+this change; `lint/lockio` is the first package there. The path and package
+name are a proposal (`lint/lockio` per the workflow-compute design doc), not a
+fixed requirement — happy to relocate under maintainer guidance if a different
+location fits the repo's conventions better.
+
+## Consequences
+
+Operators get a single command to distinguish "the edge is broken" from "the
+app is broken" during an incident instead of manually inspecting response
+bodies. Any host app on this framework can adopt `lint/lockio` for its own
+lock/lease-across-I/O invariant instead of hand-rolling the checker, as
+workflow-compute did. workflow-compute's own copy of this checker
+(`internal/server/mutation_lifecycle_guard_test.go`) is tracked to swap to
+this package in a follow-up once released, per its own FOLLOWUPS expiry row.
+
+Rollback is simple: remove `cmd/wfctl/doctor_app.go`, the `app` dispatch
+branch in `cmd/wfctl/doctor.go`, the `lint/` directory, and the associated
+docs/tests; no other command or package depends on either addition.

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -17,6 +17,7 @@ application directories at the root.
 | `plugins/` | Built-in engine plugins. |
 | `plugin/` | Plugin SDK, manifests, external plugin adapters, and contracts. |
 | `cigen/` | Config-derived CI plan analyzer and built-in renderers. |
+| `lint/` | Reusable go/analysis-style static checkers, parameterized for use by any Workflow host app (e.g. `lint/lockio`). |
 | `iac/`, `infra/`, `platform/`, `provider/` | Infrastructure planning, provider, and platform abstractions. |
 | `ui/` | React visual builder. |
 | `mcp/` | MCP server and tools. |

--- a/docs/WFCTL.md
+++ b/docs/WFCTL.md
@@ -446,6 +446,54 @@ wfctl plugin install
 wfctl update --check
 ```
 
+#### `doctor app` — deployed-app probe
+
+Explicitly-online, read-only probe of a deployed app's health endpoint. Unlike
+plain `wfctl doctor`, which only inspects the local checkout (ADR 0052), this
+subcommand makes real HTTP requests to a URL you provide. It runs N sequential
+requests followed by M lightly-concurrent requests and reports per-request
+latency spread, failure-origin classification, and health flip-flop rate.
+
+```bash
+wfctl doctor app <url> [options]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--health-path` | `/healthz` | Path appended to `<url>` for each probe |
+| `--probes` | `5` | Number of sequential probes |
+| `--concurrency` | `3` | Number of lightly-concurrent probes fired after the sequential probes |
+| `--timeout` | `10s` | Per-request timeout |
+| `--format` | `text` | `text` or `json` |
+| `--strict` | `false` | Exit non-zero on warnings or errors |
+
+Each probe response is classified by content-type and body shape only — never
+by provider-specific markers:
+
+- **healthy**: a 2xx response.
+- **platform-edge**: a non-2xx response with an HTML body. The request never
+  reached the app; a reverse proxy or load balancer answered with its own
+  default error page (DigitalOcean App Platform, AWS ALB, and nginx all
+  default to an HTML error page in this shape).
+- **app-origin**: a non-2xx response with a JSON body. The request reached the
+  app, which returned its own structured error.
+- **transport-error**: no HTTP response was received at all (connection
+  refused, timeout, DNS/TLS failure).
+- **unknown**: a response that matched neither body shape.
+
+This distinction is the one that costs the most debugging time in practice: an
+edge proxy's HTML error page and the app's own JSON error both surface to a
+human as "the health check failed," but they point at completely different
+places to look next.
+
+Examples:
+
+```bash
+wfctl doctor app https://staging.example.com
+wfctl doctor app https://staging.example.com --health-path /health --probes 10 --concurrency 5
+wfctl doctor app https://staging.example.com --format json --strict
+```
+
 ### `repair`
 
 Plan or apply safe lifecycle repairs for the local project. The command is

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/text v0.38.0
 	golang.org/x/time v0.15.0
+	golang.org/x/tools v0.46.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -255,7 +256,6 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
-	golang.org/x/tools v0.46.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260622175928-b703f567277d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/lint/lockio/lockio.go
+++ b/lint/lockio/lockio.go
@@ -17,13 +17,13 @@
 // The checker enforces two independent rules, both driven purely by method
 // name — no lock-state data-flow tracking, no type information:
 //
-//  1. Restricted I/O (Class ClassRestrictedIO): a call to one of
+//  1. Restricted I/O (ClassRestrictedIO): a call to one of
 //     Config.RestrictedIOMethods is flagged unless the enclosing function is
 //     listed in Config.PermanentIOCallers. These methods are assumed to do
 //     I/O directly under the assumption that the caller already holds the
 //     lock; only sanctioned wrapper functions (or storage backends with no
 //     separable lock/I-O split) should call them.
-//  2. Uncovered return paths (Class ClassUncoveredReturnPath): once a
+//  2. Uncovered return paths (ClassUncoveredReturnPath): once a
 //     function calls one of Config.AcquireMethods using the idiom
 //     `v, err := recv.Acquire(...); if err != nil { return ... }`, every
 //     return path reachable afterward must pass through a call to one of
@@ -33,12 +33,12 @@
 //     with no guarantee of running before (or ever, relative to) the
 //     enclosing function's return.
 //
-// Scope note: Class ClassUncoveredReturnPath checks release-path
+// Scope note: ClassUncoveredReturnPath checks release-path
 // completeness for the acquire idiom above — it does not itself detect I/O
 // happening between a Lock() call and a deferred Unlock(), since a
 // `defer mu.Unlock()` trivially covers every return path by construction. A
 // plain sync.Mutex Lock()/defer Unlock() wrapping a restricted I/O call is
-// still caught, but by Class ClassRestrictedIO (list the I/O method in
+// still caught, but by ClassRestrictedIO (list the I/O method in
 // Config.RestrictedIOMethods), not by ClassUncoveredReturnPath. A cross-repo
 // sweep of Workflow ecosystem code found this exact shape — a lock held
 // across a slow I/O call via Lock()/defer Unlock(), contending with a

--- a/lint/lockio/lockio.go
+++ b/lint/lockio/lockio.go
@@ -32,6 +32,19 @@
 //     inside an unawaited `go func(){ ... }()` does not count: it returns
 //     with no guarantee of running before (or ever, relative to) the
 //     enclosing function's return.
+//
+// Scope note: Class ClassUncoveredReturnPath checks release-path
+// completeness for the acquire idiom above — it does not itself detect I/O
+// happening between a Lock() call and a deferred Unlock(), since a
+// `defer mu.Unlock()` trivially covers every return path by construction. A
+// plain sync.Mutex Lock()/defer Unlock() wrapping a restricted I/O call is
+// still caught, but by Class ClassRestrictedIO (list the I/O method in
+// Config.RestrictedIOMethods), not by ClassUncoveredReturnPath. A cross-repo
+// sweep of Workflow ecosystem code found this exact shape — a lock held
+// across a slow I/O call via Lock()/defer Unlock(), contending with a
+// hot-path caller of the same lock — in at least nine instances beyond the
+// workflow-compute incident that motivated this package; see
+// lockio_test.go's "ecosystem shape" fixtures.
 package lockio
 
 import (

--- a/lint/lockio/lockio.go
+++ b/lint/lockio/lockio.go
@@ -1,0 +1,184 @@
+// Package lockio provides a go/analysis-style checker that flags a lock (or
+// lease) held across a store I/O round trip. It generalizes a checker
+// originally written directly inside a Workflow host app's test suite to
+// enforce "no lock held across store I/O" for one specific set of method
+// names; this package makes the same detection logic reusable by any host
+// app, parameterized entirely by method name.
+//
+// Background: a staging incident traced to a lock held while a slow store
+// write ran, starving unrelated requests behind it, and was made worse
+// because the two symptom shapes it produced — a platform edge proxy's own
+// HTML error page, and the app's own structured error once contention
+// resolved — looked identical from the outside for hours. See
+// https://github.com/GoCodeAlone/workflow-compute
+// (docs/plans/2026-07-04-durable-mutation-lifecycle-design.md, "Upstream
+// Guards" U2) for the full incident writeup that motivated this package.
+//
+// The checker enforces two independent rules, both driven purely by method
+// name — no lock-state data-flow tracking, no type information:
+//
+//  1. Restricted I/O (Class ClassRestrictedIO): a call to one of
+//     Config.RestrictedIOMethods is flagged unless the enclosing function is
+//     listed in Config.PermanentIOCallers. These methods are assumed to do
+//     I/O directly under the assumption that the caller already holds the
+//     lock; only sanctioned wrapper functions (or storage backends with no
+//     separable lock/I-O split) should call them.
+//  2. Uncovered return paths (Class ClassUncoveredReturnPath): once a
+//     function calls one of Config.AcquireMethods using the idiom
+//     `v, err := recv.Acquire(...); if err != nil { return ... }`, every
+//     return path reachable afterward must pass through a call to one of
+//     Config.ReleaseMethods before returning, unless the enclosing function
+//     is listed in Config.PermanentReturnPathFunctions. A release call
+//     inside an unawaited `go func(){ ... }()` does not count: it returns
+//     with no guarantee of running before (or ever, relative to) the
+//     enclosing function's return.
+package lockio
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Class identifies which rule a Violation broke.
+type Class string
+
+const (
+	// ClassRestrictedIO marks a call to a RestrictedIOMethods entry from a
+	// function not listed in PermanentIOCallers.
+	ClassRestrictedIO Class = "restricted-io"
+	// ClassUncoveredReturnPath marks a return path reachable after an
+	// AcquireMethods call that is not covered by a synchronous
+	// ReleaseMethods call.
+	ClassUncoveredReturnPath Class = "uncovered-return-path"
+)
+
+// Config parameterizes the checker for one host codebase's lock/lease and
+// store-I/O method names. All four method-name sets are matched against the
+// selector name of a call expression (e.g. "Save" for `a.Save()`); receiver
+// type is not checked, so pick names specific enough to a single codebase's
+// convention to avoid false matches on unrelated types.
+type Config struct {
+	// AcquireMethods are method names whose call, recognized only via the
+	// idiom `v, err := recv.Method(...); if err != nil { return ... }`,
+	// begins a critical section that must be closed by a ReleaseMethods call
+	// on every path reachable afterward.
+	AcquireMethods map[string]bool
+
+	// ReleaseMethods are method names that legitimately end a critical
+	// section opened by an AcquireMethods call — by committing, aborting, or
+	// otherwise releasing the lock/lease.
+	ReleaseMethods map[string]bool
+
+	// RestrictedIOMethods are method names that perform store I/O directly,
+	// assuming a lock/lease is already held. A RestrictedIOMethods entry
+	// that should also satisfy the ReleaseMethods requirement (i.e. calling
+	// it does complete the critical section, even when the call site itself
+	// is separately flagged as unsanctioned) must be listed in both maps;
+	// the two sets are independent by design.
+	RestrictedIOMethods map[string]bool
+
+	// PermanentIOCallers are function/method names allowed to call
+	// RestrictedIOMethods directly: structural exceptions such as the
+	// sanctioned release helper itself, or a storage backend with no
+	// separate lock/I-O split — not migration debt, not expected to shrink.
+	PermanentIOCallers map[string]bool
+
+	// PermanentReturnPathFunctions are function names exempt from the
+	// uncovered-return-path check: verified safe by means outside this
+	// checker's single-function, block-scoped reach (for example, a boolean
+	// flag set immediately before an unconditional release call two
+	// statements earlier that the checker cannot correlate back).
+	PermanentReturnPathFunctions map[string]bool
+}
+
+func (c Config) isAcquire(name string) bool        { return name != "" && c.AcquireMethods[name] }
+func (c Config) isRelease(name string) bool        { return name != "" && c.ReleaseMethods[name] }
+func (c Config) isRestrictedIO(name string) bool   { return name != "" && c.RestrictedIOMethods[name] }
+func (c Config) permanentIOCaller(n string) bool   { return c.PermanentIOCallers[n] }
+func (c Config) permanentReturnPath(n string) bool { return c.PermanentReturnPathFunctions[n] }
+
+// Violation is one finding from FindViolations (or an Analyzer built with
+// NewAnalyzer).
+type Violation struct {
+	Pos   token.Pos
+	File  string // base name, e.g. "server.go"
+	Func  string // enclosing function/method name
+	Class Class
+}
+
+// Key returns a stable identity for the violation independent of line
+// number, in the form "file|class|func". Host apps can use this to build a
+// shrink-only allowlist test the way workflow-compute's original guard test
+// did: fail loudly both on an undocumented new violation and on a stale
+// allowlist entry that no longer violates.
+func (v Violation) Key() string {
+	return v.File + "|" + string(v.Class) + "|" + v.Func
+}
+
+// FindViolations scans already-parsed files sharing fset for both violation
+// classes using cfg. Files may come from a single package or be scanned
+// independently; each file is analyzed on its own (no cross-file call
+// resolution), matching the original checker's per-file design.
+func FindViolations(fset *token.FileSet, files []*ast.File, cfg Config) []Violation {
+	var violations []Violation
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			name := fn.Name.Name
+			fileName := filepath.Base(fset.Position(fn.Pos()).Filename)
+
+			if callsRestrictedIO(fn.Body, cfg) && !cfg.permanentIOCaller(name) {
+				violations = append(violations, Violation{
+					Pos: fn.Pos(), File: fileName, Func: name, Class: ClassRestrictedIO,
+				})
+			}
+
+			if cfg.isAcquire(name) {
+				continue // the acquire method's own definition is not a call site
+			}
+			if cfg.permanentReturnPath(name) {
+				continue
+			}
+			if acquireReturnPathUncovered(fn, cfg) {
+				violations = append(violations, Violation{
+					Pos: fn.Pos(), File: fileName, Func: name, Class: ClassUncoveredReturnPath,
+				})
+			}
+		}
+	}
+	return violations
+}
+
+// NewAnalyzer builds a go/analysis.Analyzer named name that reports both
+// violation classes from cfg via pass.Reportf at each violation's function
+// declaration position.
+func NewAnalyzer(name, doc string, cfg Config) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: name,
+		Doc:  doc,
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			for _, v := range FindViolations(pass.Fset, pass.Files, cfg) {
+				pass.Reportf(v.Pos, "%s", violationMessage(v))
+			}
+			return nil, nil
+		},
+	}
+}
+
+func violationMessage(v Violation) string {
+	switch v.Class {
+	case ClassRestrictedIO:
+		return fmt.Sprintf("%s: %s calls a restricted store I/O method directly; only a permanently-allowlisted caller may do this", v.Class, v.Func)
+	case ClassUncoveredReturnPath:
+		return fmt.Sprintf("%s: %s has a return path after acquiring a lock/lease that is not covered by a release call", v.Class, v.Func)
+	default:
+		return fmt.Sprintf("%s: %s", v.Class, v.Func)
+	}
+}

--- a/lint/lockio/lockio_test.go
+++ b/lint/lockio/lockio_test.go
@@ -1,0 +1,261 @@
+package lockio
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// testConfig deliberately uses method names that differ from the
+// workflow-compute checker this package generalizes (which used
+// beginMutationLocked/saveLocked/saveMutationAndUnlockLocked/abort*). Using a
+// distinct vocabulary here proves the detection logic is driven by Config,
+// not by any hardcoded name.
+func testConfig() Config {
+	return Config{
+		AcquireMethods:      map[string]bool{"AcquireLease": true},
+		ReleaseMethods:      map[string]bool{"Commit": true, "Abort": true, "rawWrite": true},
+		RestrictedIOMethods: map[string]bool{"rawWrite": true},
+		PermanentIOCallers:  map[string]bool{"Commit": true},
+	}
+}
+
+func parseFixture(t *testing.T, src string) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", "package fixture\n\n"+src, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return fset, f
+}
+
+func TestRestrictedIOOutsidePermanentCallerIsFlagged(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) badRawWriteCaller() error {
+	return a.rawWrite()
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "badRawWriteCaller", ClassRestrictedIO) {
+		t.Fatalf("checker bug: known-bad restricted-IO caller was not flagged; violations=%+v", violations)
+	}
+}
+
+func TestRestrictedIOFromPermanentCallerIsNotFlagged(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) Commit(before int) error {
+	return a.rawWrite()
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if hasViolation(violations, "Commit", ClassRestrictedIO) {
+		t.Fatalf("checker false positive: permanently-allowlisted caller was flagged; violations=%+v", violations)
+	}
+}
+
+func TestAcquireReturnPathMissingReleaseIsFlagged(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) badAcquireReturnPath() error {
+	before, err := a.AcquireLease()
+	if err != nil {
+		return err
+	}
+	if somethingWrong() {
+		a.mu.Unlock()
+		return errors.New("nope")
+	}
+	return a.Commit(before)
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "badAcquireReturnPath", ClassUncoveredReturnPath) {
+		t.Fatalf("checker bug: known-bad uncovered return path was not flagged; violations=%+v", violations)
+	}
+}
+
+func TestAcquireFullyCoveredPathsAreNotFlagged(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) goodAcquireReturnPath() error {
+	before, err := a.AcquireLease()
+	if err != nil {
+		return err
+	}
+	if somethingWrong() {
+		return a.Abort(errors.New("nope"))
+	}
+	return a.Commit(before)
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if hasViolation(violations, "goodAcquireReturnPath", ClassUncoveredReturnPath) {
+		t.Fatalf("checker false positive: known-good return path was flagged; violations=%+v", violations)
+	}
+}
+
+func TestSecondCriticalSectionNotCoveredByFirstSectionsRelease(t *testing.T) {
+	// Regression fixture ported from the original workflow-compute checker:
+	// a function that opens and fully closes one critical section, then
+	// opens a second one that leaks on its own no-work exit, must still be
+	// flagged — a release call that closed the first section must not be
+	// mistaken for covering the second.
+	fset, f := parseFixture(t, `
+func (a *App) badSecondSectionLeak(now int) error {
+	before, err := a.AcquireLease()
+	if err != nil {
+		return err
+	}
+	if err := a.rawWrite(); err != nil {
+		return err
+	}
+	before2, err2 := a.AcquireLease()
+	if err2 != nil {
+		return err2
+	}
+	if !somethingChanged(before2) {
+		return nil
+	}
+	return a.Commit(before)
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "badSecondSectionLeak", ClassUncoveredReturnPath) {
+		t.Fatalf("checker bug: second-critical-section no-work leak was not flagged; violations=%+v", violations)
+	}
+}
+
+func TestAsyncReleaseCallDoesNotCoverReturnPath(t *testing.T) {
+	// Regression fixture for the goroutine-opaque marker-traversal bug found
+	// in the original checker's quality review: a release call fired only
+	// inside an unawaited `go func(){...}()` returns no guarantee it runs
+	// before (or even after) the enclosing function's return, so it must not
+	// be mistaken for covering that return path. This is a plausible real
+	// mistake ("clean up in the background, don't block the response"), not
+	// a hypothetical one.
+	fset, f := parseFixture(t, `
+func (a *App) badAsyncAbort() error {
+	before, err := a.AcquireLease()
+	if err != nil {
+		return err
+	}
+	if somethingWrong() {
+		go func() { a.Abort(nil) }()
+		return errors.New("nope")
+	}
+	return a.Commit(before)
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "badAsyncAbort", ClassUncoveredReturnPath) {
+		t.Fatalf("checker bug: return path covered only by an async (go func) release call was not flagged; violations=%+v", violations)
+	}
+}
+
+func TestPermanentReturnPathFunctionIsExempt(t *testing.T) {
+	cfg := testConfig()
+	cfg.PermanentReturnPathFunctions = map[string]bool{"exemptFunc": true}
+	fset, f := parseFixture(t, `
+func (a *App) exemptFunc() error {
+	before, err := a.AcquireLease()
+	if err != nil {
+		return err
+	}
+	if changed {
+		return nil
+	}
+	return a.Commit(before)
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, cfg)
+	if hasViolation(violations, "exemptFunc", ClassUncoveredReturnPath) {
+		t.Fatalf("checker false positive: permanent-return-path function was flagged; violations=%+v", violations)
+	}
+}
+
+func TestViolationKeyFormat(t *testing.T) {
+	v := Violation{File: "server.go", Class: ClassRestrictedIO, Func: "badFn"}
+	if got, want := v.Key(), "server.go|restricted-io|badFn"; got != want {
+		t.Fatalf("Key() = %q, want %q", got, want)
+	}
+}
+
+func TestFindViolationsScansMultipleFilesIndependently(t *testing.T) {
+	fset := token.NewFileSet()
+	f1, err := parser.ParseFile(fset, "a.go", `package fixture
+
+func (a *App) badInFileA() error {
+	return a.rawWrite()
+}
+`, 0)
+	if err != nil {
+		t.Fatalf("parse a.go: %v", err)
+	}
+	f2, err := parser.ParseFile(fset, "b.go", `package fixture
+
+func (a *App) badInFileB() error {
+	return a.rawWrite()
+}
+`, 0)
+	if err != nil {
+		t.Fatalf("parse b.go: %v", err)
+	}
+	violations := FindViolations(fset, []*ast.File{f1, f2}, testConfig())
+	if !hasViolation(violations, "badInFileA", ClassRestrictedIO) || !hasViolation(violations, "badInFileB", ClassRestrictedIO) {
+		t.Fatalf("expected violations in both files; got %+v", violations)
+	}
+	for _, v := range violations {
+		wantFile := map[string]string{"badInFileA": "a.go", "badInFileB": "b.go"}[v.Func]
+		if v.File != wantFile {
+			t.Errorf("violation for %s has File=%q, want %q", v.Func, v.File, wantFile)
+		}
+	}
+}
+
+// TestAnalyzerReportsViolations proves the go/analysis.Analyzer wiring
+// itself: NewAnalyzer's Run function must invoke pass.Reportf (via
+// pass.Report) for a known-bad fixture, so any host app can plug this
+// checker into golangci-lint, go vet, or a standalone multichecker binary,
+// not just call FindViolations directly from a test.
+func TestAnalyzerReportsViolations(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) badRawWriteCaller() error {
+	return a.rawWrite()
+}
+`)
+	var diags []analysis.Diagnostic
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{f},
+		Report: func(d analysis.Diagnostic) {
+			diags = append(diags, d)
+		},
+	}
+	analyzer := NewAnalyzer("lockio", "test analyzer", testConfig())
+	if _, err := analyzer.Run(pass); err != nil {
+		t.Fatalf("analyzer.Run: %v", err)
+	}
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic from a known-bad fixture")
+	}
+	found := false
+	for _, d := range diags {
+		if d.Message != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("diagnostics were reported with empty messages")
+	}
+}
+
+func hasViolation(violations []Violation, fn string, class Class) bool {
+	for _, v := range violations {
+		if v.Func == fn && v.Class == class {
+			return true
+		}
+	}
+	return false
+}

--- a/lint/lockio/lockio_test.go
+++ b/lint/lockio/lockio_test.go
@@ -57,6 +57,69 @@ func (a *App) Commit(before int) error {
 	}
 }
 
+// The following three fixtures are modeled on a cross-repo sweep (team-lead,
+// 2026-07-04; full inventory to land at workflow-compute's
+// docs/validation/2026-07-04-ecosystem-lock-io-scan.md) that found the same
+// lock-across-I/O shape workflow-compute hit in at least nine instances
+// across the ecosystem beyond workflow-compute itself. Each fixture uses a
+// plain sync.Mutex Lock()/defer Unlock() — not the error-returning
+// AcquireLease idiom the Class B fixtures above exercise — to prove Class A
+// (a direct call to a restricted I/O method outside a sanctioned caller)
+// generalizes to that shape too: Class A never reasoned about lock state in
+// the first place, so it flags these the same way it flags workflow-compute's
+// saveLocked, independent of whether Lock()/Unlock() or an error-returning
+// acquire surrounds the call. Method/field names are anonymized generics,
+// not the real identifiers from the swept repos.
+
+func TestRestrictedIOEcosystemShapeSchedulerShutdownHoldsLockAcrossSave(t *testing.T) {
+	// A scheduler's Stop() holds its lock across a slow persistence save.
+	fset, f := parseFixture(t, `
+func (s *Scheduler) Stop() error {
+	s.schedulerLock.Lock()
+	defer s.schedulerLock.Unlock()
+	return s.persistenceHandler.rawWrite()
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "Stop", ClassRestrictedIO) {
+		t.Fatalf("checker bug: ecosystem-shaped Stop() was not flagged; violations=%+v", violations)
+	}
+}
+
+func TestRestrictedIOEcosystemShapePolicySaveContendsWithHotPathRLock(t *testing.T) {
+	// An authz module holds its mutex across a policy save while every
+	// request-path Enforce() call takes the same mutex to read — contention
+	// on every request during a save.
+	fset, f := parseFixture(t, `
+func (m *Module) SavePolicy() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.enforcer.rawWrite()
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "SavePolicy", ClassRestrictedIO) {
+		t.Fatalf("checker bug: ecosystem-shaped SavePolicy() was not flagged; violations=%+v", violations)
+	}
+}
+
+func TestRestrictedIOEcosystemShapeProviderDriverListContendsWithHealthCheck(t *testing.T) {
+	// A cloud provider driver holds its deployment mutex across a slow list
+	// API call while a health check contends for the same mutex on every
+	// tick.
+	fset, f := parseFixture(t, `
+func (d *Driver) refreshDeployments() error {
+	d.deploymentMu.Lock()
+	defer d.deploymentMu.Unlock()
+	return d.rawWrite()
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "refreshDeployments", ClassRestrictedIO) {
+		t.Fatalf("checker bug: ecosystem-shaped refreshDeployments() was not flagged; violations=%+v", violations)
+	}
+}
+
 func TestAcquireReturnPathMissingReleaseIsFlagged(t *testing.T) {
 	fset, f := parseFixture(t, `
 func (a *App) badAcquireReturnPath() error {

--- a/lint/lockio/lockio_test.go
+++ b/lint/lockio/lockio_test.go
@@ -140,6 +140,46 @@ func (a *App) badAcquireReturnPath() error {
 	}
 }
 
+// The following two fixtures are regressions for a Copilot review finding on
+// the upstream PR: walkBlock previously didn't inspect a for-loop's or
+// switch's header expressions (Init/Cond/Post, Tag, Assign) for acquire/
+// release calls before recursing into the loop/switch body, so a return
+// inside that body could go unflagged even though the critical section began
+// in the header. Both fixtures put the AcquireLease call in the header and a
+// bare return in the body to prove the header now extends the running state
+// into the body, matching how IfStmt's Init/Cond already worked.
+
+func TestForLoopHeaderAcquireIsDetectedInBody(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) badForInitAcquireLeaksInBody() error {
+	for a.AcquireLease(); true; {
+		return errors.New("nope")
+	}
+	return nil
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "badForInitAcquireLeaksInBody", ClassUncoveredReturnPath) {
+		t.Fatalf("checker bug: acquire call in a for-loop's Init was not detected inside the loop body; violations=%+v", violations)
+	}
+}
+
+func TestSwitchHeaderAcquireIsDetectedInBody(t *testing.T) {
+	fset, f := parseFixture(t, `
+func (a *App) badSwitchInitAcquireLeaksInBody() error {
+	switch a.AcquireLease(); {
+	case somethingWrong():
+		return errors.New("nope")
+	}
+	return a.Commit(nil)
+}
+`)
+	violations := FindViolations(fset, []*ast.File{f}, testConfig())
+	if !hasViolation(violations, "badSwitchInitAcquireLeaksInBody", ClassUncoveredReturnPath) {
+		t.Fatalf("checker bug: acquire call in a switch's Init was not detected inside a case body; violations=%+v", violations)
+	}
+}
+
 func TestAcquireFullyCoveredPathsAreNotFlagged(t *testing.T) {
 	fset, f := parseFixture(t, `
 func (a *App) goodAcquireReturnPath() error {

--- a/lint/lockio/walk.go
+++ b/lint/lockio/walk.go
@@ -1,0 +1,241 @@
+package lockio
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// selectorCallName returns a call expression's method/function name, e.g.
+// "Save" for a.Save(). Bare identifier calls (returning "") never match any
+// configured method name, since Config sets only ever contain method-style
+// names.
+func selectorCallName(call *ast.CallExpr) string {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// nodeContainsCall reports whether any call expression within node matches
+// isMatch. node may be nil (e.g. an absent else-branch), in which case it
+// reports false.
+func nodeContainsCall(node ast.Node, isMatch func(string) bool) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isMatch(selectorCallName(call)) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// nodeContainsSyncCall is like nodeContainsCall but treats *ast.GoStmt as
+// opaque, not descending into it. A call launched via `go func(){...}()`
+// returns immediately with no guarantee it runs before (or even after) the
+// enclosing function's return, so it must not count as covering a return
+// path — unlike nodeContainsCall, which is still used unmodified for the
+// restricted-I/O check (a direct call is unsafe regardless of sync/async
+// context) and for acquire-call detection.
+func nodeContainsSyncCall(node ast.Node, isMatch func(string) bool) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if _, ok := n.(*ast.GoStmt); ok {
+			return false // don't descend into an async launch
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isMatch(selectorCallName(call)) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func callsRestrictedIO(node ast.Node, cfg Config) bool {
+	return nodeContainsCall(node, cfg.isRestrictedIO)
+}
+
+func containsAcquireCall(node ast.Node, cfg Config) bool {
+	return nodeContainsCall(node, cfg.isAcquire)
+}
+
+// acquireCallErrVar reports whether stmt is `x, err := a.Acquire()` for some
+// Acquire in cfg.AcquireMethods, returning the name bound to the call's error
+// result.
+func acquireCallErrVar(stmt ast.Stmt, cfg Config) (string, bool) {
+	assign, ok := stmt.(*ast.AssignStmt)
+	if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
+		return "", false
+	}
+	call, ok := assign.Rhs[0].(*ast.CallExpr)
+	if !ok || !cfg.isAcquire(selectorCallName(call)) {
+		return "", false
+	}
+	ident, ok := assign.Lhs[len(assign.Lhs)-1].(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return ident.Name, true
+}
+
+// isErrNilCheck reports whether cond is `errVar != nil` (or `nil != errVar`).
+func isErrNilCheck(cond ast.Expr, errVar string) bool {
+	bin, ok := cond.(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return false
+	}
+	isVar := func(e ast.Expr) bool {
+		ident, ok := e.(*ast.Ident)
+		return ok && ident.Name == errVar
+	}
+	isNil := func(e ast.Expr) bool {
+		ident, ok := e.(*ast.Ident)
+		return ok && ident.Name == "nil"
+	}
+	return (isVar(bin.X) && isNil(bin.Y)) || (isNil(bin.X) && isVar(bin.Y))
+}
+
+// returnPathWalker walks a function body in source order, tracking whether a
+// critical section has been successfully opened (sawAcquire) and whether a
+// sanctioned release call has fired since then on the current path
+// (releaseSeen). Any return statement reached with sawAcquire && !releaseSeen,
+// and whose own result expressions don't themselves contain a release call,
+// is flagged.
+//
+// Design choice (favors false positives over false negatives, appropriate
+// for a lock-safety guard): nested blocks (if/for/switch/select bodies)
+// inherit the incoming state but do not leak their own progress back out to
+// the parent block or sibling branches. A shared-tail pattern needs its
+// release call restated per branch or hoisted before the fork.
+//
+// Special case: `x, err := a.Acquire(); if err != nil { ... return ... }` is
+// exempt from the release requirement on that branch — no critical section
+// was ever opened when acquisition itself fails.
+type returnPathWalker struct {
+	cfg     Config
+	flagged bool
+}
+
+func (w *returnPathWalker) walkBlock(stmts []ast.Stmt, sawAcquire, releaseSeen bool) {
+	for i := 0; i < len(stmts); i++ {
+		stmt := stmts[i]
+		if errVar, ok := acquireCallErrVar(stmt, w.cfg); ok {
+			sawAcquire = true
+			// A fresh acquisition resets whether this path is "covered":
+			// some functions open and fully close more than one critical
+			// section in sequence, and a release call that closed an
+			// earlier, already-finished section must not be mistaken for
+			// covering a later one.
+			releaseSeen = false
+			if i+1 < len(stmts) {
+				if ifStmt, ok2 := stmts[i+1].(*ast.IfStmt); ok2 && ifStmt.Init == nil && isErrNilCheck(ifStmt.Cond, errVar) {
+					i++ // the paired acquire-failure check is exempt; skip it
+					continue
+				}
+			}
+			continue
+		}
+		switch s := stmt.(type) {
+		case *ast.ReturnStmt:
+			hasRelease := nodeContainsSyncCall(s, w.cfg.isRelease)
+			if sawAcquire && !releaseSeen && !hasRelease {
+				w.flagged = true
+			}
+			if nodeContainsCall(s, w.cfg.isAcquire) {
+				sawAcquire = true
+			}
+			if hasRelease {
+				releaseSeen = true
+			}
+		case *ast.IfStmt:
+			// Init/Cond execute unconditionally on reaching this statement,
+			// so they extend the running state for the branches and for
+			// code after the if.
+			if s.Init != nil {
+				sawAcquire = sawAcquire || nodeContainsCall(s.Init, w.cfg.isAcquire)
+				releaseSeen = releaseSeen || nodeContainsSyncCall(s.Init, w.cfg.isRelease)
+			}
+			sawAcquire = sawAcquire || nodeContainsCall(s.Cond, w.cfg.isAcquire)
+			releaseSeen = releaseSeen || nodeContainsSyncCall(s.Cond, w.cfg.isRelease)
+			if s.Body != nil {
+				w.walkBlock(s.Body.List, sawAcquire, releaseSeen)
+			}
+			switch e := s.Else.(type) {
+			case *ast.BlockStmt:
+				w.walkBlock(e.List, sawAcquire, releaseSeen)
+			case *ast.IfStmt:
+				w.walkBlock([]ast.Stmt{e}, sawAcquire, releaseSeen)
+			}
+		case *ast.BlockStmt:
+			w.walkBlock(s.List, sawAcquire, releaseSeen)
+		case *ast.ForStmt:
+			if s.Body != nil {
+				w.walkBlock(s.Body.List, sawAcquire, releaseSeen)
+			}
+		case *ast.RangeStmt:
+			if s.Body != nil {
+				w.walkBlock(s.Body.List, sawAcquire, releaseSeen)
+			}
+		case *ast.SwitchStmt:
+			for _, c := range s.Body.List {
+				if cc, ok := c.(*ast.CaseClause); ok {
+					w.walkBlock(cc.Body, sawAcquire, releaseSeen)
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			for _, c := range s.Body.List {
+				if cc, ok := c.(*ast.CaseClause); ok {
+					w.walkBlock(cc.Body, sawAcquire, releaseSeen)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, c := range s.Body.List {
+				if cc, ok := c.(*ast.CommClause); ok {
+					w.walkBlock(cc.Body, sawAcquire, releaseSeen)
+				}
+			}
+		default:
+			if nodeContainsCall(stmt, w.cfg.isAcquire) {
+				sawAcquire = true
+			}
+			if nodeContainsSyncCall(stmt, w.cfg.isRelease) {
+				releaseSeen = true
+			}
+		}
+	}
+}
+
+// acquireReturnPathUncovered reports whether fn has any return path reachable
+// after a successful AcquireMethods call that lacks a sanctioned release
+// call.
+func acquireReturnPathUncovered(fn *ast.FuncDecl, cfg Config) bool {
+	if fn.Body == nil || !containsAcquireCall(fn.Body, cfg) {
+		return false
+	}
+	w := &returnPathWalker{cfg: cfg}
+	w.walkBlock(fn.Body.List, false, false)
+	return w.flagged
+}

--- a/lint/lockio/walk.go
+++ b/lint/lockio/walk.go
@@ -192,20 +192,49 @@ func (w *returnPathWalker) walkBlock(stmts []ast.Stmt, sawAcquire, releaseSeen b
 		case *ast.BlockStmt:
 			w.walkBlock(s.List, sawAcquire, releaseSeen)
 		case *ast.ForStmt:
+			// Init/Cond/Post execute unconditionally on reaching this
+			// statement (Init and Cond at least once; Post only after a
+			// completed iteration, but a call there is still reachable
+			// before any return inside Body), so — like IfStmt's Init/Cond —
+			// they extend the running state for the loop body.
+			if s.Init != nil {
+				sawAcquire = sawAcquire || nodeContainsCall(s.Init, w.cfg.isAcquire)
+				releaseSeen = releaseSeen || nodeContainsSyncCall(s.Init, w.cfg.isRelease)
+			}
+			sawAcquire = sawAcquire || nodeContainsCall(s.Cond, w.cfg.isAcquire)
+			releaseSeen = releaseSeen || nodeContainsSyncCall(s.Cond, w.cfg.isRelease)
+			if s.Post != nil {
+				sawAcquire = sawAcquire || nodeContainsCall(s.Post, w.cfg.isAcquire)
+				releaseSeen = releaseSeen || nodeContainsSyncCall(s.Post, w.cfg.isRelease)
+			}
 			if s.Body != nil {
 				w.walkBlock(s.Body.List, sawAcquire, releaseSeen)
 			}
 		case *ast.RangeStmt:
+			sawAcquire = sawAcquire || nodeContainsCall(s.X, w.cfg.isAcquire)
+			releaseSeen = releaseSeen || nodeContainsSyncCall(s.X, w.cfg.isRelease)
 			if s.Body != nil {
 				w.walkBlock(s.Body.List, sawAcquire, releaseSeen)
 			}
 		case *ast.SwitchStmt:
+			if s.Init != nil {
+				sawAcquire = sawAcquire || nodeContainsCall(s.Init, w.cfg.isAcquire)
+				releaseSeen = releaseSeen || nodeContainsSyncCall(s.Init, w.cfg.isRelease)
+			}
+			sawAcquire = sawAcquire || nodeContainsCall(s.Tag, w.cfg.isAcquire)
+			releaseSeen = releaseSeen || nodeContainsSyncCall(s.Tag, w.cfg.isRelease)
 			for _, c := range s.Body.List {
 				if cc, ok := c.(*ast.CaseClause); ok {
 					w.walkBlock(cc.Body, sawAcquire, releaseSeen)
 				}
 			}
 		case *ast.TypeSwitchStmt:
+			if s.Init != nil {
+				sawAcquire = sawAcquire || nodeContainsCall(s.Init, w.cfg.isAcquire)
+				releaseSeen = releaseSeen || nodeContainsSyncCall(s.Init, w.cfg.isRelease)
+			}
+			sawAcquire = sawAcquire || nodeContainsCall(s.Assign, w.cfg.isAcquire)
+			releaseSeen = releaseSeen || nodeContainsSyncCall(s.Assign, w.cfg.isRelease)
 			for _, c := range s.Body.List {
 				if cc, ok := c.(*ast.CaseClause); ok {
 					w.walkBlock(cc.Body, sawAcquire, releaseSeen)


### PR DESCRIPTION
## Summary

- Add `wfctl doctor app <url>`: an explicitly-online, read-only probe of a deployed app's health endpoint (latency p50/p99, platform-edge-HTML vs app-origin-JSON failure classification, health flip-flop rate).
- Add `lint/lockio`: a reusable `go/analysis`-style checker for "lock held across store I/O," parameterized by lock acquire/release method names, restricted I/O method names, and allowlists.
- Add ADR 0054 recording both additions, explicitly flagged for maintainer sign-off (see "Scope expansion — please confirm" below).

## Motivation

A workflow-compute staging incident traced to a lock held across a slow store write, starving unrelated requests. Diagnosing it cost hours largely because two failure shapes looked identical from the outside: an edge proxy's own HTML error page (request never reached the app) vs. the app's own JSON structured error (request reached the app, which was busy). `doctor app` turns that diagnostic into a one-command check. The fix itself relied on an in-repo `go/ast` checker enforcing "every lock acquisition has a release on every return path" (including a goroutine-opaque traversal bug found and fixed in review); `lint/lockio` generalizes that checker so any Workflow host app can adopt it instead of hand-rolling one.

A cross-repo sweep of Workflow ecosystem code found the same lock-across-I/O shape in at least 9 instances beyond the workflow-compute incident — including a scheduler holding its lock across a persistence save, an authz module holding its mutex across a policy save while every request-path call contends for the same mutex, and a cloud provider driver holding its deployment mutex across a list call while health checks contend. `lint/lockio`'s test suite includes three fixtures modeled on those shapes (anonymized) as documentary evidence that the checker applies directly to real ecosystem code, not as new structural test coverage — Class A's detection is lock-syntax-agnostic by design, so these fixtures exercise the same code path as the package's simplest Class A test. Full inventory: workflow-compute `docs/validation/2026-07-04-ecosystem-lock-io-scan.md` (landing shortly; will link once merged).

Full design context: workflow-compute `docs/plans/2026-07-04-durable-mutation-lifecycle-design.md`, "Upstream Guards" section (U1/U2).

## Scope expansion — please confirm

Two things here go beyond precedent and are flagged explicitly rather than assumed, per ADR 0054:

1. **ADR 0052 said `wfctl doctor` is checkout-only** ("must avoid network access unless explicitly requested"). `doctor app` is a new, explicitly-invoked (`doctor app <url>`, not a flag on the base command) online mode that makes real HTTP requests to an operator-supplied URL. Deliberate, not an oversight — flagging for sign-off.
2. **`lint/` is a new top-level directory.** `docs/REPO_LAYOUT.md` had no home for reusable static-analysis tooling before this change. `lint/lockio` is the first package there — the path/name is a proposal, happy to relocate per maintainer convention.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (3 pre-existing failures in docs-generate tests requiring `git tag`, reproduced identically on a clean `origin/main` checkout — not caused by this PR)
- [x] `go test -race ./lint/... ./cmd/wfctl/...` passes
- [x] `golangci-lint run ./... --new-from-rev=origin/main` → 0 issues
- [x] Manual: `wfctl doctor app <url>` against fixture servers simulating DigitalOcean/ALB/nginx default error pages and an app-origin JSON error (see `cmd/wfctl/doctor_app_test.go`)

## Checklist

- [x] CHANGELOG.md updated (Keep-a-Changelog format)
- [x] No secrets or credentials included
- [ ] One feature or bugfix per PR — this PR bundles U1 + U2 per the locked plan (Task 12 of workflow-compute's durable-mutation-lifecycle plan treats them as one upstream PR); flagging in case the maintainer would rather split them
