### PR TITLE
ci: stage v0.86 consumer authority

### DIFF
--- a/.github/public-workflow-action-allowlist.json
+++ b/.github/public-workflow-action-allowlist.json
@@ -622,5 +622,53 @@
     "contextSHA256": "37b7935261b56568daee7ad04ebb647f5a53bef336b5da0e8efb5df5e666e06a",
     "state": "staged",
     "rationale": "Staged v0.86 CI authority. Pinned golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee for reviewed ci.yml automation."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "uses": "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "nodeSHA256": "e0b5e84df1e7033b6b3010f753c094203cbcd50be4df4b1b28aee9f3c99fb76d",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Pinned action for reviewed credential-free contract-consumer selection."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    "nodeSHA256": "3f624ba5323484d3010b31e4cf7e56131ba385fcfbe11904ea1badaf2efdd606",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Pinned action for reviewed credential-free contract-consumer evidence."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "uses": "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "nodeSHA256": "a2bd659dbf282777d3d9f5622c07c2c3f7f9f14d34f57159b01c5abb5dd68577",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Pinned action for reviewed credential-free contract-consumer compilation."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "uses": "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c",
+    "nodeSHA256": "812450ca51874d257842490fc8a072d4e7d60f8d04717ef86cddddb072b7081b",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Pinned action for reviewed credential-free contract-consumer compilation."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "uses": "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "nodeSHA256": "c8e509ab5752b2e9cac19d9aa8cefea20cd4b34861f3fef645b690dccf456d35",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Pinned action for reviewed credential-free contract wire validation."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "uses": "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c",
+    "nodeSHA256": "eba9b3a4de6ba55217e7c38019b54f84dd4ede5a5736d3acb2446eeeeabb4fc1",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Pinned action for reviewed credential-free contract wire validation."
   }
 ]

--- a/.github/public-workflow-command-allowlist.json
+++ b/.github/public-workflow-command-allowlist.json
@@ -2454,5 +2454,277 @@
     "contextSHA256": "37b7935261b56568daee7ad04ebb647f5a53bef336b5da0e8efb5df5e666e06a",
     "state": "staged",
     "rationale": "Staged v0.86 CI authority. Exact reviewed true statement for ci.yml automation."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "$assignment",
+    "statementSHA256": "06d0aeef84e477d9ea7e5b95df411e86356002f38b0b03928d5968029a4d0d93",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "$assignment",
+    "statementSHA256": "4c618f8d1ab23a2a817b6b1c12e946cf13e125fbdf9456c3c4b10421a259c715",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "$assignment",
+    "statementSHA256": "6ea35d706cf45fa4c01c1af9e5b34fe92958e190e72fa73496dfec33e9d599ed",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "$assignment",
+    "statementSHA256": "fb7ce4967241ab606ceb3137f5ba9727a222c1f7fb9243810cb1e2dcc85caa88",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "cd",
+    "statementSHA256": "617d0c1e7b0db83efa17ce5f0b2cb6afdbb6f96f913c49aa3ba8e56f844fa0d1",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "cp",
+    "statementSHA256": "0400d3049d1816e4463f9405ea563868fe9f3f3fa9e4652e3afc6bea4df6a11d",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "cp",
+    "statementSHA256": "71f69876cbbd64fad0550ed5810eb17d3b5385db74c1972546514a3d0c7c9664",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "echo",
+    "statementSHA256": "06d0aeef84e477d9ea7e5b95df411e86356002f38b0b03928d5968029a4d0d93",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "echo",
+    "statementSHA256": "26afe138ce773c4b81dcde96a74ff739c632cba6e7ba4cc047d775cf61d8f12a",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "echo",
+    "statementSHA256": "4986e55f389de3c89eaba365a5fd756ec8119650e339d354c42bd57d5a747d9c",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "echo",
+    "statementSHA256": "96af94a417e3db0bdf46ba3e34fa42fb1000794985c8402bfa63e05e4d240f39",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "echo",
+    "statementSHA256": "b85fea1f3f7a80abfefd86b95178dfbb5ec829cc0d9b21bb18e303f0a3bfbb54",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "echo",
+    "statementSHA256": "bc52e2d0df2673ad93172648def787d0d777811a9096ae8fb9155cf6058f60c5",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "exit",
+    "statementSHA256": "06d0aeef84e477d9ea7e5b95df411e86356002f38b0b03928d5968029a4d0d93",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "exit",
+    "statementSHA256": "96af94a417e3db0bdf46ba3e34fa42fb1000794985c8402bfa63e05e4d240f39",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "exit",
+    "statementSHA256": "b85fea1f3f7a80abfefd86b95178dfbb5ec829cc0d9b21bb18e303f0a3bfbb54",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "exit",
+    "statementSHA256": "bc52e2d0df2673ad93172648def787d0d777811a9096ae8fb9155cf6058f60c5",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "git",
+    "statementSHA256": "5e3f2a72457c9fb6661cdceb03eca9ed5df2358c30daf930b537d0df224616f7",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "git",
+    "statementSHA256": "eaf60c2e981e404f5897f8681a3c179993c9b33478331f721e181918b12a491b",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "go",
+    "statementSHA256": "617d0c1e7b0db83efa17ce5f0b2cb6afdbb6f96f913c49aa3ba8e56f844fa0d1",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "go",
+    "statementSHA256": "a65972d083c0ae1369f5d486f15a5229a7bd87f8575244efbc5616a75ef4ec72",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "jq",
+    "statementSHA256": "26afe138ce773c4b81dcde96a74ff739c632cba6e7ba4cc047d775cf61d8f12a",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "jq",
+    "statementSHA256": "4986e55f389de3c89eaba365a5fd756ec8119650e339d354c42bd57d5a747d9c",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "mkdir",
+    "statementSHA256": "4aa7ddfa24aae3483065033124fda086cb9dbc01efadfc935174afc47a037cfa",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "mkdir",
+    "statementSHA256": "b614920ded3af985a3d43760faa114f8d97c31b55cdf6d83ad6c7888edb97dba",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "return",
+    "statementSHA256": "06d0aeef84e477d9ea7e5b95df411e86356002f38b0b03928d5968029a4d0d93",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "rm",
+    "statementSHA256": "fa4e62c428a5272c75697f838cb03002ae82f9b48497b45321aad2c51307888a",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "run-contract-consumer-shard.sh",
+    "statementSHA256": "617d0c1e7b0db83efa17ce5f0b2cb6afdbb6f96f913c49aa3ba8e56f844fa0d1",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "select-contract-consumers.sh",
+    "statementSHA256": "06d0aeef84e477d9ea7e5b95df411e86356002f38b0b03928d5968029a4d0d93",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "select-contract-consumers.sh",
+    "statementSHA256": "465b598a77398f1f970a823f7c08683a2b3f38ed6a3f7e8c7bd7b2f567b1486f",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "set",
+    "statementSHA256": "06d0aeef84e477d9ea7e5b95df411e86356002f38b0b03928d5968029a4d0d93",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "test-select-contract-consumers.sh",
+    "statementSHA256": "c3832fac5fa1a91dd3589042edec67b5eade0b3d004465a52704561275df70db",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "trap",
+    "statementSHA256": "0e320b2fb321c3f478a90a072c8f73e488309908ec4c31f87171f79a33d58368",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "command": "trap",
+    "statementSHA256": "61ae0022eb44b2485d1c2d9594dba0f5b23202fec9e4c4e6d386f1b8c4ece63a",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "rationale": "Exact reviewed command for credential-free contract-consumer compatibility."
   }
 ]

--- a/.github/public-workflow-executable-allowlist.json
+++ b/.github/public-workflow-executable-allowlist.json
@@ -62,5 +62,29 @@
     "state": "staged",
     "sha256": "7d209bb35ff3a7a46b22f9a10a920eb30218c3403726d1dac72e0bffd1d914a4",
     "rationale": "Staged v0.86 CI authority. Exercises fail-closed public workflow policy mutations in CI."
+  },
+  {
+    "path": ".github/workflows/scripts/select-contract-consumers.sh",
+    "workflowPath": ".github/workflows/cross-plugin-build-test.yml",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "sha256": "b2b85a11b27246bef525a78c23b3a10fe99d34ee31d29f7e92722778bc6596ad",
+    "rationale": "Selects released contract consumers without executing candidate Go."
+  },
+  {
+    "path": ".github/workflows/scripts/run-contract-consumer-shard.sh",
+    "workflowPath": ".github/workflows/cross-plugin-build-test.yml",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "sha256": "cedc17a1193bb42e191e96db7f024cf0c9c985b8ef60328fda6e8e35d9e40563",
+    "rationale": "Builds and loads immutable public contract-consumer releases without provider authority."
+  },
+  {
+    "path": ".github/workflows/scripts/test-select-contract-consumers.sh",
+    "workflowPath": ".github/workflows/cross-plugin-build-test.yml",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "sha256": "47c43498b33e4ab9f410e2eeff5eb124cd953fe657d81fbcd004133a41408c3c",
+    "rationale": "Exercises hermetic contract selection, provenance, runtime parity, and real local loading."
   }
 ]

--- a/.github/public-workflow-presence-allowlist.json
+++ b/.github/public-workflow-presence-allowlist.json
@@ -110,5 +110,11 @@
     "contextSHA256": "37b7935261b56568daee7ad04ebb647f5a53bef336b5da0e8efb5df5e666e06a",
     "state": "staged",
     "presence": "present"
+  },
+  {
+    "path": ".github/workflows/cross-plugin-build-test.yml",
+    "contextSHA256": "5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4",
+    "state": "staged",
+    "presence": "present"
   }
 ]


### PR DESCRIPTION
## What changed

- retained the realized active `cross-plugin-build-test.yml` trust context
- staged the frozen Workflow v0.86 consumer-workflow context `5416093bc5a985f34af5326bd3a7484154084a7911ca6a8384d00b7a34cd2ff4`
- bound 6 pinned action nodes, 34 exact shell statements, and 3 reviewed executable hashes
- changed only the four public-workflow trust allowlists

## Why

Workflow policy requires future workflow authority to land in a separate trust-only pull request before the implementation can adopt it. This stages the provider-neutral, credential-free contract-consumer workflow without changing or executing candidate workflow code. The authoritative selection job does not execute candidate Go; compiled runtime parity remains in a separate output-free validation job.

## Validation

- trusted-base stage-only policy transition: pass
- frozen future candidate analysis across all 11 public workflows: pass
- full public-workflow policy mutation suite: pass
- candidate `actionlint`, ShellCheck, bash syntax, provider-neutrality, and exact digest checks: pass
- full hermetic contract-consumer orchestration and real local `wfctl` handshake: pass
- adversarial scope/security review: SHIP-IT

No workflow, script, policy implementation, secret manifest, runner, provider command, provider API, OIDC permission, self-hosted authority, or live workload changes in this PR.