### PR TITLE
Add prevalidated rolling deployment contract alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Configs that still reference the legacy types now fail to load with an actionabl
 
 ## [Unreleased]
 
+### Added
+
+- `module.PrevalidatedRollingDriver` and
+  `module.PrevalidatedRollingDriverProvider` as compatibility aliases for
+  providers whose deployment strategy validates a candidate image before rolling
+  the stable service. The legacy `BlueGreenDriver` names remain available for
+  existing providers and `step.deploy_blue_green` configs.
+
 ### Fixed
 
 - Plugin-owned top-level wfctl commands now resolve project-local installs from

--- a/module/infra_module.go
+++ b/module/infra_module.go
@@ -115,8 +115,8 @@ func (m *InfraModule) Init(app modular.Application) error {
 	return nil
 }
 
-// registerDeployDrivers registers deploy-capable drivers at "<name>" (and
-// "<name>.bluegreen" / "<name>.canary" if available).
+// registerDeployDrivers registers the highest-priority deploy-capable driver at
+// "<name>" for pipeline deploy steps.
 func (m *InfraModule) registerDeployDrivers(app modular.Application) {
 	// PrevalidatedRollingDriverProvider → register at "<name>" through the
 	// legacy step.deploy_blue_green service contract.

--- a/module/infra_module.go
+++ b/module/infra_module.go
@@ -102,10 +102,12 @@ func (m *InfraModule) Init(app modular.Application) error {
 	// step.deploy_rolling (and friends) can resolve this module by its plain name.
 	//
 	// Priority (highest first):
-	//   1. Provider implements BlueGreenDriverProvider → also exposes BlueGreenDriver.
-	//   2. Provider implements CanaryDriverProvider    → also exposes CanaryDriver.
-	//   3. Provider implements DeployDriverProvider    → uses a provider-supplied driver.
-	//   4. Fallback: wrap the ResourceDriver in an infraDeployAdapter.
+	//   1. Provider implements PrevalidatedRollingDriverProvider → exposes the
+	//      prevalidated rolling driver through the legacy blue/green step contract.
+	//   2. Provider implements BlueGreenDriverProvider → also exposes BlueGreenDriver.
+	//   3. Provider implements CanaryDriverProvider    → also exposes CanaryDriver.
+	//   4. Provider implements DeployDriverProvider    → uses a provider-supplied driver.
+	//   5. Fallback: wrap the ResourceDriver in an infraDeployAdapter.
 	//
 	// Registrations are best-effort; if a service already exists at "<name>" we
 	// skip silently rather than fail the whole module.
@@ -116,6 +118,15 @@ func (m *InfraModule) Init(app modular.Application) error {
 // registerDeployDrivers registers deploy-capable drivers at "<name>" (and
 // "<name>.bluegreen" / "<name>.canary" if available).
 func (m *InfraModule) registerDeployDrivers(app modular.Application) {
+	// PrevalidatedRollingDriverProvider → register at "<name>" through the
+	// legacy step.deploy_blue_green service contract.
+	if prp, ok := m.provider.(PrevalidatedRollingDriverProvider); ok {
+		if prd := prp.ProvidePrevalidatedRollingDriver(m.name); prd != nil {
+			_ = app.RegisterService(m.name, prd)
+			return
+		}
+	}
+
 	// BlueGreenDriverProvider → register at "<name>" as BlueGreenDriver.
 	if bgp, ok := m.provider.(BlueGreenDriverProvider); ok {
 		if bgd := bgp.ProvideBlueGreenDriver(m.name); bgd != nil {

--- a/module/infra_module_deploy_bridge.go
+++ b/module/infra_module_deploy_bridge.go
@@ -19,9 +19,21 @@ type DeployDriverProvider interface {
 
 // BlueGreenDriverProvider is an optional extension of interfaces.IaCProvider
 // for providers that support blue/green deployments.
+//
+// Deprecated: use PrevalidatedRollingDriverProvider for providers whose
+// strategy validates a candidate deployment before rolling the stable service.
 type BlueGreenDriverProvider interface {
 	// ProvideBlueGreenDriver returns a BlueGreenDriver for the named resource, or nil.
 	ProvideBlueGreenDriver(resourceName string) BlueGreenDriver
+}
+
+// PrevalidatedRollingDriverProvider is an optional extension of
+// interfaces.IaCProvider for providers that support prevalidated rolling
+// deployments.
+type PrevalidatedRollingDriverProvider interface {
+	// ProvidePrevalidatedRollingDriver returns a PrevalidatedRollingDriver for
+	// the named resource, or nil.
+	ProvidePrevalidatedRollingDriver(resourceName string) PrevalidatedRollingDriver
 }
 
 // CanaryDriverProvider is an optional extension of interfaces.IaCProvider

--- a/module/infra_module_deploy_bridge_test.go
+++ b/module/infra_module_deploy_bridge_test.go
@@ -93,9 +93,10 @@ func (d *deployCapableDriver) DestroyCanary(_ context.Context) error {
 
 type deployProviderMock struct {
 	*infraMockProvider
-	deployDriver *deployCapableDriver
-	bgDriver     *deployCapableDriver
-	canaryDriver *deployCapableDriver
+	deployDriver       *deployCapableDriver
+	bgDriver           *deployCapableDriver
+	prevalidatedDriver *deployCapableDriver
+	canaryDriver       *deployCapableDriver
 }
 
 func (p *deployProviderMock) ProvideDeployDriver(_ string) DeployDriver {
@@ -108,6 +109,13 @@ func (p *deployProviderMock) ProvideDeployDriver(_ string) DeployDriver {
 func (p *deployProviderMock) ProvideBlueGreenDriver(_ string) BlueGreenDriver {
 	if p.bgDriver != nil {
 		return p.bgDriver
+	}
+	return nil
+}
+
+func (p *deployProviderMock) ProvidePrevalidatedRollingDriver(_ string) PrevalidatedRollingDriver {
+	if p.prevalidatedDriver != nil {
+		return p.prevalidatedDriver
 	}
 	return nil
 }
@@ -272,6 +280,52 @@ func TestBridge_BlueGreenDriverProvider_FullLifecycle(t *testing.T) {
 	}
 	if !bgd.greenCreated || !bgd.trafficSwitched || !bgd.blueDestroyed {
 		t.Error("expected full blue/green lifecycle to be executed")
+	}
+}
+
+// ─── Tests: PrevalidatedRollingDriverProvider optional interface ─────────────
+
+func TestBridge_PrevalidatedRollingDriverProvider_RegisteredAtPlainName(t *testing.T) {
+	baseProvider, _ := newTestProvider("aws", "infra.container_service")
+	driver := newDeployCapableDriver("nginx:1.24", 1)
+	provider := &deployProviderMock{
+		infraMockProvider:  baseProvider,
+		prevalidatedDriver: driver,
+	}
+	m := NewInfraModule("my-svc", "infra.container_service", map[string]any{"provider": "aws"})
+	app := initWithProvider(t, m, "aws", provider)
+
+	svc, ok := app.services["my-svc"]
+	if !ok {
+		t.Fatal("expected 'my-svc' to be registered")
+	}
+	if _, ok := svc.(PrevalidatedRollingDriver); !ok {
+		t.Errorf("expected PrevalidatedRollingDriver, got %T", svc)
+	}
+
+	legacy, err := resolveBlueGreenDriver(app, "my-svc", "test-step")
+	if err != nil {
+		t.Fatalf("resolveBlueGreenDriver: %v", err)
+	}
+	if legacy != BlueGreenDriver(driver) {
+		t.Fatalf("resolved legacy driver = %T, want provider-supplied prevalidated driver", legacy)
+	}
+}
+
+func TestBridge_PrevalidatedRollingDriverProvider_PreferredOverLegacyBlueGreenProvider(t *testing.T) {
+	baseProvider, _ := newTestProvider("aws", "infra.container_service")
+	legacy := newDeployCapableDriver("nginx:1.24", 1)
+	prevalidated := newDeployCapableDriver("nginx:1.25", 2)
+	provider := &deployProviderMock{
+		infraMockProvider:  baseProvider,
+		bgDriver:           legacy,
+		prevalidatedDriver: prevalidated,
+	}
+	m := NewInfraModule("my-svc", "infra.container_service", map[string]any{"provider": "aws"})
+	app := initWithProvider(t, m, "aws", provider)
+
+	if app.services["my-svc"] != PrevalidatedRollingDriver(prevalidated) {
+		t.Fatalf("expected PrevalidatedRollingDriverProvider to take precedence over BlueGreenDriverProvider")
 	}
 }
 

--- a/module/pipeline_step_deploy_blue_green.go
+++ b/module/pipeline_step_deploy_blue_green.go
@@ -8,18 +8,32 @@ import (
 	"github.com/GoCodeAlone/modular"
 )
 
+// PrevalidatedRollingDriver extends DeployDriver with the ability to validate a
+// new environment before rolling the validated image onto the stable service.
+//
+// The method names match the historical BlueGreenDriver contract so existing
+// deploy_blue_green steps keep working while provider implementations migrate to
+// the more accurate name.
+type PrevalidatedRollingDriver interface {
+	DeployDriver
+	// CreateGreen creates a new validation environment with the given image.
+	CreateGreen(ctx context.Context, image string) error
+	// SwitchTraffic promotes the validated image according to the provider's
+	// deployment strategy.
+	SwitchTraffic(ctx context.Context) error
+	// DestroyBlue tears down the temporary validation environment.
+	DestroyBlue(ctx context.Context) error
+	// GreenEndpoint returns the URL/address of the validation environment.
+	GreenEndpoint(ctx context.Context) (string, error)
+}
+
 // BlueGreenDriver extends DeployDriver with the ability to manage two environments
 // (blue/green) and switch traffic between them.
+//
+// Deprecated: use PrevalidatedRollingDriver for providers whose implementation
+// validates a candidate deployment before rolling the stable service.
 type BlueGreenDriver interface {
-	DeployDriver
-	// CreateGreen creates a new "green" environment with the given image.
-	CreateGreen(ctx context.Context, image string) error
-	// SwitchTraffic routes all traffic to the green environment.
-	SwitchTraffic(ctx context.Context) error
-	// DestroyBlue tears down the old "blue" environment.
-	DestroyBlue(ctx context.Context) error
-	// GreenEndpoint returns the URL/address of the green environment.
-	GreenEndpoint(ctx context.Context) (string, error)
+	PrevalidatedRollingDriver
 }
 
 // resolveBlueGreenDriver looks up a BlueGreenDriver from the service registry.

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -3010,7 +3010,7 @@ func (r *ModuleSchemaRegistry) registerBuiltins() {
 		Category:    "deployment",
 		Description: "Deploys using blue/green strategy: creates green environment, verifies it, switches traffic, destroys blue",
 		ConfigFields: []ConfigFieldDef{
-			{Key: "service", Label: "Service", Type: FieldTypeString, Required: true, Description: "BlueGreenDriver service name"},
+			{Key: "service", Label: "Service", Type: FieldTypeString, Required: true, Description: "PrevalidatedRollingDriver or legacy BlueGreenDriver service name"},
 			{Key: "image", Label: "Image", Type: FieldTypeString, Required: true, Description: "Docker image to deploy"},
 			{Key: "health_check", Label: "Health Check", Type: FieldTypeMap, Description: "Health check config: {path, timeout}"},
 			{Key: "traffic_switch", Label: "Traffic Switch", Type: FieldTypeSelect, Options: []string{"dns", "lb"}, Description: "Traffic switch mechanism", DefaultValue: "lb"},

--- a/schema/step_schema_builtins.go
+++ b/schema/step_schema_builtins.go
@@ -2684,7 +2684,7 @@ func (r *StepSchemaRegistry) registerBuiltins() {
 		Plugin:      "cicd",
 		Description: "Deploys an image using blue/green strategy: creates a green environment, verifies it, switches traffic, and destroys the old blue environment.",
 		ConfigFields: []ConfigFieldDef{
-			{Key: "service", Type: FieldTypeString, Description: "BlueGreenDriver service name", Required: true},
+			{Key: "service", Type: FieldTypeString, Description: "PrevalidatedRollingDriver or legacy BlueGreenDriver service name", Required: true},
 			{Key: "image", Type: FieldTypeString, Description: "Docker image to deploy (template expressions supported)", Required: true},
 			{Key: "health_check", Type: FieldTypeMap, Description: "Health check config (path string, timeout duration)"},
 			{Key: "traffic_switch", Type: FieldTypeSelect, Description: "Traffic switch mechanism", Options: []string{"dns", "lb"}, DefaultValue: "lb"},

--- a/schema/testdata/editor-schemas.golden.json
+++ b/schema/testdata/editor-schemas.golden.json
@@ -5023,7 +5023,7 @@
           "key": "service",
           "label": "Service",
           "type": "string",
-          "description": "BlueGreenDriver service name",
+          "description": "PrevalidatedRollingDriver or legacy BlueGreenDriver service name",
           "required": true
         },
         {


### PR DESCRIPTION
## Summary

- Add `module.PrevalidatedRollingDriver` and `module.PrevalidatedRollingDriverProvider` for providers whose deploy strategy prevalidates a candidate image before rolling the stable service.
- Keep `BlueGreenDriver` as a compatibility contract for existing providers and `step.deploy_blue_green` configs.
- Prefer the new provider hook in `InfraModule` registration, update schema descriptions, and refresh the editor schema golden.

Closes #1000.

## Test plan

- `GOWORK=off go test ./module -run 'TestBridge_PrevalidatedRollingDriverProvider' -count=1`
- `GOWORK=off go test ./module ./schema -count=1`
- `GOWORK=off go test ./...`
- `GOWORK=off golangci-lint run --new-from-rev=origin/main --timeout=10m`
- `git diff --check`

## Regression proof

With the production alias/bridge code reverted and the new tests retained:

```text
$ GOWORK=off go test ./module -run 'TestBridge_PrevalidatedRollingDriverProvider' -count=1
module/infra_module_deploy_bridge_test.go:116:73: undefined: PrevalidatedRollingDriver
module/infra_module_deploy_bridge_test.go:302:19: undefined: PrevalidatedRollingDriver
module/infra_module_deploy_bridge_test.go:327:31: undefined: PrevalidatedRollingDriver
FAIL github.com/GoCodeAlone/workflow/module [build failed]
```

With the fix restored:

```text
$ GOWORK=off go test ./module -run 'TestBridge_PrevalidatedRollingDriverProvider' -count=1
ok github.com/GoCodeAlone/workflow/module 0.644s
```
