### PR TITLE
Avoid locks across persistence I/O

### DIFF
--- a/module/api_crud_handler.go
+++ b/module/api_crud_handler.go
@@ -264,7 +264,6 @@ func (h *RESTAPIHandler) handlePut(resourceId string, w http.ResponseWriter, r *
 	if err := json.NewEncoder(w).Encode(updated); err != nil {
 		_ = err
 	}
-	return
 }
 
 // handleDelete handles DELETE requests for removing resources.
@@ -301,7 +300,6 @@ func (h *RESTAPIHandler) handleDelete(resourceId string, w http.ResponseWriter, 
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	return
 }
 
 // handleSubActionGet handles GET requests for sub-resource data (e.g., /summary).

--- a/module/api_crud_handler.go
+++ b/module/api_crud_handler.go
@@ -235,10 +235,10 @@ func (h *RESTAPIHandler) handlePut(resourceId string, w http.ResponseWriter, r *
 	}
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	// Check if resource exists
 	if _, ok := h.resources[resourceId]; !ok {
+		h.mu.Unlock()
 		w.WriteHeader(http.StatusNotFound)
 		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Resource not found"}); err != nil {
 			_ = err
@@ -251,17 +251,20 @@ func (h *RESTAPIHandler) handlePut(resourceId string, w http.ResponseWriter, r *
 		ID:   resourceId,
 		Data: data,
 	}
+	updated := h.resources[resourceId]
+	h.mu.Unlock()
 
 	// Write-through to persistence
 	if h.persistence != nil {
-		if err := h.persistence.SaveResource(h.resourceName, resourceId, data); err != nil {
+		if err := h.persistence.SaveResource(h.resourceName, resourceId, updated.Data); err != nil {
 			h.logger.Warn(fmt.Sprintf("failed to persist resource %s/%s: %v", h.resourceName, resourceId, err))
 		}
 	}
 
-	if err := json.NewEncoder(w).Encode(h.resources[resourceId]); err != nil {
+	if err := json.NewEncoder(w).Encode(updated); err != nil {
 		_ = err
 	}
+	return
 }
 
 // handleDelete handles DELETE requests for removing resources.
@@ -275,10 +278,10 @@ func (h *RESTAPIHandler) handleDelete(resourceId string, w http.ResponseWriter, 
 	}
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	// Check if resource exists
 	if _, ok := h.resources[resourceId]; !ok {
+		h.mu.Unlock()
 		w.WriteHeader(http.StatusNotFound)
 		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Resource not found"}); err != nil {
 			_ = err
@@ -288,6 +291,7 @@ func (h *RESTAPIHandler) handleDelete(resourceId string, w http.ResponseWriter, 
 
 	// Delete the resource
 	delete(h.resources, resourceId)
+	h.mu.Unlock()
 
 	// Write-through to persistence
 	if h.persistence != nil {
@@ -297,6 +301,7 @@ func (h *RESTAPIHandler) handleDelete(resourceId string, w http.ResponseWriter, 
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+	return
 }
 
 // handleSubActionGet handles GET requests for sub-resource data (e.g., /summary).

--- a/module/api_workflow_handler.go
+++ b/module/api_workflow_handler.go
@@ -102,20 +102,24 @@ func (h *RESTAPIHandler) syncResourceStateFromEngine(instanceId, resourceId stri
 	}
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
+	var persistID string
+	var persistData map[string]any
 	if res, exists := h.resources[resourceId]; exists {
 		res.State = instance.CurrentState
 		res.LastUpdate = instance.LastUpdated.Format(time.RFC3339)
 		res.Data["state"] = res.State
 		res.Data["lastUpdate"] = res.LastUpdate
 		h.resources[resourceId] = res
+		persistID = res.ID
+		persistData = maps.Clone(res.Data)
+	}
+	h.mu.Unlock()
 
-		// Write-through to persistence
-		if h.persistence != nil {
-			if err := h.persistence.SaveResource(h.resourceName, res.ID, res.Data); err != nil {
-				h.logger.Warn(fmt.Sprintf("failed to persist resource %s/%s: %v", h.resourceName, res.ID, err))
-			}
+	// Write-through to persistence
+	if h.persistence != nil && persistID != "" {
+		if err := h.persistence.SaveResource(h.resourceName, persistID, persistData); err != nil {
+			h.logger.Warn(fmt.Sprintf("failed to persist resource %s/%s: %v", h.resourceName, persistID, err))
 		}
 	}
 }

--- a/module/iac_state_postgres.go
+++ b/module/iac_state_postgres.go
@@ -25,9 +25,10 @@ type PostgresConn interface {
 // PostgresIaCStateStore persists IaC state in a PostgreSQL table using pgx/v5.
 // Locking uses pg_advisory_lock() for serialised access per resource.
 type PostgresIaCStateStore struct {
-	conn PostgresConn
-	mu   sync.Mutex
-	held map[string]int64 // resourceID -> advisory key
+	conn      PostgresConn
+	mu        sync.Mutex
+	held      map[string]int64 // resourceID -> advisory key
+	acquiring map[string]struct{}
 }
 
 // NewPostgresIaCStateStore creates a PostgreSQL-backed state store.
@@ -47,16 +48,18 @@ func NewPostgresIaCStateStore(ctx context.Context, dsn string) (*PostgresIaCStat
 		return nil, fmt.Errorf("iac postgres state: create table: %w", err)
 	}
 	return &PostgresIaCStateStore{
-		conn: conn,
-		held: make(map[string]int64),
+		conn:      conn,
+		held:      make(map[string]int64),
+		acquiring: make(map[string]struct{}),
 	}, nil
 }
 
 // NewPostgresIaCStateStoreWithConn creates a store with an injected connection (for testing).
 func NewPostgresIaCStateStoreWithConn(conn PostgresConn) *PostgresIaCStateStore {
 	return &PostgresIaCStateStore{
-		conn: conn,
-		held: make(map[string]int64),
+		conn:      conn,
+		held:      make(map[string]int64),
+		acquiring: make(map[string]struct{}),
 	}
 }
 
@@ -113,32 +116,52 @@ func (s *PostgresIaCStateStore) DeleteState(ctx context.Context, resourceID stri
 // Lock acquires a PostgreSQL advisory lock for the resource.
 func (s *PostgresIaCStateStore) Lock(ctx context.Context, resourceID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if _, held := s.held[resourceID]; held {
+		s.mu.Unlock()
 		return fmt.Errorf("iac postgres state: Lock %q: already locked", resourceID)
 	}
+	if s.acquiring == nil {
+		s.acquiring = make(map[string]struct{})
+	}
+	if _, acquiring := s.acquiring[resourceID]; acquiring {
+		s.mu.Unlock()
+		return fmt.Errorf("iac postgres state: Lock %q: already locking", resourceID)
+	}
+	s.acquiring[resourceID] = struct{}{}
+	s.mu.Unlock()
+
 	key := advisoryKey(resourceID)
 	if err := s.conn.AcquireAdvisoryLock(ctx, key); err != nil {
+		s.mu.Lock()
+		delete(s.acquiring, resourceID)
+		s.mu.Unlock()
 		return fmt.Errorf("iac postgres state: Lock %q: %w", resourceID, err)
 	}
+
+	s.mu.Lock()
+	delete(s.acquiring, resourceID)
 	s.held[resourceID] = key
+	s.mu.Unlock()
 	return nil
 }
 
 // Unlock releases the PostgreSQL advisory lock for the resource.
 func (s *PostgresIaCStateStore) Unlock(ctx context.Context, resourceID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	key, held := s.held[resourceID]
 	if !held {
+		s.mu.Unlock()
 		return fmt.Errorf("iac postgres state: Unlock %q: not locked", resourceID)
 	}
+	delete(s.held, resourceID)
+	s.mu.Unlock()
+
 	if _, err := s.conn.ReleaseAdvisoryLock(ctx, key); err != nil {
+		s.mu.Lock()
+		s.held[resourceID] = key
+		s.mu.Unlock()
 		return fmt.Errorf("iac postgres state: Unlock %q: %w", resourceID, err)
 	}
-	delete(s.held, resourceID)
 	return nil
 }
 

--- a/module/iac_state_postgres_test.go
+++ b/module/iac_state_postgres_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/module"
 )
@@ -13,6 +14,12 @@ import (
 type mockPGConn struct {
 	rows  map[string]*module.IaCState // resource_id -> state
 	locks map[string]bool
+}
+
+type blockingAcquirePGConn struct {
+	*mockPGConn
+	entered chan struct{}
+	release chan struct{}
 }
 
 type scanErrRows struct {
@@ -104,6 +111,14 @@ func newMockPGConn() *mockPGConn {
 	}
 }
 
+func newBlockingAcquirePGConn() *blockingAcquirePGConn {
+	return &blockingAcquirePGConn{
+		mockPGConn: newMockPGConn(),
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+}
+
 func (m *mockPGConn) UpsertState(_ context.Context, st *module.IaCState) error {
 	if st == nil {
 		return fmt.Errorf("state is nil")
@@ -149,6 +164,16 @@ func (m *mockPGConn) AcquireAdvisoryLock(_ context.Context, key int64) error {
 	}
 	m.locks[k] = true
 	return nil
+}
+
+func (m *blockingAcquirePGConn) AcquireAdvisoryLock(ctx context.Context, key int64) error {
+	select {
+	case <-m.entered:
+	default:
+		close(m.entered)
+		<-m.release
+	}
+	return m.mockPGConn.AcquireAdvisoryLock(ctx, key)
 }
 
 func (m *mockPGConn) ReleaseAdvisoryLock(_ context.Context, key int64) (bool, error) {
@@ -367,6 +392,44 @@ func TestPostgresIaCStateStore_LockUnlock(t *testing.T) {
 	}
 	if err := store.Lock(context.Background(), "res-1"); err != nil {
 		t.Fatalf("Lock after unlock: %v", err)
+	}
+}
+
+func TestPostgresIaCStateStore_LockDoesNotBlockDifferentResource(t *testing.T) {
+	conn := newBlockingAcquirePGConn()
+	store := newTestPostgresStore(conn)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- store.Lock(context.Background(), "res-1")
+	}()
+
+	select {
+	case <-conn.entered:
+	case <-time.After(time.Second):
+		close(conn.release)
+		t.Fatal("first Lock did not reach advisory lock acquisition")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- store.Lock(context.Background(), "res-2")
+	}()
+
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			close(conn.release)
+			t.Fatalf("second Lock: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(conn.release)
+		t.Fatal("different resource Lock blocked behind advisory lock acquisition")
+	}
+
+	close(conn.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Lock: %v", err)
 	}
 }
 

--- a/module/jwt_auth.go
+++ b/module/jwt_auth.go
@@ -1067,12 +1067,12 @@ func (j *JWTAuthModule) extractPathParam(path, prefix string) string {
 	return path[idx+len(prefix):]
 }
 
-// loadSeedUsers reads a JSON seed file and registers users that don't already exist.
+// loadSeedUsers reads a JSON seed file and prepares seed users for insertion.
 // The seed format matches the api.handler seed format: [{id, data: {email, name, password, role, ...}}]
-func (j *JWTAuthModule) loadSeedUsers(path string) error {
+func (j *JWTAuthModule) loadSeedUsers(path string) ([]*User, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("failed to read seed file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to read seed file %s: %w", path, err)
 	}
 
 	var seeds []struct {
@@ -1080,17 +1080,13 @@ func (j *JWTAuthModule) loadSeedUsers(path string) error {
 		Data map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal(data, &seeds); err != nil {
-		return fmt.Errorf("failed to parse seed file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to parse seed file %s: %w", path, err)
 	}
 
+	users := make([]*User, 0, len(seeds))
 	for _, seed := range seeds {
 		email, _ := seed.Data["email"].(string)
 		if email == "" {
-			continue
-		}
-
-		// Skip if already loaded from persistence or memory
-		if _, exists := j.users[email]; exists {
 			continue
 		}
 
@@ -1125,28 +1121,10 @@ func (j *JWTAuthModule) loadSeedUsers(path string) error {
 			Metadata:     metadata,
 			CreatedAt:    time.Now(),
 		}
-		j.users[email] = user
-
-		// Track highest numeric ID
-		var idNum int
-		if _, err := fmt.Sscanf(seed.ID, "%d", &idNum); err == nil && idNum >= j.nextID {
-			j.nextID = idNum + 1
-		}
-
-		// Write-through to persistence
-		if j.persistence != nil {
-			_ = j.persistence.SaveUser(UserRecord{
-				ID:           user.ID,
-				Email:        user.Email,
-				Name:         user.Name,
-				PasswordHash: user.PasswordHash,
-				Metadata:     user.Metadata,
-				CreatedAt:    user.CreatedAt,
-			})
-		}
+		users = append(users, user)
 	}
 
-	return nil
+	return users, nil
 }
 
 // Start loads persisted users if available, then seed users.
@@ -1161,39 +1139,70 @@ func (j *JWTAuthModule) Start(ctx context.Context) error {
 		}
 	}
 
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
 	// Load persisted users first (they take priority over seeds)
+	var persisted []UserRecord
 	if j.persistence != nil {
 		users, err := j.persistence.LoadUsers()
 		if err == nil {
-			for _, u := range users {
-				if _, exists := j.users[u.Email]; exists {
-					continue
-				}
-				j.users[u.Email] = &User{
-					ID:           u.ID,
-					Email:        u.Email,
-					Name:         u.Name,
-					PasswordHash: u.PasswordHash,
-					Metadata:     u.Metadata,
-					CreatedAt:    u.CreatedAt,
-				}
-				var idNum int
-				if _, err := fmt.Sscanf(u.ID, "%d", &idNum); err == nil && idNum >= j.nextID {
-					j.nextID = idNum + 1
-				}
-			}
+			persisted = users
 		}
 	}
 
 	// Load seed users (skips any already loaded from persistence)
+	var seedUsers []*User
 	if j.seedFile != "" {
-		if err := j.loadSeedUsers(j.seedFile); err != nil {
+		users, err := j.loadSeedUsers(j.seedFile)
+		if err != nil {
 			// Non-fatal: log but don't prevent startup
 			j.logger.Warn("failed to load seed users", "file", j.seedFile, "error", err)
+		} else {
+			seedUsers = users
 		}
+	}
+
+	var seedRecordsToPersist []UserRecord
+	j.mu.Lock()
+	for _, u := range persisted {
+		if _, exists := j.users[u.Email]; exists {
+			continue
+		}
+		j.users[u.Email] = &User{
+			ID:           u.ID,
+			Email:        u.Email,
+			Name:         u.Name,
+			PasswordHash: u.PasswordHash,
+			Metadata:     u.Metadata,
+			CreatedAt:    u.CreatedAt,
+		}
+		var idNum int
+		if _, err := fmt.Sscanf(u.ID, "%d", &idNum); err == nil && idNum >= j.nextID {
+			j.nextID = idNum + 1
+		}
+	}
+	for _, user := range seedUsers {
+		if _, exists := j.users[user.Email]; exists {
+			continue
+		}
+		j.users[user.Email] = user
+		var idNum int
+		if _, err := fmt.Sscanf(user.ID, "%d", &idNum); err == nil && idNum >= j.nextID {
+			j.nextID = idNum + 1
+		}
+		if j.persistence != nil {
+			seedRecordsToPersist = append(seedRecordsToPersist, UserRecord{
+				ID:           user.ID,
+				Email:        user.Email,
+				Name:         user.Name,
+				PasswordHash: user.PasswordHash,
+				Metadata:     user.Metadata,
+				CreatedAt:    user.CreatedAt,
+			})
+		}
+	}
+	j.mu.Unlock()
+
+	for _, record := range seedRecordsToPersist {
+		_ = j.persistence.SaveUser(record)
 	}
 
 	return nil

--- a/module/jwt_auth_test.go
+++ b/module/jwt_auth_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -504,6 +506,52 @@ func TestJWTAuth_SetupStatus_WithUsers(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp["needsSetup"] != false {
 		t.Errorf("expected needsSetup=false, got %v", resp["needsSetup"])
+	}
+}
+
+func TestJWTAuth_StartSeedLoadDoesNotStarveUserCount(t *testing.T) {
+	j := setupJWTAuth(t)
+	seedPath := filepath.Join(t.TempDir(), "users.json")
+	seeds := []map[string]any{}
+	for i := 0; i < 8; i++ {
+		seeds = append(seeds, map[string]any{
+			"id": string(rune('1' + i)),
+			"data": map[string]any{
+				"email":    string(rune('a'+i)) + "@example.com",
+				"name":     "Seed User",
+				"password": "secret123",
+			},
+		})
+	}
+	data, err := json.Marshal(seeds)
+	if err != nil {
+		t.Fatalf("marshal seeds: %v", err)
+	}
+	if err := os.WriteFile(seedPath, data, 0o600); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	j.SetSeedFile(seedPath)
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- j.Start(t.Context())
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	countDone := make(chan struct{})
+	go func() {
+		_ = j.userCount()
+		close(countDone)
+	}()
+
+	select {
+	case <-countDone:
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("userCount blocked behind seed user loading")
+	}
+
+	if err := <-startDone; err != nil {
+		t.Fatalf("Start: %v", err)
 	}
 }
 

--- a/module/storage_artifact_fs.go
+++ b/module/storage_artifact_fs.go
@@ -99,13 +99,20 @@ func (m *ArtifactFSModule) Upload(_ context.Context, key string, reader io.Reade
 		return fmt.Errorf("artifact store %q: Upload %q: failed to create directory: %w", m.name, key, err)
 	}
 
-	f, err := os.Create(path) //nolint:gosec // G703: key sanitized by artifactPath
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*") //nolint:gosec // G304: directory and prefix derived from sanitized artifact path
 	if err != nil {
-		return fmt.Errorf("artifact store %q: Upload %q: failed to create file: %w", m.name, key, err)
+		return fmt.Errorf("artifact store %q: Upload %q: failed to create temp file: %w", m.name, key, err)
 	}
+	tmpPath := tmp.Name()
+	cleanupTmp := true
+	defer func() {
+		if cleanupTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
-	size, copyErr := io.Copy(f, reader)
-	closeErr := f.Close()
+	size, copyErr := io.Copy(tmp, reader)
+	closeErr := tmp.Close()
 	if copyErr != nil {
 		return fmt.Errorf("artifact store %q: Upload %q: failed to write: %w", m.name, key, copyErr)
 	}
@@ -114,7 +121,6 @@ func (m *ArtifactFSModule) Upload(_ context.Context, key string, reader io.Reade
 	}
 
 	if m.cfg.MaxSize > 0 && size > m.cfg.MaxSize {
-		_ = os.Remove(path) //nolint:gosec // G703: key sanitized by artifactPath
 		return fmt.Errorf("artifact store %q: Upload %q: size %d exceeds limit %d", m.name, key, size, m.cfg.MaxSize)
 	}
 
@@ -127,9 +133,34 @@ func (m *ArtifactFSModule) Upload(_ context.Context, key string, reader io.Reade
 	if err != nil {
 		return fmt.Errorf("artifact store %q: Upload %q: failed to marshal metadata: %w", m.name, key, err)
 	}
-	if err := os.WriteFile(metaPath(path), metaData, 0o600); err != nil { //nolint:gosec // G306
+
+	metaTmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".meta.tmp-*") //nolint:gosec // G304: directory and prefix derived from sanitized artifact path
+	if err != nil {
+		return fmt.Errorf("artifact store %q: Upload %q: failed to create metadata temp file: %w", m.name, key, err)
+	}
+	metaTmpPath := metaTmp.Name()
+	cleanupMetaTmp := true
+	defer func() {
+		if cleanupMetaTmp {
+			_ = os.Remove(metaTmpPath)
+		}
+	}()
+	if _, err := metaTmp.Write(metaData); err != nil {
+		_ = metaTmp.Close()
 		return fmt.Errorf("artifact store %q: Upload %q: failed to write metadata: %w", m.name, key, err)
 	}
+	if err := metaTmp.Close(); err != nil {
+		return fmt.Errorf("artifact store %q: Upload %q: failed to close metadata: %w", m.name, key, err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("artifact store %q: Upload %q: failed to publish file: %w", m.name, key, err)
+	}
+	cleanupTmp = false
+	if err := os.Rename(metaTmpPath, metaPath(path)); err != nil {
+		return fmt.Errorf("artifact store %q: Upload %q: failed to publish metadata: %w", m.name, key, err)
+	}
+	cleanupMetaTmp = false
 
 	return nil
 }

--- a/module/storage_artifact_fs.go
+++ b/module/storage_artifact_fs.go
@@ -95,9 +95,6 @@ type artifactMeta struct {
 func (m *ArtifactFSModule) Upload(_ context.Context, key string, reader io.Reader, metadata map[string]string) error {
 	path := m.artifactPath(key)
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil { //nolint:gosec // G703: key sanitized by artifactPath (TrimPrefix + filepath.Join)
 		return fmt.Errorf("artifact store %q: Upload %q: failed to create directory: %w", m.name, key, err)
 	}
@@ -141,9 +138,6 @@ func (m *ArtifactFSModule) Upload(_ context.Context, key string, reader io.Reade
 func (m *ArtifactFSModule) Download(_ context.Context, key string) (io.ReadCloser, map[string]string, error) {
 	path := m.artifactPath(key)
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -165,9 +159,6 @@ func (m *ArtifactFSModule) Download(_ context.Context, key string) (io.ReadClose
 
 // List returns ArtifactInfo for all artifacts whose key starts with prefix.
 func (m *ArtifactFSModule) List(_ context.Context, prefix string) ([]ArtifactInfo, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	var results []ArtifactInfo
 
 	err := filepath.Walk(m.cfg.BasePath, func(path string, info os.FileInfo, walkErr error) error {
@@ -224,9 +215,6 @@ func (m *ArtifactFSModule) List(_ context.Context, prefix string) ([]ArtifactInf
 func (m *ArtifactFSModule) Delete(_ context.Context, key string) error {
 	path := m.artifactPath(key)
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("artifact store %q: Delete %q: not found", m.name, key)
@@ -241,8 +229,6 @@ func (m *ArtifactFSModule) Delete(_ context.Context, key string) error {
 // Exists reports whether an artifact with the given key exists.
 func (m *ArtifactFSModule) Exists(_ context.Context, key string) (bool, error) {
 	path := m.artifactPath(key)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
 	_, err := os.Stat(path)
 	if err == nil {
 		return true, nil

--- a/module/storage_artifact_fs_lock_test.go
+++ b/module/storage_artifact_fs_lock_test.go
@@ -1,0 +1,39 @@
+package module
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestArtifactFSDownloadDoesNotBlockBehindStoreMutex(t *testing.T) {
+	store := NewArtifactFSModule("artifacts", ArtifactFSConfig{BasePath: t.TempDir()})
+	if err := store.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := store.Upload(context.Background(), "a.txt", strings.NewReader("hello"), nil); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	readDone := make(chan error, 1)
+	go func() {
+		rc, _, err := store.Download(context.Background(), "a.txt")
+		if rc != nil {
+			_ = rc.Close()
+		}
+		readDone <- err
+	}()
+
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("Download: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Download blocked behind store mutex")
+	}
+}

--- a/platform/providers/dockercompose/state_store.go
+++ b/platform/providers/dockercompose/state_store.go
@@ -35,9 +35,6 @@ func NewFileStateStore(baseDir string) (*FileStateStore, error) {
 
 // SaveResource persists a resource output to the state directory.
 func (s *FileStateStore) SaveResource(_ context.Context, contextPath string, output *platform.ResourceOutput) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	dir := s.contextDir(contextPath)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create context directory: %w", err)
@@ -57,9 +54,6 @@ func (s *FileStateStore) SaveResource(_ context.Context, contextPath string, out
 
 // GetResource retrieves a resource's state from the state directory.
 func (s *FileStateStore) GetResource(_ context.Context, contextPath, resourceName string) (*platform.ResourceOutput, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	path := filepath.Join(s.contextDir(contextPath), "resource-"+resourceName+".json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -78,9 +72,6 @@ func (s *FileStateStore) GetResource(_ context.Context, contextPath, resourceNam
 
 // ListResources returns all resources in a context path.
 func (s *FileStateStore) ListResources(_ context.Context, contextPath string) ([]*platform.ResourceOutput, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	dir := s.contextDir(contextPath)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -116,9 +107,6 @@ func (s *FileStateStore) ListResources(_ context.Context, contextPath string) ([
 
 // DeleteResource removes a resource from state.
 func (s *FileStateStore) DeleteResource(_ context.Context, contextPath, resourceName string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	path := filepath.Join(s.contextDir(contextPath), "resource-"+resourceName+".json")
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete resource state: %w", err)
@@ -128,9 +116,6 @@ func (s *FileStateStore) DeleteResource(_ context.Context, contextPath, resource
 
 // SavePlan persists an execution plan.
 func (s *FileStateStore) SavePlan(_ context.Context, plan *platform.Plan) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	dir := filepath.Join(s.baseDir, "plans")
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create plans directory: %w", err)
@@ -150,9 +135,6 @@ func (s *FileStateStore) SavePlan(_ context.Context, plan *platform.Plan) error 
 
 // GetPlan retrieves an execution plan by ID.
 func (s *FileStateStore) GetPlan(_ context.Context, planID string) (*platform.Plan, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	// Validate planID to prevent path traversal.
 	if strings.Contains(planID, "/") || strings.Contains(planID, "\\") || strings.Contains(planID, "..") {
 		return nil, fmt.Errorf("invalid plan ID %q", planID)
@@ -176,9 +158,6 @@ func (s *FileStateStore) GetPlan(_ context.Context, planID string) (*platform.Pl
 
 // ListPlans lists plans for a context path, ordered by creation time descending.
 func (s *FileStateStore) ListPlans(_ context.Context, _ string, limit int) ([]*platform.Plan, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	dir := filepath.Join(s.baseDir, "plans")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -240,9 +219,6 @@ func (s *FileStateStore) Lock(_ context.Context, contextPath string, ttl time.Du
 
 // Dependencies returns dependency references for resources that depend on the given resource.
 func (s *FileStateStore) Dependencies(_ context.Context, contextPath, _ string) ([]platform.DependencyRef, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	path := filepath.Join(s.contextDir(contextPath), "dependencies.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -261,9 +237,6 @@ func (s *FileStateStore) Dependencies(_ context.Context, contextPath, _ string) 
 
 // AddDependency records a cross-resource dependency.
 func (s *FileStateStore) AddDependency(_ context.Context, dep platform.DependencyRef) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	dir := s.contextDir(dep.SourceContext)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create context directory: %w", err)

--- a/platform/providers/dockercompose/state_store_lock_test.go
+++ b/platform/providers/dockercompose/state_store_lock_test.go
@@ -1,0 +1,42 @@
+package dockercompose
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/platform"
+)
+
+func TestFileStateStoreGetResourceDoesNotBlockBehindStoreMutex(t *testing.T) {
+	store, err := NewFileStateStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStateStore: %v", err)
+	}
+	ctx := context.Background()
+	if err := store.SaveResource(ctx, "ctx-a", &platform.ResourceOutput{
+		Name:       "resource-a",
+		Type:       "service",
+		Properties: map[string]any{},
+	}); err != nil {
+		t.Fatalf("SaveResource: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := store.GetResource(ctx, "ctx-a", "resource-a")
+		readDone <- err
+	}()
+
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("GetResource: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("GetResource blocked behind store mutex")
+	}
+}

--- a/platform/state/sqlite_store.go
+++ b/platform/state/sqlite_store.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -16,7 +17,8 @@ import (
 	"github.com/GoCodeAlone/workflow/platform"
 	"github.com/google/uuid"
 
-	_ "modernc.org/sqlite"
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 //go:embed migrations/001_initial.sql
@@ -254,7 +256,10 @@ func (s *SQLiteStore) Lock(ctx context.Context, contextPath string, ttl time.Dur
 	`, contextPath, holderID, now.Format(time.RFC3339), expiresAt.Format(time.RFC3339))
 	s.mu.Unlock()
 	if err != nil {
-		return nil, &platform.LockConflictError{ContextPath: contextPath}
+		if isSQLiteConstraint(err) {
+			return nil, &platform.LockConflictError{ContextPath: contextPath}
+		}
+		return nil, fmt.Errorf("sqlite lock %q: %w", contextPath, err)
 	}
 
 	return &sqliteLockHandle{
@@ -262,6 +267,11 @@ func (s *SQLiteStore) Lock(ctx context.Context, contextPath string, ttl time.Dur
 		contextPath: contextPath,
 		holderID:    holderID,
 	}, nil
+}
+
+func isSQLiteConstraint(err error) bool {
+	var sqliteErr *sqlite.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_CONSTRAINT
 }
 
 // Dependencies returns dependency references for resources that depend on

--- a/platform/state/sqlite_store.go
+++ b/platform/state/sqlite_store.go
@@ -252,8 +252,8 @@ func (s *SQLiteStore) Lock(ctx context.Context, contextPath string, ttl time.Dur
 		INSERT INTO platform_locks (context_path, holder, acquired_at, expires_at)
 		VALUES (?, ?, ?, ?)
 	`, contextPath, holderID, now.Format(time.RFC3339), expiresAt.Format(time.RFC3339))
+	s.mu.Unlock()
 	if err != nil {
-		s.mu.Unlock()
 		return nil, &platform.LockConflictError{ContextPath: contextPath}
 	}
 
@@ -377,7 +377,6 @@ func (h *sqliteLockHandle) Unlock(ctx context.Context) error {
 	_, err := h.store.db.ExecContext(ctx, `
 		DELETE FROM platform_locks WHERE context_path = ? AND holder = ?
 	`, h.contextPath, h.holderID)
-	h.store.mu.Unlock()
 	return err
 }
 

--- a/platform/state/sqlite_store_test.go
+++ b/platform/state/sqlite_store_test.go
@@ -501,6 +501,36 @@ func TestSQLiteStore_Lock(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_LockDoesNotBlockDifferentContext(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	handle, err := store.Lock(ctx, "acme/prod", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("Lock acme/prod: %v", err)
+	}
+	defer handle.Unlock(ctx)
+
+	lockDone := make(chan error, 1)
+	go func() {
+		other, err := store.Lock(ctx, "acme/staging", 5*time.Minute)
+		if err == nil {
+			err = other.Unlock(ctx)
+		}
+		lockDone <- err
+	}()
+
+	select {
+	case err := <-lockDone:
+		if err != nil {
+			t.Fatalf("Lock acme/staging: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Lock for different context blocked behind existing lock")
+	}
+}
+
 func TestSQLiteStore_Lock_Refresh(t *testing.T) {
 	t.Parallel()
 	store := newTestSQLiteStore(t)

--- a/plugin/external/manager.go
+++ b/plugin/external/manager.go
@@ -20,6 +20,7 @@ type ExternalPluginManager struct {
 	pluginsDir string
 	logger     *log.Logger
 
+	opsMu   sync.Mutex
 	mu      sync.RWMutex
 	clients map[string]*goplugin.Client
 
@@ -92,14 +93,17 @@ func (m *ExternalPluginManager) DiscoverPlugins() ([]string, error) {
 // creates an ExternalPluginAdapter. The plugin must have been previously
 // discovered via DiscoverPlugins.
 func (m *ExternalPluginManager) LoadPlugin(name string) (*ExternalPluginAdapter, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.opsMu.Lock()
+	defer m.opsMu.Unlock()
 
+	m.mu.RLock()
 	if _, exists := m.clients[name]; exists {
+		m.mu.RUnlock()
 		return nil, fmt.Errorf("plugin %q is already loaded", name)
 	}
+	m.mu.RUnlock()
 
-	launch, err := m.startPluginLocked(name)
+	launch, err := m.startPluginUnlocked(name)
 	if err != nil {
 		return nil, err
 	}
@@ -107,13 +111,20 @@ func (m *ExternalPluginManager) LoadPlugin(name string) (*ExternalPluginAdapter,
 		return nil, err
 	}
 
+	m.mu.Lock()
+	if _, exists := m.clients[name]; exists {
+		m.mu.Unlock()
+		launch.client.Kill()
+		return nil, fmt.Errorf("plugin %q is already loaded", name)
+	}
 	m.clients[name] = launch.client
+	m.mu.Unlock()
 	m.logger.Printf("plugin %q loaded successfully", name)
 
 	return launch.adapter, nil
 }
 
-func (m *ExternalPluginManager) startPluginLocked(name string) (*pluginLaunch, error) {
+func (m *ExternalPluginManager) startPluginUnlocked(name string) (*pluginLaunch, error) {
 	if m.startPlugin != nil {
 		return m.startPlugin(name)
 	}
@@ -159,6 +170,10 @@ func (m *ExternalPluginManager) startPluginLocked(name string) (*pluginLaunch, e
 
 	m.logger.Printf("starting plugin %q (version %s)", name, manifest.Version)
 
+	m.mu.RLock()
+	callbackServer := m.callbackServer
+	m.mu.RUnlock()
+
 	// Run the plugin subprocess with its own directory as the working directory.
 	// This ensures plugins that extract embedded assets (e.g. ui_dist/) write to
 	// their own directory rather than inheriting the parent's working directory,
@@ -169,7 +184,7 @@ func (m *ExternalPluginManager) startPluginLocked(name string) (*pluginLaunch, e
 
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  Handshake,
-		Plugins:          goplugin.PluginSet{"plugin": &GRPCPlugin{CallbackServer: m.callbackServer}},
+		Plugins:          goplugin.PluginSet{"plugin": &GRPCPlugin{CallbackServer: callbackServer}},
 		Cmd:              cmd,
 		Stderr:           pluginStderr,
 		SyncStderr:       pluginStderr,
@@ -235,17 +250,20 @@ func (w *pluginStderrForwarder) Write(p []byte) (int, error) {
 
 // UnloadPlugin stops the named plugin subprocess and removes it from the internal map.
 func (m *ExternalPluginManager) UnloadPlugin(name string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.opsMu.Lock()
+	defer m.opsMu.Unlock()
 
+	m.mu.Lock()
 	client, exists := m.clients[name]
 	if !exists {
+		m.mu.Unlock()
 		return fmt.Errorf("plugin %q is not loaded", name)
 	}
+	delete(m.clients, name)
+	m.mu.Unlock()
 
 	m.logger.Printf("unloading plugin %q", name)
 	client.Kill()
-	delete(m.clients, name)
 	m.logger.Printf("plugin %q unloaded", name)
 
 	return nil
@@ -254,24 +272,28 @@ func (m *ExternalPluginManager) UnloadPlugin(name string) error {
 // ReloadPlugin starts and validates the replacement before stopping the
 // currently loaded plugin. Candidate failure leaves the old process registered.
 func (m *ExternalPluginManager) ReloadPlugin(name string) (*ExternalPluginAdapter, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.opsMu.Lock()
+	defer m.opsMu.Unlock()
 
+	m.mu.RLock()
 	oldClient, wasLoaded := m.clients[name]
+	m.mu.RUnlock()
 	if !wasLoaded {
-		launch, err := m.startPluginLocked(name)
+		launch, err := m.startPluginUnlocked(name)
 		if err != nil {
 			return nil, err
 		}
 		if err := validatePluginLaunch(name, launch); err != nil {
 			return nil, err
 		}
+		m.mu.Lock()
 		m.clients[name] = launch.client
+		m.mu.Unlock()
 		m.logger.Printf("plugin %q loaded successfully", name)
 		return launch.adapter, nil
 	}
 
-	launch, err := m.startPluginLocked(name)
+	launch, err := m.startPluginUnlocked(name)
 	if err != nil {
 		m.logger.Printf("plugin %q reload failed; keeping existing plugin active: %v", name, err)
 		return nil, fmt.Errorf("reload plugin %q: %w", name, err)
@@ -281,7 +303,9 @@ func (m *ExternalPluginManager) ReloadPlugin(name string) (*ExternalPluginAdapte
 		return nil, fmt.Errorf("reload plugin %q: %w", name, err)
 	}
 
+	m.mu.Lock()
 	m.clients[name] = launch.client
+	m.mu.Unlock()
 	oldClient.Kill()
 	m.logger.Printf("plugin %q reloaded successfully", name)
 	return launch.adapter, nil
@@ -322,13 +346,17 @@ func (m *ExternalPluginManager) IsLoaded(name string) bool {
 
 // Shutdown kills all loaded plugin subprocesses.
 func (m *ExternalPluginManager) Shutdown() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.opsMu.Lock()
+	defer m.opsMu.Unlock()
 
-	for name, client := range m.clients {
+	m.mu.Lock()
+	clients := m.clients
+	m.clients = make(map[string]*goplugin.Client)
+	m.mu.Unlock()
+
+	for name, client := range clients {
 		m.logger.Printf("shutting down plugin %q", name)
 		client.Kill()
 	}
-	m.clients = make(map[string]*goplugin.Client)
 	m.logger.Printf("all external plugins shut down")
 }

--- a/plugin/external/manager_test.go
+++ b/plugin/external/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	goplugin "github.com/GoCodeAlone/go-plugin"
 )
@@ -105,6 +106,51 @@ func TestExternalPluginManagerLoadPluginStoresCandidateAfterValidation(t *testin
 	}
 	if _, err := manager.LoadPlugin("safe-plugin"); err == nil {
 		t.Fatal("duplicate load should fail")
+	}
+}
+
+func TestExternalPluginManagerLoadPluginDoesNotStarveLoadedReads(t *testing.T) {
+	manager := NewExternalPluginManager(t.TempDir(), log.Default())
+	started := make(chan struct{})
+	release := make(chan struct{})
+	manager.startPlugin = func(string) (*pluginLaunch, error) {
+		close(started)
+		<-release
+		return &pluginLaunch{client: &goplugin.Client{}, adapter: &ExternalPluginAdapter{}}, nil
+	}
+
+	loadDone := make(chan error, 1)
+	go func() {
+		_, err := manager.LoadPlugin("slow-plugin")
+		loadDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("LoadPlugin did not reach start hook")
+	}
+
+	readDone := make(chan bool, 1)
+	go func() {
+		readDone <- manager.IsLoaded("other-plugin")
+	}()
+
+	select {
+	case loaded := <-readDone:
+		if loaded {
+			close(release)
+			t.Fatal("unexpected loaded result for unrelated plugin")
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(release)
+		t.Fatal("IsLoaded blocked behind plugin startup")
+	}
+
+	close(release)
+	if err := <-loadDone; err != nil {
+		t.Fatalf("LoadPlugin: %v", err)
 	}
 }
 

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -30,6 +30,7 @@ type PluginInfo struct {
 // PluginManager handles plugin registration, dependency resolution, lifecycle management,
 // enable/disable state persistence, and HTTP route dispatch.
 type PluginManager struct {
+	opsMu   sync.Mutex
 	mu      sync.RWMutex
 	plugins map[string]NativePlugin // all registered plugins
 	enabled map[string]bool         // enabled state
@@ -91,24 +92,24 @@ func (pm *PluginManager) Register(p NativePlugin) error {
 // Returns an error if the plugin is not registered, if a dependency is missing,
 // or if a circular dependency is detected.
 func (pm *PluginManager) Enable(name string) error {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
+	pm.opsMu.Lock()
+	defer pm.opsMu.Unlock()
 
+	pm.mu.RLock()
 	if _, exists := pm.plugins[name]; !exists {
+		pm.mu.RUnlock()
 		return fmt.Errorf("plugin %q is not registered", name)
 	}
 
 	// Resolve enable order via topological sort
 	order, err := pm.resolveEnableOrder(name)
+	pm.mu.RUnlock()
 	if err != nil {
 		return err
 	}
 
 	// Enable each plugin in dependency order
 	for _, pName := range order {
-		if pm.enabled[pName] {
-			continue
-		}
 		if err := pm.enableOne(pName); err != nil {
 			return fmt.Errorf("enable %q: %w", pName, err)
 		}
@@ -119,28 +120,29 @@ func (pm *PluginManager) Enable(name string) error {
 // Disable disables a plugin and all plugins that depend on it (reverse dependency order).
 // Returns an error if the plugin is not registered.
 func (pm *PluginManager) Disable(name string) error {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
+	pm.opsMu.Lock()
+	defer pm.opsMu.Unlock()
 
+	pm.mu.RLock()
 	if _, exists := pm.plugins[name]; !exists {
+		pm.mu.RUnlock()
 		return fmt.Errorf("plugin %q is not registered", name)
 	}
 
 	if !pm.enabled[name] {
+		pm.mu.RUnlock()
 		return nil // already disabled
 	}
 
 	// Find all enabled plugins that transitively depend on this one
 	order, err := pm.resolveDisableOrder(name)
+	pm.mu.RUnlock()
 	if err != nil {
 		return err
 	}
 
 	// Disable in reverse dependency order (dependents first)
 	for _, pName := range order {
-		if !pm.enabled[pName] {
-			continue
-		}
 		if err := pm.disableOne(pName); err != nil {
 			return fmt.Errorf("disable %q: %w", pName, err)
 		}
@@ -172,13 +174,118 @@ func (pm *PluginManager) EnabledPlugins() []NativePlugin {
 	return result
 }
 
+// enableOne enables a single plugin (no dependency resolution). Caller must hold pm.opsMu.
+func (pm *PluginManager) enableOne(name string) error {
+	pm.mu.RLock()
+	p := pm.plugins[name]
+	if p == nil {
+		pm.mu.RUnlock()
+		return fmt.Errorf("plugin %q is not registered", name)
+	}
+	if pm.enabled[name] {
+		pm.mu.RUnlock()
+		return nil
+	}
+	ctx := pm.ctx
+	for _, dep := range p.Dependencies() {
+		depPlugin, ok := pm.plugins[dep.Name]
+		if !ok {
+			pm.mu.RUnlock()
+			return fmt.Errorf("dependency %q not registered", dep.Name)
+		}
+		if dep.MinVersion != "" {
+			ok, err := CheckVersion(depPlugin.Version(), ">="+dep.MinVersion)
+			if err != nil {
+				pm.mu.RUnlock()
+				return fmt.Errorf("check version for dep %q: %w", dep.Name, err)
+			}
+			if !ok {
+				pm.mu.RUnlock()
+				return fmt.Errorf("dependency %q version %s does not satisfy >= %s",
+					dep.Name, depPlugin.Version(), dep.MinVersion)
+			}
+		}
+	}
+	pm.mu.RUnlock()
+
+	// Create a per-plugin mux and register routes
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+
+	// Call OnEnable
+	if err := p.OnEnable(ctx); err != nil {
+		return fmt.Errorf("OnEnable: %w", err)
+	}
+
+	pm.mu.Lock()
+	if pm.enabled[name] {
+		pm.mu.Unlock()
+		return nil
+	}
+	pm.muxes[name] = mux
+	pm.enabled[name] = true
+	pm.mu.Unlock()
+
+	pm.persistState(name, true, p.Version())
+	pm.logger.Info("Plugin enabled", "plugin", name)
+	return nil
+}
+
+// disableOne disables a single plugin (no dependent resolution). Caller must hold pm.opsMu.
+func (pm *PluginManager) disableOne(name string) error {
+	pm.mu.RLock()
+	p := pm.plugins[name]
+	if p == nil {
+		pm.mu.RUnlock()
+		return fmt.Errorf("plugin %q is not registered", name)
+	}
+	if !pm.enabled[name] {
+		pm.mu.RUnlock()
+		return nil
+	}
+	ctx := pm.ctx
+	pm.mu.RUnlock()
+
+	// Call OnDisable
+	if err := p.OnDisable(ctx); err != nil {
+		pm.logger.Warn("OnDisable error (continuing)", "plugin", name, "error", err)
+	}
+
+	pm.mu.Lock()
+	delete(pm.muxes, name)
+	pm.enabled[name] = false
+	pm.mu.Unlock()
+
+	pm.persistState(name, false, p.Version())
+	pm.logger.Info("Plugin disabled", "plugin", name)
+	return nil
+}
+
 // AllPlugins returns info about all registered plugins sorted by name.
 func (pm *PluginManager) AllPlugins() []PluginInfo {
 	pm.mu.RLock()
-	defer pm.mu.RUnlock()
-
-	result := make([]PluginInfo, 0, len(pm.plugins))
+	snapshots := make([]struct {
+		name    string
+		plugin  NativePlugin
+		enabled bool
+	}, 0, len(pm.plugins))
 	for name, p := range pm.plugins {
+		snapshots = append(snapshots, struct {
+			name    string
+			plugin  NativePlugin
+			enabled bool
+		}{
+			name:    name,
+			plugin:  p,
+			enabled: pm.enabled[name],
+		})
+	}
+	pm.mu.RUnlock()
+
+	result := make([]PluginInfo, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		name := snapshot.name
+		p := snapshot.plugin
 		uiPages := p.UIPages()
 		if uiPages == nil {
 			uiPages = []UIPageDef{}
@@ -192,7 +299,7 @@ func (pm *PluginManager) AllPlugins() []PluginInfo {
 			Name:         name,
 			Version:      p.Version(),
 			Description:  p.Description(),
-			Enabled:      pm.enabled[name],
+			Enabled:      snapshot.enabled,
 			UIPages:      uiPages,
 			Dependencies: deps,
 		}
@@ -373,62 +480,6 @@ func (pm *PluginManager) initDB() error {
 	if err != nil {
 		return fmt.Errorf("create plugin_state table: %w", err)
 	}
-	return nil
-}
-
-// enableOne enables a single plugin (no dependency resolution). Caller must hold pm.mu.
-func (pm *PluginManager) enableOne(name string) error {
-	p := pm.plugins[name]
-
-	// Check version constraints on dependencies
-	for _, dep := range p.Dependencies() {
-		depPlugin, ok := pm.plugins[dep.Name]
-		if !ok {
-			return fmt.Errorf("dependency %q not registered", dep.Name)
-		}
-		if dep.MinVersion != "" {
-			ok, err := CheckVersion(depPlugin.Version(), ">="+dep.MinVersion)
-			if err != nil {
-				return fmt.Errorf("check version for dep %q: %w", dep.Name, err)
-			}
-			if !ok {
-				return fmt.Errorf("dependency %q version %s does not satisfy >= %s",
-					dep.Name, depPlugin.Version(), dep.MinVersion)
-			}
-		}
-	}
-
-	// Create a per-plugin mux and register routes
-	mux := http.NewServeMux()
-	p.RegisterRoutes(mux)
-	pm.muxes[name] = mux
-
-	// Call OnEnable
-	if err := p.OnEnable(pm.ctx); err != nil {
-		delete(pm.muxes, name)
-		return fmt.Errorf("OnEnable: %w", err)
-	}
-
-	pm.enabled[name] = true
-	pm.persistState(name, true, p.Version())
-	pm.logger.Info("Plugin enabled", "plugin", name)
-	return nil
-}
-
-// disableOne disables a single plugin (no dependent resolution). Caller must hold pm.mu.
-func (pm *PluginManager) disableOne(name string) error {
-	p := pm.plugins[name]
-
-	// Call OnDisable
-	if err := p.OnDisable(pm.ctx); err != nil {
-		pm.logger.Warn("OnDisable error (continuing)", "plugin", name, "error", err)
-	}
-
-	// Remove routes
-	delete(pm.muxes, name)
-	pm.enabled[name] = false
-	pm.persistState(name, false, p.Version())
-	pm.logger.Info("Plugin disabled", "plugin", name)
 	return nil
 }
 

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -1,13 +1,94 @@
 package plugin
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // --- PluginManager additional coverage tests ---
+
+var blockingPluginStateDriverCounter atomic.Uint64
+
+type blockingPluginStateDriver struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingPluginStateDB(t *testing.T) (*sql.DB, *blockingPluginStateDriver) {
+	t.Helper()
+	d := &blockingPluginStateDriver{entered: make(chan struct{}), release: make(chan struct{})}
+	name := fmt.Sprintf("blocking_plugin_state_%d", blockingPluginStateDriverCounter.Add(1))
+	sql.Register(name, d)
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("open blocking driver: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, d
+}
+
+func (d *blockingPluginStateDriver) Open(string) (driver.Conn, error) {
+	return &blockingPluginStateConn{driver: d}, nil
+}
+
+type blockingPluginStateConn struct {
+	driver *blockingPluginStateDriver
+}
+
+func (c *blockingPluginStateConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare not implemented")
+}
+
+func (c *blockingPluginStateConn) Close() error {
+	return nil
+}
+
+func (c *blockingPluginStateConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("transactions not implemented")
+}
+
+func (c *blockingPluginStateConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return driver.RowsAffected(0), nil
+}
+
+func (c *blockingPluginStateConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	c.driver.once.Do(func() { close(c.driver.entered) })
+	<-c.driver.release
+	return &pluginStateRows{remaining: 1}, nil
+}
+
+type pluginStateRows struct {
+	remaining int
+}
+
+func (r *pluginStateRows) Columns() []string {
+	return []string{"enabled_at", "disabled_at"}
+}
+
+func (r *pluginStateRows) Close() error {
+	return nil
+}
+
+func (r *pluginStateRows) Next(dest []driver.Value) error {
+	if r.remaining == 0 {
+		return io.EOF
+	}
+	r.remaining--
+	dest[0] = "2026-07-04T00:00:00Z"
+	dest[1] = nil
+	return nil
+}
 
 func TestPluginManager_NilDB(t *testing.T) {
 	t.Parallel()
@@ -101,6 +182,46 @@ func TestPluginManager_AllPlugins(t *testing.T) {
 	}
 }
 
+func TestPluginManager_AllPluginsDoesNotStarveRegistrationDuringTimestampQuery(t *testing.T) {
+	db, driver := newBlockingPluginStateDB(t)
+	pm := NewPluginManager(db, nil)
+	if err := pm.Register(newSimplePlugin("alpha", "1.0.0", "Alpha plugin")); err != nil {
+		t.Fatalf("Register alpha: %v", err)
+	}
+
+	listDone := make(chan struct{})
+	go func() {
+		_ = pm.AllPlugins()
+		close(listDone)
+	}()
+
+	select {
+	case <-driver.entered:
+	case <-time.After(time.Second):
+		close(driver.release)
+		t.Fatal("AllPlugins did not reach timestamp query")
+	}
+
+	registerDone := make(chan error, 1)
+	go func() {
+		registerDone <- pm.Register(newSimplePlugin("beta", "1.0.0", "Beta plugin"))
+	}()
+
+	select {
+	case err := <-registerDone:
+		if err != nil {
+			close(driver.release)
+			t.Fatalf("Register beta: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(driver.release)
+		t.Fatal("Register blocked behind AllPlugins timestamp query")
+	}
+
+	close(driver.release)
+	<-listDone
+}
+
 func TestPluginManager_EnabledPlugins(t *testing.T) {
 	t.Parallel()
 
@@ -182,6 +303,54 @@ func TestPluginManager_EnableWithVersionConstraint(t *testing.T) {
 
 	if err := pm.Enable("consumer"); err != nil {
 		t.Fatalf("Enable with valid version constraint: %v", err)
+	}
+}
+
+func TestPluginManager_EnableDoesNotStarveEnabledReadsDuringPluginCallback(t *testing.T) {
+	pm := NewPluginManager(nil, nil)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	blocking := newSimplePlugin("blocking", "1.0.0", "Blocking plugin")
+	blocking.onEnableFn = func(PluginContext) error {
+		close(entered)
+		<-release
+		return nil
+	}
+	if err := pm.Register(blocking); err != nil {
+		t.Fatalf("Register blocking: %v", err)
+	}
+
+	enableDone := make(chan error, 1)
+	go func() {
+		enableDone <- pm.Enable("blocking")
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("Enable did not reach OnEnable callback")
+	}
+
+	readDone := make(chan bool, 1)
+	go func() {
+		readDone <- pm.IsEnabled("unrelated")
+	}()
+
+	select {
+	case enabled := <-readDone:
+		if enabled {
+			close(release)
+			t.Fatal("unexpected enabled result for unrelated plugin")
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(release)
+		t.Fatal("IsEnabled blocked behind OnEnable callback")
+	}
+
+	close(release)
+	if err := <-enableDone; err != nil {
+		t.Fatalf("Enable: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid holding auth, plugin, state-store, artifact-store, and REST handler locks across persistence or lifecycle I/O
- narrow plugin manager and external plugin manager lock scopes around callbacks/process work
- add starvation regressions for the lock-across-I/O paths

## Verification
- GOWORK=off go test ./module ./plugin ./plugin/external ./platform/state ./platform/providers/dockercompose -count=1
- GOWORK=off go test -race ./module ./plugin ./plugin/external ./platform/state ./platform/providers/dockercompose -run 'Test.*DoesNotBlock|Test.*DoesNotStarve|TestSQLiteStore_Lock|TestRESTAPIHandler_HandlePut_UpdateResource|TestRESTAPIHandler_HandleDelete_Success' -count=1
- revert proof: focused regression tests fail when old lock-across-I/O behavior is restored

## Downstream impact
No public config/API change. This affects broad Go module consumers listed in the portfolio: most workflow-plugin-* repos, workflow-scenarios, ratchet/ratchet-cli, workflow-cloud, app repos, and registry-shipped in-engine plugins. After merge and workflow release, downstream consumers can bump workflow; registry entries sourced from workflow do not need contract changes unless republished to pin a new engine binary.

Refs GoCodeAlone/workspace#133
